### PR TITLE
test(proof): the 'cron does not launder the refusal' assertion was vacuous — make it survive its own mutation (DIVE-2100)

### DIFF
--- a/tests/proof_identity_guard_unit.sh
+++ b/tests/proof_identity_guard_unit.sh
@@ -181,6 +181,14 @@ publish_rc_for() {
   && ok_t "refusal and no-op do not converge on one exit code" || bad_t "codes converged"
 # And the cron driver must not launder the refusal into success the way it
 # legitimately does for the no-op.
+#
+# DIVE-2100: these two grade _proof_tick's MAPPING TABLE in isolation — they stub
+# _proof_publish and feed it a LITERAL rc, so they say nothing about which rc the
+# real refusal actually produces. Named accordingly. The end-to-end property
+# ("a no-identity box fails its nightly cron") is asserted below, unstubbed,
+# because the literal 4 here is a restatement of the coupling, not a test of it:
+# a future renumbering of the refusal code that dutifully updates the assertions
+# above would leave this pair grading a code nothing returns — green and vacuous.
 tick_rc_for() {
   ( _FAKE_RC="$1"
     _proof_publish() { return "$_FAKE_RC"; }
@@ -189,10 +197,39 @@ tick_rc_for() {
     _proof_tick >/dev/null 2>&1 ) ; echo $?
 }
 [[ "$(tick_rc_for 3)" == "0" ]] \
-  && ok_t "cron tick maps the no-op to success (unchanged)" || bad_t "tick no-op" "got=$(tick_rc_for 3)"
+  && ok_t "tick mapping table: rc 3 -> success (unit, stubbed publish)" || bad_t "tick no-op" "got=$(tick_rc_for 3)"
 [[ "$(tick_rc_for 4)" != "0" ]] \
-  && ok_t "cron tick does NOT launder the refusal into a healthy night" \
-  || bad_t "tick laundered refusal" "got=$(tick_rc_for 4)"
+  && ok_t "tick mapping table: rc 4 stays non-zero (unit, stubbed publish)" \
+  || bad_t "tick laundered rc 4" "got=$(tick_rc_for 4)"
+
+# --- Case 10: END-TO-END — a no-identity box FAILS its nightly cron ----------
+# DIVE-2100. The property the whole DIVE-2051 fix exists to guarantee, asserted
+# as ONE unbroken chain instead of two halves joined by a literal:
+#   real _proof_identity -> real _proof_build guard -> real _proof_publish rc
+#   mapping -> real _proof_tick mapping -> non-zero.
+# Nothing is stubbed. `_PROOF_GATE_SKIP=1` is production's own seam for the OSS-39
+# approval gate (cmd_proof.sh:203), not a test double, and the repo points at the
+# unreachable file:// url so `git ls-remote` fails locally with no network — the
+# guard fires long before either matters.
+# Renumber `return 4` in _proof_build to ANY value _proof_tick maps to success and
+# this reds by name; that is the regression this case exists for.
+tick_rc_real() {
+  ( git config --global --unset user.name  2>/dev/null
+    git config --global --unset user.email 2>/dev/null
+    printf '{"enabled":true,"repo":"%s","branch":"status"}\n' "$UNREACHABLE" > "$STATE_DIR/proof.json"
+    export _PROOF_GATE_SKIP=1
+    _proof_tick >/dev/null 2>"$TMP/tick-err" ) ; echo $?
+}
+RC="$(tick_rc_real)"
+[[ "$RC" != "0" ]] \
+  && ok_t "END-TO-END: a no-identity box fails its nightly cron (nothing stubbed)" \
+  || bad_t "end-to-end tick laundered the refusal" "rc=$RC err=$(head -3 "$TMP/tick-err")"
+# …and it must fail for the IDENTITY reason. Without this, any incidental error
+# (missing jq, an unrelated fail) would satisfy the assertion above for the wrong
+# reason — and deleting the guard outright would read as a pass.
+grep -q "NO GIT IDENTITY CONFIGURED" "$TMP/tick-err" \
+  && ok_t "END-TO-END: the cron failure is the identity refusal, not an incidental error" \
+  || bad_t "end-to-end failure reason" "err=$(head -5 "$TMP/tick-err")"
 
 echo
 echo "passed: $PASS  failed: $FAIL"


### PR DESCRIPTION
**Tests-only. `src/` and the bundle are byte-identical to main** — verified: 0 non-test files changed, branch bundle sha == main's (`cecb81f7`). No version bump owed.

The assertion named *'cron tick does NOT launder the refusal into a healthy night'* **survived the exact mutation it was named for.** It stubbed `_proof_publish` and asserted a literal `rc 4`, so it graded the mapping in isolation and never touched the real refusal — the end-to-end property was split in two with the constant duplicated on both sides. A future renumbering that updated one side would have shipped the silent-failure bug with a green suite.

Fixed by adding an unstubbed end-to-end case plus a stderr reason-check, and **renaming the two stubbed assertions to their real (unit) scope** rather than deleting them — they test something, just not what their names claimed.

**Proof bar, reproduced independently by me:** pristine 24/0. Mutating  →  reds *'END-TO-END: a no-identity box fails its nightly cron'* **by name**. dev3's full matrix: 4→3 gives 20/4, 4→0 gives 20/4, never-fires 17/7, always-fires 23/1.

**Author:** dev3. **Stated residual:** verified non-root only (their sudo is scoped to the CLI); the new case is uid-independent by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)