### PR TITLE
test: de-flake the loop --wait harnesses that raced a fixed sleep 1 (DIVE-1951)

### DIFF
--- a/tests/crashloop_run_loop_unit.sh
+++ b/tests/crashloop_run_loop_unit.sh
@@ -55,7 +55,13 @@ RUN_CMD='true' RUN_CMD_FIRST='' AGENT_NAME='tester' \
   FAST_SECS=999 CRASHLOOP_N=1 BACKOFF_CAP=1 CRASHLOOP_FLAG="$FLAG" \
   run_loop &
 LOOP_PID=$!
-sleep 1
+# poll for the flag rather than assuming one second is enough for the loop to
+# trip detection — on a loaded CI runner it is not, and the kill below then
+# lands BEFORE the flag/alert ever drop (flaky red, no bug). Bounded ~10s.
+for _i in $(seq 1 100); do [[ -f "$FLAG" ]] && break; sleep 0.1; done
+# never fail SILENTLY into a missing flag: say so out loud, or the assertions
+# below red as if the product misbehaved when the CHECK simply ran out of time.
+[[ -f "$FLAG" ]] || echo "crashloop: TIMED OUT after ~10s waiting for $FLAG — assertions below fail on a missing flag, not on a product bug" >&2
 kill "$LOOP_PID" 2>/dev/null || true
 wait "$LOOP_PID" 2>/dev/null || true
 

--- a/tests/loop_grade_unit.sh
+++ b/tests/loop_grade_unit.sh
@@ -72,11 +72,38 @@ run --target="$NAC" --verifier=main >/dev/null 2>&1; [[ $? -ne 0 ]] && ok_t "no 
 
 # helper: the grader task id for the most recent grade loop row
 latest_grade_child() { db "SELECT TRIM(child_task_ids,'[]') FROM loop_runs WHERE topology='grade' ORDER BY started_at DESC, rowid DESC LIMIT 1;"; }
+latest_grade_running() { db "SELECT loop_id FROM loop_runs WHERE topology='grade' AND status='running' ORDER BY started_at DESC, rowid DESC LIMIT 1;"; }
+
+# Poll until a probe reports the background --wait spawn has actually landed its
+# row, instead of assuming a fixed `sleep 1` is enough. On a loaded 2-core CI
+# runner the spawn path (task insert + loop row, several sqlite/jq execs) can
+# take longer than a second: the id below then comes back EMPTY, the UPDATE that
+# is supposed to steer the waiter no-ops, and the waiter burns its full --wait
+# and reports the wrong status — a flaky red with no bug behind it (DIVE-1951).
+# Same precedent as wait_graders() in loop_panel_unit.sh. Bounded ~10s.
+poll_new() { # <prev-value> <probe...> → echo first value that is non-empty and != prev
+  local prev="$1"; shift
+  local i out=""
+  for i in $(seq 1 100); do
+    out=$("$@")
+    [[ -n "$out" && "$out" != "$prev" ]] && { printf '%s' "$out"; return 0; }
+    sleep 0.1
+  done
+  # never fail SILENTLY into an empty id: an empty return here makes the assertion
+  # below red as if the product misbehaved, when in fact the CHECK never got an
+  # answer. Say so out loud (DIVE-1951).
+  echo "poll_new: TIMED OUT after ~10s waiting for '$*' to yield a new value (prev='$prev', last='$out') — the next assertion fails on an EMPTY id, not on a product bug" >&2
+  printf '%s' "$out"; return 1
+}
+# every grade case below already has EARLIER grade rows, so "non-empty" is not
+# enough to prove the new one landed — poll until the newest child differs from
+# the one captured before the spawn.
 
 # --- T3: --wait, grader scores high → verdict pass, scorecard persisted
+prev_child=$(latest_grade_child)
 ( cmd_loop_grade --target="$TGT" --verifier=main --threshold=70 --wait=20 >"$TMP"/loop-grade-pass.out 2>&1 ) &
 bgpid=$!
-sleep 1; g3=$(latest_grade_child)
+g3=$(poll_new "$prev_child" latest_grade_child)
 db "UPDATE tasks SET status='done', result='{\"overall\":88,\"criteria\":[{\"name\":\"compile\",\"score\":95,\"reason\":\"ok\"},{\"name\":\"tests\",\"score\":80}]}' WHERE id=$g3;"
 wait $bgpid
 v3=$(jq -r '.data.verdict' "$TMP"/loop-grade-pass.out 2>/dev/null)
@@ -91,28 +118,30 @@ sccrit=$(printf '%s' "$sc" | jq -r '.criteria | length' 2>/dev/null)
   && ok_t "scorecard_json persisted (overall=$scov, ${sccrit} criteria)" || bad_t "scorecard persist" "$sc"
 
 # --- T4: --wait, grader scores low → verdict fail
+prev_child=$(latest_grade_child)
 ( cmd_loop_grade --target="$TGT" --verifier=main --threshold=70 --wait=20 >"$TMP"/loop-grade-fail.out 2>&1 ) &
 bgpid=$!
-sleep 1; g4=$(latest_grade_child)
+g4=$(poll_new "$prev_child" latest_grade_child)
 db "UPDATE tasks SET status='done', result='{\"overall\":40,\"criteria\":[{\"name\":\"compile\",\"score\":40}]}' WHERE id=$g4;"
 wait $bgpid
 v4=$(jq -r '.data.verdict' "$TMP"/loop-grade-fail.out 2>/dev/null)
 [[ "$v4" == "fail" ]] && ok_t "--wait low score → fail" || bad_t "grade fail" "$(cat "$TMP"/loop-grade-fail.out)"
 
 # --- T5: --wait, grader returns unparseable result → escalated (never silent pass)
+prev_child=$(latest_grade_child)
 ( cmd_loop_grade --target="$TGT" --verifier=main --wait=20 >"$TMP"/loop-grade-esc.out 2>&1 ) &
 bgpid=$!
-sleep 1; g5=$(latest_grade_child)
+g5=$(poll_new "$prev_child" latest_grade_child)
 db "UPDATE tasks SET status='done', result='not json at all' WHERE id=$g5;"
 wait $bgpid
 v5=$(jq -r '.data.verdict' "$TMP"/loop-grade-esc.out 2>/dev/null)
 [[ "$v5" == "escalated" ]] && ok_t "--wait unparseable → escalated" || bad_t "grade escalate" "$(cat "$TMP"/loop-grade-esc.out)"
 
 # --- T6: kill mid-wait → killed
+prev_running=$(latest_grade_running)
 ( cmd_loop_grade --target="$TGT" --verifier=main --wait=20 >"$TMP"/loop-grade-kill.out 2>&1 ) &
 bgpid=$!
-sleep 1
-klid=$(db "SELECT loop_id FROM loop_runs WHERE topology='grade' AND status='running' ORDER BY started_at DESC, rowid DESC LIMIT 1;")
+klid=$(poll_new "$prev_running" latest_grade_running)
 db "UPDATE loop_runs SET kill_requested=1 WHERE loop_id='$klid';"
 wait $bgpid
 kst=$(jq -r '.data.status' "$TMP"/loop-grade-kill.out 2>/dev/null)
@@ -124,9 +153,10 @@ LID=$(printf '%s' "$lout" | jq -r '.data.ident')
 lout2=$(JSON_MODE=1 cmd_task_loop_start --title="ungraded loop" --owner=dev --steps='[{"agent":"dev","label":"other"}]' 2>/dev/null)
 LID2=$(printf '%s' "$lout2" | jq -r '.data.ident')
 [[ "$LID" =~ ^DIVE- && "$LID2" =~ ^DIVE- ]] && ok_t "seed builder loops ($LID, $LID2)" || bad_t "seed builder loops" "$lout / $lout2"
+prev_child=$(latest_grade_child)
 ( cmd_loop_grade --target="$LID" --verifier=main --accept="loop completes" --wait=20 >"$TMP"/loop-grade-ls.out 2>&1 ) &
 bgpid=$!
-sleep 1; g7=$(latest_grade_child)
+g7=$(poll_new "$prev_child" latest_grade_child)
 db "UPDATE tasks SET status='done', result='{\"overall\":84,\"criteria\":[{\"name\":\"loop completes\",\"score\":84,\"reason\":\"ok\"}]}' WHERE id=$g7;"
 wait $bgpid
 ls_out=$(JSON_MODE=1 cmd_task_loop_ls 2>/dev/null)

--- a/tests/loop_spawn_unit.sh
+++ b/tests/loop_spawn_unit.sh
@@ -81,10 +81,32 @@ out=$(run --agent=main --prompt=y --ceiling=12345); c=$(printf '%s' "$out" | jq 
 loop_by_prompt() { db "SELECT lr.loop_id FROM loop_runs lr, tasks t WHERE lr.child_task_ids='['||t.id||']' AND t.body LIKE '%$1%' ORDER BY t.id DESC LIMIT 1;"; }
 task_by_prompt() { db "SELECT t.id FROM tasks t WHERE t.body LIKE '%$1%' ORDER BY t.id DESC LIMIT 1;"; }
 
+# Poll until a probe reports the background --wait spawn has actually landed its
+# row, instead of assuming a fixed `sleep 1` is enough. On a loaded 2-core CI
+# runner the spawn path (task insert + loop row, several sqlite/jq execs) can
+# take longer than a second: the id below then comes back EMPTY, the UPDATE that
+# is supposed to steer the waiter no-ops, and the waiter burns its full --wait
+# and reports the wrong status — a flaky red with no bug behind it (DIVE-1951).
+# Same precedent as wait_graders() in loop_panel_unit.sh. Bounded ~10s.
+poll_new() { # <prev-value> <probe...> → echo first value that is non-empty and != prev
+  local prev="$1"; shift
+  local i out=""
+  for i in $(seq 1 100); do
+    out=$("$@")
+    [[ -n "$out" && "$out" != "$prev" ]] && { printf '%s' "$out"; return 0; }
+    sleep 0.1
+  done
+  # never fail SILENTLY into an empty id: an empty return here makes the assertion
+  # below red as if the product misbehaved, when in fact the CHECK never got an
+  # answer. Say so out loud (DIVE-1951).
+  echo "poll_new: TIMED OUT after ~10s waiting for '$*' to yield a new value (prev='$prev', last='$out') — the next assertion fails on an EMPTY id, not on a product bug" >&2
+  printf '%s' "$out"; return 1
+}
+
 # --- T4: --wait halts on KILL (flip kill_requested mid-wait)
 ( cmd_loop_spawn --agent=main --prompt="UNIQ_killme" --wait=20 >"$TMP"/loop-kill.out 2>&1 ) &
 bgpid=$!
-sleep 1; klid=$(loop_by_prompt UNIQ_killme)
+klid=$(poll_new "" loop_by_prompt UNIQ_killme)
 db "UPDATE loop_runs SET kill_requested=1 WHERE loop_id='$klid';"
 wait $bgpid
 kst=$(jq -r '.data.status' "$TMP"/loop-kill.out 2>/dev/null)
@@ -93,7 +115,7 @@ kst=$(jq -r '.data.status' "$TMP"/loop-kill.out 2>/dev/null)
 # --- T5: --wait halts on CEILING breach
 ( cmd_loop_spawn --agent=main --prompt="UNIQ_spendy" --ceiling=1000 --wait=20 >"$TMP"/loop-ceil.out 2>&1 ) &
 bgpid=$!
-sleep 1; clid=$(loop_by_prompt UNIQ_spendy)
+clid=$(poll_new "" loop_by_prompt UNIQ_spendy)
 db "UPDATE loop_runs SET tokens_spent=5000 WHERE loop_id='$clid';"
 wait $bgpid
 cst=$(jq -r '.data.status' "$TMP"/loop-ceil.out 2>/dev/null)
@@ -102,7 +124,7 @@ cst=$(jq -r '.data.status' "$TMP"/loop-ceil.out 2>/dev/null)
 # --- T6: --wait returns clean done + result passthrough
 ( cmd_loop_spawn --agent=main --prompt="UNIQ_finish" --wait=20 >"$TMP"/loop-done.out 2>&1 ) &
 bgpid=$!
-sleep 1; dtid=$(task_by_prompt UNIQ_finish)
+dtid=$(poll_new "" task_by_prompt UNIQ_finish)
 db "UPDATE tasks SET status='done', result='shipped clean' WHERE id=$dtid;"
 wait $bgpid
 dst=$(jq -r '.data.status' "$TMP"/loop-done.out 2>/dev/null)

--- a/tests/loop_verify_unit.sh
+++ b/tests/loop_verify_unit.sh
@@ -56,18 +56,46 @@ tid3=$(mk_target maker "UNIQ_target_three"); db "UPDATE tasks SET status='done' 
 ( cmd_loop_verify --target="$tid" --verifier=grader --max-iters=0 ) >/dev/null 2>&1; [[ $? -ne 0 ]] && ok_t "--max-iters=0 rejected" || bad_t "max-iters" "exit 0"
 ( cmd_loop_verify --target="$tid" --verifier=grader --ceiling=x ) >/dev/null 2>&1; [[ $? -ne 0 ]] && ok_t "non-int --ceiling rejected" || bad_t "ceiling" "exit 0"
 
+# Poll until a probe reports the background --wait spawn has actually landed its
+# row, instead of assuming a fixed `sleep 1` is enough. On a loaded 2-core CI
+# runner the spawn path (task insert + loop row, several sqlite/jq execs) can
+# take longer than a second: the id below then comes back EMPTY, the UPDATE that
+# is supposed to steer the waiter no-ops, and the waiter burns its full --wait
+# and reports the wrong status — a flaky red with no bug behind it (DIVE-1951).
+# Same precedent as wait_graders() in loop_panel_unit.sh. Bounded ~10s.
+poll_new() { # <prev-value> <probe...> → echo first value that is non-empty and != prev
+  local prev="$1"; shift
+  local i out=""
+  for i in $(seq 1 100); do
+    out=$("$@")
+    [[ -n "$out" && "$out" != "$prev" ]] && { printf '%s' "$out"; return 0; }
+    sleep 0.1
+  done
+  # never fail SILENTLY into an empty id: an empty return here makes the assertion
+  # below red as if the product misbehaved, when in fact the CHECK never got an
+  # answer. Say so out loud (DIVE-1951).
+  echo "poll_new: TIMED OUT after ~10s waiting for '$*' to yield a new value (prev='$prev', last='$out') — the next assertion fails on an EMPTY id, not on a product bug" >&2
+  printf '%s' "$out"; return 1
+}
+
+# the loop row for a target only exists once cmd_loop_verify is past its
+# terminal-target validation — poll for it before flipping the target, or the
+# flip can land first and the command legitimately rejects a done target.
+lv_loop_for() { db "SELECT lr.loop_id FROM loop_runs lr WHERE lr.child_task_ids='[$1]' ORDER BY lr.started_at DESC LIMIT 1;"; }
+
 # --- T5: --wait → done verdict pass (flip target done mid-wait)
 tidw=$(mk_target maker "UNIQ_target_wait")
 ( cmd_loop_verify --target="$tidw" --verifier=grader --wait=20 >"$TMP"/lv-done.out 2>&1 ) &
-bg=$!; sleep 1; db "UPDATE tasks SET status='done', result='graded PASS' WHERE id=$tidw;"; wait $bg
+bg=$!; poll_new "" lv_loop_for "$tidw" >/dev/null
+db "UPDATE tasks SET status='done', result='graded PASS' WHERE id=$tidw;"; wait $bg
 dst=$(jq -r '.data.status' "$TMP"/lv-done.out 2>/dev/null); dvd=$(jq -r '.data.verdict' "$TMP"/lv-done.out 2>/dev/null); dres=$(jq -r '.data.result' "$TMP"/lv-done.out 2>/dev/null)
 [[ "$dst" == "done" && "$dvd" == "pass" && "$dres" == "graded PASS" ]] && ok_t "--wait → done/pass with result" || bad_t "wait done" "$(cat "$TMP"/lv-done.out)"
 
 # --- T6: --wait halts on KILL
 tidk=$(mk_target maker "UNIQ_target_kill")
 ( cmd_loop_verify --target="$tidk" --verifier=grader --wait=20 >"$TMP"/lv-kill.out 2>&1 ) &
-bg=$!; sleep 1
-klid=$(db "SELECT lr.loop_id FROM loop_runs lr WHERE lr.child_task_ids='[$tidk]' ORDER BY lr.started_at DESC LIMIT 1;")
+bg=$!
+klid=$(poll_new "" lv_loop_for "$tidk")
 db "UPDATE loop_runs SET kill_requested=1 WHERE loop_id='$klid';"; wait $bg
 kst=$(jq -r '.data.status' "$TMP"/lv-kill.out 2>/dev/null)
 [[ "$kst" == "killed" ]] && ok_t "--wait halts on kill → killed" || bad_t "kill" "$(cat "$TMP"/lv-kill.out)"
@@ -75,8 +103,8 @@ kst=$(jq -r '.data.status' "$TMP"/lv-kill.out 2>/dev/null)
 # --- T7: --wait halts on CEILING
 tidc=$(mk_target maker "UNIQ_target_ceil")
 ( cmd_loop_verify --target="$tidc" --verifier=grader --ceiling=1000 --wait=20 >"$TMP"/lv-ceil.out 2>&1 ) &
-bg=$!; sleep 1
-clid=$(db "SELECT lr.loop_id FROM loop_runs lr WHERE lr.child_task_ids='[$tidc]' ORDER BY lr.started_at DESC LIMIT 1;")
+bg=$!
+clid=$(poll_new "" lv_loop_for "$tidc")
 db "UPDATE loop_runs SET tokens_spent=5000 WHERE loop_id='$clid';"; wait $bg
 cst=$(jq -r '.data.status' "$TMP"/lv-ceil.out 2>/dev/null); cvd=$(jq -r '.data.verdict' "$TMP"/lv-ceil.out 2>/dev/null)
 [[ "$cst" == "escalated" && "$cvd" == "escalated" ]] && ok_t "--wait halts on ceiling → escalated" || bad_t "ceiling halt" "$(cat "$TMP"/lv-ceil.out)"


### PR DESCRIPTION
Four loop harnesses backgrounded a `--wait` command then slept a fixed 1s before reading back the row it should have inserted. Under CPU contention the row has not landed: the id reads back EMPTY, the steering UPDATE no-ops, and the waiter burns its full `--wait` and reports the wrong status. Reproduced 8/8 on 2 cores; CI hit it on main @6b7d62d (`FAILED: tests/loop_spawn_unit.sh`, `FAIL - kill halt`, PASS=15 FAIL=1).

Replaces the fixed sleep with a bounded ~10s poll for the row actually landing, matching `wait_graders()` in `loop_panel_unit.sh`. Timeouts now announce themselves on stderr ("the next assertion fails on an EMPTY id, not on a product bug") so an expired wait cannot masquerade as a product failure.

tests/ only, 4 files. Not a regression: main was green again at c137bc4 with no fix, and 963ab7b0 red at 09:11Z is a second intermittent of the same shape.

Built by dev3, reviewed by main (DIVE-1951).

🤖 Generated with [Claude Code](https://claude.com/claude-code)