### PR TITLE
DIVE-1002: least-privilege agent isolation (standard-by-default + scoped admin)

### DIFF
--- a/5dive
+++ b/5dive
@@ -5754,16 +5754,28 @@ create_agent_user() {
   fi
 }
 
-# DIVE-1002: an 'admin' agent can run the company, not `rm -rf` the box. It gets
-# passwordless sudo scoped to a fleet-management allowlist: the 5dive CLI (which
-# is the sanctioned API for create/rm/provision/restart agents and box ops) plus
-# lifecycle control of the box's own 5dive systemd units and their logs. It does
-# NOT get an arbitrary-root shell (`sudo bash`, `sudo su`, `sudo -u <x> -i`,
-# editors as root, etc.), so a prompt-injected or compromised admin worker is
-# bounded to fleet ops, aligning with the sudo-reduction line (DIVE-756/916).
-# The file is validated with `visudo -c` before install so a malformed entry can
-# never lock the box out; on failure we remove it and fail loudly rather than
-# leaving a broken /etc/sudoers.d.
+# DIVE-1002: an 'admin' agent can run the company, not `rm -rf` the box. Its sudo
+# is scoped to a single mediated surface — the 5dive CLI (the sanctioned API for
+# create/rm/provision/restart agents and box ops) — plus start|stop|restart of
+# the box's own 5dive systemd units. That's it.
+#
+# What is deliberately NOT granted, and why (all are one-line root escapes):
+#   - `systemd-run *`    runs ANY command as root (`systemd-run --pty bash`) —
+#                        a wildcard on it == NOPASSWD: ALL. Agents that need a
+#                        deferred self-restart use `5dive agent restart --defer`,
+#                        which runs systemd-run internally under the already-root
+#                        CLI, so no raw grant is required.
+#   - `journalctl *`     pages through less by default -> `!sh` GTFOBins escape.
+#                        Logs go through `5dive agent logs` (--no-pager path).
+#   - `systemctl status` also pages by default -> same `!sh` escape. Only the
+#                        non-paging start|stop|restart verbs are granted.
+#   - `sudo bash|su|-u <x> -i` — direct root/other-user shells.
+# Granting the whole `5dive` CLI as root makes it a standing invariant that NO
+# 5dive subcommand may exec agent-controlled input as root (else it becomes an
+# admin->root vector). See DIVE-756/916 (sudo reduction), DIVE-950 (forge).
+#
+# The file is `visudo -c` validated before install so a malformed entry can never
+# lock the box out; on failure we remove it and fail loudly.
 write_admin_sudoers() {
   local user="$1" f="/etc/sudoers.d/${user}" tmp
   tmp=$(mktemp)
@@ -5776,14 +5788,13 @@ write_admin_sudoers() {
 ${user} ALL=(root) NOPASSWD: \\
   /usr/local/bin/5dive, /usr/local/bin/5dive *, \\
   /usr/bin/systemctl start 5dive-agent@*, /usr/bin/systemctl stop 5dive-agent@*, \\
-  /usr/bin/systemctl restart 5dive-agent@*, /usr/bin/systemctl status 5dive-agent@*, \\
+  /usr/bin/systemctl restart 5dive-agent@*, \\
   /usr/bin/systemctl start 5dive-*.service, /usr/bin/systemctl stop 5dive-*.service, \\
-  /usr/bin/systemctl restart 5dive-*.service, /usr/bin/systemctl status 5dive-*.service, \\
+  /usr/bin/systemctl restart 5dive-*.service, \\
   /bin/systemctl start 5dive-agent@*, /bin/systemctl stop 5dive-agent@*, \\
-  /bin/systemctl restart 5dive-agent@*, /bin/systemctl status 5dive-agent@*, \\
+  /bin/systemctl restart 5dive-agent@*, \\
   /bin/systemctl start 5dive-*.service, /bin/systemctl stop 5dive-*.service, \\
-  /bin/systemctl restart 5dive-*.service, /bin/systemctl status 5dive-*.service, \\
-  /usr/bin/systemd-run *, /usr/bin/journalctl *, /bin/journalctl *
+  /bin/systemctl restart 5dive-*.service
 SUDOERS
   chmod 440 "$tmp"
   if visudo -cf "$tmp" >/dev/null 2>&1; then
@@ -6719,12 +6730,34 @@ cmd_create() {
 }
 
 cmd_restart() {
-  local name="${1:-}"
-  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent restart <name>"
+  local name="" defer=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --defer) defer=1 ;;
+      -*)      fail "$E_USAGE" "unknown flag: $1" ;;
+      *)       [[ -z "$name" ]] && name="$1" || fail "$E_USAGE" "extra arg: $1" ;;
+    esac
+    shift
+  done
+  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent restart <name> [--defer]"
   require_agent "$name"
-  systemctl restart "5dive-agent@${name}.service" >&2
-  ok "agent '$name' restarted." \
-     '{name:$n, action:"restart"}' --arg n "$name"
+  if (( defer )); then
+    # DIVE-1002: CLI-mediated deferred restart. `sudo 5dive` already runs as
+    # root, so the CLI fires systemd-run internally — an (scoped-)admin agent
+    # can restart itself via `sudo 5dive agent restart <self> --defer` and never
+    # needs a raw `sudo systemd-run` grant (which is arbitrary root). The ~1s
+    # transient unit survives the caller's own session teardown, so an agent
+    # restarting itself (e.g. after editing model/effort) doesn't SIGTERM the
+    # restart mid-flight.
+    systemd-run --on-active=1 --collect \
+      /bin/systemctl restart "5dive-agent@${name}.service" >&2
+    ok "agent '$name' restart scheduled (deferred ~1s)." \
+       '{name:$n, action:"restart", deferred:true}' --arg n "$name"
+  else
+    systemctl restart "5dive-agent@${name}.service" >&2
+    ok "agent '$name' restarted." \
+       '{name:$n, action:"restart"}' --arg n "$name"
+  fi
 }
 
 cmd_rm() {
@@ -17275,6 +17308,16 @@ _crew_ingest_url() { echo "${ZEROHUMAN_INGEST_URL:-https://api.5dive.com/a2a/rec
 
 cmd_crew() {
   local sub="${1:-help}"; shift || true
+  # DIVE-1002 invariant: no `sudo 5dive` subcommand may exec agent-controlled
+  # input as root. Crews install + run agent-authored Python from their own venv
+  # (cmd_crew_run) and are a per-user feature — installed and run under the
+  # invoking user's $HOME/.5dive/crews, never needing root. Refuse EUID 0 so the
+  # admin "5dive CLI as root" grant can't reach crew exec and become an
+  # admin->root escalation. Run crews as yourself, without sudo. (help is
+  # allowed as root so `sudo 5dive crew` still prints usage.)
+  if [[ "$sub" != "help" && "$sub" != "-h" && "$sub" != "--help" && "$(id -u)" == "0" ]]; then
+    fail "$E_PERMISSION" "5dive crew must run as your own user, not root — crews execute agent-authored code from their venv, so running as root would be a privilege escalation. Re-run without sudo (crews live in your \$HOME)."
+  fi
   case "$sub" in
     install)          cmd_crew_install "$@" ;;
     secret)           cmd_crew_secret "$@" ;;

--- a/5dive
+++ b/5dive
@@ -56,7 +56,7 @@ SYSTEMD_UNIT="5dive-agent@"
 # can't read. ensure_state stamps this into agents.json on create + migrates
 # v0 (no version field) registries in place. Keep migrations pure-jq so they
 # run without extra deps.
-readonly REGISTRY_SCHEMA_VERSION=1
+readonly REGISTRY_SCHEMA_VERSION=2
 
 # Exclusive lock for mutating commands. Two dashboard clicks on "create" with
 # the same name used to race on adduser + registry_write; now every mutation
@@ -2025,7 +2025,16 @@ ensure_state() {
     if (( current < REGISTRY_SCHEMA_VERSION )); then
       local tmp
       tmp=$(mktemp "${REGISTRY}.XXXXXX")
-      jq --argjson v "$REGISTRY_SCHEMA_VERSION" '.schemaVersion = $v' "$REGISTRY" > "$tmp"
+      # v1 -> v2 (DIVE-1002): least-privilege isolation default. Pre-v2 agents
+      # had no explicit `isolation` field and were provisioned as full-sudo
+      # admins (create_agent_user's old default). Stamp them explicit-admin so
+      # the new standard-by-default logic never silently downgrades a live
+      # admin: their tier is now recorded, not inferred. Existing sudoers files
+      # are untouched — this only makes the registry honest about what they are.
+      jq --argjson v "$REGISTRY_SCHEMA_VERSION" \
+        '.schemaVersion = $v
+         | (.agents // {}) |= with_entries(.value.isolation //= "admin")' \
+        "$REGISTRY" > "$tmp"
       chown root:claude "$tmp"
       chmod 640 "$tmp"
       mv "$tmp" "$REGISTRY"
@@ -5724,7 +5733,10 @@ cmd_info() {
 }
 
 create_agent_user() {
-  local name="$1" isolation="${2:-admin}"
+  # DIVE-1002: least-privilege by default — callers pass an explicitly resolved
+  # tier (cmd_create resolves standard-by-default + bootstrap-admin). The
+  # fallback here is 'standard', never 'admin', so no path silently grants root.
+  local name="$1" isolation="${2:-standard}"
   local user="agent-${name}"
   if ! id -u "$user" &>/dev/null; then
     adduser --disabled-password --gecos "" "$user" >/dev/null
@@ -5733,12 +5745,54 @@ create_agent_user() {
   local groups="systemd-journal"
   [[ "$isolation" != "sandboxed" ]] && groups="claude,systemd-journal"
   usermod -aG "$groups" "$user"
-  # Only admin gets full sudo.
+  # Admin gets sudo SCOPED to fleet-management ops (not blanket root). standard
+  # and sandboxed get no sudoers at all.
   if [[ "$isolation" == "admin" ]]; then
-    cat > "/etc/sudoers.d/${user}" <<SUDOERS
-${user} ALL=(ALL) NOPASSWD: ALL
+    write_admin_sudoers "$user"
+  else
+    rm -f "/etc/sudoers.d/${user}"
+  fi
+}
+
+# DIVE-1002: an 'admin' agent can run the company, not `rm -rf` the box. It gets
+# passwordless sudo scoped to a fleet-management allowlist: the 5dive CLI (which
+# is the sanctioned API for create/rm/provision/restart agents and box ops) plus
+# lifecycle control of the box's own 5dive systemd units and their logs. It does
+# NOT get an arbitrary-root shell (`sudo bash`, `sudo su`, `sudo -u <x> -i`,
+# editors as root, etc.), so a prompt-injected or compromised admin worker is
+# bounded to fleet ops, aligning with the sudo-reduction line (DIVE-756/916).
+# The file is validated with `visudo -c` before install so a malformed entry can
+# never lock the box out; on failure we remove it and fail loudly rather than
+# leaving a broken /etc/sudoers.d.
+write_admin_sudoers() {
+  local user="$1" f="/etc/sudoers.d/${user}" tmp
+  tmp=$(mktemp)
+  # Commands are inlined (not Cmnd_Alias) so each per-agent file is fully
+  # self-contained: sudoers alias names must be uppercase and would collide
+  # across per-agent files. Line continuations keep it readable.
+  cat > "$tmp" <<SUDOERS
+# Managed by 5dive (DIVE-1002). Fleet-management scope for admin agent ${user}.
+# Do not edit by hand; regenerated on agent create/provision.
+${user} ALL=(root) NOPASSWD: \\
+  /usr/local/bin/5dive, /usr/local/bin/5dive *, \\
+  /usr/bin/systemctl start 5dive-agent@*, /usr/bin/systemctl stop 5dive-agent@*, \\
+  /usr/bin/systemctl restart 5dive-agent@*, /usr/bin/systemctl status 5dive-agent@*, \\
+  /usr/bin/systemctl start 5dive-*.service, /usr/bin/systemctl stop 5dive-*.service, \\
+  /usr/bin/systemctl restart 5dive-*.service, /usr/bin/systemctl status 5dive-*.service, \\
+  /bin/systemctl start 5dive-agent@*, /bin/systemctl stop 5dive-agent@*, \\
+  /bin/systemctl restart 5dive-agent@*, /bin/systemctl status 5dive-agent@*, \\
+  /bin/systemctl start 5dive-*.service, /bin/systemctl stop 5dive-*.service, \\
+  /bin/systemctl restart 5dive-*.service, /bin/systemctl status 5dive-*.service, \\
+  /usr/bin/systemd-run *, /usr/bin/journalctl *, /bin/journalctl *
 SUDOERS
-    chmod 440 "/etc/sudoers.d/${user}"
+  chmod 440 "$tmp"
+  if visudo -cf "$tmp" >/dev/null 2>&1; then
+    chown root:root "$tmp"
+    mv "$tmp" "$f"
+    chmod 440 "$f"
+  else
+    rm -f "$tmp"
+    fail "$E_GENERIC" "generated sudoers for ${user} failed visudo validation; aborting (no partial install)"
   fi
 }
 
@@ -5758,7 +5812,7 @@ delete_agent_user() {
 valid_autonomy() { [[ "$1" =~ ^(standard|yolo|son-of-anton)$ ]]; }
 
 write_agent_env() {
-  local name="$1" type="$2" channels="$3" workdir="${4:-}" profile="${5:-}" isolation="${6:-admin}"
+  local name="$1" type="$2" channels="$3" workdir="${4:-}" profile="${5:-}" isolation="${6:-standard}"
   local env_file="${ENV_DIR}/${name}.env"
   # DIVE-499: per-agent autonomy mode (standard|yolo, alias son-of-anton). The
   # caller sets _AUTONOMY_OVERRIDE to change it (create --yolo / `set autonomy=`);
@@ -5999,7 +6053,7 @@ cmd_create() {
   local cos_owner_id=""
   local byo_provider="" byo_api_key=""
   local skills_arg="" skills_set=0 no_skills=0 defer_auth=0
-  local isolation="admin" no_team_bot=0
+  local isolation="" isolation_explicit=0 no_team_bot=0
   local autonomy="standard"   # DIVE-499
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -6021,7 +6075,7 @@ cmd_create() {
       --no-skills)                 no_skills=1 ;;
       --no-team-bot)               no_team_bot=1 ;;
       --defer-auth)                defer_auth=1 ;;
-      --isolation=*)               isolation="${1#--isolation=}" ;;
+      --isolation=*)               isolation="${1#--isolation=}"; isolation_explicit=1 ;;
       -*)                          fail "$E_USAGE" "unknown flag: $1" ;;
       *)                           [[ -z "$name" ]] && name="$1" || fail "$E_USAGE" "extra arg: $1" ;;
     esac
@@ -6044,6 +6098,20 @@ cmd_create() {
       (( channels_explicit )) || channels="dashboard"
     elif ! channel_in_list dashboard "$channels"; then
       channels="${channels},dashboard"
+    fi
+  fi
+  # DIVE-1002: least-privilege by default. Absent an explicit --isolation, new
+  # agents are 'standard'. Bootstrap exception: the FIRST agent on a fresh box
+  # (empty registry) is auto-granted 'admin' so the box has a fleet-manager out
+  # of the gate. We resolve the tier here and RECORD it explicitly in the
+  # registry below — admin is never re-derived from create-order (which would
+  # break if that agent is later deleted or a worker is created first). An
+  # explicit --isolation always wins in either direction.
+  if (( ! isolation_explicit )); then
+    if [[ "$(registry_read | jq -r '(.agents // {}) | length')" == "0" ]]; then
+      isolation="admin"
+    else
+      isolation="standard"
     fi
   fi
   valid_isolation "$isolation" || fail "$E_VALIDATION" "invalid --isolation (admin|standard|sandboxed)"

--- a/5dive
+++ b/5dive
@@ -26,7 +26,7 @@ esac
 
 # Bumped on every public release. `build.sh` checks this line exists; CI fails
 # the bundle-drift check if it's missing or empty.
-readonly FIVE_VERSION="0.6.25"
+readonly FIVE_VERSION="0.6.26"
 
 # GitHub org our repos live under. The org is being renamed
 # 5dive-com -> 5dive-ai (2026-06); fetches must work on either side of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ release.
 
 ## [Unreleased]
 
+### Security
+
+- DIVE-1002: least-privilege agent isolation. New agents now default to
+  `standard` isolation (zero sudo) instead of `admin` — a compromised or
+  prompt-injected worker can no longer reach root. Bootstrap convenience: the
+  FIRST agent on a fresh box (empty registry) is auto-granted `admin`, but the
+  resolved tier is recorded EXPLICITLY in the registry (never re-derived from
+  create-order); an explicit `--isolation` always wins. The `admin` tier is now
+  SCOPED to a `visudo`-validated allowlist — the `5dive` CLI plus non-paging
+  `systemctl start|stop|restart` of `5dive-agent@*` / `5dive-*.service` — and no
+  longer grants blanket `ALL=(ALL) NOPASSWD: ALL`. The three indirect root
+  escapes (`systemd-run *`, `journalctl *`, `systemctl status *` pager `!sh`) are
+  excluded; a new `5dive agent restart <name> --defer` runs the deferred
+  systemd-run internally (fixed command) so admins never need a raw grant, and
+  `5dive crew` now refuses EUID 0 (it execs agent-authored venv Python). Registry
+  schema v1->v2 stamps existing field-less agents as explicit `isolation:admin`
+  so no live admin is silently downgraded (their sudoers files are untouched; the
+  scoped allowlist applies to new admins/fresh boxes). New
+  `tests/agent_isolation_unit.sh` (15/15).
+
 ### Added
 
 - OSS-12: gate SLA escalation — an unanswered T2 gate walks the org chart

--- a/projects-CLAUDE.md
+++ b/projects-CLAUDE.md
@@ -5,8 +5,12 @@
 - Your settings: `/home/$(whoami)/.claude/settings.json`. Restart your service after editing:
 
   ```bash
-  sudo systemd-run --on-active=1 --collect \
-    /bin/systemctl restart "5dive-agent@$(whoami | sed 's/^agent-//').service"
+  sudo 5dive agent restart "$(whoami | sed 's/^agent-//')" --defer
   ```
+
+  `--defer` fires the restart ~1s later (via a transient unit) so it survives
+  this session's teardown. It's CLI-mediated on purpose: scoped-admin agents are
+  granted `5dive` but not raw `systemd-run` (which would be arbitrary root), so
+  always restart through the CLI rather than calling `systemd-run` yourself.
 
 - Host & inter-agent CLI: `5dive --help`.

--- a/src/cmd_agent.sh
+++ b/src/cmd_agent.sh
@@ -340,7 +340,10 @@ cmd_info() {
 }
 
 create_agent_user() {
-  local name="$1" isolation="${2:-admin}"
+  # DIVE-1002: least-privilege by default — callers pass an explicitly resolved
+  # tier (cmd_create resolves standard-by-default + bootstrap-admin). The
+  # fallback here is 'standard', never 'admin', so no path silently grants root.
+  local name="$1" isolation="${2:-standard}"
   local user="agent-${name}"
   if ! id -u "$user" &>/dev/null; then
     adduser --disabled-password --gecos "" "$user" >/dev/null
@@ -349,12 +352,54 @@ create_agent_user() {
   local groups="systemd-journal"
   [[ "$isolation" != "sandboxed" ]] && groups="claude,systemd-journal"
   usermod -aG "$groups" "$user"
-  # Only admin gets full sudo.
+  # Admin gets sudo SCOPED to fleet-management ops (not blanket root). standard
+  # and sandboxed get no sudoers at all.
   if [[ "$isolation" == "admin" ]]; then
-    cat > "/etc/sudoers.d/${user}" <<SUDOERS
-${user} ALL=(ALL) NOPASSWD: ALL
+    write_admin_sudoers "$user"
+  else
+    rm -f "/etc/sudoers.d/${user}"
+  fi
+}
+
+# DIVE-1002: an 'admin' agent can run the company, not `rm -rf` the box. It gets
+# passwordless sudo scoped to a fleet-management allowlist: the 5dive CLI (which
+# is the sanctioned API for create/rm/provision/restart agents and box ops) plus
+# lifecycle control of the box's own 5dive systemd units and their logs. It does
+# NOT get an arbitrary-root shell (`sudo bash`, `sudo su`, `sudo -u <x> -i`,
+# editors as root, etc.), so a prompt-injected or compromised admin worker is
+# bounded to fleet ops, aligning with the sudo-reduction line (DIVE-756/916).
+# The file is validated with `visudo -c` before install so a malformed entry can
+# never lock the box out; on failure we remove it and fail loudly rather than
+# leaving a broken /etc/sudoers.d.
+write_admin_sudoers() {
+  local user="$1" f="/etc/sudoers.d/${user}" tmp
+  tmp=$(mktemp)
+  # Commands are inlined (not Cmnd_Alias) so each per-agent file is fully
+  # self-contained: sudoers alias names must be uppercase and would collide
+  # across per-agent files. Line continuations keep it readable.
+  cat > "$tmp" <<SUDOERS
+# Managed by 5dive (DIVE-1002). Fleet-management scope for admin agent ${user}.
+# Do not edit by hand; regenerated on agent create/provision.
+${user} ALL=(root) NOPASSWD: \\
+  /usr/local/bin/5dive, /usr/local/bin/5dive *, \\
+  /usr/bin/systemctl start 5dive-agent@*, /usr/bin/systemctl stop 5dive-agent@*, \\
+  /usr/bin/systemctl restart 5dive-agent@*, /usr/bin/systemctl status 5dive-agent@*, \\
+  /usr/bin/systemctl start 5dive-*.service, /usr/bin/systemctl stop 5dive-*.service, \\
+  /usr/bin/systemctl restart 5dive-*.service, /usr/bin/systemctl status 5dive-*.service, \\
+  /bin/systemctl start 5dive-agent@*, /bin/systemctl stop 5dive-agent@*, \\
+  /bin/systemctl restart 5dive-agent@*, /bin/systemctl status 5dive-agent@*, \\
+  /bin/systemctl start 5dive-*.service, /bin/systemctl stop 5dive-*.service, \\
+  /bin/systemctl restart 5dive-*.service, /bin/systemctl status 5dive-*.service, \\
+  /usr/bin/systemd-run *, /usr/bin/journalctl *, /bin/journalctl *
 SUDOERS
-    chmod 440 "/etc/sudoers.d/${user}"
+  chmod 440 "$tmp"
+  if visudo -cf "$tmp" >/dev/null 2>&1; then
+    chown root:root "$tmp"
+    mv "$tmp" "$f"
+    chmod 440 "$f"
+  else
+    rm -f "$tmp"
+    fail "$E_GENERIC" "generated sudoers for ${user} failed visudo validation; aborting (no partial install)"
   fi
 }
 
@@ -374,7 +419,7 @@ delete_agent_user() {
 valid_autonomy() { [[ "$1" =~ ^(standard|yolo|son-of-anton)$ ]]; }
 
 write_agent_env() {
-  local name="$1" type="$2" channels="$3" workdir="${4:-}" profile="${5:-}" isolation="${6:-admin}"
+  local name="$1" type="$2" channels="$3" workdir="${4:-}" profile="${5:-}" isolation="${6:-standard}"
   local env_file="${ENV_DIR}/${name}.env"
   # DIVE-499: per-agent autonomy mode (standard|yolo, alias son-of-anton). The
   # caller sets _AUTONOMY_OVERRIDE to change it (create --yolo / `set autonomy=`);
@@ -615,7 +660,7 @@ cmd_create() {
   local cos_owner_id=""
   local byo_provider="" byo_api_key=""
   local skills_arg="" skills_set=0 no_skills=0 defer_auth=0
-  local isolation="admin" no_team_bot=0
+  local isolation="" isolation_explicit=0 no_team_bot=0
   local autonomy="standard"   # DIVE-499
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -637,7 +682,7 @@ cmd_create() {
       --no-skills)                 no_skills=1 ;;
       --no-team-bot)               no_team_bot=1 ;;
       --defer-auth)                defer_auth=1 ;;
-      --isolation=*)               isolation="${1#--isolation=}" ;;
+      --isolation=*)               isolation="${1#--isolation=}"; isolation_explicit=1 ;;
       -*)                          fail "$E_USAGE" "unknown flag: $1" ;;
       *)                           [[ -z "$name" ]] && name="$1" || fail "$E_USAGE" "extra arg: $1" ;;
     esac
@@ -660,6 +705,20 @@ cmd_create() {
       (( channels_explicit )) || channels="dashboard"
     elif ! channel_in_list dashboard "$channels"; then
       channels="${channels},dashboard"
+    fi
+  fi
+  # DIVE-1002: least-privilege by default. Absent an explicit --isolation, new
+  # agents are 'standard'. Bootstrap exception: the FIRST agent on a fresh box
+  # (empty registry) is auto-granted 'admin' so the box has a fleet-manager out
+  # of the gate. We resolve the tier here and RECORD it explicitly in the
+  # registry below — admin is never re-derived from create-order (which would
+  # break if that agent is later deleted or a worker is created first). An
+  # explicit --isolation always wins in either direction.
+  if (( ! isolation_explicit )); then
+    if [[ "$(registry_read | jq -r '(.agents // {}) | length')" == "0" ]]; then
+      isolation="admin"
+    else
+      isolation="standard"
     fi
   fi
   valid_isolation "$isolation" || fail "$E_VALIDATION" "invalid --isolation (admin|standard|sandboxed)"

--- a/src/cmd_agent.sh
+++ b/src/cmd_agent.sh
@@ -361,16 +361,28 @@ create_agent_user() {
   fi
 }
 
-# DIVE-1002: an 'admin' agent can run the company, not `rm -rf` the box. It gets
-# passwordless sudo scoped to a fleet-management allowlist: the 5dive CLI (which
-# is the sanctioned API for create/rm/provision/restart agents and box ops) plus
-# lifecycle control of the box's own 5dive systemd units and their logs. It does
-# NOT get an arbitrary-root shell (`sudo bash`, `sudo su`, `sudo -u <x> -i`,
-# editors as root, etc.), so a prompt-injected or compromised admin worker is
-# bounded to fleet ops, aligning with the sudo-reduction line (DIVE-756/916).
-# The file is validated with `visudo -c` before install so a malformed entry can
-# never lock the box out; on failure we remove it and fail loudly rather than
-# leaving a broken /etc/sudoers.d.
+# DIVE-1002: an 'admin' agent can run the company, not `rm -rf` the box. Its sudo
+# is scoped to a single mediated surface — the 5dive CLI (the sanctioned API for
+# create/rm/provision/restart agents and box ops) — plus start|stop|restart of
+# the box's own 5dive systemd units. That's it.
+#
+# What is deliberately NOT granted, and why (all are one-line root escapes):
+#   - `systemd-run *`    runs ANY command as root (`systemd-run --pty bash`) —
+#                        a wildcard on it == NOPASSWD: ALL. Agents that need a
+#                        deferred self-restart use `5dive agent restart --defer`,
+#                        which runs systemd-run internally under the already-root
+#                        CLI, so no raw grant is required.
+#   - `journalctl *`     pages through less by default -> `!sh` GTFOBins escape.
+#                        Logs go through `5dive agent logs` (--no-pager path).
+#   - `systemctl status` also pages by default -> same `!sh` escape. Only the
+#                        non-paging start|stop|restart verbs are granted.
+#   - `sudo bash|su|-u <x> -i` — direct root/other-user shells.
+# Granting the whole `5dive` CLI as root makes it a standing invariant that NO
+# 5dive subcommand may exec agent-controlled input as root (else it becomes an
+# admin->root vector). See DIVE-756/916 (sudo reduction), DIVE-950 (forge).
+#
+# The file is `visudo -c` validated before install so a malformed entry can never
+# lock the box out; on failure we remove it and fail loudly.
 write_admin_sudoers() {
   local user="$1" f="/etc/sudoers.d/${user}" tmp
   tmp=$(mktemp)
@@ -383,14 +395,13 @@ write_admin_sudoers() {
 ${user} ALL=(root) NOPASSWD: \\
   /usr/local/bin/5dive, /usr/local/bin/5dive *, \\
   /usr/bin/systemctl start 5dive-agent@*, /usr/bin/systemctl stop 5dive-agent@*, \\
-  /usr/bin/systemctl restart 5dive-agent@*, /usr/bin/systemctl status 5dive-agent@*, \\
+  /usr/bin/systemctl restart 5dive-agent@*, \\
   /usr/bin/systemctl start 5dive-*.service, /usr/bin/systemctl stop 5dive-*.service, \\
-  /usr/bin/systemctl restart 5dive-*.service, /usr/bin/systemctl status 5dive-*.service, \\
+  /usr/bin/systemctl restart 5dive-*.service, \\
   /bin/systemctl start 5dive-agent@*, /bin/systemctl stop 5dive-agent@*, \\
-  /bin/systemctl restart 5dive-agent@*, /bin/systemctl status 5dive-agent@*, \\
+  /bin/systemctl restart 5dive-agent@*, \\
   /bin/systemctl start 5dive-*.service, /bin/systemctl stop 5dive-*.service, \\
-  /bin/systemctl restart 5dive-*.service, /bin/systemctl status 5dive-*.service, \\
-  /usr/bin/systemd-run *, /usr/bin/journalctl *, /bin/journalctl *
+  /bin/systemctl restart 5dive-*.service
 SUDOERS
   chmod 440 "$tmp"
   if visudo -cf "$tmp" >/dev/null 2>&1; then
@@ -1326,12 +1337,34 @@ cmd_create() {
 }
 
 cmd_restart() {
-  local name="${1:-}"
-  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent restart <name>"
+  local name="" defer=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --defer) defer=1 ;;
+      -*)      fail "$E_USAGE" "unknown flag: $1" ;;
+      *)       [[ -z "$name" ]] && name="$1" || fail "$E_USAGE" "extra arg: $1" ;;
+    esac
+    shift
+  done
+  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent restart <name> [--defer]"
   require_agent "$name"
-  systemctl restart "5dive-agent@${name}.service" >&2
-  ok "agent '$name' restarted." \
-     '{name:$n, action:"restart"}' --arg n "$name"
+  if (( defer )); then
+    # DIVE-1002: CLI-mediated deferred restart. `sudo 5dive` already runs as
+    # root, so the CLI fires systemd-run internally — an (scoped-)admin agent
+    # can restart itself via `sudo 5dive agent restart <self> --defer` and never
+    # needs a raw `sudo systemd-run` grant (which is arbitrary root). The ~1s
+    # transient unit survives the caller's own session teardown, so an agent
+    # restarting itself (e.g. after editing model/effort) doesn't SIGTERM the
+    # restart mid-flight.
+    systemd-run --on-active=1 --collect \
+      /bin/systemctl restart "5dive-agent@${name}.service" >&2
+    ok "agent '$name' restart scheduled (deferred ~1s)." \
+       '{name:$n, action:"restart", deferred:true}' --arg n "$name"
+  else
+    systemctl restart "5dive-agent@${name}.service" >&2
+    ok "agent '$name' restarted." \
+       '{name:$n, action:"restart"}' --arg n "$name"
+  fi
 }
 
 cmd_rm() {

--- a/src/cmd_crew.sh
+++ b/src/cmd_crew.sh
@@ -30,6 +30,16 @@ _crew_ingest_url() { echo "${ZEROHUMAN_INGEST_URL:-https://api.5dive.com/a2a/rec
 
 cmd_crew() {
   local sub="${1:-help}"; shift || true
+  # DIVE-1002 invariant: no `sudo 5dive` subcommand may exec agent-controlled
+  # input as root. Crews install + run agent-authored Python from their own venv
+  # (cmd_crew_run) and are a per-user feature — installed and run under the
+  # invoking user's $HOME/.5dive/crews, never needing root. Refuse EUID 0 so the
+  # admin "5dive CLI as root" grant can't reach crew exec and become an
+  # admin->root escalation. Run crews as yourself, without sudo. (help is
+  # allowed as root so `sudo 5dive crew` still prints usage.)
+  if [[ "$sub" != "help" && "$sub" != "-h" && "$sub" != "--help" && "$(id -u)" == "0" ]]; then
+    fail "$E_PERMISSION" "5dive crew must run as your own user, not root — crews execute agent-authored code from their venv, so running as root would be a privilege escalation. Re-run without sudo (crews live in your \$HOME)."
+  fi
   case "$sub" in
     install)          cmd_crew_install "$@" ;;
     secret)           cmd_crew_secret "$@" ;;

--- a/src/header.sh
+++ b/src/header.sh
@@ -56,7 +56,7 @@ SYSTEMD_UNIT="5dive-agent@"
 # can't read. ensure_state stamps this into agents.json on create + migrates
 # v0 (no version field) registries in place. Keep migrations pure-jq so they
 # run without extra deps.
-readonly REGISTRY_SCHEMA_VERSION=1
+readonly REGISTRY_SCHEMA_VERSION=2
 
 # Exclusive lock for mutating commands. Two dashboard clicks on "create" with
 # the same name used to race on adduser + registry_write; now every mutation

--- a/src/header.sh
+++ b/src/header.sh
@@ -26,7 +26,7 @@ esac
 
 # Bumped on every public release. `build.sh` checks this line exists; CI fails
 # the bundle-drift check if it's missing or empty.
-readonly FIVE_VERSION="0.6.25"
+readonly FIVE_VERSION="0.6.26"
 
 # GitHub org our repos live under. The org is being renamed
 # 5dive-com -> 5dive-ai (2026-06); fetches must work on either side of the

--- a/src/lib/state.sh
+++ b/src/lib/state.sh
@@ -15,7 +15,16 @@ ensure_state() {
     if (( current < REGISTRY_SCHEMA_VERSION )); then
       local tmp
       tmp=$(mktemp "${REGISTRY}.XXXXXX")
-      jq --argjson v "$REGISTRY_SCHEMA_VERSION" '.schemaVersion = $v' "$REGISTRY" > "$tmp"
+      # v1 -> v2 (DIVE-1002): least-privilege isolation default. Pre-v2 agents
+      # had no explicit `isolation` field and were provisioned as full-sudo
+      # admins (create_agent_user's old default). Stamp them explicit-admin so
+      # the new standard-by-default logic never silently downgrades a live
+      # admin: their tier is now recorded, not inferred. Existing sudoers files
+      # are untouched — this only makes the registry honest about what they are.
+      jq --argjson v "$REGISTRY_SCHEMA_VERSION" \
+        '.schemaVersion = $v
+         | (.agents // {}) |= with_entries(.value.isolation //= "admin")' \
+        "$REGISTRY" > "$tmp"
       chown root:claude "$tmp"
       chmod 640 "$tmp"
       mv "$tmp" "$REGISTRY"

--- a/tests/agent_isolation_unit.sh
+++ b/tests/agent_isolation_unit.sh
@@ -75,8 +75,9 @@ if command -v visudo >/dev/null 2>&1; then
   cat > "$SFILE" <<SUD
 ${user} ALL=(root) NOPASSWD: \\
   /usr/local/bin/5dive, /usr/local/bin/5dive *, \\
-  /usr/bin/systemctl restart 5dive-agent@*, /bin/systemctl restart 5dive-agent@*, \\
-  /usr/bin/systemd-run *, /usr/bin/journalctl *, /bin/journalctl *
+  /usr/bin/systemctl start 5dive-agent@*, /usr/bin/systemctl stop 5dive-agent@*, \\
+  /usr/bin/systemctl restart 5dive-agent@*, \\
+  /bin/systemctl restart 5dive-*.service
 SUD
   if visudo -cf "$SFILE" >/dev/null 2>&1; then
     ok_t "scoped admin sudoers passes visudo -c"
@@ -91,9 +92,35 @@ SUD
   else
     ok_t "scoped sudoers is NOT blanket ALL=(ALL) NOPASSWD: ALL"
   fi
+  # DIVE-1002 (Marcus review): the three indirect root escapes must be ABSENT.
+  # Assert against the REAL generated body in src/cmd_agent.sh, not just SFILE.
+  BODY=$(sed -n '/^write_admin_sudoers()/,/^}/p' src/cmd_agent.sh)
+  for esc in 'systemd-run' 'journalctl' 'systemctl status'; do
+    if grep -qF "$esc" <<<"$BODY"; then
+      bad_t "admin allowlist must NOT contain '$esc' (root-escapable)" ""
+    else
+      ok_t "admin allowlist excludes '$esc'"
+    fi
+  done
+  grep -qF '/usr/local/bin/5dive' <<<"$BODY" \
+    && ok_t "real write_admin_sudoers still grants the 5dive CLI" \
+    || bad_t "real write_admin_sudoers grants 5dive" ""
 else
   echo "# visudo not present; skipping sudoers shape asserts"
 fi
+
+# ---- 2b. crew refuses root (invariant: no sudo 5dive subcmd execs as root) ---
+CREW_BODY=$(sed -n '/^cmd_crew()/,/^  case/p' src/cmd_crew.sh)
+grep -q 'id -u.*== *"0"' <<<"$CREW_BODY" && grep -q 'E_PERMISSION' <<<"$CREW_BODY" \
+  && ok_t "cmd_crew refuses to run as root (blocks admin->root via crew exec)" \
+  || bad_t "cmd_crew root guard" "expected an EUID-0 refusal in cmd_crew"
+
+# ---- 2c. agent restart --defer runs a FIXED command, not caller-injected -----
+RESTART_BODY=$(sed -n '/^cmd_restart()/,/^}/p' src/cmd_agent.sh)
+grep -q 'restart "5dive-agent@\${name}.service"' <<<"$RESTART_BODY" \
+  && ! grep -qE '\--defer.*\$\{?[0-9]|defer.*eval' <<<"$RESTART_BODY" \
+  && ok_t "restart --defer wraps a FIXED systemctl restart (no caller-injected cmd)" \
+  || bad_t "restart --defer fixed command" "deferred command must not be caller-templated"
 
 # ---- 3. v1 -> v2 migration stamps explicit isolation ------------------------
 LEGACY='{"schemaVersion":1,"agents":{"old1":{"type":"claude"},"old2":{"type":"claude","isolation":"standard"}}}'

--- a/tests/agent_isolation_unit.sh
+++ b/tests/agent_isolation_unit.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# DIVE-1002 isolated unit harness for least-privilege agent isolation.
+#
+# Sources the src/ libs directly (no root, no adduser, no network) and exercises
+# the pure pieces of the standard-by-default + scoped-admin design:
+#   1. Bootstrap resolution: empty registry -> admin, non-empty -> standard,
+#      explicit --isolation always wins.
+#   2. write_admin_sudoers: produces a visudo-valid file that grants the 5dive
+#      CLI + 5dive service lifecycle but NOT blanket `ALL=(ALL) ... ALL` root.
+#   3. v1->v2 migration jq: stamps explicit isolation:"admin" on legacy agents
+#      that lacked the field (no silent downgrade).
+# Run: bash tests/agent_isolation_unit.sh
+set -uo pipefail
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/agent-iso-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/state.sh lib/audit.sh lib/registry.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+# cmd_agent.sh defines create_agent_user/write_admin_sudoers; source just that
+# file's function defs (it has no top-level side effects at source time).
+# shellcheck source=/dev/null
+source "$SRC/cmd_agent.sh"
+
+STATE_DIR="$TMP"
+REGISTRY="$STATE_DIR/agents.json"
+JSON_MODE=1
+set +e   # header.sh enabled `set -e`; tests deliberately expect non-zero exits
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# ---- 1. bootstrap resolution (mirror of cmd_create's inline logic) ----------
+resolve() {  # $1=explicit_flag  $2=explicit_value
+  local isolation="$2" isolation_explicit="$1"
+  if (( ! isolation_explicit )); then
+    if [[ "$(registry_read | jq -r '(.agents // {}) | length')" == "0" ]]; then
+      isolation="admin"; else isolation="standard"; fi
+  fi
+  printf '%s' "$isolation"
+}
+
+echo '{"agents":{}}' > "$REGISTRY"
+[[ "$(resolve 0 '')" == "admin" ]] \
+  && ok_t "empty registry, no flag -> admin (bootstrap)" \
+  || bad_t "empty registry -> admin" "got $(resolve 0 '')"
+
+echo '{"agents":{"boss":{"type":"claude","isolation":"admin"}}}' > "$REGISTRY"
+[[ "$(resolve 0 '')" == "standard" ]] \
+  && ok_t "non-empty registry, no flag -> standard (least-priv)" \
+  || bad_t "non-empty -> standard" "got $(resolve 0 '')"
+
+[[ "$(resolve 1 'admin')" == "admin" ]] \
+  && ok_t "explicit --isolation=admin wins on populated box" \
+  || bad_t "explicit admin wins" "got $(resolve 1 'admin')"
+
+echo '{"agents":{}}' > "$REGISTRY"
+[[ "$(resolve 1 'standard')" == "standard" ]] \
+  && ok_t "explicit --isolation=standard wins even as first agent" \
+  || bad_t "explicit standard wins" "got $(resolve 1 'standard')"
+
+# ---- 2. write_admin_sudoers: scoped, visudo-valid, no blanket root ----------
+if command -v visudo >/dev/null 2>&1; then
+  SFILE="$TMP/sudoers-test"
+  # Mirror write_admin_sudoers' inlined body (the real fn writes to a root-only
+  # /etc/sudoers.d path); assert the generated shape is visudo-valid + scoped.
+  user="agent-testadmin"
+  cat > "$SFILE" <<SUD
+${user} ALL=(root) NOPASSWD: \\
+  /usr/local/bin/5dive, /usr/local/bin/5dive *, \\
+  /usr/bin/systemctl restart 5dive-agent@*, /bin/systemctl restart 5dive-agent@*, \\
+  /usr/bin/systemd-run *, /usr/bin/journalctl *, /bin/journalctl *
+SUD
+  if visudo -cf "$SFILE" >/dev/null 2>&1; then
+    ok_t "scoped admin sudoers passes visudo -c"
+  else
+    bad_t "scoped admin sudoers visudo" "$(visudo -cf "$SFILE" 2>&1)"
+  fi
+  grep -q '/usr/local/bin/5dive' "$SFILE" \
+    && ok_t "scoped sudoers grants the 5dive fleet CLI" \
+    || bad_t "sudoers grants 5dive" ""
+  if grep -qE 'NOPASSWD:[[:space:]]*ALL[[:space:]]*$|=\(ALL\)[[:space:]]*NOPASSWD:[[:space:]]*ALL' "$SFILE"; then
+    bad_t "sudoers must NOT grant blanket root" "found ALL=(ALL) NOPASSWD: ALL"
+  else
+    ok_t "scoped sudoers is NOT blanket ALL=(ALL) NOPASSWD: ALL"
+  fi
+else
+  echo "# visudo not present; skipping sudoers shape asserts"
+fi
+
+# ---- 3. v1 -> v2 migration stamps explicit isolation ------------------------
+LEGACY='{"schemaVersion":1,"agents":{"old1":{"type":"claude"},"old2":{"type":"claude","isolation":"standard"}}}'
+migrated=$(jq '.schemaVersion = 2
+  | (.agents // {}) |= with_entries(.value.isolation //= "admin")' <<<"$LEGACY")
+[[ "$(jq -r '.agents.old1.isolation' <<<"$migrated")" == "admin" ]] \
+  && ok_t "migration stamps legacy fieldless agent as explicit admin" \
+  || bad_t "migration stamps old1=admin" "$(jq -c .agents <<<"$migrated")"
+[[ "$(jq -r '.agents.old2.isolation' <<<"$migrated")" == "standard" ]] \
+  && ok_t "migration preserves an already-explicit standard agent" \
+  || bad_t "migration keeps old2=standard" "$(jq -c .agents <<<"$migrated")"
+
+echo "-----"
+printf 'PASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Security fix (lodar-raised, Marcus-gated). New agents no longer get blanket superadmin sudo by default.

## What changed
1. **Standard by default** — new agents get `standard` isolation (zero sudo), not `admin`. `create_agent_user`/`write_agent_env` fallbacks flipped to `standard` so no path silently grants root.
2. **Bootstrap admin, recorded explicitly** — the first agent on an empty-registry box auto-resolves to `admin`, but the resolved tier is written into `agents.json` (never re-derived from create-order). Explicit `--isolation` always wins either way.
3. **Scoped admin sudo** — replaces `ALL=(ALL) NOPASSWD: ALL` with a `visudo`-validated allowlist: the `5dive` CLI + non-paging `systemctl start|stop|restart` of `5dive-agent@*` / `5dive-*.service`. The three indirect root escapes are excluded:
   - `systemd-run *` (arbitrary root) → replaced by `5dive agent restart <name> --defer`, which runs systemd-run internally with a fixed command.
   - `journalctl *` (pager `!sh`) → logs go through `5dive agent logs` (`--no-pager`).
   - `systemctl status *` (pager `!sh`) → only non-paging verbs granted.
4. **Invariant enforced** — `5dive crew` now refuses EUID 0 (it execs agent-authored venv Python; reachable via `sudo 5dive crew run` it was a real admin→root hole).
5. **No downgrade** — registry schema v1→v2 stamps existing field-less agents as explicit `isolation:admin`; their sudoers files are untouched. The scoped allowlist applies to new admins / fresh boxes.

## Tests
- New `tests/agent_isolation_unit.sh` (15/15): bootstrap resolution, visudo validity, all three escapes absent, crew root-refusal, `restart --defer` fixed-command, migration.
- Full existing suite green; `shellcheck -S error` clean.

## Known limitation
Existing admins keep their old full-sudo files (re-scoping a live agent's sudoers is a careful follow-up). The fresh-box least-privilege story is intact.

Security re-reviewed and passed by Marcus. Smoke (real Hetzner agent matrix) run separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)