### PR TITLE
fix(install): fail-soft absent 5dive.sha256 so offline install-smoke survives (DIVE-1271)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -49,7 +49,14 @@ refresh_managed_files() {
   local _bundle_tmp; _bundle_tmp="$(mktemp "${BIN_DIR}/.5dive.XXXXXX")"
   curl -fsSL "$REPO/5dive" -o "$_bundle_tmp" || { rm -f "$_bundle_tmp"; die "failed to download 5dive bundle from $REPO/5dive"; }
   local _want _got
-  _want="$(curl -fsSL "$REPO/5dive.sha256" 2>/dev/null | tr -d '[:space:]')"
+  # `|| _want=""` is load-bearing: under `set -euo pipefail` (line 6) a plain
+  # assignment whose command-substitution pipeline fails aborts the whole script
+  # BEFORE the else-branch below can treat an absent checksum as fail-soft. The
+  # offline install-smoke bundle (REPO=file:///opt/5dive-bundle) ships no
+  # 5dive.sha256, so curl exits 37 (CURLE_FILE_COULDNT_READ_FILE) and pipefail
+  # propagates it — reddening docker-install at the "Installing CLI binaries"
+  # step (DIVE-1271). Swallowing it here keeps the absent-checksum-warns contract.
+  _want="$(curl -fsSL "$REPO/5dive.sha256" 2>/dev/null | tr -d '[:space:]')" || _want=""
   if [[ -n "$_want" ]]; then
     _got="$(sha256sum "$_bundle_tmp" | awk '{print $1}')"
     if [[ "$_want" != "$_got" ]]; then

--- a/tests/install_checksum_unit.sh
+++ b/tests/install_checksum_unit.sh
@@ -21,4 +21,19 @@ grep -q 'checksum mismatch' install.sh && ok_t "install.sh fails closed on misma
 grep -q 'skipping integrity check' install.sh && ok_t "install.sh warns (not fatal) on absent checksum" || bad_t "no absent-checksum warn"
 grep -q 'mktemp "${BIN_DIR}/.5dive' install.sh && ok_t "install.sh swaps atomically (temp in BIN_DIR)" || bad_t "no atomic-swap temp"
 
+# DIVE-1271 regression: the absent-checksum path must be fail-soft *under the
+# real installer flags*. install.sh runs `set -euo pipefail`, so a plain
+# assignment whose curl-pipeline fails (offline bundle with no 5dive.sha256 →
+# curl exit 37) aborts the whole install BEFORE the warn branch — which is what
+# reddened docker-install. A text-only grep can't catch this; reproduce the
+# exact fetch line against a bundle that omits 5dive.sha256 and assert survival.
+fetch_line="$(grep -E '^\s*_want="\$\(curl .*5dive\.sha256' install.sh)"
+bundle="$(mktemp -d)"; : > "$bundle/5dive"   # bundle has 5dive but NO 5dive.sha256
+if bash -c "set -euo pipefail; REPO='file://$bundle'; $fetch_line; [[ -z \"\$_want\" ]]" 2>/dev/null; then
+  ok_t "absent-checksum fetch is fail-soft under set -euo pipefail (offline bundle)"
+else
+  bad_t "absent-checksum fetch aborts under set -euo pipefail" "curl exit 37 propagates via pipefail — needs '|| _want=\"\"'"
+fi
+rm -rf "$bundle"
+
 echo; echo "$PASS passed, $FAIL failed"; [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Real root cause of the exit-37 install-smoke RED is **not** the telegram-agent-CLAUDE.md fetch (that file IS in the docker bundle and its fetch succeeds). It is DIVE-1261 (b6a31d7): `refresh_managed_files` fetches `5dive.sha256` with a plain assignment under script-wide `set -euo pipefail`. The offline bundle (REPO=file:///opt/5dive-bundle) omits 5dive.sha256 → curl exit 37 → pipefail propagates → errexit aborts install.sh at the "Installing CLI binaries" step, before the intended absent-checksum warn branch.

Fix: `|| _want=""` on the fetch. Hardened tests/install_checksum_unit.sh to reproduce the offline no-sha256 case under real installer flags (old grep-only assertion passed on the buggy code). 8/8 green; new guard goes RED on the pre-fix line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)