### PR TITLE
test: make three unit harnesses independent of host state (DIVE-1919)

### DIFF
--- a/tests/managed_settings_selfheal_unit.sh
+++ b/tests/managed_settings_selfheal_unit.sh
@@ -77,8 +77,14 @@ awk '/reconcile_managed_settings "\$ms"/{found=1} END{exit !found}' src/cmd_doct
   && ok_t "doctor heals the live managed-settings file (\$ms) under repair" \
   || bad_t "doctor heals \$ms" ""
 if grep -q 'DOCTOR_REPAIR' src/cmd_doctor.sh; then
-  # assert the reconcile call sits inside a DOCTOR_REPAIR guard (read-only default)
-  sed -n '/managed-settings/,/allowlisted"/p' src/cmd_doctor.sh | grep -q 'DOCTOR_REPAIR' \
+  # Assert the reconcile call sits inside a DOCTOR_REPAIR guard (read-only default).
+  # DIVE-1919: anchor on the CALL, not on a sed range. The old range
+  # (/managed-settings/,/allowlisted"/) closed on the first later line ending in
+  # `allowlisted"` — which is the check's own OK message, several lines ABOVE the
+  # guard — so the range never contained DOCTOR_REPAIR and this assertion red-ed
+  # on correct code as soon as that message was worded that way. Look at the lines
+  # immediately preceding the call instead: that is the property under test.
+  grep -B 5 'reconcile_managed_settings "\$ms"' src/cmd_doctor.sh | grep -q 'DOCTOR_REPAIR' \
     && ok_t "reconcile is guarded by DOCTOR_REPAIR (bare doctor stays a preview)" \
     || bad_t "repair guard" "reconcile must only fire under --fix"
 fi

--- a/tests/pi_channel_wiring_unit.sh
+++ b/tests/pi_channel_wiring_unit.sh
@@ -43,9 +43,19 @@ got=$(_tg_access_state_dir "agent-foo" pi)
 # --- pi_plugin_dir() resolves from the env override ---------------------------
 _pdir=$(mktemp -d); : > "$_pdir/server.ts"
 [[ "$(TELEGRAM_PI_PLUGIN_DIR="$_pdir" pi_plugin_dir)" == "$_pdir" ]] && ok_t "pi_plugin_dir resolves TELEGRAM_PI_PLUGIN_DIR" || bad_t "pi_plugin_dir override"
-# absent server.ts -> resolver returns nonzero (fail-fast at create)
+# absent server.ts -> the override is REJECTED. DIVE-1919: assert on the property
+# under test (the bad override is not returned), NOT on a nonzero rc. The resolver
+# deliberately continues to its canonical fallbacks (/usr/local/lib/5dive/telegram-pi,
+# the 5dive-plugins checkout), so on a control-plane host where a real telegram-pi
+# IS installed the resolver correctly succeeds with the FALLBACK and an rc-based
+# assertion fails — i.e. the old assertion really tested "no telegram-pi is
+# installed anywhere on this machine", which is host state, not behaviour. Do not
+# "fix" this by making an invalid override suppress valid fallbacks.
 rm -f "$_pdir/server.ts"
-TELEGRAM_PI_PLUGIN_DIR="$_pdir" pi_plugin_dir >/dev/null 2>&1 && bad_t "pi_plugin_dir should reject dir w/o server.ts" || ok_t "pi_plugin_dir rejects dir w/o server.ts"
+_got=$(TELEGRAM_PI_PLUGIN_DIR="$_pdir" pi_plugin_dir 2>/dev/null)
+[[ "$_got" != "$_pdir" ]] \
+  && ok_t "pi_plugin_dir rejects dir w/o server.ts (falls through to canonical paths)" \
+  || bad_t "pi_plugin_dir should reject dir w/o server.ts" "resolved to the invalid override '$_got'"
 rm -rf "$_pdir"
 
 # --- the three new pi functions are defined ----------------------------------

--- a/tests/task_park_gate_guard_unit.sh
+++ b/tests/task_park_gate_guard_unit.sh
@@ -23,6 +23,17 @@ for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
   source "$SRC/$f"
 done
 STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+# DIVE-1919: BIND the gate-proof paths to the isolated STATE_DIR too. tasks_db.sh
+# derives them at SOURCE time (line ~1240), i.e. from the DEFAULT /var/lib/5dive,
+# so re-pointing STATE_DIR afterwards is not enough — `_gate_proof_enforced` kept
+# stat-ing the LIVE host file. On a control-plane box where root has flipped
+# enforcement on (/var/lib/5dive/gate-proof.enforce exists) T2's `task answer
+# --human` was rejected E_AUTH_REQUIRED and the harness died rc=6 mid-run; on a
+# clean CI runner the file is absent, enforcement is dormant and it passed. Same
+# two-line binding the sibling gate harnesses already do (gate_nonce_unit.sh,
+# gate_tier2_floor_unit.sh, gate_channel_proof_unit.sh, ...).
+GATE_PROOF_KEY="$STATE_DIR/gate-proof.key"
+GATE_PROOF_ENFORCE="$STATE_DIR/gate-proof.enforce"
 JSON_MODE=1
 mkdir -p "$TASKS_DIR"; set +e
 


### PR DESCRIPTION
Three unit harnesses were asserting facts about the BOX rather than about the code, so the suite went red on the control-plane host and green on a pristine CI runner. That gap is corrosive on its own: it trains everyone to ignore red, and then a real failure reads as the usual noise.

- `pi_channel_wiring_unit.sh` — the invalid-override case asserted `pi_plugin_dir` returns nonzero, which only holds when no telegram-pi is installed anywhere on the machine. The resolver deliberately falls through to its canonical paths, so on a box that HAS the plugin it correctly succeeds with the fallback. Now asserts the actual property under test: the bad override is not what comes back.
- `task_park_gate_guard_unit.sh` — `tasks_db.sh` derives `GATE_PROOF_KEY`/`ENFORCE` at SOURCE time, so re-pointing `STATE_DIR` afterwards left `_gate_proof_enforced` stat-ing the live `/var/lib/5dive` flag. With enforcement on, T2's `--human` answer was rejected `E_AUTH_REQUIRED` and the harness died rc=6 mid-run. Both paths now bound to the isolated `STATE_DIR`, as the sibling gate harnesses already do.
- `managed_settings_selfheal_unit.sh` — its sed range closed on the check's own OK message, ABOVE the `DOCTOR_REPAIR` guard it was hunting for, so it red-ed on correct code. Re-anchored on the reconcile call.

Tests-only: no product source changed, so no bundle rebuild or version bump.

Verified 142/142 by the maker on the control-plane host, and independently re-run by the reviewer from a clean `git archive` extraction of this branch (rc=0). Branch descends from current `main`.

The installed-host CI job that was the second half of this ask is split to DIVE-1949 — the delegated-push GitHub App lacks `workflows` permission and the file was remote-rejected. The systemic fix for the other ~53 harnesses that re-point `STATE_DIR` after sourcing is DIVE-1950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)