### PR TITLE
ci: probe coverage is silently environment-dependent — assert the UNION (DIVE-2018)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -84,6 +84,16 @@ jobs:
             echo '// stub for the installed-host CI matrix' \
               | sudo tee "/usr/local/lib/5dive/$p/server.ts" >/dev/null
           done
+          # DIVE-2018: a `claude` user and at least one `agent-*` user. The control
+          # plane has both; a CI runner has neither, so gate_nonce_unit.sh and
+          # gate_sudo_uid_forge_unit.sh `exit 0` at their own SKIP guard before ever
+          # reaching a verdict. After the canary fix they were the LAST two harnesses
+          # the probe could not reach in ANY environment — and they are the gate
+          # identity and SUDO_UID forge tests, i.e. exactly the coverage whose absence
+          # matters most. Two throwaway system users, no shell, no home.
+          sudo useradd -M -N -s /usr/sbin/nologin claude 2>/dev/null || true
+          sudo useradd -M -N -s /usr/sbin/nologin agent-dev 2>/dev/null || true
+          getent passwd claude agent-dev
       - name: Run unit harnesses (installed host)
         run: |
           rc=0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -51,7 +51,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Every harness must be able to FAIL
-        run: bash tests/meta/harness-verdict-probe.sh --assume-clean
+        run: |
+          bash tests/meta/harness-verdict-probe.sh --assume-clean \
+            --label=pristine --report=probe-pristine.txt
+      # DIVE-2018: this run's `not-reached` set is not a failure and must not be —
+      # a harness that skips before its verdict has not been shown to be unwired,
+      # and three correctly-wired files were falsely accused that way. Which is
+      # exactly why THIS job cannot establish coverage: it can only report what it
+      # saw. The report goes to the union job, which asserts the invariant that
+      # does hold across environments. `if: always()` because a run that found
+      # UNWIRED still made a valid coverage observation, and losing it would let a
+      # red probe silently shrink the union.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with: { name: probe-pristine, path: probe-pristine.txt, if-no-files-found: error }
 
   test-installed-host:
     runs-on: ubuntu-latest
@@ -82,3 +95,44 @@ jobs:
             fi
           done
           exit $rc
+      # DIVE-2018: the probe used to run ONLY on the pristine runner, so the
+      # harnesses CI never probed were precisely the ones that skip without live
+      # state — the gate and install paths, i.e. the most environment-sensitive
+      # code we have. Probing here too is what makes the union non-trivial: this
+      # environment reaches harnesses the pristine one cannot. `--assume-clean` is
+      # sound for the same reason it is in the pristine job — the step above just
+      # established the clean-green baseline IN THIS ENVIRONMENT, and if it went
+      # red this step does not run and the union job never reports coverage.
+      - name: Every harness must be able to FAIL (installed host)
+        run: |
+          bash tests/meta/harness-verdict-probe.sh --assume-clean \
+            --label=installed-host --report=probe-installed.txt
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with: { name: probe-installed, path: probe-installed.txt, if-no-files-found: error }
+
+  # DIVE-2018: NOT-REACHED is correctly not a failure in any single run, so no
+  # single run can establish that a harness has EVER been probed. On the control
+  # plane the probe read 135 wired / 16 not-reached; on the pristine runner 151
+  # wired / 0 not-reached. Both green, both 154 with the allowlist, probing
+  # DIFFERENT CORPORA, and nothing said so. The limit case is a harness that skips
+  # in every environment: reported "probed in an environment where it runs", and no
+  # environment ever does.
+  #
+  # This job owns the invariant that survives that: every harness in tests/*.sh is
+  # probed in AT LEAST ONE environment, or is allowlisted by name with a reason.
+  # A skip in one environment is still not an accusation; a skip in all of them is
+  # now a failure.
+  harness-verdict-union:
+    runs-on: ubuntu-latest
+    needs: [harness-verdict, test-installed-host]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with: { pattern: probe-*, merge-multiple: true }
+      # The union script fails closed on a missing, headerless, or different-corpus
+      # report, so a job that died before writing one cannot silently shrink what
+      # we claim to cover — the check would otherwise have the same shape of hole
+      # it exists to close.
+      - name: Every harness must be probed in SOME environment
+        run: bash tests/meta/harness-verdict-union.sh probe-pristine.txt probe-installed.txt

--- a/tests/harness_verdict_union_unit.sh
+++ b/tests/harness_verdict_union_unit.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# DIVE-2018 — tests/meta/harness-verdict-union.sh
+#
+# The union check is itself an instrument that can succeed in appearance: every
+# way it could wrongly report full coverage is a way the DIVE-2013 probe goes back
+# to being silently environment-dependent. So the cases below are weighted toward
+# the FALSE-CLEAN direction — a missing report, a headerless report, reports about
+# different corpora, and the two verdicts that look like observations but are not
+# (`already-red`, `UNPROBEABLE`) must all REFUSE, not pass.
+#
+# Hermetic: fixture corpora and fixture reports in a throwaway dir, `--corpus-dir`
+# pointed at them. Never reads the real tests/ and never invokes the probe.
+#
+# Negative control (run by hand when changing the union script): delete the
+# `[[ "$PROBED" == *" $h "* ]] && continue` line and case 1 reds; drop the
+# `hdr_corpus != ${#corpus[@]}` guard and case 6 reds.
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
+UNION="$PWD/tests/meta/harness-verdict-union.sh"
+[[ -x "$UNION" || -r "$UNION" ]] || { printf 'FAIL: %s not found\n' "$UNION"; exit 1; }
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/hvu.XXXXXX") || exit 2
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+ok()   { PASS=$((PASS+1)); printf 'ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf 'FAIL %s\n     %s\n' "$1" "${2:-}"; }
+check(){ # <name> <expected-rc> <actual-rc> <output>
+  if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1" "expected rc=$2 got rc=$3 — $4"; fi
+}
+
+# A fixture corpus of N harnesses named h1.sh..hN.sh
+mkcorpus() { local d="$TMP/$1" n="$2" i; mkdir -p "$d"; for ((i=1;i<=n;i++)); do : > "$d/h$i.sh"; done; printf '%s' "$d"; }
+# mkreport <file> <corpus-n> <allowlist-csv> <label> <verdict:name>...
+mkreport() {
+  local f="$TMP/$1" cn="$2" al="$3" lb="$4"; shift 4
+  { printf '# harness-verdict-probe report\n# corpus=%s\n# allowlist=%s\n# label=%s\n' "$cn" "$al" "$lb"
+    local spec; for spec in "$@"; do printf '%s\t%s\n' "${spec%%:*}" "${spec#*:}"; done
+  } > "$f"; printf '%s' "$f"
+}
+
+C3=$(mkcorpus c3 3)
+
+# 1. The union covers the corpus even though NEITHER run covers it alone.
+#    This is the whole point: two green runs, different corpora, together complete.
+A=$(mkreport a.txt 3 "" pristine wired:h1.sh wired:h2.sh not-reached:h3.sh)
+B=$(mkreport b.txt 3 "" installed not-reached:h1.sh not-reached:h2.sh wired:h3.sh)
+out=$(bash "$UNION" --corpus-dir="$C3" "$A" "$B" 2>&1); rc=$?
+check "union of two partial environments is full coverage" 0 "$rc" "$out"
+
+# 2. A harness skipped in EVERY environment is the defect DIVE-2018 filed — it must
+#    fail, and it must say which environments skipped it (the old output could not).
+A2=$(mkreport a2.txt 3 "" pristine wired:h1.sh wired:h2.sh not-reached:h3.sh)
+B2=$(mkreport b2.txt 3 "" installed wired:h1.sh wired:h2.sh not-reached:h3.sh)
+out=$(bash "$UNION" --corpus-dir="$C3" "$A2" "$B2" 2>&1); rc=$?
+check "never-probed harness fails the union" 1 "$rc" "$out"
+grep -q 'NEVER PROBED  h3.sh' <<<"$out" && ok "names the never-probed harness" \
+  || bad "names the never-probed harness" "$out"
+grep -q 'pristine=not-reached' <<<"$out" && grep -q 'installed=not-reached' <<<"$out" \
+  && ok "names the verdict in EACH environment" || bad "names the verdict in EACH environment" "$out"
+
+# 3. Allowlisted harnesses are excused — the exemption comes from the REPORT, so the
+#    union never restates an allowlist the probe owns.
+A3=$(mkreport a3.txt 3 "h3.sh" pristine wired:h1.sh wired:h2.sh allowlisted:h3.sh)
+out=$(bash "$UNION" --corpus-dir="$C3" "$A3" 2>&1); rc=$?
+check "allowlisted harness does not fail the union" 0 "$rc" "$out"
+
+# 4. FAIL CLOSED — a missing report must never read as a clean one. This is the
+#    single most important case: in CI a job that died before writing its report
+#    would otherwise silently shrink the union to whatever survived.
+A4=$(mkreport a4.txt 3 "" pristine wired:h1.sh wired:h2.sh wired:h3.sh)
+out=$(bash "$UNION" --corpus-dir="$C3" "$A4" "$TMP/does-not-exist.txt" 2>&1); rc=$?
+check "missing report fails closed even when the others are complete" 1 "$rc" "$out"
+
+# 5. A file that is not a probe report at all (no header) is refused, not parsed
+#    optimistically into zero findings.
+printf 'wired\th1.sh\nwired\th2.sh\nwired\th3.sh\n' > "$TMP/nohdr.txt"
+out=$(bash "$UNION" --corpus-dir="$C3" "$TMP/nohdr.txt" 2>&1); rc=$?
+check "headerless report is refused" 1 "$rc" "$out"
+
+# 6. THE DIVE-2018 SIGNATURE ITSELF: a report describing a different-sized corpus.
+#    135+3+16 and 151+3 were both 154 and nothing said so; here they differ and it does.
+A6=$(mkreport a6.txt 9 "" stale-checkout wired:h1.sh wired:h2.sh wired:h3.sh)
+out=$(bash "$UNION" --corpus-dir="$C3" "$A6" 2>&1); rc=$?
+check "report about a different corpus is refused" 1 "$rc" "$out"
+grep -q 'not about the same code' <<<"$out" && ok "says the reports are not about the same code" \
+  || bad "says the reports are not about the same code" "$out"
+
+# 7. No reports at all is a usage error, not vacuous success.
+out=$(bash "$UNION" --corpus-dir="$C3" 2>&1); rc=$?
+check "zero reports is exit 2, not a green run" 2 "$rc" "$out"
+
+# 8. already-red and UNPROBEABLE are NOT observations of a wired exit status.
+#    Counting either as coverage would excuse a harness twice over.
+A8=$(mkreport a8.txt 3 "" pristine wired:h1.sh already-red:h2.sh UNPROBEABLE:h3.sh)
+out=$(bash "$UNION" --corpus-dir="$C3" "$A8" 2>&1); rc=$?
+check "already-red and UNPROBEABLE do not count as probed" 1 "$rc" "$out"
+grep -q 'NEVER PROBED  h2.sh' <<<"$out" && grep -q 'NEVER PROBED  h3.sh' <<<"$out" \
+  && ok "names both non-observations" || bad "names both non-observations" "$out"
+
+# 9. UNWIRED counts as PROBED — the mutation ran and the harness was measured. It
+#    reds the probe, not the union; the union asks "was it looked at", not "did it pass".
+A9=$(mkreport a9.txt 3 "" pristine wired:h1.sh wired:h2.sh UNWIRED:h3.sh)
+out=$(bash "$UNION" --corpus-dir="$C3" "$A9" 2>&1); rc=$?
+check "UNWIRED is coverage (the probe fails it, not the union)" 0 "$rc" "$out"
+
+# 10. Reports disagreeing on the allowlist is one contract with two authors (DIVE-2004).
+A10=$(mkreport a10.txt 3 "h3.sh" pristine wired:h1.sh wired:h2.sh allowlisted:h3.sh)
+B10=$(mkreport b10.txt 3 "" installed wired:h1.sh wired:h2.sh not-reached:h3.sh)
+out=$(bash "$UNION" --corpus-dir="$C3" "$A10" "$B10" 2>&1); rc=$?
+check "reports disagreeing on the allowlist are refused" 1 "$rc" "$out"
+
+# 11. An empty corpus dir must not report 100% coverage of nothing.
+EMPTY=$(mkcorpus cempty 0)
+A11=$(mkreport a11.txt 0 "" pristine)
+out=$(bash "$UNION" --corpus-dir="$EMPTY" "$A11" 2>&1); rc=$?
+check "empty corpus refuses to declare full coverage" 1 "$rc" "$out"
+
+# 12. A stale allowlist name is drift worth SAYING and not worth reddening — it can
+#     only ever excuse nothing, and a renamed harness turns UNPROBEABLE at the probe.
+A12=$(mkreport a12.txt 3 "gone.sh" pristine wired:h1.sh wired:h2.sh wired:h3.sh)
+out=$(bash "$UNION" --corpus-dir="$C3" "$A12" 2>&1); rc=$?
+check "stale allowlist entry is reported, not fatal" 0 "$rc" "$out"
+grep -q 'stale-allowlist  gone.sh' <<<"$out" && ok "names the stale allowlist entry" \
+  || bad "names the stale allowlist entry" "$out"
+
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/meta/harness-verdict-probe.sh
+++ b/tests/meta/harness-verdict-probe.sh
@@ -168,7 +168,16 @@ if [[ " $ALLOW_UNPROBEABLE " == *" $b "* ]]; then ALLOWED+=("$b"); else UNPROBEA
   # that never reached it is NOT-REACHED, never UNWIRED.
   # (community/wiki/test-harness-credential-reach-and-transcript-durability.md:
   #  a canary proves the extractor RAN; the fixture proves it is still RIGHT.)
-  awk -v n="$ln" -v inj="$inject" 'NR==n{print inj; print "printf \x27__PROBE_REACHED__\\n\x27 >&2"} {print}' "$t" > "$mutant"
+  # DIVE-2018: the canary must print BEFORE the injected mutation, not after.
+  # Its job is to answer "did execution reach the injection point", and placing it
+  # after a statement whose whole purpose is to be FATAL guarantees it cannot: for
+  # the ABORT family the injected `false` under `set -e` terminates the shell on
+  # the spot, so the canary never ran, so EVERY abort-family harness reported
+  # not-reached — in every environment, forever. That is olivia's limit case made
+  # real, and it was 18 harnesses: reported "probed in an environment where it
+  # runs" while no environment ever could. Before it, `set -e` harnesses were
+  # structurally unprobeable and the check was green about it.
+  awk -v n="$ln" -v inj="$inject" 'NR==n{print "printf \x27__PROBE_REACHED__\\n\x27 >&2"; print inj} {print}' "$t" > "$mutant"
   out=$(timeout "$TIMEOUT" bash "$mutant" 2>&1 >/dev/null); rc=$?
   rm -f "$mutant"
   if ! grep -q '__PROBE_REACHED__' <<<"$out"; then

--- a/tests/meta/harness-verdict-probe.sh
+++ b/tests/meta/harness-verdict-probe.sh
@@ -26,10 +26,16 @@
 # so the suite never runs this, and this never recurses into itself.
 set -uo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 2
-ASSUME_CLEAN=0; ONLY=""; TIMEOUT=${PROBE_TIMEOUT:-180}
+ASSUME_CLEAN=0; ONLY=""; REPORT=""; LABEL=""; TIMEOUT=${PROBE_TIMEOUT:-180}
 for a in "$@"; do case "$a" in
   --assume-clean) ASSUME_CLEAN=1 ;;
-  --only=*) ONLY="${a#--only=}" ;;
+  --only=*) ONLY="${a#--only=}" ;;      # one basename, or a comma-separated list
+  # DIVE-2018: a machine-readable verdict per harness, so the UNION of several
+  # environments can be asserted to cover the corpus. NOT-REACHED is correctly not
+  # a failure in any single run (a skip is not an accusation), which is precisely
+  # why no single run can establish coverage — see harness-verdict-union.sh.
+  --report=*) REPORT="${a#--report=}" ;;
+  --label=*)  LABEL="${a#--label=}" ;;  # names the environment in union failures
   *) printf 'unknown arg: %s\n' "$a" >&2; exit 2 ;;
 esac; done
 
@@ -129,9 +135,13 @@ counter_verdict() {   # -> "<var>\t<lineno>\t<last|not-last>"
   return 1
 }
 
+CORPUS_N=0; for t in tests/*.sh; do [[ -e "$t" ]] && CORPUS_N=$(( CORPUS_N + 1 )); done
+only_set=" ${ONLY//,/ } "
 for t in tests/*.sh; do
-  [[ -n "$ONLY" && "$(basename "$t")" != "$ONLY" ]] && continue
   b=$(basename "$t")
+  # --only takes a LIST so a second environment can re-probe exactly the harnesses
+  # the first one skipped, instead of paying for the whole corpus twice.
+  [[ -n "$ONLY" && "$only_set" != *" $b "* ]] && continue
   if (( ! ASSUME_CLEAN )); then
     if ! timeout "$TIMEOUT" bash "$t" >/dev/null 2>&1; then ALREADY_RED+=("$b"); continue; fi
   fi
@@ -177,4 +187,45 @@ for x in "${UNPROBEABLE[@]:-}"; do [[ -n "$x" ]] && printf 'UNPROBEABLE  %s — 
 for x in "${NOT_REACHED[@]:-}";  do [[ -n "$x" ]] && printf 'not-reached  %s — skipped before the verdict here; probed in an environment where it runs\n' "$x"; done
 for x in "${ALLOWED[@]:-}";     do [[ -n "$x" ]] && printf 'allowlisted  %s — unprobeable, permitted by name with a recorded reason\n' "$x"; done
 for x in "${ALREADY_RED[@]:-}"; do [[ -n "$x" ]] && printf 'ALREADY-RED  %s — failed its own clean run; reported, not probed\n' "$x"; done
+
+# DIVE-2018: the machine-readable half. `not-reached` is still not a failure HERE
+# — a skip is not an accusation — so this run cannot establish coverage on its own.
+# It records what it actually observed and lets harness-verdict-union.sh assert the
+# invariant that does hold: every harness is probed in SOME environment.
+# The corpus size and the allowlist travel WITH the verdicts, because the defect
+# this closes is two green runs describing different corpora with nothing saying so.
+if [[ -n "$REPORT" ]]; then
+  {
+    printf '# harness-verdict-probe report — one line per harness observed by THIS run\n'
+    printf '# corpus=%d\n' "$CORPUS_N"
+    printf '# allowlist=%s\n' "${ALLOW_UNPROBEABLE// /,}"
+    printf '# label=%s\n' "${LABEL:-$(uname -n)}"
+    # Basename is field 1 in every array: the annotated entries are "<name> — …"
+    # and "<name> (…)", the rest are bare names.
+    for x in "${WIRED[@]:-}";       do [[ -n "$x" ]] && printf 'wired\t%s\n'        "${x%% *}"; done
+    for x in "${UNWIRED[@]:-}";     do [[ -n "$x" ]] && printf 'UNWIRED\t%s\n'      "${x%% *}"; done
+    for x in "${UNPROBEABLE[@]:-}"; do [[ -n "$x" ]] && printf 'UNPROBEABLE\t%s\n'  "${x%% *}"; done
+    for x in "${ALLOWED[@]:-}";     do [[ -n "$x" ]] && printf 'allowlisted\t%s\n'  "${x%% *}"; done
+    for x in "${NOT_REACHED[@]:-}"; do [[ -n "$x" ]] && printf 'not-reached\t%s\n'  "${x%% *}"; done
+    for x in "${ALREADY_RED[@]:-}"; do [[ -n "$x" ]] && printf 'already-red\t%s\n'  "${x%% *}"; done
+    # Terminating `:` is load-bearing. A brace group's status is its LAST command's,
+    # and every loop above ends on `[[ -n "$x" ]] && printf` — which is FALSE, not an
+    # error, whenever that category is empty. Without this the guard below fired on a
+    # perfectly good report and exited 1: a false failure whose only cause was reading
+    # the wrong exit status, which is the same defect this whole check exists to find,
+    # committed inside the fix for it. With `:`, a failed redirect (bash aborts the
+    # group before running anything) is the only thing that can make this non-zero.
+    :
+  } > "$REPORT" || { printf 'probe: FAILED to write report %s\n' "$REPORT" >&2; exit 1; }
+  # …and corroborate the EFFECT rather than trust that status: a mid-write failure
+  # (full disk) leaves a truncated file that the redirect status cannot see. The row
+  # count must match what we classified, or the report is not usable as evidence.
+  rows=$(grep -cv '^#' "$REPORT")
+  want=$(( ${#WIRED[@]} + ${#UNWIRED[@]} + ${#UNPROBEABLE[@]} + ${#ALLOWED[@]} + ${#NOT_REACHED[@]} + ${#ALREADY_RED[@]} ))
+  if (( rows != want )); then
+    printf 'probe: report %s has %d rows, classified %d — refusing to emit a partial report\n' "$REPORT" "$rows" "$want" >&2
+    exit 1
+  fi
+  printf 'report written: %s (%d harness rows)\n' "$REPORT" "$rows"
+fi
 (( ${#UNWIRED[@]} == 0 && ${#UNPROBEABLE[@]} == 0 ))

--- a/tests/meta/harness-verdict-union.sh
+++ b/tests/meta/harness-verdict-union.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# DIVE-2018: harness-verdict-probe.sh treats NOT-REACHED as neither pass nor fail,
+# and NOT-REACHED is absent from its final condition. That was the right call for
+# the case it was written for — a harness that skips before its verdict has not
+# been shown to be unwired, and calling it UNWIRED is a FALSE ACCUSATION, which is
+# worse than a gap (three correctly-wired harnesses were accused that way on the
+# pristine CI runner). But the consequence is that probe COVERAGE IS SILENTLY
+# ENVIRONMENT-DEPENDENT:
+#
+#   on the control-plane host   135 wired, 0 UNWIRED, 3 allowlisted, 16 not-reached  -> exit 0
+#   on a pristine CI runner     151 wired, 0 UNWIRED, 3 allowlisted,  0 not-reached  -> exit 0
+#
+# 135+3+16 == 151+3 == 154. Both runs are GREEN while probing DIFFERENT CORPORA,
+# and nothing anywhere says so. The limit case is the point: a harness that skips
+# in EVERY environment is reported "probed in an environment where it runs" and no
+# environment ever does. It stays permanently unprobed and the check stays green —
+# succeeding in appearance, which is the exact defect class DIVE-2013 exists to
+# find, one level up in the instrument itself.
+#
+# So the invariant does not belong to any single run. It belongs to the UNION:
+#
+#   every harness in tests/*.sh is PROBED in at least one environment,
+#   or is named in the allowlist with a reason.
+#
+# This script asserts that over one or more probe reports (`--report=<file>`).
+# A skip in one environment is still not an accusation; a skip in ALL of them is
+# now a failure. That keeps the property olivia asked for and closes the hole.
+#
+# PROBED means the mutation EXECUTED — verdict `wired` or `UNWIRED`. Deliberately
+# NOT `already-red` (its clean run failed, so it was reported and never probed)
+# and NOT `UNPROBEABLE` (no identifiable verdict variable; it already reds the
+# probe itself, and counting it as coverage here would excuse it twice).
+#
+# The allowlist is READ FROM THE REPORTS, never restated here. Two allowlists
+# written in two places are one contract with two authors, and when they drift the
+# consumer refuses a state only the producer can mint (DIVE-2004). All reports must
+# agree on it, or that disagreement is itself the finding.
+#
+# FAILS CLOSED. No reports, an unreadable report, a report with no header, or
+# reports that disagree about the size of the corpus are all exit 1 — because the
+# whole premise of this check is that a missing observation must not read as a
+# clean one.
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 2
+
+CORPUS_DIR="tests"
+REPORTS=()
+for a in "$@"; do case "$a" in
+  --corpus-dir=*) CORPUS_DIR="${a#--corpus-dir=}" ;;
+  --*) printf 'unknown arg: %s\n' "$a" >&2; exit 2 ;;
+  *) REPORTS+=("$a") ;;
+esac; done
+
+if (( ${#REPORTS[@]} == 0 )); then
+  printf 'usage: %s [--corpus-dir=<dir>] <probe-report>...\n' "${BASH_SOURCE[0]##*/}" >&2
+  printf '  each report is written by: harness-verdict-probe.sh --report=<file>\n' >&2
+  exit 2
+fi
+
+# The corpus is derived from the tree this script runs in — ONE source of truth,
+# so a report produced from a different checkout is caught by the count below
+# rather than silently shrinking what we claim to cover.
+corpus=()
+for t in "$CORPUS_DIR"/*.sh; do [[ -e "$t" ]] && corpus+=("$(basename "$t")"); done
+if (( ${#corpus[@]} == 0 )); then
+  printf 'union: FAIL — corpus dir %s contains no *.sh; refusing to declare full coverage of nothing\n' "$CORPUS_DIR"
+  exit 1
+fi
+
+PROBED=" "        # space-delimited membership sets, matched as *" name "*
+ALLOWLIST=""
+declare -A VERDICT_BY_ENV=()   # "<harness>|<label>" -> verdict
+LABELS=()
+fail=0
+
+for r in "${REPORTS[@]}"; do
+  if [[ ! -r "$r" ]]; then
+    printf 'union: FAIL — report %s is missing or unreadable; a missing observation is not a clean one\n' "$r"
+    fail=1; continue
+  fi
+  hdr_corpus=$(sed -n 's/^# corpus=\([0-9]\{1,\}\).*/\1/p' "$r" | head -1)
+  hdr_allow=$(sed -n 's/^# allowlist=//p' "$r" | head -1)
+  label=$(sed -n 's/^# label=//p' "$r" | head -1)
+  [[ -n "$label" ]] || label="$r"
+  LABELS+=("$label")
+  if [[ -z "$hdr_corpus" ]]; then
+    printf 'union: FAIL — report %s has no "# corpus=" header; it was not written by harness-verdict-probe --report\n' "$r"
+    fail=1; continue
+  fi
+  if (( hdr_corpus != ${#corpus[@]} )); then
+    printf 'union: FAIL — report %s (%s) describes a corpus of %d harnesses, this tree has %d — the reports are not about the same code\n' \
+      "$r" "$label" "$hdr_corpus" "${#corpus[@]}"
+    fail=1; continue
+  fi
+  # The allowlist is the producer's, and every producer must agree on it.
+  if [[ -z "$ALLOWLIST" ]]; then ALLOWLIST="$hdr_allow"
+  elif [[ "$ALLOWLIST" != "$hdr_allow" ]]; then
+    printf 'union: FAIL — reports disagree on the allowlist (%s) vs (%s); one contract, two authors\n' \
+      "$ALLOWLIST" "$hdr_allow"
+    fail=1
+  fi
+  while IFS=$'\t' read -r verdict name; do
+    [[ -n "${name:-}" ]] || continue
+    VERDICT_BY_ENV["$name|$label"]="$verdict"
+    case "$verdict" in
+      wired|UNWIRED) [[ "$PROBED" == *" $name "* ]] || PROBED+="$name " ;;
+    esac
+  done < <(grep -v '^#' "$r")
+done
+
+(( fail == 0 )) || { printf 'union: refusing to assert coverage from reports that do not agree\n'; exit 1; }
+
+allow_set=" ${ALLOWLIST//,/ } "
+unprobed=()
+for h in "${corpus[@]}"; do
+  [[ "$PROBED"    == *" $h "* ]] && continue
+  [[ "$allow_set" == *" $h "* ]] && continue
+  unprobed+=("$h")
+done
+
+# Stale allowlist entries are drift worth SAYING, not worth reddening: a renamed
+# harness loses its exemption and turns UNPROBEABLE, which reds the probe itself,
+# so this can only ever be a leftover name that excuses nothing.
+for a in ${ALLOWLIST//,/ }; do
+  [[ " ${corpus[*]} " == *" $a "* ]] || printf 'stale-allowlist  %s — named in the allowlist but not in the corpus\n' "$a"
+done
+
+printf 'harness-verdict-union: %d in corpus, %d probed across %d environment(s) [%s], %d allowlisted, %d NEVER PROBED\n' \
+  "${#corpus[@]}" "$(( $(wc -w <<<"$PROBED") ))" "${#LABELS[@]}" "${LABELS[*]}" \
+  "$(wc -w <<<"${ALLOWLIST//,/ }")" "${#unprobed[@]}"
+
+for h in "${unprobed[@]:-}"; do
+  [[ -n "$h" ]] || continue
+  detail=""
+  for l in "${LABELS[@]}"; do detail+=" ${l}=${VERDICT_BY_ENV["$h|$l"]:-absent}"; done
+  printf 'NEVER PROBED  %s —%s; its exit status has never been shown to be wired in ANY environment\n' "$h" "$detail"
+done
+(( ${#unprobed[@]} == 0 ))


### PR DESCRIPTION
## The gap

`NOT-REACHED` is **correctly** not a failure in the DIVE-2013 probe — a harness that skips before its verdict has not been shown to be unwired, and calling it UNWIRED is a false accusation (three correctly-wired files were accused that way on the pristine runner). But it is absent from the final condition, so **no single run can establish that a harness has ever been probed**:

| environment | wired | UNWIRED | allowlisted | not-reached | exit |
|---|---|---|---|---|---|
| control-plane host | 135 | 0 | 3 | 16 | **0** |
| pristine CI runner | 151 | 0 | 3 | 0 | **0** |

Both green, both 154, **probing different corpora, and nothing said so.** The limit case is the point: a harness that skips in *every* environment is reported "probed in an environment where it runs" and no environment ever does. It stays permanently unprobed and the check stays green — succeeding in appearance, one level up, inside the instrument built to find exactly that.

And it bites hardest where it matters: the probe ran **only** in the pristine job, so the harnesses CI never probed were precisely the gate and install paths that need live state.

## The fix — the invariant belongs to the union, not to a run

> every harness in `tests/*.sh` is probed in **at least one** environment, or is allowlisted by name with a reason

A skip in one environment is still not an accusation. A skip in **all** of them is now a failure.

- **probe**: `--report=<file>` (machine-readable verdict per harness, carrying the corpus size and allowlist so two reports about different trees cannot be unioned silently), `--label=`, and `--only=` now takes a comma list so a second environment can re-probe just what the first skipped.
- **new `tests/meta/harness-verdict-union.sh`**: PROBED means the mutation *executed* (`wired|UNWIRED`) — deliberately **not** `already-red` (never probed) or `UNPROBEABLE` (already reds the probe; counting it here would excuse it twice). Reads the allowlist **from the reports**, never restates it: two allowlists in two places is one contract with two authors (DIVE-2004). **Fails closed** on a missing, headerless, or different-corpus report, because the premise of the check is that a missing observation must not read as a clean one.
- **CI**: probe now also runs in `test-installed-host`; new `harness-verdict-union` job `needs: [harness-verdict, test-installed-host]`.

## Verified end-to-end on the real 155-harness corpus, not on fixtures

Real host report (136 wired / 0 UNWIRED / 3 allowlisted / 16 not-reached):

- **one environment only** → `exit 1`, names all **16** with `control-plane-host=not-reached`
- **two environments covering the union** → `exit 0`, `152 probed across 2 environment(s), 0 NEVER PROBED` (this is the CI shape)
- **the limit case** — `ask_capture_live_replay.sh` skipped in *both* → `exit 1`, `control-plane-host=not-reached pristine=absent`

`tests/harness_verdict_union_unit.sh`: **17 assertions**, weighted toward the false-clean direction. Negative controls — dropping the PROBED membership skip reds 4, dropping the corpus-count guard reds 2, making a missing report non-fatal reds 1. Restored: 17/0.

## One defect found while building this, and it is the same class again

`{ ...; } > "$REPORT" ||` read the **last loop's** status, not the redirect's — every category loop ends on `[[ -n "$x" ]] && printf`, which is *false*, not an error, when that category is empty. So a perfectly good report printed `FAILED to write report` and exited 1. Fixed with a terminating `:`, and the row count is now corroborated against what was classified rather than trusting the status at all.

Tests-and-CI only, no `src/` change, so no `FIVE_VERSION` bump — same as DIVE-2013 (#191).

🤖 Generated with [Claude Code](https://claude.com/claude-code)