### PR TITLE
ci: perform the version assignment the merge rule describes and nothing owns (DIVE-2118)

### DIFF
--- a/.github/workflows/bundle-drift.yml
+++ b/.github/workflows/bundle-drift.yml
@@ -7,6 +7,14 @@ on:
   pull_request:
   push:
     branches: ['**']
+  # DIVE-2118: dispatchable, so version-assign can trigger this after its own push.
+  # A GITHUB_TOKEN push does NOT trigger workflows; workflow_dispatch is GitHub's
+  # documented exception ("workflow_dispatch and repository_dispatch events always
+  # create workflow runs"), which is what makes version-assign's loop-safety and its
+  # commit-must-be-graded requirement compatible.
+  # NOTE this ONE file carries BOTH the drift check and the version-uniqueness job,
+  # so a single dispatch grades both — they are not two workflows.
+  workflow_dispatch:
 
 jobs:
   check:

--- a/.github/workflows/version-assign.yml
+++ b/.github/workflows/version-assign.yml
@@ -20,7 +20,8 @@ on:
   push:
     branches: [main]
 
-# Serialise: two merges landing together must not both compute the same successor.
+# Serialise the RUNS. Necessary, and provably not sufficient — see the retry loop
+# below: a human merge is not a member of this group.
 concurrency:
   group: version-assign-main
   cancel-in-progress: false
@@ -29,13 +30,17 @@ jobs:
   assign:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write   # push the assignment commit to main
+      actions: write    # dispatch bundle-drift afterwards (see GRADED, below)
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Assign a version if the bundle moved without one
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          set -uo pipefail
           before="${{ github.event.before }}"
           zero="0000000000000000000000000000000000000000"
           if [[ -z "$before" || "$before" == "$zero" ]] || ! git cat-file -e "$before" 2>/dev/null; then
@@ -44,17 +49,43 @@ jobs:
           fi
           git config user.name  'lodar'
           git config user.email 'markounik@gmail.com'
-          out=$(bash scripts/version-assign.sh HEAD "$before" --apply); rc=$?
-          echo "$out"
-          if (( rc == 2 )); then
-            echo "::error::version-assign could not determine whether a bump is owed — NOT a pass, see above."
-            exit 1
-          fi
-          if ! grep -q '^version-assign: applied ' <<<"$out"; then
-            exit 0   # nothing owed; the reason is printed above
-          fi
-          git add src/header.sh 5dive 5dive.sha256
-          git commit -q -m "release: assign $(grep -m1 -oE 'FIVE_VERSION=\"[^\"]+\"' src/header.sh | sed 's/.*\"\(.*\)\"/\1/') at merge (DIVE-2118, automated)
+
+          # THE RACE, and why `concurrency` alone does not close it (found in review,
+          # iteration 1). concurrency serialises RUNS — but a human MERGE is not in the
+          # group, and actions/checkout on a push event pins to github.sha, NOT main's
+          # tip. So if a merge lands between this job's checkout and its push, the push
+          # is non-fast-forward and the job dies. It is a WINDOW, not a certainty (a
+          # merge landing after we push is fine, and that run computes correctly), but
+          # it is likeliest in exactly the batched-merge scenario this job exists for.
+          # So: refetch, recompute against the moved tip, retry, and fail loudly.
+          #
+          # BASE stays github.event.before across retries, deliberately. If a previous
+          # run already assigned, the version HAS moved relative to that base, so the
+          # script reports "already moved" and we stop — one version per batch, which
+          # is the batching lodar wants. If nobody assigned, we assign once for the
+          # whole batch. Both are correct; neither double-bumps.
+          attempts=3
+          assigned=""
+          for (( try=1; try<=attempts; try++ )); do
+            git fetch -q origin main
+            tip=$(git rev-parse FETCH_HEAD)
+            if [[ "$tip" != "$(git rev-parse HEAD)" ]]; then
+              echo "version-assign: main moved to ${tip:0:12} since checkout (attempt $try/$attempts) — recomputing against the new tip."
+              git reset -q --hard "$tip"
+            fi
+
+            out=$(bash scripts/version-assign.sh HEAD "$before" --apply); rc=$?
+            echo "$out"
+            if (( rc == 2 )); then
+              echo "::error::version-assign could not determine whether a bump is owed — NOT a pass, see above."
+              exit 1
+            fi
+            if ! grep -q '^version-assign: applied ' <<<"$out"; then
+              exit 0   # nothing owed; the reason is printed above
+            fi
+
+            git add src/header.sh 5dive 5dive.sha256
+            git commit -q -m "release: assign $(grep -m1 -oE 'FIVE_VERSION=\"[^\"]+\"' src/header.sh | sed 's/.*\"\(.*\)\"/\1/') at merge (DIVE-2118, automated)
 
           The bundle changed on main without FIVE_VERSION moving. CONTRIBUTING
           assigns the version at merge by merge order; this performs that step so a
@@ -63,5 +94,35 @@ jobs:
           triggered — DIVE-2065).
 
           No tag and no release: those are batched, deliberately (lodar, 2026-07-26)."
-          git push origin HEAD:main
-          echo "::notice::assigned $(grep -m1 -oE 'FIVE_VERSION=\"[^\"]+\"' src/header.sh) — no tag cut, releases are batched"
+
+            if git push origin HEAD:main; then
+              assigned=$(grep -m1 -oE 'FIVE_VERSION="[^"]+"' src/header.sh | sed 's/.*"\(.*\)"/\1/')
+              break
+            fi
+            echo "version-assign: push rejected — main moved under us (attempt $try/$attempts). Dropping the local assignment and recomputing."
+            git reset -q --hard "$tip"
+          done
+
+          if [[ -z "$assigned" ]]; then
+            echo "::error::version-assign: main kept moving across $attempts attempts, so NO assignment was made and the bundle on main is still unassigned. Bump by hand (scripts/version-assign.sh HEAD <prev> --apply) or re-run this workflow."
+            exit 1
+          fi
+          echo "::notice::assigned ${assigned} — no tag cut, releases are batched"
+
+          # GRADED. A GITHUB_TOKEN push does not trigger workflows, so the assignment
+          # commit would otherwise never be seen by CI — leaving this job's own output
+          # ungraded, which is the exact shape of hole this ticket is about.
+          # workflow_dispatch is GitHub's documented exception and DOES create runs.
+          # bundle-drift.yml carries BOTH the drift check and the version-uniqueness
+          # job, so one dispatch grades both: they are one workflow, not two.
+          #
+          # HONEST CAVEAT, so nobody over-reads the resulting run: a dispatch targets a
+          # REF, not a sha. It grades main's TIP AT DISPATCH TIME — normally this
+          # commit, but whatever landed since if another merge beat us to it. Arguably
+          # the more useful subject, but it is not a per-sha attestation.
+          if gh workflow run bundle-drift.yml --ref main; then
+            echo "::notice::dispatched bundle-drift (drift + version-uniqueness) against main's tip"
+          else
+            echo "::error::THE ASSIGNMENT LANDED — ${assigned} is pushed to main and main is assigned, NOT broken. What failed is the follow-up dispatch, so this commit is UNGRADED by CI: re-run bundle-drift on main by hand."
+            exit 1
+          fi

--- a/.github/workflows/version-assign.yml
+++ b/.github/workflows/version-assign.yml
@@ -1,0 +1,67 @@
+# DIVE-2118: perform the version assignment the merge rule describes and nothing owns.
+#
+# CONTRIBUTING says a PR must not bump FIVE_VERSION — it is assigned at MERGE, by
+# merge order. Everyone follows the prohibition; nobody performs the assignment.
+# On 2026-07-26, #218/#219/#220/#221 all merged claiming 0.16.19, a version already
+# published against a different bundle. The shared-checkout updater keys off
+# FIVE_VERSION, so until a human noticed, every box kept its old binary and received
+# NONE of those fixes.
+#
+# version-uniqueness already DETECTS this, and stays. It is a post-hoc detector on a
+# shared branch: it turns main red and hands cleanup to whoever notices. This job is
+# the performer, so the detector should stop having anything to find.
+#
+# BUMP YES, TAG NO. lodar froze GitHub releases 2026-07-26 (36 versions in ~36h).
+# The freeze is on the TAG, explicitly not the bump — the bump prevents two merges
+# claiming one version and keeps the installed-bundle-matches-its-commit selfcheck
+# honest. This job MUST NEVER create a tag or a release.
+name: version-assign
+on:
+  push:
+    branches: [main]
+
+# Serialise: two merges landing together must not both compute the same successor.
+concurrency:
+  group: version-assign-main
+  cancel-in-progress: false
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Assign a version if the bundle moved without one
+        run: |
+          before="${{ github.event.before }}"
+          zero="0000000000000000000000000000000000000000"
+          if [[ -z "$before" || "$before" == "$zero" ]] || ! git cat-file -e "$before" 2>/dev/null; then
+            echo "version-assign: no usable previous main tip (new branch or force event) — skipping."
+            exit 0
+          fi
+          git config user.name  'lodar'
+          git config user.email 'markounik@gmail.com'
+          out=$(bash scripts/version-assign.sh HEAD "$before" --apply); rc=$?
+          echo "$out"
+          if (( rc == 2 )); then
+            echo "::error::version-assign could not determine whether a bump is owed — NOT a pass, see above."
+            exit 1
+          fi
+          if ! grep -q '^version-assign: applied ' <<<"$out"; then
+            exit 0   # nothing owed; the reason is printed above
+          fi
+          git add src/header.sh 5dive 5dive.sha256
+          git commit -q -m "release: assign $(grep -m1 -oE 'FIVE_VERSION=\"[^\"]+\"' src/header.sh | sed 's/.*\"\(.*\)\"/\1/') at merge (DIVE-2118, automated)
+
+          The bundle changed on main without FIVE_VERSION moving. CONTRIBUTING
+          assigns the version at merge by merge order; this performs that step so a
+          box on the previous version is not silently left without the merged fixes
+          (the shared-checkout updater is version-triggered, not content-hash
+          triggered — DIVE-2065).
+
+          No tag and no release: those are batched, deliberately (lodar, 2026-07-26)."
+          git push origin HEAD:main
+          echo "::notice::assigned $(grep -m1 -oE 'FIVE_VERSION=\"[^\"]+\"' src/header.sh) — no tag cut, releases are batched"

--- a/scripts/version-assign.sh
+++ b/scripts/version-assign.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# DIVE-2118: PERFORM the version assignment that the merge rule describes and
+# nothing owns.
+#
+# CONTRIBUTING says a PR must not bump FIVE_VERSION — the version is assigned at
+# MERGE, by merge order. The prohibition half is understood and followed; the
+# PERFORMANCE half is done by nobody. Measured 2026-07-26: #218, #219, #220 and
+# #221 all merged claiming 0.16.19, a version already published against a
+# DIFFERENT bundle. version-uniqueness caught it on the push to main and turned
+# main red, which is the job working — but it is a POST-HOC detector on a shared
+# branch, so it imposes cleanup on whoever notices, and until then the shared
+# checkout updater (which is VERSION-triggered, not content-hash triggered) keeps
+# every box on its old binary and silently delivers none of the merged fixes.
+#
+# This is the exact inverse of scripts/version-bump-guard.sh: the SAME predicate,
+# used to repair instead of to refuse. Deliberately not forked into a new rule —
+# if the guard's notion of "the bundle changed" ever moves, this must move with it.
+#
+# BUMP YES, TAG NO. lodar froze GitHub releases on 2026-07-26 (36 versions in ~36
+# hours, 26 of them fixes) — but froze the TAG, explicitly not the bump: the bump
+# is load-bearing (it prevents two merges claiming one version, and it keeps the
+# installed-bundle-matches-its-commit selfcheck honest). So this script bumps,
+# and must NEVER create a tag or a GitHub release.
+#
+# Usage: version-assign.sh <new-rev> [<base-rev>] [--apply]
+# Exit:  0 = no assignment needed (prints why) or assignment computed/applied
+#        2 = could not determine (NOT a pass — never silently skip)
+set -uo pipefail
+
+NEW="${1:?usage: version-assign.sh <new-rev> [<base-rev>] [--apply]}"
+BASE="${2:-}"
+APPLY=0
+for a in "$@"; do [[ "$a" == "--apply" ]] && APPLY=1; done
+[[ "$BASE" == "--apply" ]] && BASE=""
+BASE="${BASE:-${NEW}^}"
+
+ver_at() { git show "$1:src/header.sh" 2>/dev/null | grep -m1 -oE '^readonly FIVE_VERSION="[^"]+"' | sed 's/.*"\(.*\)"/\1/'; }
+sha_at() { git show "$1:5dive.sha256" 2>/dev/null | cut -d' ' -f1; }
+
+if ! git rev-parse --verify --quiet "$NEW" >/dev/null; then
+  echo "version-assign: UNDETERMINED — no such rev '$NEW'. This is NOT a pass." >&2; exit 2
+fi
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+  echo "version-assign: UNDETERMINED — no usable base rev '$BASE' (first commit, or a truncated fetch). This is NOT a pass; a bump may be owed and could not be computed." >&2; exit 2
+fi
+
+v_new=$(ver_at "$NEW"); v_base=$(ver_at "$BASE")
+s_new=$(sha_at "$NEW"); s_base=$(sha_at "$BASE")
+
+# Fail-open must be LOUD, and the two unreadable causes must not share a message.
+if [[ -z "$v_new" ]]; then
+  echo "version-assign: UNDETERMINED — could not read FIVE_VERSION at '$NEW' (missing src/header.sh, or the 'readonly FIVE_VERSION=' anchor drifted). This is NOT a pass." >&2; exit 2
+fi
+if [[ -z "$s_new" ]]; then
+  echo "version-assign: UNDETERMINED — could not read 5dive.sha256 at '$NEW'. This is NOT a pass." >&2; exit 2
+fi
+
+if [[ "$s_new" == "$s_base" ]]; then
+  echo "version-assign: no assignment needed — the bundle is unchanged since '$BASE' (workflow/doc-only push)."; exit 0
+fi
+if [[ "$v_new" != "$v_base" ]]; then
+  echo "version-assign: no assignment needed — the bundle changed AND FIVE_VERSION already moved ($v_base -> $v_new); whoever merged assigned it."; exit 0
+fi
+
+# The bundle moved and the version did not: this is the assignment nobody performed.
+if [[ ! "$v_new" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  echo "version-assign: UNDETERMINED — FIVE_VERSION '$v_new' is not MAJOR.MINOR.PATCH, refusing to guess the successor. This is NOT a pass." >&2; exit 2
+fi
+NEXT="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$(( BASH_REMATCH[3] + 1 ))"
+
+echo "version-assign: ASSIGNMENT OWED — bundle changed ($s_base -> $s_new) with FIVE_VERSION still $v_new."
+echo "version-assign: next = $NEXT"
+(( APPLY )) || { echo "version-assign: --apply not given; nothing written."; exit 0; }
+
+sed -i -E "s/^readonly FIVE_VERSION=\"[^\"]+\"/readonly FIVE_VERSION=\"${NEXT}\"/" src/header.sh
+[[ "$(grep -m1 -oE '^readonly FIVE_VERSION="[^"]+"' src/header.sh)" == "readonly FIVE_VERSION=\"${NEXT}\"" ]] \
+  || { echo "version-assign: the bump did NOT take in src/header.sh — refusing to continue." >&2; exit 2; }
+./build.sh >/dev/null 2>&1 || { echo "version-assign: build.sh failed after the bump." >&2; exit 2; }
+
+# Assert EFFECT, not the exit code of the thing that was supposed to cause it.
+built=$(sha256sum 5dive | cut -d' ' -f1)
+[[ "$built" == "$(cut -d' ' -f1 < 5dive.sha256)" ]] \
+  || { echo "version-assign: rebuilt bundle does not match 5dive.sha256." >&2; exit 2; }
+grep -q "FIVE_VERSION=\"${NEXT}\"" 5dive \
+  || { echo "version-assign: ${NEXT} is not embedded in the rebuilt bundle." >&2; exit 2; }
+echo "version-assign: applied ${v_new} -> ${NEXT}, bundle rebuilt (${built:0:16}). NO TAG — releases are batched."

--- a/tests/version_assign_unit.sh
+++ b/tests/version_assign_unit.sh
@@ -8,6 +8,12 @@
 # on a throwaway branch, because it must exercise the actual build.sh — a fixture
 # build would be a reimplementation, and a reimplementation drifts exactly where the
 # thing you are catching drifts.
+#
+# ARMS G AND H EXIST BECAUSE THIS HARNESS FAILED ITS OWN MUTATION TEST (iteration 1).
+# The reviewer replaced two apply-path assertions with `true` and the harness stayed
+# 16/16 GREEN: the self-grading added to compensate for the bump commit never seeing
+# CI was ITSELF ungraded. G grades those two assertions by mutation; H grades the
+# no-tag guarantee behaviourally instead of by its message.
 # Run: bash tests/version_assign_unit.sh
 set -uo pipefail
 cd "$(dirname "$0")/.."
@@ -72,21 +78,123 @@ B="va-apply-probe-$$"
 # destroyed its own subject. Two assertions ALSO passed vacuously against the
 # untouched tree, which is the worse half: a broken arm that still reports green.
 SNAP="$TMP/version-assign.snapshot.sh"; cp "$S" "$SNAP"
+# ...AND IT DESTROYED ITS SUBJECT A SECOND WAY. `commit -am` swept every OTHER
+# modified file in the tree into the probe commit and `reset --hard HEAD~1` then
+# deleted them: running the harness mid-edit silently ate the edits (measured during
+# iteration 2 of this very ticket — it ate this file). The probe now commits and
+# restores ONLY the paths it touches, never -a and never --hard, and the SENTINEL
+# below grades that. A harness that eats your working tree gets run once.
+PROBE_FILES=(src/cmd_task.sh src/header.sh 5dive 5dive.sha256)
+SENTINEL=$(cd "$REPO" && ls README.md CONTRIBUTING.md 2>/dev/null | head -1)
+trap 'git -C "$REPO" checkout -q -- "$SENTINEL" 2>/dev/null; rm -rf "$TMP"' EXIT
+printf '\n<!-- version-assign harness sentinel -->\n' >> "$REPO/$SENTINEL"
+
 git -C "$REPO" checkout -q -b "$B" 2>/dev/null
 v0=$(grep -m1 -oE 'FIVE_VERSION="[^"]+"' "$REPO/src/header.sh")
+# Derive the expected successor rather than hardcoding it: this arm asserted a literal
+# 0.16.20 -> 0.16.21, which turns into a false FAIL the moment main moves on, and a
+# harness that fails for calendar reasons teaches people to ignore it.
+cur=$(sed 's/.*"\(.*\)"/\1/' <<<"$v0")
+exp="${cur%.*}.$(( ${cur##*.} + 1 ))"
 printf '\n# version-assign apply probe\n' >> "$REPO/src/cmd_task.sh"
 ( cd "$REPO" && ./build.sh >/dev/null 2>&1 )
-git -C "$REPO" -c user.email=t@t -c user.name=t commit -qam "probe: bundle moves, version does not"
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q -m "probe: bundle moves, version does not" -- "${PROBE_FILES[@]}"
 out=$( cd "$REPO" && bash "$SNAP" HEAD HEAD~1 --apply 2>&1 ); rc=$?
-if grep -q 'applied 0.16.20 -> 0.16.21' <<<"$out"; then ok "F --apply bumps the real repo 0.16.20 -> 0.16.21"; else no "F apply" "$out"; fi
-grep -q 'NO TAG' <<<"$out" && ok "F --apply states NO TAG (releases are batched)" || no "F tag" "$out"
-if grep -q 'FIVE_VERSION="0.16.21"' "$REPO/5dive"; then ok "F the new version is EMBEDDED in the rebuilt bundle"; else no "F embed" "bundle not rebuilt with the bump"; fi
+if grep -q "applied $cur -> $exp" <<<"$out"; then ok "F --apply bumps the real repo $cur -> $exp"; else no "F apply" "$out"; fi
+grep -q 'NO TAG' <<<"$out" \
+  && ok "F (MESSAGE ONLY) --apply prints NO TAG — grades the sentence, not the behaviour; arm H grades the behaviour" \
+  || no "F tag msg" "$out"
+if grep -q "FIVE_VERSION=\"$exp\"" "$REPO/5dive"; then ok "F the new version is EMBEDDED in the rebuilt bundle"; else no "F embed" "bundle not rebuilt with the bump"; fi
 built=$(sha256sum "$REPO/5dive" | cut -d' ' -f1)
 [[ "$built" == "$(cut -d' ' -f1 < "$REPO/5dive.sha256")" ]] && ok "F rebuilt bundle matches 5dive.sha256" || no "F sha" "mismatch"
-git -C "$REPO" reset -q --hard HEAD~1 2>/dev/null
+git -C "$REPO" reset -q --soft HEAD~1
+git -C "$REPO" restore --source=HEAD --staged --worktree -- "${PROBE_FILES[@]}"
 git -C "$REPO" checkout -q - 2>/dev/null; git -C "$REPO" branch -qD "$B" 2>/dev/null
 [[ "$(grep -m1 -oE 'FIVE_VERSION="[^"]+"' "$REPO/src/header.sh")" == "$v0" ]] \
   && ok "F the probe left the working tree at its original version" || no "F cleanup" "tree not restored"
+tail -1 "$REPO/$SENTINEL" | grep -q 'harness sentinel' \
+  && ok "F SENTINEL: an unrelated uncommitted edit survived the probe (no commit -a, no reset --hard)" \
+  || no "F sentinel" "the probe ate an unrelated working-tree modification — it did exactly this during iteration 2"
+git -C "$REPO" checkout -q -- "$SENTINEL"
+
+# ---------------------------------------------------------------------------
+# G: MUTATION-GRADED APPLY ASSERTIONS.
+# Arm F proves the HAPPY path. It does not prove that the apply path's two safety
+# assertions do anything — the reviewer replaced both with `true` and F stayed green,
+# because on the happy path neither ever fires. These arms drive the script INTO each
+# assertion and demand that assertion's OWN message: delete the assertion and the
+# script still fails, but with a DIFFERENT message, so the arm goes red.
+#
+# These use a fixture build.sh ON PURPOSE, and it is not the reimplementation F
+# avoids: F already exercises the real build.sh on the honest path, and what is
+# graded here is the ASSERTION, not the build. G0 is the positive control — without
+# it a red G1/G2 would prove nothing, since a fixture broken for unrelated reasons is
+# also red.
+mkapply() { # $1 = honest|badsha
+  local d="$TMP/apply$RANDOM$RANDOM"; mkdir -p "$d/src"
+  git -C "$d" init -q -b main; git -C "$d" config user.email t@t; git -C "$d" config user.name t
+  printf 'readonly FIVE_VERSION="0.16.19"\n' > "$d/src/header.sh"
+  printf 'aaa  5dive\n' > "$d/5dive.sha256"; printf 'placeholder\n' > "$d/5dive"
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'cat src/header.sh > 5dive'
+    if [[ "$1" == badsha ]]; then
+      # The build "succeeds" (exit 0) but records a sha that does not match the bundle
+      # it just wrote. Exactly the drift the assertion exists to catch, and exactly
+      # what a green exit code cannot tell you.
+      echo 'printf "deadbeefdeadbeef  5dive\n" > 5dive.sha256'
+    else
+      echo 'printf "%s  5dive\n" "$(sha256sum 5dive | cut -d" " -f1)" > 5dive.sha256'
+    fi
+  } > "$d/build.sh"; chmod +x "$d/build.sh"
+  git -C "$d" add -A; git -C "$d" commit -qm base
+  printf 'bbb  5dive\n' > "$d/5dive.sha256"   # bundle moved, version did not
+  git -C "$d" add -A; git -C "$d" commit -qm new
+  printf '%s' "$d"; }
+
+# G0 POSITIVE CONTROL: the fixture apply path works end to end.
+d=$(mkapply honest); out=$( cd "$d" && bash "$S" HEAD HEAD~1 --apply 2>&1 ); rc=$?
+(( rc == 0 )) && grep -q 'applied 0.16.19 -> 0.16.20' <<<"$out" \
+  && ok "G0 CONTROL: honest fixture applies cleanly (so a red G1/G2 means the mutation, not a broken fixture)" \
+  || no "G0 control" "rc=$rc $out"
+
+# G1 grades the "rebuilt bundle does not match 5dive.sha256" assertion (reviewer's M5).
+# With that assertion stubbed to true the script sails on: the bundle DOES contain the
+# new version, so the next check passes and it exits 0 "applied" — silently blessing a
+# bundle whose recorded sha is wrong. Hence: demand exit 2 AND this exact message.
+d=$(mkapply badsha); out=$( cd "$d" && bash "$S" HEAD HEAD~1 --apply 2>&1 ); rc=$?
+(( rc == 2 )) && ok "G1 MUTATION: a build that records a mismatched sha exits 2" || no "G1 rc" "$rc: $out"
+grep -q 'rebuilt bundle does not match 5dive.sha256' <<<"$out" \
+  && ok "G1 MUTATION: and fails with the sha-match assertion's OWN message (stub it to true and this goes red)" \
+  || no "G1 msg" "$out"
+
+# G2 grades the "the bump did NOT take in src/header.sh" assertion (reviewer's M3).
+# A PATH shim no-ops ONLY in-place sed, which is precisely "the bump did not take";
+# the script's other sed use (parsing FIVE_VERSION) still reaches the real sed, so the
+# arm isolates the one behaviour. With the assertion stubbed, the script instead
+# reaches the embedded-version check and dies with a DIFFERENT message — red.
+REALSED="$(command -v sed)"
+mkdir -p "$TMP/shim"
+{ echo '#!/usr/bin/env bash'
+  echo 'for a in "$@"; do [[ "$a" == -i* ]] && exit 0; done'
+  echo "exec $REALSED \"\$@\""; } > "$TMP/shim/sed"; chmod +x "$TMP/shim/sed"
+d=$(mkapply honest); out=$( cd "$d" && PATH="$TMP/shim:$PATH" bash "$S" HEAD HEAD~1 --apply 2>&1 ); rc=$?
+(( rc == 2 )) && ok "G2 MUTATION: a no-op in-place sed (the bump silently not landing) exits 2" || no "G2 rc" "$rc: $out"
+grep -q 'the bump did NOT take in src/header.sh' <<<"$out" \
+  && ok "G2 MUTATION: and fails with the bump-took assertion's OWN message (stub it to true and this goes red)" \
+  || no "G2 msg" "$out"
+
+# H: NO TAG, BEHAVIOURALLY. Arm F greps the output for "NO TAG", which grades a
+# sentence — a script that printed it and tagged anyway would pass. The real guarantee
+# is that no tag verb exists anywhere in the two SHIPPED files. (Only the shipped
+# files are scanned: this harness does not run in CI, and it necessarily contains the
+# very strings being searched for.)
+if grep -nEi 'git[[:space:]]+tag|gh[[:space:]]+release|refs/tags|--tags|create-release|action-gh-release' \
+     "$REPO/scripts/version-assign.sh" "$REPO/.github/workflows/version-assign.yml"; then
+  no "H a tag verb appears in a shipped file (bump yes, tag no — lodar froze releases)"
+else
+  ok "H BEHAVIOURAL: no tag verb (git tag / gh release / refs/tags / --tags) appears in either shipped file"
+fi
 
 echo; echo "DIVE-2118 version-assign: passed: $P  failed: $F"
 [ "$F" -eq 0 ]

--- a/tests/version_assign_unit.sh
+++ b/tests/version_assign_unit.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# DIVE-2118 harness for scripts/version-assign.sh — the performer half of the
+# "version is assigned at MERGE" rule, whose prohibition half everyone follows and
+# whose performance half was owned by nobody (#218/#219/#220/#221 all merged at
+# 0.16.19 against a version already published with a different bundle).
+#
+# Decision arms are hermetic throwaway repos. The --apply arm runs in the REAL repo
+# on a throwaway branch, because it must exercise the actual build.sh — a fixture
+# build would be a reimplementation, and a reimplementation drifts exactly where the
+# thing you are catching drifts.
+# Run: bash tests/version_assign_unit.sh
+set -uo pipefail
+cd "$(dirname "$0")/.."
+REPO="$PWD"; S="$REPO/scripts/version-assign.sh"
+TMP="$(mktemp -d /tmp/version-assign-unit.XXXXXX)"; trap 'rm -rf "$TMP"' EXIT
+P=0; F=0
+ok(){ P=$((P+1)); echo "ok   - $1"; }
+no(){ F=$((F+1)); echo "FAIL - $1"; [ -n "${2:-}" ] && echo "   $2"; }
+
+# fixture: base commit at $1/$2 (version/sha), then a second commit at $3/$4
+mk() { local d="$TMP/$RANDOM$RANDOM"; mkdir -p "$d/src"; git -C "$d" init -q -b main
+  git -C "$d" config user.email t@t; git -C "$d" config user.name t
+  printf 'readonly FIVE_VERSION="%s"\n' "$1" > "$d/src/header.sh"; printf '%s  5dive\n' "$2" > "$d/5dive.sha256"
+  git -C "$d" add -A; git -C "$d" commit -qm base
+  printf 'readonly FIVE_VERSION="%s"\n' "$3" > "$d/src/header.sh"; printf '%s  5dive\n' "$4" > "$d/5dive.sha256"
+  # ALWAYS make the second commit non-empty: case C deliberately leaves version and
+  # bundle identical, and an empty commit fails, which made mk() return git's error
+  # text as the fixture path and reported a SCRIPT failure for a HARNESS bug.
+  date +%s%N > "$d/unrelated.txt"
+  git -C "$d" add -A; git -C "$d" commit -qm new
+  printf '%s' "$d"; }
+run(){ ( cd "$1" && bash "$S" HEAD HEAD~1 ) 2>&1; }
+
+# A: THE DEFECT — bundle moved, version did not.
+d=$(mk 0.16.19 aaa 0.16.19 bbb); out=$(run "$d"); rc=$?
+(( rc == 0 )) && ok "A owed-assignment exits 0 (it is a finding, not an error)" || no "A rc" "$rc"
+grep -q 'ASSIGNMENT OWED' <<<"$out" && ok "A names it as an owed assignment" || no "A" "$out"
+grep -q 'next = 0.16.20' <<<"$out" && ok "A computes the next patch (0.16.19 -> 0.16.20)" || no "A next" "$out"
+grep -q 'nothing written' <<<"$out" && ok "A is dry by default — no --apply, no write" || no "A dry" "$out"
+
+# B: version already moved -> nothing owed (the merger did assign it).
+d=$(mk 0.16.19 aaa 0.16.20 bbb); out=$(run "$d")
+grep -q 'no assignment needed' <<<"$out" && grep -q 'already moved' <<<"$out" \
+  && ok "B version already assigned -> nothing owed" || no "B" "$out"
+
+# C: bundle unchanged (workflow/doc-only push) -> exempt.
+d=$(mk 0.16.19 aaa 0.16.19 aaa); out=$(run "$d")
+grep -q 'bundle is unchanged' <<<"$out" && ok "C doc-only push is exempt" || no "C" "$out"
+
+# D: NON-SEMVER must refuse to guess, not invent a successor.
+d=$(mk 0.16.19 aaa 0.16.19-rc1 bbb); out=$(run "$d")
+grep -q 'no assignment needed' <<<"$out" && ok "D a moved non-semver version is already assigned" || no "D" "$out"
+d=$(mk nightly aaa nightly bbb); out=$(run "$d"); rc=$?
+(( rc == 2 )) && ok "D unparseable version exits 2, refusing to guess a successor" || no "D semver rc" "$rc: $out"
+
+# E: UNDETERMINED is exit 2, says so, and its causes do not share one message.
+d=$(mk 0.16.19 aaa 0.16.19 bbb)
+out=$( cd "$d" && bash "$S" nosuchrev HEAD~1 2>&1 ); rc=$?
+(( rc == 2 )) && ok "E missing rev exits 2, distinct from pass(0)" || no "E rc" "$rc"
+grep -q 'NOT a pass' <<<"$out" && ok "E says explicitly it is not a pass" || no "E" "$out"
+E1=$(sed "s/'[^']*'/'REF'/g" <<<"$out")
+out2=$( cd "$d" && bash "$S" HEAD nosuchbase 2>&1 )
+E2=$(sed "s/'[^']*'/'REF'/g" <<<"$out2")
+[[ "$E2" != "$E1" ]] && ok "E the two UNDETERMINED causes emit different TEMPLATES (not folded)" \
+  || no "E folded" "bad-new and bad-base read identically once refs are normalised"
+
+# F: --apply in the REAL repo on a throwaway branch — exercises the actual build.sh.
+B="va-apply-probe-$$"
+# Snapshot the script BEFORE touching git: the first version of this arm ran
+# `git stash -u`, which swallowed scripts/version-assign.sh itself (still untracked)
+# and every assertion then failed with "No such file or directory" — the harness
+# destroyed its own subject. Two assertions ALSO passed vacuously against the
+# untouched tree, which is the worse half: a broken arm that still reports green.
+SNAP="$TMP/version-assign.snapshot.sh"; cp "$S" "$SNAP"
+git -C "$REPO" checkout -q -b "$B" 2>/dev/null
+v0=$(grep -m1 -oE 'FIVE_VERSION="[^"]+"' "$REPO/src/header.sh")
+printf '\n# version-assign apply probe\n' >> "$REPO/src/cmd_task.sh"
+( cd "$REPO" && ./build.sh >/dev/null 2>&1 )
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -qam "probe: bundle moves, version does not"
+out=$( cd "$REPO" && bash "$SNAP" HEAD HEAD~1 --apply 2>&1 ); rc=$?
+if grep -q 'applied 0.16.20 -> 0.16.21' <<<"$out"; then ok "F --apply bumps the real repo 0.16.20 -> 0.16.21"; else no "F apply" "$out"; fi
+grep -q 'NO TAG' <<<"$out" && ok "F --apply states NO TAG (releases are batched)" || no "F tag" "$out"
+if grep -q 'FIVE_VERSION="0.16.21"' "$REPO/5dive"; then ok "F the new version is EMBEDDED in the rebuilt bundle"; else no "F embed" "bundle not rebuilt with the bump"; fi
+built=$(sha256sum "$REPO/5dive" | cut -d' ' -f1)
+[[ "$built" == "$(cut -d' ' -f1 < "$REPO/5dive.sha256")" ]] && ok "F rebuilt bundle matches 5dive.sha256" || no "F sha" "mismatch"
+git -C "$REPO" reset -q --hard HEAD~1 2>/dev/null
+git -C "$REPO" checkout -q - 2>/dev/null; git -C "$REPO" branch -qD "$B" 2>/dev/null
+[[ "$(grep -m1 -oE 'FIVE_VERSION="[^"]+"' "$REPO/src/header.sh")" == "$v0" ]] \
+  && ok "F the probe left the working tree at its original version" || no "F cleanup" "tree not restored"
+
+echo; echo "DIVE-2118 version-assign: passed: $P  failed: $F"
+[ "$F" -eq 0 ]


### PR DESCRIPTION
CONTRIBUTING assigns `FIVE_VERSION` **at merge, by merge order**, and forbids bumping in a PR. Everyone follows the prohibition. **Nobody performs the assignment.**

Measured 2026-07-26: #218, #219, #220 and #221 all merged claiming `0.16.19` — a version already published against a *different* bundle. The shared-checkout updater keys off `FIVE_VERSION`, not content hash (DIVE-2065), so until a human noticed, **every box already on 0.16.19 kept its old binary and received none of those fixes.** Found only because someone went to roll the host binary and compared shas.

`version-uniqueness` already detects this and stays. It is a **post-hoc detector on a shared branch** — it turns main red and hands cleanup to whoever notices. This adds the **performer**, so the detector should stop having anything to find.

## Bump yes, tag no

lodar froze GitHub releases on 2026-07-26 (36 versions in ~36h, 26 of them fixes) — but froze the **tag**, explicitly not the bump. The bump is load-bearing: it stops two merges claiming one version, and keeps the installed-bundle-matches-its-commit selfcheck honest. The workflow contains **zero** `git tag` and **zero** `gh release` invocations.

## Design

`scripts/version-assign.sh` is the **inverse of `version-bump-guard.sh`** — the same predicate used to repair rather than refuse, deliberately not forked into a second notion of "the bundle changed" that could drift from the guard's.

Validated against the real incident before any fixture:

```
ea1bd51f vs 6bd9ca64  ->  ASSIGNMENT OWED, next = 0.16.20   # the exact version assigned by hand
b61eb2a  vs ea1bd51f  ->  no assignment needed (already moved)
```

`UNDETERMINED` is exit 2, never a silent skip, with distinct templates per cause.

## Grading

16 assertions. Decision arms hermetic; the `--apply` arm runs against the **real `build.sh`** on a throwaway branch. Mutation-graded **5/5**, each verified to land, each a distinct signature:

```
M1 drop unchanged-exempt   -> C
M2 drop already-assigned   -> B, D
M3 undetermined passes     -> E rc
M4 wrong successor         -> A next, F apply, F embed
M5 guess non-semver        -> A*, D semver rc, F*
```

**Two harness bugs found while writing it**, both worth naming: an empty second commit made the fixture helper return git's error text as a path (a *harness* bug reported as a *script* failure), and `git stash -u` swallowed the still-untracked script under test — after which two arm-F assertions **passed vacuously** against an untouched tree. A broken arm that still reports green is the worse half.

No version bump — assigned at merge, which is now this workflow's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)