### PR TITLE
test: the DIVE-2072 rule-2 assertion graded interpolation, not message distinctness

### DIFF
--- a/tests/hook_staleness_unit.sh
+++ b/tests/hook_staleness_unit.sh
@@ -74,9 +74,18 @@ D2=$(mkrepo e2); git -C "$D2" checkout -q --orphan orphan; git -C "$D2" rm -rqf 
 echo z > "$D2/z"; git -C "$D2" add -A; git -C "$D2" commit -qm orphan
 run "$D2" HEAD main; rc=$?
 (( rc == 2 )) && ok_t "E unrelated histories also exit 2" || bad_t "E orphan" "rc=$rc $(cat "$TMP/err")"
-[[ "$(cat "$TMP/err")" != "$E1" ]] \
-  && ok_t "E the two UNDETERMINED causes emit DIFFERENT messages (rule 2: not folded)" \
-  || bad_t "E folded messages" "a missing ref and unrelated histories read identically — the rare one hides in the routine one"
+# olivia, verifying DIVE-2072: the first version of this compared the two runs
+# RAW — and they use different MAIN_REF values ('nonexistent-ref' vs 'main'), so
+# the interpolated ref name ALONE made the strings differ. It graded string
+# interpolation, not message distinctness, and stayed GREEN under a mutation that
+# folded both causes into one shared template. Normalise the quoted ref out of
+# both before comparing, so only the TEMPLATE is under test.
+norm_ref() { sed "s/'[^']*'/'REF'/g"; }
+E1N=$(printf '%s' "$E1" | norm_ref)
+E2N=$(norm_ref < "$TMP/err")
+[[ "$E2N" != "$E1N" ]] \
+  && ok_t "E the two UNDETERMINED causes emit DIFFERENT message TEMPLATES (rule 2: not folded)" \
+  || bad_t "E folded messages" "a missing ref and unrelated histories read identically once the ref name is normalised out — the rare one hides in the routine one"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" == 0 ]]


### PR DESCRIPTION
Follow-up to #219, which merged at `6bd9ca6` before this landed.

**Found by olivia verifying DIVE-2072.** Her M5 folded both `UNDETERMINED` causes into one shared template and the harness stayed **12/12 green**.

The assertion compared the two runs **raw** — and they use different `MAIN_REF` values (`nonexistent-ref` vs `main`), so the interpolated ref name alone made the strings differ. It was grading string *interpolation* while claiming to grade message *distinctness*: an assertion written for rule 2 in a form that structurally could not detect a rule-2 violation.

Fix normalises the quoted refs out of both, so only the template is compared. Verified against the real mutation — a full two-line fold now reds `E folded messages`; restored, 12/12.

## A third mutation failure mode, worth recording

My first attempt to reproduce olivia's M5 folded only the **first** of the two lines, and the harness stayed green. That was *correct* — the second lines still differed, so it wasn't a fold, it was an edit near one.

So a mutation that **under-applies** is indistinguishable from a surviving one, and it defeats every land-assertion we have: the diff is non-empty, the anchor matched, the tree changed. It just didn't reproduce the defect. That's distinct from the two VOID cases (never landed / pattern never matched), which land-assertions *do* catch.

**A mutation is evidence only if it reproduces the defect, not if it merely edits near it.** Non-empty diff is necessary, not sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)