### PR TITLE
DIVE-1563: council human-as-seat roster schema + seatIsHuman/resolveSeatChat

### DIFF
--- a/src/council/engine.mjs
+++ b/src/council/engine.mjs
@@ -202,8 +202,43 @@ export const SEAT_AGENT_ALIAS = { theo: 'marketing', lilbro: 'creative' }
 export function resolveSeatAgent(seat) {
   if (!seat) return ''
   if (typeof seat === 'string') return SEAT_AGENT_ALIAS[seat] || seat
+  if (seatIsHuman(seat)) return ''   // (DIVE-1563) a human seat is a principal, never dispatched as a registry agent
   if (seat.agent && typeof seat.agent === 'string') return seat.agent
   return SEAT_AGENT_ALIAS[seat.id] || seat.id
+}
+
+// (DIVE-1563) HUMAN-AS-SEAT SCHEMA. A council seat MAY be a human principal rather than a registry
+// agent — marked `{ kind: 'human' }` (or `human: true`) with a chat/principal binding naming which
+// Telegram chat receives the ballot + whose allowFrom the tap is authenticated against. This is the
+// prerequisite for DIVE-1548 human-as-seat voting (design: council-human-as-seat-voting-design-dive1548):
+// dispatchBallotVote (DIVE-1564) branches on seatIsHuman to emit a Telegram ballot instead of an
+// agent-directed ask. PURELY ADDITIVE + back-compat (main steer 2026-07-20): a bare-string seat or an
+// existing {id, agent?, lens?} seat is NEVER human, needs ZERO migration, and — because canonicalGenesis/
+// canonicalMotion seal only id/chair/lens — serializes to byte-identical sealed bytes. seatIsHuman
+// defaults false when the marker is absent; resolveSeatChat only fires for a human seat.
+export function seatIsHuman(seat) {
+  return !!seat && typeof seat === 'object' && (seat.kind === 'human' || seat.human === true)
+}
+// The chat/principal a human seat's ballot is delivered to + authenticated against. An explicit
+// `chat` (a resolved tg chat/user id) wins; else a resolvable `principal` string (e.g. 'human:main')
+// the bash/plugin layer resolves via the DIVE-1546 founder resolver. Returns '' for a non-human OR an
+// unbound human seat — dispatch (DIVE-1564) must fail closed on '' and never silently drop the ballot.
+export function resolveSeatChat(seat) {
+  if (!seatIsHuman(seat)) return ''
+  if (seat.chat != null && String(seat.chat).trim()) return String(seat.chat).trim()
+  if (seat.principal && typeof seat.principal === 'string' && seat.principal.trim()) return seat.principal.trim()
+  return ''
+}
+// The extra record fields a HUMAN seat carries beyond {id,lens,chair}. Empty {} for an agent seat, so
+// spreading it into a seat projection is a no-op for all-agent rosters (seal + JSON both unchanged).
+// Applied at every seat->record projection (addSeat + genesis/motion/bench serializers) so a promoted
+// human seat keeps its marker across reloads instead of silently reverting to an agent.
+export function humanSeatFields(seat) {
+  if (!seatIsHuman(seat)) return {}
+  const f = { kind: 'human' }
+  const chat = resolveSeatChat(seat)
+  if (chat) f.chat = chat
+  return f
 }
 export const DEFAULT_THRESHOLD = 3   // default flat pass-threshold; overridable per bench
 
@@ -543,7 +578,7 @@ export function addSeat(seats, seat) {
   const s = typeof seat === 'string' ? { id: seat } : seat
   if (!s || !s.id) throw new Error('addSeat: seat needs an id')
   if ((seats || []).some(x => x.id === s.id)) return seats.slice()   // already seated (idempotent)
-  return [...(seats || []), { id: s.id, lens: s.lens || `${s.id} — council seat.` }]
+  return [...(seats || []), { id: s.id, lens: s.lens || `${s.id} — council seat.`, ...humanSeatFields(s) }]
 }
 export function removeSeat(seats, seatId) {
   return (seats || []).filter(x => x.id !== seatId)
@@ -613,7 +648,7 @@ export function buildMotionRecord({ motion, verdict, seats, threshold, veto, pre
     outcome: (verdict && verdict.recommendation) || null,
     tally: (verdict && verdict.tally) || null,
     recused: (verdict && verdict.recused) || recusalFor(motion),
-    seats: seats.map(s => ({ id: s.id, lens: s.lens, ...(s.chair ? { chair: true } : {}) })),
+    seats: seats.map(s => ({ id: s.id, lens: s.lens, ...(s.chair ? { chair: true } : {}), ...humanSeatFields(s) })),
     threshold: threshold || { rule: 'majority' },
     veto: veto ? { principal: veto.principal, resolved: String(veto.resolved) } : null,
     receiptDigest: receiptDigest || '',   // links the motion to the convene receipt that decided it
@@ -966,7 +1001,7 @@ export function buildGenesisRecord({ seats, chair, threshold, veto, prevDigest, 
     version: 1,
     seq: Number(seq) || 0,
     council: 'council',
-    seats: seats.map(s => ({ id: s.id, lens: s.lens, ...(s.chair ? { chair: true } : {}) })),
+    seats: seats.map(s => ({ id: s.id, lens: s.lens, ...(s.chair ? { chair: true } : {}), ...humanSeatFields(s) })),
     chair: chair || null,
     threshold: threshold || { rule: 'majority' },
     veto: { principal: veto.principal, resolved: String(veto.resolved) },
@@ -1006,7 +1041,7 @@ export function genesisToBench(rec) {
   return {
     description: DEFAULT_COUNCIL.description,
     mode: DEFAULT_COUNCIL.mode,
-    seats: rec.seats.map(s => ({ id: s.id, lens: s.lens, ...(s.chair ? { chair: true } : {}) })),
+    seats: rec.seats.map(s => ({ id: s.id, lens: s.lens, ...(s.chair ? { chair: true } : {}), ...humanSeatFields(s) })),
     threshold: rec.threshold,
     genesis: true,           // marks this bench as motion-governed (raw add/rm refused)
     seededAt: rec.stampedAt,

--- a/tests/council_engine_unit.mjs
+++ b/tests/council_engine_unit.mjs
@@ -18,6 +18,7 @@ import {
   buildGenesisRecord, canonicalGenesis, normalizeConstitution, parseConstitutionFrontmatter,
   precedentTokens, selectPrecedents, precedentCitations, precedentCitationBrief, seatPrompt,
   subjectFromText, parseCanonicalVotes, scoreSeatVote, seatTrackRecord, seatTrackRecordBrief,
+  seatIsHuman, resolveSeatChat, humanSeatFields,
 } from '../src/council/engine.mjs'
 
 let pass = 0, fail = 0
@@ -419,6 +420,39 @@ ok(seatB.scored === 2 && seatB.correct === 1 && seatB.dissents === 2 && seatB.vi
 ok(tr.seats[0].calibration >= tr.seats[tr.seats.length - 1].calibration, 'CNCL-17: seats sort by calibration desc')
 ok(seatTrackRecordBrief('b', tr).includes('vindicated') && seatTrackRecordBrief('zzz', tr) === 'zzz: no scored record yet', 'CNCL-17: brief summarizes a seat (and a no-record seat)')
 ok(seatTrackRecord([], {}).seats.length === 0 && seatTrackRecord(null, null).scoredReceipts === 0, 'CNCL-17: empty/null inputs are safe')
+
+// ---- DIVE-1563: human-as-seat roster schema (prereq for DIVE-1548) ----
+// seatIsHuman: marker-gated, defaults false for every existing seat shape (back-compat).
+ok(seatIsHuman({ id: 'lodar', kind: 'human' }) === true, 'human: {kind:human} seat IS human')
+ok(seatIsHuman({ id: 'lodar', human: true }) === true, 'human: {human:true} seat IS human')
+ok(seatIsHuman({ id: 'eng-lead', lens: 'x' }) === false, 'human: plain {id,lens} seat is NOT human')
+ok(seatIsHuman({ id: 'brand', agent: 'marketing' }) === false, 'human: {id,agent} seat is NOT human')
+ok(seatIsHuman('eng-lead') === false, 'human: bare-string seat is NOT human')
+ok(seatIsHuman(null) === false && seatIsHuman(undefined) === false, 'human: null/undefined seat is NOT human')
+// resolveSeatChat: explicit chat wins; principal is a fallback; '' for non-human / unbound.
+ok(resolveSeatChat({ kind: 'human', chat: '12345' }) === '12345', 'human: explicit chat resolves')
+ok(resolveSeatChat({ kind: 'human', principal: 'human:main' }) === 'human:main', 'human: principal binding resolves when no chat')
+ok(resolveSeatChat({ kind: 'human', chat: ' 99 ', principal: 'human:main' }) === '99', 'human: chat wins over principal, trimmed')
+ok(resolveSeatChat({ kind: 'human' }) === '', 'human: unbound human seat resolves to "" (dispatch fails closed)')
+ok(resolveSeatChat({ id: 'eng-lead', lens: 'x' }) === '', 'human: non-human seat has no chat')
+// resolveSeatAgent: a human seat is never dispatched as a registry agent; agent seats unchanged.
+ok(resolveSeatAgent({ id: 'lodar', kind: 'human', chat: '1' }) === '', 'human: human seat resolves to NO agent')
+ok(resolveSeatAgent({ id: 'brand', agent: 'marketing' }) === 'marketing', 'human: agent seat still resolves its agent (regression)')
+ok(resolveSeatAgent('theo') === 'marketing', 'human: alias seat still resolves (regression)')
+// humanSeatFields: no-op for agent seats (byte-identical rosters); carries {kind,chat} for human seats.
+ok(JSON.stringify(humanSeatFields({ id: 'eng-lead', lens: 'x' })) === '{}', 'human: agent seat contributes NO extra record fields')
+ok(JSON.stringify(humanSeatFields({ id: 'lodar', kind: 'human', chat: '77' })) === JSON.stringify({ kind: 'human', chat: '77' }), 'human: human seat carries kind+chat into the record')
+// Round-trip through addSeat + a sealed genesis record: the marker survives; agent seats unchanged.
+const withHuman = addSeat([{ id: 'eng-lead', lens: 'x' }], { id: 'lodar', kind: 'human', chat: '77' })
+ok(seatIsHuman(withHuman[1]) === true && withHuman[1].chat === '77', 'human: addSeat preserves the human marker + chat')
+ok(seatIsHuman(withHuman[0]) === false, 'human: addSeat leaves the agent seat non-human')
+const gRecH = buildGenesisRecord({ seats: withHuman, chair: 'eng-lead', threshold: { rule: 'majority' }, veto: { principal: 'human:main', resolved: '1' }, prevDigest: '', stampedAt: 'T', seq: 0 })
+ok(seatIsHuman(gRecH.seats.find(s => s.id === 'lodar')) === true, 'human: sealed genesis record preserves the human seat marker')
+ok(seatIsHuman(genesisToBench(gRecH).seats.find(s => s.id === 'lodar')) === true, 'human: genesisToBench carries the human marker into the bench roster')
+// Seal invariant: canonicalGenesis reads only id/chair/lens, so the human marker does NOT alter sealed bytes.
+const gAgentOnly = buildGenesisRecord({ seats: [{ id: 'eng-lead', lens: 'x' }, { id: 'lodar', lens: 'lodar — council seat.' }], chair: 'eng-lead', threshold: { rule: 'majority' }, veto: { principal: 'human:main', resolved: '1' }, prevDigest: '', stampedAt: 'T', seq: 0 })
+const gHumanMarked = buildGenesisRecord({ seats: [{ id: 'eng-lead', lens: 'x' }, { id: 'lodar', lens: 'lodar — council seat.', kind: 'human', chat: '77' }], chair: 'eng-lead', threshold: { rule: 'majority' }, veto: { principal: 'human:main', resolved: '1' }, prevDigest: '', stampedAt: 'T', seq: 0 })
+ok(canonicalGenesis(gAgentOnly) === canonicalGenesis(gHumanMarked), 'human: marker is seal-invisible (identical canonical bytes -> no digest drift)')
 
 console.log(`\nCNCL-6/11/15/17/19 engine: ${pass} passed, ${fail} failed (bound to src/council/engine.mjs)`)
 process.exit(fail ? 1 : 0)


### PR DESCRIPTION
Build sub-task **1/4** of DIVE-1548 (human-as-seat council voting via Telegram buttons). Design: `community/wiki/council-human-as-seat-voting-design-dive1548.md` (cut A, main-confirmed 2026-07-20). **Prerequisite** for DIVE-1564 (dispatch branch).

## What
The roster had no human-seat concept — `resolveSeatAgent(seat)` always resolved a seat to a registry agent. This adds the marker + helpers so a seat can be a human principal:

- **`seatIsHuman(seat)`** — marker-gated (`{kind:'human'}` or `human:true`); false for every existing seat shape.
- **`resolveSeatChat(seat)`** — the chat/principal binding the ballot is delivered to + authed against (explicit `chat` wins, else a resolvable `principal` e.g. `human:main`); `''` for non-human/unbound → dispatch fails closed.
- **`resolveSeatAgent`** hardened — a human seat resolves to **no** agent.
- **`humanSeatFields(seat)`** — `{}` for agent seats, `{kind,chat}` for human seats; spread into `addSeat` + genesis/motion/bench serializers so a promoted human seat keeps its marker across reloads.

## Guarantees (main steer 2026-07-20: purely additive, zero migration)
- Bare-string / `{id,agent?,lens?}` seats resolve **exactly** as before — an all-agent council needs no migration.
- **Seal-safe:** `canonicalGenesis`/`canonicalMotion` read only `id/chair/lens`, so the human marker is seal-invisible → **no digest drift** (asserted).

## Tests
- `council_engine_unit.mjs`: **195/0** (+21 new assertions covering marker detection, chat resolution, agent-resolution regression, round-trip through addSeat/genesis/bench, and the seal-invariant).
- Wrapper `council_unit.sh`: green. `council_dispatch/cosign/constitution` units: green.
- No bundle/sha256 change — `engine.mjs` ships as a runtime sibling of `cli.mjs` (verified `./build.sh` produces an identical bundle).

Maker: agent-dev · Verifier: main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)