### PR TITLE
chore: automate merged-branch and stale-PR cleanup (DIVE-1527)

### DIFF
--- a/.github/workflows/branch-hygiene.yml
+++ b/.github/workflows/branch-hygiene.yml
@@ -1,0 +1,67 @@
+name: branch-hygiene
+
+on:
+  schedule:
+    - cron: '17 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: Delete API-confirmed merged branches and run stale-PR handling
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: branch-hygiene
+  cancel-in-progress: false
+
+jobs:
+  merged-branches:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Plan merged-branch cleanup
+        if: github.event_name == 'workflow_dispatch' && !inputs.apply
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH_HYGIENE_PRESERVE: ${{ vars.BRANCH_HYGIENE_PRESERVE }}
+        run: scripts/branch-hygiene.sh --dry-run
+
+      - name: Delete API-confirmed merged branches
+        if: github.event_name == 'schedule' || inputs.apply
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH_HYGIENE_PRESERVE: ${{ vars.BRANCH_HYGIENE_PRESERVE }}
+        run: scripts/branch-hygiene.sh --apply
+
+  stale-pull-requests:
+    if: github.event_name == 'schedule' || inputs.apply
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ github.token }}
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          stale-pr-message: >-
+            This pull request has had no activity for 30 days. It will close
+            after 14 more inactive days; comment or push to keep it open.
+          close-pr-message: >-
+            Closing after 14 days with no activity since the stale warning.
+            Reopen when the branch is ready to continue.
+          exempt-pr-labels: pinned,security,no-stale
+          operations-per-run: 100

--- a/.github/workflows/branch-hygiene.yml
+++ b/.github/workflows/branch-hygiene.yml
@@ -41,6 +41,22 @@ jobs:
           BRANCH_HYGIENE_PRESERVE: ${{ vars.BRANCH_HYGIENE_PRESERVE }}
         run: scripts/branch-hygiene.sh --apply
 
+      # A GitHub-hosted runner cannot inspect or remove worktrees on the 5dive
+      # VM. DIVE-1527's rollout left 2 residual ordinary directories after
+      # permission failures, 15 exact-head-merged worktree registrations, and
+      # 7 dangling metadata records for an owner/root follow-up. Keep this
+      # visible in every run rather than implying remote-ref cleanup covers the
+      # host; open-PR, dirty, detached, and non-matching worktrees stay preserved.
+      - name: Report host worktree follow-up
+        if: always()
+        run: |
+          echo '::notice title=Host worktree follow-up::Remote branch cleanup does not clean VM worktrees. DIVE-1527 left 2 residual directories, 15 merged registrations, and 7 dangling records for owner/root cleanup.'
+          {
+            echo '### Host worktree follow-up'
+            echo
+            echo 'This hosted workflow cleans remote refs only. DIVE-1527 left 2 residual ordinary directories after permission failures, 15 exact-head-merged worktree registrations, and 7 dangling metadata records for owner/root cleanup. Open-PR, dirty, detached, and non-matching worktrees remain preserved.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   stale-pull-requests:
     if: github.event_name == 'schedule' || inputs.apply
     runs-on: ubuntu-latest

--- a/scripts/branch-hygiene.sh
+++ b/scripts/branch-hygiene.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Delete only repository branches whose exact current head was merged by a PR.
+#
+# This intentionally asks the GitHub API for PR merge state. Git ancestry is not
+# sufficient because this repository normally squash-merges pull requests.
+
+set -euo pipefail
+
+mode="dry-run"
+case "${1:-}" in
+  ""|--dry-run) ;;
+  --apply) mode="apply" ;;
+  *) echo "usage: $0 [--dry-run|--apply]" >&2; exit 2 ;;
+esac
+
+GH_BIN="${GH_BIN:-gh}"
+command -v "$GH_BIN" >/dev/null 2>&1 || {
+  echo "branch-hygiene: '$GH_BIN' is required" >&2
+  exit 2
+}
+command -v jq >/dev/null 2>&1 || {
+  echo "branch-hygiene: 'jq' is required" >&2
+  exit 2
+}
+
+repo="${GITHUB_REPOSITORY:-}"
+if [[ -z "$repo" ]]; then
+  repo=$("$GH_BIN" repo view --json nameWithOwner --jq .nameWithOwner)
+fi
+[[ "$repo" == */* ]] || {
+  echo "branch-hygiene: expected OWNER/REPO, got '$repo'" >&2
+  exit 2
+}
+owner="${repo%%/*}"
+
+urlencode() {
+  jq -rn --arg value "$1" '$value | @uri'
+}
+
+declare -A preserve=()
+while IFS= read -r branch; do
+  [[ -n "$branch" ]] && preserve["$branch"]=1
+done < <(printf '%s\n' "${BRANCH_HYGIENE_PRESERVE:-}" | tr ',' '\n')
+
+default_branch=$("$GH_BIN" api "repos/$repo" --jq .default_branch)
+preserve["$default_branch"]=1
+
+# Every open PR head is a hard preserve, including fork heads whose ref happens
+# to match a branch in this repository. The conservative false-positive is safe.
+while IFS= read -r branch; do
+  [[ -n "$branch" ]] && preserve["$branch"]=1
+done < <("$GH_BIN" api --paginate "repos/$repo/pulls?state=open&per_page=100" --jq '.[].head.ref')
+
+candidate_count=0
+deleted_count=0
+skipped_count=0
+
+echo "branch-hygiene: mode=$mode repo=$repo default=$default_branch"
+
+while IFS=$'\t' read -r branch sha protected; do
+  [[ -n "$branch" ]] || continue
+
+  if [[ "$protected" == "true" ]]; then
+    echo "PRESERVE protected branch=$branch sha=$sha"
+    ((skipped_count += 1))
+    continue
+  fi
+  if [[ -n "${preserve[$branch]:-}" ]]; then
+    echo "PRESERVE open-or-explicit branch=$branch sha=$sha"
+    ((skipped_count += 1))
+    continue
+  fi
+
+  # Requiring the PR head SHA to equal the branch's current SHA prevents an old
+  # merged PR from deleting a later branch that reused the same name.
+  closed_prs=$("$GH_BIN" api --method GET "repos/$repo/pulls" \
+    -f state=closed -f "head=$owner:$branch" -f per_page=100)
+  merge_row=$(jq -r --arg sha "$sha" '
+    [.[] | select(.merged_at != null and .head.sha == $sha)]
+    | sort_by(.merged_at) | last
+    | if . == null then empty else [.number, .merged_at] | @tsv end
+  ' <<<"$closed_prs")
+
+  if [[ -z "$merge_row" ]]; then
+    echo "PRESERVE no-exact-merged-pr branch=$branch sha=$sha"
+    ((skipped_count += 1))
+    continue
+  fi
+
+  IFS=$'\t' read -r pr_number merged_at <<<"$merge_row"
+  echo "DELETE-CANDIDATE branch=$branch sha=$sha pr=#$pr_number merged_at=$merged_at"
+  ((candidate_count += 1))
+  [[ "$mode" == "apply" ]] || continue
+
+  # Fail closed on races: the ref must still point at the inventoried SHA and it
+  # must still have no open PR immediately before deletion.
+  encoded_branch=$(urlencode "$branch")
+  current_sha=$("$GH_BIN" api "repos/$repo/branches/$encoded_branch" --jq .commit.sha)
+  if [[ "$current_sha" != "$sha" ]]; then
+    echo "PRESERVE changed-since-inventory branch=$branch old=$sha new=$current_sha"
+    continue
+  fi
+  open_count=$("$GH_BIN" api --method GET "repos/$repo/pulls" \
+    -f state=open -f "head=$owner:$branch" -f per_page=1 --jq length)
+  if [[ "$open_count" != "0" ]]; then
+    echo "PRESERVE newly-open-pr branch=$branch"
+    continue
+  fi
+
+  encoded_ref=$(urlencode "heads/$branch")
+  "$GH_BIN" api --method DELETE "repos/$repo/git/refs/$encoded_ref" >/dev/null
+  echo "DELETED branch=$branch sha=$sha pr=#$pr_number"
+  ((deleted_count += 1))
+done < <("$GH_BIN" api --paginate "repos/$repo/branches?per_page=100" \
+  --jq '.[] | [.name, .commit.sha, .protected] | @tsv')
+
+echo "SUMMARY candidates=$candidate_count deleted=$deleted_count preserved=$skipped_count mode=$mode"

--- a/tests/branch_hygiene_unit.sh
+++ b/tests/branch_hygiene_unit.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+cat >"$TMP/gh" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+args="$*"
+
+case "$args" in
+  "api repos/acme/demo --jq .default_branch")
+    echo main
+    ;;
+  *"pulls?state=open&per_page=100"*)
+    echo open-live
+    ;;
+  *"branches?per_page=100"*)
+    printf '%s\n' \
+      $'main\tMAIN\tfalse' \
+      $'open-live\tOPEN\tfalse' \
+      $'merged-old\tMERGED\tfalse' \
+      $'merged-preserved\tKEEP\tfalse' \
+      $'reused-head\tREUSED\tfalse' \
+      $'changed-head\tCHANGED\tfalse' \
+      $'protected-release\tPROTECTED\ttrue' \
+      $'no-pr\tNONE\tfalse'
+    ;;
+  *"-f head=acme:merged-old"*"-f state=closed"*|*"-f state=closed"*"-f head=acme:merged-old"*)
+    echo '[{"number":12,"merged_at":"2026-07-01T00:00:00Z","head":{"sha":"MERGED"}}]'
+    ;;
+  *"-f head=acme:merged-preserved"*"-f state=closed"*|*"-f state=closed"*"-f head=acme:merged-preserved"*)
+    echo '[{"number":13,"merged_at":"2026-07-02T00:00:00Z","head":{"sha":"KEEP"}}]'
+    ;;
+  *"-f head=acme:reused-head"*"-f state=closed"*|*"-f state=closed"*"-f head=acme:reused-head"*)
+    echo '[{"number":14,"merged_at":"2026-07-03T00:00:00Z","head":{"sha":"OLD-SHA"}}]'
+    ;;
+  *"-f head=acme:changed-head"*"-f state=closed"*|*"-f state=closed"*"-f head=acme:changed-head"*)
+    echo '[{"number":15,"merged_at":"2026-07-04T00:00:00Z","head":{"sha":"CHANGED"}}]'
+    ;;
+  *"-f state=closed"*)
+    echo '[]'
+    ;;
+  "api repos/acme/demo/branches/merged-old --jq .commit.sha")
+    echo MERGED
+    ;;
+  "api repos/acme/demo/branches/changed-head --jq .commit.sha")
+    echo NEW-SHA
+    ;;
+  *"-f state=open"*"-f head=acme:merged-old"*)
+    echo 0
+    ;;
+  *"--method DELETE repos/acme/demo/git/refs/heads%2Fmerged-old")
+    echo "$args" >>"${GH_MOCK_LOG:?}"
+    ;;
+  *)
+    echo "unexpected gh invocation: $args" >&2
+    exit 99
+    ;;
+esac
+MOCK
+chmod +x "$TMP/gh"
+
+dry_output=$(GH_BIN="$TMP/gh" GITHUB_REPOSITORY=acme/demo \
+  BRANCH_HYGIENE_PRESERVE=merged-preserved \
+  "$ROOT/scripts/branch-hygiene.sh" --dry-run)
+
+grep -q 'PRESERVE open-or-explicit branch=open-live' <<<"$dry_output"
+grep -q 'PRESERVE open-or-explicit branch=merged-preserved' <<<"$dry_output"
+grep -q 'PRESERVE no-exact-merged-pr branch=reused-head' <<<"$dry_output"
+grep -q 'DELETE-CANDIDATE branch=merged-old sha=MERGED pr=#12' <<<"$dry_output"
+grep -q 'DELETE-CANDIDATE branch=changed-head sha=CHANGED pr=#15' <<<"$dry_output"
+grep -q 'SUMMARY candidates=2 deleted=0' <<<"$dry_output"
+
+: >"$TMP/deletes.log"
+apply_output=$(GH_BIN="$TMP/gh" GH_MOCK_LOG="$TMP/deletes.log" \
+  GITHUB_REPOSITORY=acme/demo BRANCH_HYGIENE_PRESERVE=merged-preserved \
+  "$ROOT/scripts/branch-hygiene.sh" --apply)
+
+grep -q 'DELETED branch=merged-old sha=MERGED pr=#12' <<<"$apply_output"
+grep -q 'PRESERVE changed-since-inventory branch=changed-head old=CHANGED new=NEW-SHA' <<<"$apply_output"
+grep -q 'SUMMARY candidates=2 deleted=1' <<<"$apply_output"
+[[ $(wc -l <"$TMP/deletes.log") -eq 1 ]]
+grep -q 'heads%2Fmerged-old' "$TMP/deletes.log"
+
+echo "branch_hygiene_unit: PASS"


### PR DESCRIPTION
Delegated-push relay for codex (assignee); gate cleared by Marcus (DIVE-1527, approve).

Weekly branch/worktree hygiene: GH Action + script that deletes branches whose PR is API-MERGED (handles squash-merges that `git branch --merged` misses) and flags stale PRs. Preserves the 6 open-PR heads + live-worktree branches.

Files: .github/workflows/branch-hygiene.yml, scripts/branch-hygiene.sh, tests/branch_hygiene_unit.sh (+272).
Tests pass (codex): shellcheck, branch_hygiene_unit, YAML parse, diff-check. Rebased clean on origin/main. Author: lodar.