### PR TITLE
harden the release guards: version-bump-guard + version-uniqueness-scan (DIVE-2071)

### DIFF
--- a/scripts/version-bump-guard.sh
+++ b/scripts/version-bump-guard.sh
@@ -25,6 +25,16 @@
 # only pushes that changed the bundle. A push that touches no source (e.g.
 # workflow/doc-only) leaves 5dive.sha256 unchanged and is exempt from #1.
 #
+# DIVE-2071: assertions 1 and 2 above are both behind `-n "$new_ver"` /
+# `-n "$new_bundle_ver"` / `-n "$new_sha"` guards, so if extraction of any of
+# them from NEW fails (missing file, or the `FIVE_VERSION=` anchor drifted —
+# a rename, a src/ reorg), every assertion above is silently skipped and this
+# script exits 0: clear to push. That is "if present then check", which
+# succeeds at nothing the moment the anchor moves — measured to pass the
+# exact DIVE-2065 incident clean when the anchor is perturbed. Extraction
+# failure at NEW is therefore checked FIRST and unconditionally, as its own
+# loud block, distinct from the two content assertions.
+#
 # Usage: version-bump-guard.sh <new-rev> [<base-rev>=origin/main]
 # Exit 0 = clear to push. Exit 1 = blocked, reason on stderr.
 set -uo pipefail
@@ -51,6 +61,23 @@ new_sha="$(_sha256file "$NEW")"
 base_sha="$(_sha256file "$BASE" 2>/dev/null || true)"
 
 fail=0
+
+# Extraction failure at NEW != clean. Checked first, unconditionally, with a
+# message distinct from the content-mismatch assertions below — an anchor
+# that can't be found is a different failure than an anchor that disagrees,
+# and folding them into one message would bury the drift signal.
+if [[ -z "$new_ver" ]]; then
+  echo "version-bump-guard: BLOCKED — could not extract FIVE_VERSION from src/header.sh at $NEW (missing file, or the 'readonly FIVE_VERSION=' anchor no longer matches). Extraction failure is not the same as a clean bundle — investigate before overriding." >&2
+  fail=1
+fi
+if [[ -z "$new_bundle_ver" ]]; then
+  echo "version-bump-guard: BLOCKED — could not extract FIVE_VERSION from the committed 5dive bundle at $NEW (missing file, or the anchor no longer matches)." >&2
+  fail=1
+fi
+if [[ -z "$new_sha" ]]; then
+  echo "version-bump-guard: BLOCKED — could not read 5dive.sha256 at $NEW (missing or empty)." >&2
+  fail=1
+fi
 
 if [[ -n "$new_ver" && -n "$new_bundle_ver" && "$new_ver" != "$new_bundle_ver" ]]; then
   echo "version-bump-guard: BLOCKED — src/header.sh declares FIVE_VERSION=$new_ver but the committed 5dive bundle embeds $new_bundle_ver." >&2

--- a/scripts/version-uniqueness-scan.sh
+++ b/scripts/version-uniqueness-scan.sh
@@ -17,6 +17,15 @@
 # run against a wider range so it also catches a TOCTOU race between two
 # pushes that each looked clear against a now-stale base.
 #
+# DIVE-2071: every assertion below is behind `[[ -z "$ver" ]] && continue` /
+# `[[ -z "$sha" ]] && continue` — "if present then check", which is silently
+# vacuous the moment the `FIVE_VERSION=` anchor drifts (a rename, a src/
+# reorg). Measured to pass the real DIVE-2065 incident clean under a
+# perturbed anchor. So extraction at the tip (NEW) is asserted first and
+# unconditionally, distinct from the per-commit skip-on-empty in the sweep
+# below (which is deliberately tolerant of *historical* commits that never
+# had these files, per this script's own scoping note above).
+#
 # Usage: version-uniqueness-scan.sh <new-ref> [<base-ref>=origin/main]
 # Exit 0 = no new collision. Exit 1 = collision, detail on stderr.
 set -uo pipefail
@@ -32,7 +41,20 @@ _ver() {
 _sha256file() { git show "$1:5dive.sha256" 2>/dev/null; }
 
 fail=0
-declare -A base_shas   # version -> newline-joined set of 5dive.sha256 contents seen
+
+new_tip_ver="$(_ver "$NEW")"
+new_tip_sha="$(_sha256file "$NEW")"
+if [[ -z "$new_tip_ver" ]]; then
+  echo "version-uniqueness: BLOCKED — could not extract FIVE_VERSION from src/header.sh at $NEW (missing file, or the 'readonly FIVE_VERSION=' anchor no longer matches). Extraction failure is not the same as a clean scan." >&2
+  fail=1
+fi
+if [[ -z "$new_tip_sha" ]]; then
+  echo "version-uniqueness: BLOCKED — could not read 5dive.sha256 at $NEW (missing or empty)." >&2
+  fail=1
+fi
+
+declare -A base_shas    # version -> newline-joined set of 5dive.sha256 contents seen
+declare -A first_owner  # version -> "source|commit" of the first commit recorded for it
 
 _seen() {  # _seen "$version" "$sha" -> 0 if already recorded
   case $'\n'"${base_shas[$1]:-}"$'\n' in
@@ -40,14 +62,17 @@ _seen() {  # _seen "$version" "$sha" -> 0 if already recorded
     *) return 1 ;;
   esac
 }
-_record() { base_shas[$1]="${base_shas[$1]:-}"$'\n'"$2"; }
+_record() {  # _record "$version" "$sha" "$source" "$commit"
+  base_shas[$1]="${base_shas[$1]:-}"$'\n'"$2"
+  [[ -n "${first_owner[$1]:-}" ]] || first_owner[$1]="$3|$4"
+}
 
 # Phase 1: everything already accepted on BASE — build the lookup, report nothing.
 while read -r commit; do
   [[ -z "$commit" ]] && continue
   ver="$(_ver "$commit")"; [[ -z "$ver" ]] && continue
   sha="$(_sha256file "$commit")"; [[ -z "$sha" ]] && continue
-  _seen "$ver" "$sha" || _record "$ver" "$sha"
+  _seen "$ver" "$sha" || _record "$ver" "$sha" base "$commit"
 done < <(git log --format=%H "$BASE" -- src/header.sh 5dive.sha256 2>/dev/null)
 
 # Phase 2: only the commits this range is introducing.
@@ -56,11 +81,19 @@ while read -r commit; do
   ver="$(_ver "$commit")"; [[ -z "$ver" ]] && continue
   sha="$(_sha256file "$commit")"; [[ -z "$sha" ]] && continue
   if [[ -n "${base_shas[$ver]:-}" ]] && ! _seen "$ver" "$sha"; then
-    echo "version-uniqueness: $commit claims FIVE_VERSION $ver, already used on $BASE with a DIFFERENT bundle." >&2
+    prior="${first_owner[$ver]}"
+    prior_source="${prior%%|*}"
+    prior_commit="${prior#*|}"
+    if [[ "$prior_source" == base ]]; then
+      where="already used on $BASE (commit $prior_commit) with a DIFFERENT bundle"
+    else
+      where="already used earlier in this range by $prior_commit (before $BASE..$NEW reaches $commit) with a DIFFERENT bundle"
+    fi
+    echo "version-uniqueness: $commit claims FIVE_VERSION $ver, $where." >&2
     echo "  $commit: 5dive.sha256=$sha" >&2
     fail=1
   fi
-  _seen "$ver" "$sha" || _record "$ver" "$sha"
+  _seen "$ver" "$sha" || _record "$ver" "$sha" range "$commit"
 done < <(git log --format=%H --reverse "$BASE..$NEW" -- src/header.sh 5dive.sha256 2>/dev/null)
 
 exit $fail

--- a/tests/version_bump_guard_unit.sh
+++ b/tests/version_bump_guard_unit.sh
@@ -61,6 +61,32 @@ commit_unrelated() {
   git rev-parse HEAD
 }
 
+# commit_missing_header BUNDLE_VERSION SHA_CONTENT MSG -> src/header.sh does
+# not exist at all (DIVE-2071 proof (a): extraction from NEW is impossible).
+commit_missing_header() {
+  rm -rf src
+  printf '#!/usr/bin/env bash\nreadonly FIVE_VERSION="%s"\necho hi\n' "$1" > 5dive
+  printf '%s\n' "$2" > 5dive.sha256
+  git add -A >/dev/null
+  git commit -q -m "$3"
+  git rev-parse HEAD
+}
+
+# commit_drifted_header VERSION BUNDLE_VERSION SHA_CONTENT MSG -> src/header.sh
+# uses a renamed identifier (FIVE_VERSION_XX) so the guards' `FIVE_VERSION=`
+# anchor can no longer find it, simulating a rename or a src/ reorg
+# (DIVE-2071 proof (b)). The bundle's own anchor is left intact so this
+# isolates the header-extraction failure specifically.
+commit_drifted_header() {
+  mkdir -p src
+  printf 'readonly FIVE_VERSION_XX="%s"\n' "$1" > src/header.sh
+  printf '#!/usr/bin/env bash\nreadonly FIVE_VERSION="%s"\necho hi\n' "$2" > 5dive
+  printf '%s\n' "$3" > 5dive.sha256
+  git add -A >/dev/null
+  git commit -q -m "$4"
+  git rev-parse HEAD
+}
+
 c0="$(commit_release 0.1.0 0.1.0 shaA "init 0.1.0")"
 # incident shape: bundle rebuilt (new content, new sha) but version NOT bumped
 c1="$(commit_release 0.1.0 0.1.0 shaB "follow-up: bundle rebuilt, version bump silently failed")"
@@ -123,6 +149,80 @@ bash "$BUMP_GUARD" "$c1" "$c1" >/dev/null 2>&1
 assert_exit "bump-guard: sanity — comparing a commit against itself never blocks" 0 "$?"
 bash "$UNIQ_SCAN" "$c1" "$c1" >/dev/null 2>&1
 assert_exit "uniqueness-scan: sanity — comparing a commit against itself never blocks" 0 "$?"
+
+# --- DIVE-2071: extraction failure at NEW must block loudly, not fail open ---
+# Proof (a): NEW is missing src/header.sh outright. Pre-fix this returned
+# rc=0 — every content assertion is behind `-n "$new_ver"`, so an empty
+# extraction skipped both of them and the guard reported "clear to push".
+git checkout -q "$c2"
+c6="$(commit_missing_header 0.1.2 shaE "src/header.sh deleted (extraction impossible)")"
+
+out="$(bash "$BUMP_GUARD" "$c6" "$c2" 2>&1)"; rc=$?
+assert_exit "bump-guard: blocks when src/header.sh is missing at NEW (was fail-open)" 1 "$rc"
+if [[ "$out" == *"could not extract FIVE_VERSION from src/header.sh"* ]]; then
+  ok_t "bump-guard: missing-header failure gets its own distinct message"
+else
+  bad_t "bump-guard: missing-header failure gets its own distinct message" "$out"
+fi
+
+out="$(bash "$UNIQ_SCAN" "$c6" "$c2" 2>&1)"; rc=$?
+assert_exit "uniqueness-scan: blocks when src/header.sh is missing at NEW (was fail-open)" 1 "$rc"
+
+# Proof (b): the FIVE_VERSION anchor in src/header.sh has drifted (renamed),
+# run against the REAL incident shape (same version, bundle rebuilt with
+# different content). Pre-fix this also returned rc=0 — it "silently passes
+# the exact bug it exists to catch" once the anchor can't be found, for
+# either commit in the pair.
+git checkout -q "$c0"
+d0="$(commit_drifted_header 0.1.0 0.1.0 shaA "init 0.1.0, but header anchor already renamed")"
+git checkout -q "$d0"
+d1="$(commit_drifted_header 0.1.0 0.1.0 shaB "bundle rebuilt, version bump silently failed, anchor still renamed")"
+
+out="$(bash "$BUMP_GUARD" "$d1" "$d0" 2>&1)"; rc=$?
+assert_exit "bump-guard: blocks the incident even when the FIVE_VERSION anchor drifted (was fail-open)" 1 "$rc"
+
+out="$(bash "$UNIQ_SCAN" "$d1" "$d0" 2>&1)"; rc=$?
+assert_exit "uniqueness-scan: blocks the incident even when the FIVE_VERSION anchor drifted (was fail-open)" 1 "$rc"
+
+# --- DIVE-2071: name the actual colliding commit; do not always blame $BASE --
+# Genuine intra-range collision: BOTH claims of the version are introduced by
+# this range itself, with no instance on BASE at all. The pre-fix message
+# unconditionally said "already used on $BASE", which is wrong here — the
+# prior claim is another NEW commit, not history reachable from BASE.
+git checkout -q "$c2"
+e0="$(commit_release 0.5.0 0.5.0 shaX "unrelated baseline, 0.5.0")"
+e1="$(commit_release 0.6.0 0.6.0 shaY "first claim of 0.6.0, introduced by this range")"
+e2="$(commit_release 0.6.0 0.6.0 shaZ "second claim of 0.6.0, different bundle, same range")"
+
+out="$(bash "$UNIQ_SCAN" "$e2" "$e0" 2>&1)"; rc=$?
+assert_exit "uniqueness-scan: catches a genuine intra-range collision" 1 "$rc"
+if [[ "$out" == *"earlier in this range"* && "$out" == *"$e1"* ]]; then
+  ok_t "uniqueness-scan: intra-range collision names the earlier NEW commit"
+else
+  bad_t "uniqueness-scan: intra-range collision names the earlier NEW commit" "$out"
+fi
+if [[ "$out" != *"already used on $e0"* ]]; then
+  ok_t "uniqueness-scan: intra-range collision does not misattribute the prior claim to \$BASE"
+else
+  bad_t "uniqueness-scan: intra-range collision does not misattribute the prior claim to \$BASE" "$out"
+fi
+
+# Control: when the prior claim genuinely lives further back in BASE's own
+# history than BASE's tip (a docs-only commit sits on top, touching neither
+# file), the message must name the ORIGINAL claiming commit, not just repeat
+# the literal $BASE argument.
+git checkout -q "$c0"
+g_base_tip="$(commit_unrelated "docs-only commit on top of 0.1.0, BASE tip")"
+git checkout -q "$g_base_tip"
+g1="$(commit_release 0.1.0 0.1.0 shaB "reuse 0.1.0 with a different bundle")"
+
+out="$(bash "$UNIQ_SCAN" "$g1" "$g_base_tip" 2>&1)"; rc=$?
+assert_exit "uniqueness-scan: catches a collision whose origin predates BASE's own tip" 1 "$rc"
+if [[ "$out" == *"already used on $g_base_tip"* && "$out" == *"$c0"* ]]; then
+  ok_t "uniqueness-scan: names the actual historical commit, not just the BASE argument"
+else
+  bad_t "uniqueness-scan: names the actual historical commit, not just the BASE argument" "$out"
+fi
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 (( FAIL == 0 ))


### PR DESCRIPTION
Hardening follow-up on the guards shipped in DIVE-2065, gate-approved by olivia, authored by dev2 (delegated push; no gh auth on their side).

Scope is deliberately narrow: `scripts/version-bump-guard.sh`, `scripts/version-uniqueness-scan.sh` and `tests/version_bump_guard_unit.sh`. **No src/ change and no bundle change, so no version bump** — the first branch delivered under the restored convention (CONTRIBUTING: don't bump in a PR; the version is assigned at merge).

Verified before opening: descends from current main, author `lodar`, bundle files changed = 0, and `FIVE_VERSION` identical to main's 0.16.7 rather than reserved ahead.