### PR TITLE
fix(init): provision node 24 before codex install (DIVE-1254)

### DIFF
--- a/5dive
+++ b/5dive
@@ -26,7 +26,7 @@ esac
 
 # Bumped on every public release. `build.sh` checks this line exists; CI fails
 # the bundle-drift check if it's missing or empty.
-readonly FIVE_VERSION="0.9.1"
+readonly FIVE_VERSION="0.9.2"
 
 # GitHub org our repos live under. The org is being renamed
 # 5dive-com -> 5dive-ai (2026-06); fetches must work on either side of the
@@ -216,14 +216,15 @@ declare -A TYPE_INSTALL=(
   # Verify the EXACT TYPE_BIN path (not `command -v codex`): a stray
   # /usr/bin/codex from apt or a codex left over under a non-v24 nvm major
   # would short-circuit the install, leaving v24/bin/codex empty and
-  # surfacing as "install reported success but bin missing". `nvm use 24`
-  # forces npm install -g to land in v24's bin dir even when the default
+  # surfacing as "install reported success but bin missing". `nvm install 24`
+  # provisions the pinned runtime on a fresh box and selects it, forcing the
+  # npm install -g to land in v24's bin dir even when the default
   # alias has drifted (same drift the nightly soft-updates hit — DIVE-1189).
   # DIVE-1189: `5dive agent install codex --upgrade` sets FORCE_INSTALL=1 to skip
   # the -x short-circuit and reinstall @latest in place; without it (the
   # provisioning path) an existing v24 codex is left untouched. \$-escaped so the
   # var expands when the recipe runs under `bash -lc`, not at array-definition time.
-  [codex]="{ [[ -z \"\${FORCE_INSTALL:-}\" ]] && [[ -x /home/claude/.nvm/versions/node/v24/bin/codex ]]; } || { . /home/claude/.nvm/nvm.sh && nvm use 24 >/dev/null && npm install -g @openai/codex@latest; }"
+  [codex]="{ [[ -z \"\${FORCE_INSTALL:-}\" ]] && [[ -x /home/claude/.nvm/versions/node/v24/bin/codex ]]; } || { . /home/claude/.nvm/nvm.sh && nvm install 24 >/dev/null && npm install -g @openai/codex@latest; }"
   # opencode.ai's installer drops the binary at ~/.opencode/bin/opencode and
   # only adds it to PATH via .bashrc — but bash -lc skips .bashrc on
   # non-interactive shells, so neither the verify check below nor the agent

--- a/src/header.sh
+++ b/src/header.sh
@@ -216,14 +216,15 @@ declare -A TYPE_INSTALL=(
   # Verify the EXACT TYPE_BIN path (not `command -v codex`): a stray
   # /usr/bin/codex from apt or a codex left over under a non-v24 nvm major
   # would short-circuit the install, leaving v24/bin/codex empty and
-  # surfacing as "install reported success but bin missing". `nvm use 24`
-  # forces npm install -g to land in v24's bin dir even when the default
+  # surfacing as "install reported success but bin missing". `nvm install 24`
+  # provisions the pinned runtime on a fresh box and selects it, forcing the
+  # npm install -g to land in v24's bin dir even when the default
   # alias has drifted (same drift the nightly soft-updates hit — DIVE-1189).
   # DIVE-1189: `5dive agent install codex --upgrade` sets FORCE_INSTALL=1 to skip
   # the -x short-circuit and reinstall @latest in place; without it (the
   # provisioning path) an existing v24 codex is left untouched. \$-escaped so the
   # var expands when the recipe runs under `bash -lc`, not at array-definition time.
-  [codex]="{ [[ -z \"\${FORCE_INSTALL:-}\" ]] && [[ -x /home/claude/.nvm/versions/node/v24/bin/codex ]]; } || { . /home/claude/.nvm/nvm.sh && nvm use 24 >/dev/null && npm install -g @openai/codex@latest; }"
+  [codex]="{ [[ -z \"\${FORCE_INSTALL:-}\" ]] && [[ -x /home/claude/.nvm/versions/node/v24/bin/codex ]]; } || { . /home/claude/.nvm/nvm.sh && nvm install 24 >/dev/null && npm install -g @openai/codex@latest; }"
   # opencode.ai's installer drops the binary at ~/.opencode/bin/opencode and
   # only adds it to PATH via .bashrc — but bash -lc skips .bashrc on
   # non-interactive shells, so neither the verify check below nor the agent

--- a/src/header.sh
+++ b/src/header.sh
@@ -26,7 +26,7 @@ esac
 
 # Bumped on every public release. `build.sh` checks this line exists; CI fails
 # the bundle-drift check if it's missing or empty.
-readonly FIVE_VERSION="0.9.1"
+readonly FIVE_VERSION="0.9.2"
 
 # GitHub org our repos live under. The org is being renamed
 # 5dive-com -> 5dive-ai (2026-06); fetches must work on either side of the

--- a/tests/codex_install_node24_unit.sh
+++ b/tests/codex_install_node24_unit.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=../src/header.sh
+source "$ROOT/src/header.sh"
+
+recipe="${TYPE_INSTALL[codex]}"
+
+[[ "$recipe" == *"nvm install 24"* ]] || {
+  echo "FAIL: codex installer must provision Node 24 before installing Codex" >&2
+  exit 1
+}
+[[ "$recipe" != *"nvm use 24"* ]] || {
+  echo "FAIL: nvm use cannot provision Node 24 on a fresh host" >&2
+  exit 1
+}
+
+nvm_pos="${recipe%%nvm install 24*}"
+npm_pos="${recipe%%npm install -g @openai/codex@latest*}"
+(( ${#nvm_pos} < ${#npm_pos} )) || {
+  echo "FAIL: Node 24 must be installed before the Codex npm package" >&2
+  exit 1
+}
+
+echo "PASS: codex install recipe provisions Node 24 before Codex"


### PR DESCRIPTION
## DIVE-1254 — codex install fails on the 5dive init path

**Bug (lodar, live 2026-07-15):** `5dive init` → pick codex → `N/A: version v24 is not yet installed` then `error: codex install reported success but /home/claude/.nvm/versions/node/v24/bin/codex still missing`.

**Cause:** the codex install recipe used `nvm use 24`, which only *selects* an already-installed runtime. On a fresh box node 24 isn't installed, so `nvm use 24` fails and the `npm install -g` lands in the wrong bin — install reports success, binary is missing.

**Fix:** `nvm use 24` → `nvm install 24` (provisions the pinned runtime on a fresh box and selects it; idempotent on boxes that already have v24, so no regression). Same class as DIVE-1189.

**Tests:** new focused unit `tests/codex_install_node24_unit.sh` asserts the recipe contains `nvm install 24`, not `nvm use 24`, and that node-24 install precedes the codex npm install. Passes; `header.sh` syntax clean.

**Provenance:** maker = **codex** agent (capability dogfood), verifier/pusher = main. codex branched off clean origin/main, committed as lodar, relayed for push (no push creds).

**Gate before merge:** create-path smoke (`5dive-api` test-vm.sh) — this fix is on the agent-create path.