### PR TITLE
docs(readme): Show HN launch polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Telegram](https://img.shields.io/badge/Telegram-@ai5dive-229ED9?logo=telegram&logoColor=white)](https://t.me/ai5dive)
 
-**Spin up named agents, each with its own model, memory, and role. Put them on an org chart with a shared backlog, and let them hand work to each other on a server you own while you sleep. They ping your phone over Telegram only when a human has to decide. Works with claude, codex, grok, antigravity.**
+**The labs are renting you an agent sandbox. This is the one you own.**
+
+**Named AI agents on one server you control — each with its own model, memory, and role. They pull work off a shared backlog, hand it to each other while you sleep, and ping your phone over Telegram only when a human has to decide.** Works with claude, codex, grok, and antigravity.
 
 ![install to a Claude agent answering on Telegram](docs/quickstart.gif)
 
-> We run our own company on this: a team of AI agents that assign each other work, report up an org chart, and escalate to a human only when they're stuck. This is the open-source core, the same binary that runs every agent on [5dive.ai](https://5dive.ai?utm_source=github&utm_medium=referral&utm_campaign=5dive-readme). MIT, no open-core split. Run it yourself, or skip the ops with the managed VM.
+> **We run our own company on this.** The agents that build 5dive.ai take work off a shared backlog, report up an org chart, cut this repo's releases, and escalate to a human only when they're stuck. What you're installing is that exact binary — the open-source core, MIT, no open-core split. Run it yourself, or skip the ops with the [managed VM](https://5dive.ai?utm_source=github&utm_medium=referral&utm_campaign=5dive-readme).
 
 **Already use Claude Code, Codex, Grok, Antigravity, or opencode?** Install the [`5dive-cli` skill](#for-your-ai-agent) and run your whole agent company in plain English — create agents, assign work, read the org chart — straight from the AI agent you already have. One line to set up: [jump to it ↓](#for-your-ai-agent).
 
@@ -36,6 +38,11 @@ sudo 5dive agent create my-agent --type=claude --channels=telegram --telegram-to
 sudo 5dive agent pair   my-agent --code=<pairing-code>
 ```
 
+
+**Requirements:** a Linux box with `systemd` and your own agent-CLI subscription or API key (Claude Pro/Max, OpenAI, …) — no account with us.
+
+> **“`curl | sudo bash`, and agents with `sudo`?”** Fair question. The installer only apt-installs deps and drops the CLI + systemd units (every file it fetches is listed at the top of [`install.sh`](install.sh)). Each agent is then its own Linux user, and you choose its blast radius — a `sandboxed` agent gets its own home, no sudo, and resource limits. Details: [Security & isolation ↓](#security--isolation).
+
 ---
 
 ## Why 5dive
@@ -51,6 +58,18 @@ sudo 5dive agent pair   my-agent --code=<pairing-code>
 **Every major agent CLI.** `claude`, `codex`, `antigravity`, `grok`, and more, all under one team.
 
 **Safe by default.** Each agent is its own Linux user under one of three isolation tiers. MIT, no open-core split.
+
+---
+
+## What you can build
+
+Not primitives — outcomes. A few teams people stand up on day one:
+
+- **On-call ops.** An agent triages your CI failures at 7am and pings you only if it can't fix them itself.
+- **A research desk.** A scout agent drafts, an editor agent reviews, and the final publish call escalates to you.
+- **A solo-founder pod.** Engineering, marketing, and support agents on one box, all reporting up to you.
+
+Each is one `5dive team import <template>` away.
 
 ---
 
@@ -121,7 +140,12 @@ That arrives on your Telegram as tap-to-answer buttons. Tap one, and the owning 
 | `openclaw`    | third-party multi-provider harness | OAuth (OpenAI) / API key | Telegram, Discord |
 | `opencode`    | OpenCode               | API key | Telegram |
 
+<details>
+<summary><b>About <code>hermes</code> / <code>openclaw</code> (third-party multi-provider harnesses)</b></summary>
+
 `hermes` and `openclaw` are community-built harnesses that can route to many providers (OpenRouter, Anthropic, Google, Moonshot, DeepSeek, Z.ai, etc.). As of April 4, 2026, Anthropic no longer permits routing consumer Claude Pro/Max OAuth through third-party harnesses. For that work, use the official `claude` type with your own API key. Background: [We Ditched OpenClaw for Claude →](https://blog.5dive.ai/blog/we-ditched-openclaw-for-claude/?utm_source=github&utm_medium=referral&utm_campaign=5dive-readme).
+
+</details>
 
 The `claude` type can also run the official Claude Code harness against a third-party Anthropic-compatible endpoint, bring your own key:
 


### PR DESCRIPTION
## What & why
Show HN launch polish for the README (OSS 5dive Show HN, Wed Jul 8). The goal for a Show HN landing page: land the pitch in 5 seconds and preempt the top skeptical comment.

## Changes
1. **First screen** — lead with the hook "The labs are renting you an agent sandbox. This is the one you own." + a tighter one-line pitch (the old opener was 4 sentences crammed into one).
2. **Security preempt** — a Requirements line + a short "`curl | sudo bash`, and agents with sudo?" answer right after Quickstart, linking to the existing Security & isolation section. This is guaranteed to be the top HN comment; get ahead of it.
3. **Dogfood proof** — strengthened, kept honest/process-level ("the agents that build 5dive.ai … cut this repo's releases"). Deliberately NOT claiming agent-authored commits (ours are attributed to lodar, so that claim would be debunked).
4. **What you can build** — an outcomes trio (on-call ops / research desk / solo-founder pod) tied to `team import`, so first-time visitors see real use, not just primitives.
5. **Declutter** — folded the hermes/openclaw Anthropic-ToS note into a `<details>` so it doesn't interrupt the first read.

## Still TODO (not in this PR — creative)
- **GIF (`docs/quickstart.gif`)**: verify/refresh it shows the magic moment — install → an agent pinging your phone with a tap-to-answer button — not just the install line. Highest-leverage asset for the launch.

---

## Show HN title (pick one)
- **Show HN: 5dive – run a company of AI agents on a server you own (MIT)**
- Show HN: The labs rent you an agent sandbox. 5dive is the one you own.

## Show HN first comment (draft)
Hey HN. 5dive runs named AI agents as systemd services on a box you own — each is its own Linux user with its own model, memory, and role. They share a task queue, report up an org chart, hand work to each other, and only ping my phone over Telegram (as tap-to-answer buttons) when something needs a human: spend, publishing, anything destructive.

Why it exists: I wanted agents that run as a service, not a session — alive when I close the laptop, reachable from my phone, on my own Claude/Codex subscription with no OAuth middleman. And I wanted more than one, working as a team.

We dogfood it hard: the company behind 5dive.ai is itself a team of these agents. They triage issues, cut releases, and run the backlog; a human steps in only at the gates. What you install is the same MIT binary — no open-core split.

Honest caveats: it runs agents with shell access, so it's built around three isolation tiers (a sandboxed agent gets no sudo and its own home). Install is `curl | sudo bash` — every file it fetches is listed at the top of install.sh, and Docker/offline paths are in the README. Works with claude, codex, grok, antigravity, opencode.

Would love feedback on the model: a company of agents on hardware you own, vs. the hosted agent sandboxes the labs are shipping. Happy to answer anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
