### PR TITLE
Fleet-wide pre-push PII guard (DIVE-1797)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -473,6 +473,26 @@ MANAGED
     ln -sfn CLAUDE.md /home/claude/projects/AGENTS.md
     chown -h claude:claude /home/claude/projects/AGENTS.md
   fi
+
+  # Fleet-wide pre-push PII guard (DIVE-1797). Point any local 5dive-ai/5dive
+  # checkout on this box at its in-repo pre-push scanner (core.hooksPath). One
+  # config per clone covers every linked worktree AND every future one, so new
+  # landing boxes get the guard on install and existing ones on the daily update
+  # cron. Best-effort + idempotent; a box with no checkout is a clean no-op.
+  # WHY here and not branch protection: our landing account is the repo admin,
+  # so a required check only gates external PRs, never our own agent commits.
+  for _cli_co in /home/*/projects/*/5dive-cli /home/*/projects/5dive/5dive-cli /root/5dive-cli; do
+    [[ -e "$_cli_co/.git" ]] || continue
+    case "$(git -C "$_cli_co" config --get remote.origin.url 2>/dev/null)" in
+      *5dive-ai/5dive*) ;;
+      *) continue ;;
+    esac
+    if [[ -x "$_cli_co/scripts/install-pii-push-guard.sh" ]]; then
+      "$_cli_co/scripts/install-pii-push-guard.sh" "$_cli_co" >/dev/null 2>&1         && ok "pii-push-guard wired ($_cli_co)"
+    else
+      git -C "$_cli_co" config --local core.hooksPath scripts/git-hooks 2>/dev/null         && ok "pii-push-guard wired ($_cli_co)"
+    fi
+  done
 }
 
 # --- Subcommand dispatch ---------------------------------------------------

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Fleet-wide pre-push PII guard (DIVE-1797, enforcement follow-up to DIVE-1774).
+#
+# WHY a local hook and not GitHub branch protection: our landing account is the
+# repo admin, so a required status check only gates EXTERNAL PRs, never our own
+# agent commits (the actual accidental-PII risk). This gates our own pushes at
+# source, before anything reaches the public 5dive-ai/5dive repo.
+#
+# WHAT it does: runs the SAME scanner the CI pii-guard uses (scripts/pii-scan.sh)
+# over the commit messages + added diff lines of the commits being pushed. A
+# non-zero exit from the scanner (a denylisted id/email/phone) blocks the push.
+#
+# DESIGN NOTES:
+#   - Calls scripts/pii-scan.sh DIRECTLY. No forked scan logic here, so it can
+#     never drift from the CI scanner (DIVE-1797 requirement c).
+#   - Installed fleet-wide via core.hooksPath=scripts/git-hooks, set once on the
+#     shared clone config so every linked worktree (and every future one)
+#     inherits it. See scripts/install-pii-push-guard.sh.
+#   - Threat model is ACCIDENTAL fixture/log PII, not a malicious actor. So if
+#     the scanner is absent (e.g. a stale branch predating DIVE-1774) the hook
+#     fails OPEN with a warning rather than blocking legitimate work; the CI
+#     pii-guard remains the post-hoc net for anything that slips past.
+set -uo pipefail
+
+TOP="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+SCAN="$TOP/scripts/pii-scan.sh"
+EMPTY_TREE=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+Z40=0000000000000000000000000000000000000000
+
+if [[ ! -f "$SCAN" ]]; then
+  echo "pii-push-guard: scanner not found ($SCAN); skipping (CI pii-guard is the net)." >&2
+  exit 0
+fi
+
+rc=0
+# The scanner is the LAST stage of each pipeline below, so the pipeline's exit
+# status IS the scanner's exit — `|| rc=1` captures a hit without the pipeline
+# subshell swallowing it. The `while read` loop runs in this shell (its stdin is
+# the ref-update list), so rc set inside persists.
+while read -r local_ref local_oid remote_ref remote_oid; do
+  [[ -z "${local_oid:-}" ]] && continue
+  [[ "$local_oid" == "$Z40" ]] && continue   # branch deletion: nothing to scan
+
+  if [[ "$remote_oid" == "$Z40" ]]; then
+    # New remote branch: scan commits not already present on any remote ref.
+    commits="$(git rev-list "$local_oid" --not --remotes 2>/dev/null)"
+    oldest="$(printf '%s\n' "$commits" | awk 'NF{last=$0} END{print last}')"
+    if [[ -n "$oldest" ]]; then
+      base="$(git rev-parse "${oldest}^" 2>/dev/null)" || base="$EMPTY_TREE"
+    else
+      base="$EMPTY_TREE"
+    fi
+  else
+    commits="$(git rev-list "${remote_oid}..${local_oid}" 2>/dev/null)"
+    base="$remote_oid"
+  fi
+
+  [[ -z "${commits// }" ]] && continue   # nothing new to push on this ref
+
+  # (1) commit messages of the pushed commits
+  git log --no-color --format='%B' "$base..$local_oid" 2>/dev/null | bash "$SCAN" >/dev/null || rc=1
+  # (2) lines ADDED by the pushed commits
+  git diff --no-color "$base" "$local_oid" 2>/dev/null \
+    | grep '^+' | grep -v '^+++' | sed 's/^+//' | bash "$SCAN" >/dev/null || rc=1
+done
+
+if [[ $rc -ne 0 ]]; then
+  echo "" >&2
+  echo "pii-push-guard: BLOCKED — a denylisted identifier is in the commits you are pushing." >&2
+  echo "  Scrub the real id/email/phone (use placeholders like <user-id>, 1234567890) and re-commit." >&2
+  echo "  Emergency override (discouraged; CI pii-guard will still flag it): git push --no-verify" >&2
+  exit 1
+fi
+exit 0

--- a/scripts/install-pii-push-guard.sh
+++ b/scripts/install-pii-push-guard.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Install the fleet-wide pre-push PII guard (DIVE-1797) on a 5dive-ai/5dive
+# checkout by pointing git at the in-repo hook via core.hooksPath.
+#
+# One install per CLONE covers the whole worktree family: core.hooksPath lives in
+# the shared clone config, so every existing linked worktree AND every future
+# `git worktree add` inherits it automatically. Relative path `scripts/git-hooks`
+# resolves against each worktree's own root at hook time, so each push is gated by
+# the hook committed on the branch it is pushing.
+#
+# Idempotent. Safe to re-run from the daily update path. No-op (exit 0) on any
+# directory that is not a 5dive-ai/5dive checkout, so provisioning can call it
+# blindly on every box.
+#
+# Usage:
+#   scripts/install-pii-push-guard.sh [repo-dir]   # default: this script's repo
+set -uo pipefail
+
+DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+# Must be a git checkout of the CLI repo. Match the origin loosely (ssh or https,
+# with or without .git) so it works regardless of how the box cloned it.
+url="$(git -C "$DIR" config --get remote.origin.url 2>/dev/null || true)"
+case "$url" in
+  *5dive-ai/5dive*) ;;
+  *) echo "pii-push-guard: $DIR is not a 5dive-ai/5dive checkout — skipping." >&2; exit 0 ;;
+esac
+
+# Must carry the hook on this checkout (skip stale branches predating the hook;
+# they inherit the config anyway once they rebase onto main).
+top="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+[[ -n "$top" ]] || { echo "pii-push-guard: $DIR has no worktree — skipping." >&2; exit 0; }
+
+# Set on the SHARED config (covers all worktrees). --local writes to the common
+# config for a worktree, which is exactly what we want here.
+current="$(git -C "$DIR" config --local --get core.hooksPath 2>/dev/null || true)"
+if [[ "$current" != "scripts/git-hooks" ]]; then
+  git -C "$DIR" config --local core.hooksPath scripts/git-hooks
+fi
+
+# Make sure the committed hook is executable on this checkout (if present).
+[[ -f "$top/scripts/git-hooks/pre-push" ]] && chmod +x "$top/scripts/git-hooks/pre-push" 2>/dev/null || true
+
+echo "pii-push-guard: core.hooksPath=scripts/git-hooks set on $(git -C "$DIR" rev-parse --git-common-dir 2>/dev/null)"


### PR DESCRIPTION
Enforcement follow-up to DIVE-1774 (olivia's option D). Local pre-push hook that runs the SAME scanner as CI (scripts/pii-scan.sh — no forked logic, req c) over pushed commits and blocks on a denylist hit. Gates our OWN pushes, which branch protection can't (landing account is repo admin).

(a) Provisioning: install.sh wires core.hooksPath on every install/daily-update, so new landing boxes get it automatically.
(b) Backfill: core.hooksPath=scripts/git-hooks set on the shared clone config -> all 89 live worktrees inherit it (+ every future worktree). One stale/dangling worktree entry (inaccessible tmp dir) excluded.
(c) Hook calls scripts/pii-scan.sh directly; fails open if scanner absent (CI net). --no-verify out of scope per accidental-PII threat model.

Tested (throwaway repo, temp denylist): clean push passes; planted id in DIFF blocks (exit 1); planted id in COMMIT MESSAGE blocks; branch-deletion + new-branch handled. This PR's own push was gated by the hook (dogfood) and passed clean.

Verify coverage:
  git -C 5dive-cli worktree list --porcelain | awk '/^worktree /{print $2}' | while read w; do echo "$w: $(git -C "$w" config --get core.hooksPath)"; done

🤖 Generated with [Claude Code](https://claude.com/claude-code)