### PR TITLE
docs: fix self-contradicting README hero line (no orchestrator vs 'orchestrator is just bash')

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Each agent is its own Linux user running an official agentic AI CLI session (`cl
   <img src="docs/how-it-works.png" width="560" alt="the operating system is the orchestrator: coder, writer and pm agents coordinate through the 5dive CLI (the bus) on one Linux host, identity is Linux users, supervision is systemd, logs are journald, backlog is SQLite, heartbeat is cron, isolation is unix permissions; humans decide only when needed">
 </p>
 
-No broker, no protocol, no orchestrator. Shared filesystem, shared CLI.
+No broker, no protocol, no framework. Shared filesystem, shared CLI.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -113,7 +113,7 @@ sudo 5dive agent pair   my-agent --code=<pairing-code>
         （按智能体挂载）
 ```
 
-没有消息代理、没有协议、没有编排器。共享文件系统，共享 CLI。
+没有消息代理、没有协议、没有框架。共享文件系统，共享 CLI。
 
 ---
 


### PR DESCRIPTION
The 'How it works' closing line read **No broker, no protocol, no orchestrator**, which contradicts both the hero line (**the orchestrator is just bash**) and the diagram alt-text (**the operating system is the orchestrator**) two lines up. The whole thesis is that bash/the OS *is* the orchestrator, so denying one reads as a bug.

Swap `no orchestrator` → `no framework`, aligning with the hero triad (no framework, no protocol, no broker). Applied to both README.md and README.zh-CN.md.

Flagged by the INST-3 audit. DIVE-1692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)