### PR TITLE
DIVE-956: widen bundle-drift CI trigger to push:'**'

### DIFF
--- a/.github/workflows/bundle-drift.yml
+++ b/.github/workflows/bundle-drift.yml
@@ -6,7 +6,7 @@ name: bundle-drift
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: ['**']
 
 jobs:
   check:


### PR DESCRIPTION
Widens `bundle-drift.yml` triggers from `push:main`+PR to `push:'**'` so **any** branch push with a committed `5dive` bundle that diverges from `build.sh` output fails CI.

**Why:** the 0.6.9 stale-bundle drift rode in on a direct feature-branch push (no PR) and never fired CI — caught manually during the DIVE-950 dormant roll. This closes that gap. CI-config only; no CLI/runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)