### PR TITLE
DIVE-938: fix RED install-smoke (curl exit 37 on missing model-tiering-CLAUDE.md)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN systemctl mask \
 # resolve to local files. Keeps install.sh as the single source of truth for
 # laying down binaries / units / hooks / skills — the Dockerfile doesn't
 # duplicate that logic.
-COPY 5dive 5dive-agent-start 5dive-refresh-plugins.sh 5dive-refresh-skills.sh install.sh projects-CLAUDE.md telegram-agent-CLAUDE.md /opt/5dive-bundle/
+COPY 5dive 5dive-agent-start 5dive-refresh-plugins.sh 5dive-refresh-skills.sh install.sh projects-CLAUDE.md telegram-agent-CLAUDE.md model-tiering-CLAUDE.md /opt/5dive-bundle/
 COPY hooks /opt/5dive-bundle/hooks/
 COPY skills /opt/5dive-bundle/skills/
 COPY systemd /opt/5dive-bundle/systemd/

--- a/install.sh
+++ b/install.sh
@@ -284,9 +284,16 @@ DIGESTCRON
   # CLAUDE.md fragment appended to every claude-type agent's $HOME/.claude/
   # CLAUDE.md at create: the self-gated Fable-orchestrator + per-subagent
   # model-tiering default (DIVE-899 — inert unless the session model is Fable).
-  curl -fsSL "$REPO/model-tiering-CLAUDE.md" -o "$LIB_DIR/model-tiering-CLAUDE.md"
-  chmod 644 "$LIB_DIR/model-tiering-CLAUDE.md"
-  ok "model-tiering-CLAUDE.md"
+  # Fail-soft: a missing/transient-404 content fragment shouldn't hard-abort
+  # the whole install (curl -f exits 37 on a file:// bundle that omits it, which
+  # is what reddened install-smoke — DIVE-938). This mirrors the team-templates
+  # staging below. The file is inert unless the session model is Fable (DIVE-899).
+  if curl -fsSL "$REPO/model-tiering-CLAUDE.md" -o "$LIB_DIR/model-tiering-CLAUDE.md"; then
+    chmod 644 "$LIB_DIR/model-tiering-CLAUDE.md"
+    ok "model-tiering-CLAUDE.md"
+  else
+    echo "warn: failed to stage model-tiering-CLAUDE.md — Fable model-tiering default won't apply until the next refresh" >&2
+  fi
 
   # Curated team templates for `5dive team import <slug>` (the compose engine
   # resolves $LIB_DIR/team-templates first). Enumerated explicitly because $REPO


### PR DESCRIPTION
## Problem
`install-smoke / docker-install` has been RED on main across several commits (pre-existing, not the README work). The docker build's final step runs `REPO=file:///opt/5dive-bundle bash install.sh`; it aborts with **curl exit 37** (`CURLE_FILE_COULDNT_READ_FILE`).

## Root cause
`model-tiering-CLAUDE.md` (added in DIVE-899) is fetched **unguarded** in install.sh but was **omitted from the demo Dockerfile's COPY list**. On the `file://` bundle path, curl -f can't read the absent file → exits 37 → `set -e` aborts the build. (The nvm "Profile not found" line in the log is benign — that call runs with `PROFILE=/dev/null` and exits 0; verified empirically.)

## Fix
- Add `model-tiering-CLAUDE.md` to the demo Dockerfile COPY so the smoke image is faithful.
- Make the fetch **fail-soft** (warn, don't abort) mirroring the existing team-templates staging, so future bundle drift or a transient 404 degrades gracefully instead of nuking the whole install.

shellcheck -S error clean. No other unguarded $REPO fetch references a file missing from the build context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)