### PR TITLE
ci: version-uniqueness tolerates the assignable transient, but only after PROVING the repair (DIVE-2125)

### DIFF
--- a/.github/workflows/bundle-drift.yml
+++ b/.github/workflows/bundle-drift.yml
@@ -82,4 +82,10 @@ jobs:
             echo "version-uniqueness: no usable previous main tip (new branch or force event) — skipping delta scan."
             exit 0
           fi
-          ./scripts/version-uniqueness-scan.sh "${{ github.sha }}" "$before"
+          # DIVE-2125: the gate, not the raw scan. version-uniqueness and version-assign
+          # are triggered by the SAME push and race — measured on 186b0e3 and 6fd082e,
+          # this job failed on the merge commit while the assigner was still computing
+          # the repair, leaving a permanently red run on a merge that ended healthy.
+          # The gate tolerates ONLY the assignable shape, and only after PROVING the
+          # repair landed by re-scanning main's new tip; anything else still fails.
+          ./scripts/version-uniqueness-gate.sh "${{ github.sha }}" "$before"

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -47,7 +47,11 @@ jobs:
       - name: Lint install + bundle + agent-start
         # Linting the bundle (not src/) lets us skip --shell=bash gymnastics
         # — bundle-drift already enforces that bundle == build.sh(src/).
-        run: shellcheck -S error install.sh 5dive 5dive-agent-start build.sh
+        # DIVE-2125 (verifier): scripts/ was linted by NOTHING, so every helper the
+        # CLI shells out to shipped unchecked. Widened rather than adding one file:
+        # measured zero findings across scripts/*.sh at -S error, so the broad fix is
+        # free today and closes the gap permanently instead of for one script.
+        run: shellcheck -S error install.sh 5dive 5dive-agent-start build.sh scripts/*.sh
 
   docker-install:
     runs-on: ubuntu-latest

--- a/scripts/version-uniqueness-gate.sh
+++ b/scripts/version-uniqueness-gate.sh
@@ -30,6 +30,17 @@
 # a predicate drift; the copy that drifts is the one that decides whether to stay
 # quiet. Same discipline as the gap#2/stranded predicate sharing in DIVE-2122.
 #
+# KNOWN LIMIT, measured by replaying both real merges. Replaying 6fd082e against its
+# true base (c742ee1) RESOLVES correctly — that is the live, uncontended case this gate
+# is for. Replaying the OLDER merge 186b0e3 now FAILS, because main has since moved two
+# assignments past it, so the repair-delta scan (new..tip) spans later merges carrying
+# their own transient collisions. The same thing happens for real if another merge
+# lands DURING the wait window: the gate fails loudly and points at the version-assign
+# run rather than going quiet. That is the correct direction to degrade, but it is a
+# real limit, not a clean pass — tightening it would mean pinning the specific
+# assignment commit (by descent from <new>), which couples this to the assigner's
+# commit-message convention. Deliberately not done here.
+#
 # Usage: version-uniqueness-gate.sh <new-ref> <base-ref>
 # Exit 0 = no collision, or a transient one PROVEN repaired. Exit 1 = collision that
 #          is not the assignable shape, is undeterminable, or was never repaired.
@@ -91,12 +102,26 @@ uniq_gate() {
       echo "  ${waited}s: main is still at ${new:0:12} — no assignment commit yet."
       continue
     fi
-    if _uniq_scan "$tip" "$base"; then
+    # PROVING THE REPAIR IS NOT "RE-SCAN AGAINST THE ORIGINAL BASE". Caught by replaying
+    # the real 6fd082e incident: base..tip STILL CONTAINS the offending merge commit, so
+    # that scan collides forever no matter how perfectly the assigner performed. A gate
+    # built on it would fail every bundle-changing merge AFTER burning the whole wait
+    # window — strictly worse than the immediate red it was meant to remove. Twelve
+    # green stub arms missed this, because the stubs encoded the same wrong assumption
+    # the code did; only the replay against real history disagreed.
+    #
+    # The repair is proven by two facts instead:
+    #   1. the shape probe no longer says OWED at the tip — an assignment really landed
+    #      (same shared predicate, so this cannot disagree with the performer), and
+    #   2. the delta the repair itself introduced (new..tip) carries no collision.
+    local tipshape
+    tipshape=$(_uniq_assign_shape "$tip" "$base"); local tiprc=$?
+    if (( tiprc != 2 )) && ! grep -q 'ASSIGNMENT OWED' <<<"$tipshape" && _uniq_scan "$tip" "$new"; then
       # Say exactly what was and was not measured. Green here does NOT mean the merge
-      # commit was clean — it means the transient was repaired and the REPAIRED tip is
-      # unique. Reporting it as though the collision never happened would be the same
+      # commit was clean — it means the transient was repaired and the repair itself is
+      # clean. Reporting it as though the collision never happened would be the same
       # class of lie this ticket is about.
-      echo "version-uniqueness: RESOLVED. ${new:0:12} DID collide — that was real, not a false alarm — and version-assign repaired it at ${tip:0:12} within ${waited}s. Uniqueness is verified against the REPAIRED TIP, not against ${new:0:12}."
+      echo "version-uniqueness: RESOLVED. ${new:0:12} DID collide — that was real, not a false alarm — and version-assign repaired it at ${tip:0:12} within ${waited}s. Verified: no assignment is still owed at the tip, and the repair's own delta ${new:0:12}..${tip:0:12} is collision-free. NOT verified, and not claimed: that ${new:0:12} itself was ever unique. It was not."
       return 0
     fi
     echo "  ${waited}s: main moved to ${tip:0:12} but the collision is still there."

--- a/scripts/version-uniqueness-gate.sh
+++ b/scripts/version-uniqueness-gate.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# DIVE-2125 — version-uniqueness went RED on every bundle-changing merge, because the
+# detector and the performer are triggered by the same push and race each other.
+#
+# MEASURED TWICE, on the only two bundle-changing merges since DIVE-2118 shipped:
+#   186b0e3 (#226): 21:39:15 push -> 21:39:22 assignment commit -> 21:39:33 the
+#                   version-uniqueness run on the MERGE COMMIT fails -> 21:39:40 the
+#                   dispatched run on the assignment commit passes.
+#   6fd082e (#224): same sequence, same outcome.
+# In both, main self-healed in ~19s and ended green — but the merge commit keeps a
+# permanently red run, because that sha is only ever checked once.
+#
+# WHY THAT IS NOT COSMETIC. version-uniqueness is the detector that CAUGHT the
+# original DIVE-2118 defect. Red on every healthy merge means a reader can no longer
+# tell "the assigner repairs this in ten seconds" from "a real collision needs a
+# human" without opening the run and checking whether an assignment commit followed.
+# The check is not wrong; it is RIGHT ABOUT A TRANSIENT STATE, and being right about a
+# transient state on every healthy merge is exactly how a detector stops being read.
+# DIVE-2118 exists partly because main sat red and a human had to notice.
+#
+# THE FIX IS NOT "IGNORE THE COLLISION". A tolerance with no proof that the repair
+# actually happened silently recreates DIVE-2118 — main unassigned, nothing red, boxes
+# quietly stuck on an old bundle. So the tolerance is bounded and self-proving: when
+# the collision is exactly the shape version-assign repairs, WAIT for the repair and
+# then verify uniqueness AGAINST THE REPAIRED TIP. If the repair does not arrive, fail
+# loudly and say the assigner did not perform.
+#
+# The "is this the assignable shape?" question is answered by running version-assign.sh
+# ITSELF (dry, no --apply) rather than by re-deriving the predicate here. Two copies of
+# a predicate drift; the copy that drifts is the one that decides whether to stay
+# quiet. Same discipline as the gap#2/stranded predicate sharing in DIVE-2122.
+#
+# Usage: version-uniqueness-gate.sh <new-ref> <base-ref>
+# Exit 0 = no collision, or a transient one PROVEN repaired. Exit 1 = collision that
+#          is not the assignable shape, is undeterminable, or was never repaired.
+set -uo pipefail
+
+FIVE_UNIQ_ASSIGN_WAIT="${FIVE_UNIQ_ASSIGN_WAIT:-120}"   # ceiling; observed repair ~11s
+FIVE_UNIQ_POLL_SECS="${FIVE_UNIQ_POLL_SECS:-10}"
+_UNIQ_HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Seams. Overridden by tests so the wait loop can be exercised without a network, a
+# clock, or a second workflow — the loop is the part most likely to be wrong, so it
+# must be the part that is actually graded.
+_uniq_scan()         { bash "$_UNIQ_HERE/version-uniqueness-scan.sh" "$1" "$2" >/dev/null 2>&1; }
+_uniq_assign_shape() { bash "$_UNIQ_HERE/version-assign.sh" "$1" "$2" 2>&1; }
+_uniq_current_main() { git fetch -q origin main 2>/dev/null; git rev-parse FETCH_HEAD 2>/dev/null; }
+
+uniq_gate() {
+  local new="$1" base="$2" out rc tip waited=0
+
+  if _uniq_scan "$new" "$base"; then
+    echo "version-uniqueness: no new collision in ${base:0:12}..${new:0:12}."
+    return 0
+  fi
+
+  out=$(_uniq_assign_shape "$new" "$base"); rc=$?
+
+  # An UNDETERMINED shape probe must never buy silence. We know there is a collision;
+  # what we do not know is whether anything is coming to fix it, and "unknown" is not
+  # "it will be handled" (DIVE-2120's bound message, same rule).
+  if (( rc == 2 )); then
+    echo "version-uniqueness: COLLISION at ${new:0:12}, and the assignable-shape probe was UNDETERMINED — refusing to wait on a repair that may never have been owed. Treating it as a real collision." >&2
+    printf '%s\n' "$out" >&2
+    return 1
+  fi
+
+  if ! grep -q 'ASSIGNMENT OWED' <<<"$out"; then
+    echo "version-uniqueness: COLLISION at ${new:0:12} that version-assign will NOT repair — this is a genuine finding and needs a human. The assignable shape is 'bundle moved AND FIVE_VERSION did not'; this is not that." >&2
+    printf '%s\n' "$out" >&2
+    return 1
+  fi
+
+  echo "version-uniqueness: the collision at ${new:0:12} IS the assignable shape (bundle moved, FIVE_VERSION did not) — version-assign should repair it. Waiting up to ${FIVE_UNIQ_ASSIGN_WAIT}s and then re-checking against main's repaired tip."
+  # The bound counts ATTEMPTS, not accumulated sleep. Accumulating the poll interval
+  # looks equivalent and is not: at FIVE_UNIQ_POLL_SECS=0 the accumulator never moves
+  # and the loop never ends — a CI job that HANGS FOREVER instead of failing, which is
+  # the worst outcome for a check whose whole purpose is to be readable. Found by this
+  # ticket's own harness, which hung instead of failing; the boundedness arm now grades
+  # a counter so a regression fails fast rather than never returning.
+  local poll="$FIVE_UNIQ_POLL_SECS" attempts i
+  [[ "$poll" =~ ^[0-9]+$ ]] || poll=10
+  (( poll > 0 )) || poll=1
+  attempts=$(( (FIVE_UNIQ_ASSIGN_WAIT + poll - 1) / poll ))
+  (( attempts > 0 )) || attempts=1
+  for (( i=1; i<=attempts; i++ )); do
+    sleep "$FIVE_UNIQ_POLL_SECS"
+    waited=$(( i * poll ))
+    tip=$(_uniq_current_main)
+    if [[ -z "$tip" || "$tip" == "$new" ]]; then
+      echo "  ${waited}s: main is still at ${new:0:12} — no assignment commit yet."
+      continue
+    fi
+    if _uniq_scan "$tip" "$base"; then
+      # Say exactly what was and was not measured. Green here does NOT mean the merge
+      # commit was clean — it means the transient was repaired and the REPAIRED tip is
+      # unique. Reporting it as though the collision never happened would be the same
+      # class of lie this ticket is about.
+      echo "version-uniqueness: RESOLVED. ${new:0:12} DID collide — that was real, not a false alarm — and version-assign repaired it at ${tip:0:12} within ${waited}s. Uniqueness is verified against the REPAIRED TIP, not against ${new:0:12}."
+      return 0
+    fi
+    echo "  ${waited}s: main moved to ${tip:0:12} but the collision is still there."
+  done
+
+  echo "version-uniqueness: COLLISION at ${new:0:12} was the assignable shape, but NO repair landed within ${FIVE_UNIQ_ASSIGN_WAIT}s. main is unassigned right now: the shared-checkout updater is version-triggered (DIVE-2065), so every box on the previous version is silently missing these fixes. Check the version-assign run for this push; bump by hand with scripts/version-assign.sh HEAD <prev> --apply if it is broken." >&2
+  return 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  uniq_gate "${1:?usage: version-uniqueness-gate.sh <new-ref> <base-ref>}" \
+            "${2:?usage: version-uniqueness-gate.sh <new-ref> <base-ref>}"
+  exit $?
+fi

--- a/tests/version_uniqueness_gate_unit.sh
+++ b/tests/version_uniqueness_gate_unit.sh
@@ -53,12 +53,42 @@ _uniq_current_main() {
   echo $(( i + 1 )) >"$TIP_IDX"
   printf '%s' "$v"
 }
+# DIVE-2125 (verifier finding): a regression in the wait bound does NOT go red, it
+# HANGS — measured exit 124 under timeout — and unit-tests.yml runs `for t in tests/*.sh`
+# with no per-test timeout, so that regression class costs a HUNG CI JOB instead of a
+# failing one. A hung job is the worst outcome for a check whose whole purpose is to be
+# readable, which is this ticket's own thesis pointed at its own harness.
+# So every gate call runs under a real `timeout`. That needs a child process: `timeout`
+# cannot wrap a shell function, so the child re-sources the gate and the stubs. If the
+# bound ever regresses, the arm gets rc=124 and goes RED on its own rc assertion.
+STUBS_FILE="$STUBD/stubs.sh"
+cat >"$STUBS_FILE" <<'STUBEOF'
+_uniq_scan()         { [[ " $SCAN_CLEAN_FOR " == *" $1 "* ]]; }
+_uniq_assign_shape() {
+  if [[ " $SHAPE_OWED_FOR " == *" $1 "* ]]; then printf '%s' "$OWED"; else printf '%s' "$NOTOWED"; fi
+  return "$SHAPE_RC"; }
+_uniq_current_main() {
+  echo x >>"$POLL_LOG"
+  local i; i=$(cat "$TIP_IDX" 2>/dev/null || echo 0)
+  local -a arr=($TIPS_STR)
+  local v="${arr[$i]:-${arr[${#arr[@]}-1]:-}}"
+  echo $(( i + 1 )) >"$TIP_IDX"
+  printf '%s' "$v"
+}
+STUBEOF
+run_gate() {
+  export SCAN_CLEAN_FOR SHAPE_OWED_FOR SHAPE_RC TIPS_STR OWED NOTOWED POLL_LOG TIP_IDX \
+         FIVE_UNIQ_POLL_SECS FIVE_UNIQ_ASSIGN_WAIT
+  timeout "${ARM_TIMEOUT:-20}" bash -c \
+    'source scripts/version-uniqueness-gate.sh; source "$1"; uniq_gate "$2" "$3"' \
+    _ "$STUBS_FILE" "$1" "$2" 2>&1
+}
 OWED='version-assign: ASSIGNMENT OWED — bundle changed (aaa -> bbb) with FIVE_VERSION still 0.16.22.'
 NOTOWED='version-assign: no assignment needed — the bundle is unchanged since BASE.'
 
 # --- 1. no collision at all: clean through, and it must NOT wait --------------
 SCAN_CLEAN_FOR="mergesha"; TIPS_STR="mergesha"; reset_stub
-out=$(uniq_gate mergesha basesha 2>&1); rc=$?
+out=$(run_gate mergesha basesha); rc=$?
 (( rc == 0 )) && ok "1 a clean scan passes" || no "1 clean must pass" "rc=$rc $out"
 (( $(polls) == 0 )) && ok "1 ...and does not wait on the assigner at all (no cost on the ordinary push)" \
                  || no "1 must not poll when clean" "polls=$(polls)"
@@ -66,7 +96,7 @@ out=$(uniq_gate mergesha basesha 2>&1); rc=$?
 # --- 2. THE FIX: the assignable transient, repaired -> passes -----------------
 SCAN_CLEAN_FOR="assignsha"; SHAPE_OWED_FOR="mergesha"; SHAPE_RC=0
 TIPS_STR="mergesha assignsha"; reset_stub
-out=$(uniq_gate mergesha basesha 2>&1); rc=$?
+out=$(run_gate mergesha basesha); rc=$?
 (( rc == 0 )) && ok "2 an assignable collision that version-assign repairs no longer fails the merge commit" \
              || no "2 repaired transient must pass" "rc=$rc $out"
 grep -q 'DID collide' <<<"$out" \
@@ -80,7 +110,7 @@ grep -q "repair's own delta" <<<"$out" && grep -q 'not claimed' <<<"$out" \
 # This is the arm that keeps the fix from silently recreating DIVE-2118.
 SCAN_CLEAN_FOR=""; SHAPE_OWED_FOR="mergesha"; SHAPE_RC=0
 TIPS_STR="mergesha"; reset_stub
-out=$(uniq_gate mergesha basesha 2>&1); rc=$?
+out=$(run_gate mergesha basesha); rc=$?
 (( rc == 1 )) && ok "3 an assignable collision that is NEVER repaired still FAILS (the tolerance is not silence)" \
              || no "3 unrepaired must fail" "rc=$rc $out"
 grep -q 'main is unassigned right now' <<<"$out" \
@@ -92,7 +122,7 @@ grep -q 'main is unassigned right now' <<<"$out" \
 # --- 4. a GENUINE collision (not the assignable shape) still fails immediately -
 SCAN_CLEAN_FOR=""; SHAPE_OWED_FOR=""; SHAPE_RC=0
 TIPS_STR="assignsha"; reset_stub
-out=$(uniq_gate mergesha basesha 2>&1); rc=$?
+out=$(run_gate mergesha basesha); rc=$?
 (( rc == 1 )) && ok "4 a collision version-assign will NOT repair still fails — the detector keeps its job" \
              || no "4 genuine collision must fail" "rc=$rc $out"
 (( $(polls) == 0 )) && ok "4 ...immediately, without burning the wait window on a repair nobody owes" \
@@ -104,7 +134,7 @@ out=$(uniq_gate mergesha basesha 2>&1); rc=$?
 SCAN_CLEAN_FOR=""; SHAPE_OWED_FOR=""; SHAPE_RC=2
 NOTOWED_SAVE="$NOTOWED"; NOTOWED='version-assign: UNDETERMINED — could not read FIVE_VERSION.'
 TIPS_STR="assignsha"; reset_stub
-out=$(uniq_gate mergesha basesha 2>&1); rc=$?
+out=$(run_gate mergesha basesha); rc=$?
 (( rc == 1 )) && grep -q 'UNDETERMINED' <<<"$out" \
   && ok "5 an UNDETERMINED shape probe is treated as a real collision, never as a pending repair" \
   || no "5 undetermined must not be tolerated" "rc=$rc $out"
@@ -114,7 +144,7 @@ out=$(uniq_gate mergesha basesha 2>&1); rc=$?
 NOTOWED="$NOTOWED_SAVE"
 SCAN_CLEAN_FOR="somethingelse"; SHAPE_OWED_FOR="mergesha othersha"; SHAPE_RC=0
 TIPS_STR="othersha othersha othersha"; reset_stub
-out=$(uniq_gate mergesha basesha 2>&1); rc=$?
+out=$(run_gate mergesha basesha); rc=$?
 (( rc == 1 )) && ok "6 main moving is NOT proof of repair — the new tip is re-scanned and still fails if it collides" \
              || no "6 tip movement must not be taken as repair" "rc=$rc $out"
 

--- a/tests/version_uniqueness_gate_unit.sh
+++ b/tests/version_uniqueness_gate_unit.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# DIVE-2125 harness for scripts/version-uniqueness-gate.sh.
+#
+# The gate exists because version-uniqueness and version-assign are triggered by the
+# SAME push and race: measured on both bundle-changing merges since DIVE-2118 shipped
+# (186b0e3 and 6fd082e), the run on the merge commit failed ~18s in while the assigner
+# was still computing the repair, and the dispatched run on the assignment commit
+# passed ~7s later. Main self-heals; the merge commit keeps a permanently red run.
+#
+# The danger in fixing it is over-correcting into silence: a tolerance that does not
+# PROVE the repair happened recreates DIVE-2118 with no red at all, which is strictly
+# worse. So the arms below weight that direction — four of the seven pin a FAILURE.
+#
+# The wait loop is stubbed at its seams (_uniq_scan / _uniq_assign_shape /
+# _uniq_current_main) rather than driven against a live repo: the loop is the part
+# most likely to be wrong, so it has to be the part that is actually exercised, and a
+# network-and-clock test would be too slow and flaky to run every push.
+# Run: bash tests/version_uniqueness_gate_unit.sh  (no root, no network)
+set -uo pipefail
+cd "$(dirname "$0")/.."
+# shellcheck source=/dev/null
+source scripts/version-uniqueness-gate.sh          # sourced => functions only
+FIVE_UNIQ_POLL_SECS=0                              # no real sleeping in tests
+FIVE_UNIQ_ASSIGN_WAIT=3                            # 3 polls, so "bounded" is gradeable
+
+P=0; F=0
+ok(){ P=$((P+1)); echo "ok   - $1"; }
+no(){ F=$((F+1)); echo "FAIL - $1"; [ -n "${2:-}" ] && echo "   $2"; }
+
+# --- seams, redefined per arm ------------------------------------------------
+# STUB STATE LIVES IN FILES, NOT VARIABLES. uniq_gate is called inside $( ), which is
+# a SUBSHELL — every variable the stubs mutate there is discarded on return. The first
+# cut used shell vars: the tip sequence never advanced (so the "repaired" arm could
+# never pass) and the poll counter read 0 forever, which made the boundedness and
+# no-wait assertions pass VACUOUSLY. A counter that is always 0 satisfies "<= 3"
+# without measuring anything.
+SCAN_CLEAN_FOR=""      # refs (space-separated) the scan considers clean
+SHAPE_OUT="";  SHAPE_RC=0
+TIPS_STR=""
+STUBD="$(mktemp -d /tmp/uniq-gate-stub.XXXXXX)"; trap 'rm -rf "$STUBD"' EXIT
+POLL_LOG="$STUBD/polls"; TIP_IDX="$STUBD/idx"
+reset_stub() { : >"$POLL_LOG"; echo 0 >"$TIP_IDX"; }
+polls()      { wc -l <"$POLL_LOG" | tr -d ' '; }
+_uniq_scan()         { [[ " $SCAN_CLEAN_FOR " == *" $1 "* ]]; }
+_uniq_assign_shape() { printf '%s' "$SHAPE_OUT"; return $SHAPE_RC; }
+_uniq_current_main() {
+  echo x >>"$POLL_LOG"
+  local i; i=$(cat "$TIP_IDX" 2>/dev/null || echo 0)
+  local -a arr=($TIPS_STR)
+  local v="${arr[$i]:-${arr[${#arr[@]}-1]:-}}"
+  echo $(( i + 1 )) >"$TIP_IDX"
+  printf '%s' "$v"
+}
+OWED='version-assign: ASSIGNMENT OWED — bundle changed (aaa -> bbb) with FIVE_VERSION still 0.16.22.'
+NOTOWED='version-assign: no assignment needed — the bundle is unchanged since BASE.'
+
+# --- 1. no collision at all: clean through, and it must NOT wait --------------
+SCAN_CLEAN_FOR="mergesha"; TIPS_STR="mergesha"; reset_stub
+out=$(uniq_gate mergesha basesha 2>&1); rc=$?
+(( rc == 0 )) && ok "1 a clean scan passes" || no "1 clean must pass" "rc=$rc $out"
+(( $(polls) == 0 )) && ok "1 ...and does not wait on the assigner at all (no cost on the ordinary push)" \
+                 || no "1 must not poll when clean" "polls=$(polls)"
+
+# --- 2. THE FIX: the assignable transient, repaired -> passes -----------------
+SCAN_CLEAN_FOR="assignsha"; SHAPE_OUT="$OWED"; SHAPE_RC=0
+TIPS_STR="mergesha assignsha"; reset_stub
+out=$(uniq_gate mergesha basesha 2>&1); rc=$?
+(( rc == 0 )) && ok "2 an assignable collision that version-assign repairs no longer fails the merge commit" \
+             || no "2 repaired transient must pass" "rc=$rc $out"
+grep -q 'DID collide' <<<"$out" \
+  && ok "2 ...and the pass states the collision WAS REAL, not a false alarm" \
+  || no "2 must not report the collision as never having happened" "$out"
+grep -q 'REPAIRED TIP' <<<"$out" \
+  && ok "2 ...and names WHICH sha it verified, so green is not read as 'the merge commit was clean'" \
+  || no "2 must name the subject it verified" "$out"
+
+# --- 3. THE OVER-CORRECTION GUARD: assignable shape, repair NEVER lands -------
+# This is the arm that keeps the fix from silently recreating DIVE-2118.
+SCAN_CLEAN_FOR=""; SHAPE_OUT="$OWED"; SHAPE_RC=0
+TIPS_STR="mergesha"; reset_stub
+out=$(uniq_gate mergesha basesha 2>&1); rc=$?
+(( rc == 1 )) && ok "3 an assignable collision that is NEVER repaired still FAILS (the tolerance is not silence)" \
+             || no "3 unrepaired must fail" "rc=$rc $out"
+grep -q 'main is unassigned right now' <<<"$out" \
+  && ok "3 ...and says main is unassigned, naming the DIVE-2065 consequence rather than just 'collision'" \
+  || no "3 failure must name the consequence" "$out"
+(( $(polls) >= 1 && $(polls) <= 3 )) && ok "3 ...and the wait is BOUNDED (it gave up after $(polls) polls, it did not hang the job)" \
+                 || no "3 wait must be bounded" "polls=$(polls)"
+
+# --- 4. a GENUINE collision (not the assignable shape) still fails immediately -
+SCAN_CLEAN_FOR=""; SHAPE_OUT="$NOTOWED"; SHAPE_RC=0
+TIPS_STR="assignsha"; reset_stub
+out=$(uniq_gate mergesha basesha 2>&1); rc=$?
+(( rc == 1 )) && ok "4 a collision version-assign will NOT repair still fails — the detector keeps its job" \
+             || no "4 genuine collision must fail" "rc=$rc $out"
+(( $(polls) == 0 )) && ok "4 ...immediately, without burning the wait window on a repair nobody owes" \
+                 || no "4 must not wait on a non-assignable collision" "polls=$(polls)"
+
+# --- 5. UNDETERMINED shape probe must NOT buy silence ------------------------
+# We know there IS a collision; what is unknown is whether a repair is coming. Unknown
+# is not "it will be handled" — same rule as DIVE-2120's bound message.
+SCAN_CLEAN_FOR=""; SHAPE_OUT='version-assign: UNDETERMINED — could not read FIVE_VERSION.'; SHAPE_RC=2
+TIPS_STR="assignsha"; reset_stub
+out=$(uniq_gate mergesha basesha 2>&1); rc=$?
+(( rc == 1 )) && grep -q 'UNDETERMINED' <<<"$out" \
+  && ok "5 an UNDETERMINED shape probe is treated as a real collision, never as a pending repair" \
+  || no "5 undetermined must not be tolerated" "rc=$rc $out"
+
+# --- 6. main moves but the collision persists -> still fails -----------------
+# The repair must be PROVEN by re-scanning, not inferred from "the tip changed".
+SCAN_CLEAN_FOR="somethingelse"; SHAPE_OUT="$OWED"; SHAPE_RC=0
+TIPS_STR="othersha othersha othersha"; reset_stub
+out=$(uniq_gate mergesha basesha 2>&1); rc=$?
+(( rc == 1 )) && ok "6 main moving is NOT proof of repair — the new tip is re-scanned and still fails if it collides" \
+             || no "6 tip movement must not be taken as repair" "rc=$rc $out"
+
+echo; echo "DIVE-2125 version-uniqueness-gate: passed: $P  failed: $F"
+[ "$F" -eq 0 ]

--- a/tests/version_uniqueness_gate_unit.sh
+++ b/tests/version_uniqueness_gate_unit.sh
@@ -35,14 +35,16 @@ no(){ F=$((F+1)); echo "FAIL - $1"; [ -n "${2:-}" ] && echo "   $2"; }
 # no-wait assertions pass VACUOUSLY. A counter that is always 0 satisfies "<= 3"
 # without measuring anything.
 SCAN_CLEAN_FOR=""      # refs (space-separated) the scan considers clean
-SHAPE_OUT="";  SHAPE_RC=0
+SHAPE_OWED_FOR=""; SHAPE_RC=0   # refs the shape probe calls ASSIGNMENT OWED
 TIPS_STR=""
 STUBD="$(mktemp -d /tmp/uniq-gate-stub.XXXXXX)"; trap 'rm -rf "$STUBD"' EXIT
 POLL_LOG="$STUBD/polls"; TIP_IDX="$STUBD/idx"
 reset_stub() { : >"$POLL_LOG"; echo 0 >"$TIP_IDX"; }
 polls()      { wc -l <"$POLL_LOG" | tr -d ' '; }
 _uniq_scan()         { [[ " $SCAN_CLEAN_FOR " == *" $1 "* ]]; }
-_uniq_assign_shape() { printf '%s' "$SHAPE_OUT"; return $SHAPE_RC; }
+_uniq_assign_shape() {
+  if [[ " $SHAPE_OWED_FOR " == *" $1 "* ]]; then printf '%s' "$OWED"; else printf '%s' "$NOTOWED"; fi
+  return $SHAPE_RC; }
 _uniq_current_main() {
   echo x >>"$POLL_LOG"
   local i; i=$(cat "$TIP_IDX" 2>/dev/null || echo 0)
@@ -62,7 +64,7 @@ out=$(uniq_gate mergesha basesha 2>&1); rc=$?
                  || no "1 must not poll when clean" "polls=$(polls)"
 
 # --- 2. THE FIX: the assignable transient, repaired -> passes -----------------
-SCAN_CLEAN_FOR="assignsha"; SHAPE_OUT="$OWED"; SHAPE_RC=0
+SCAN_CLEAN_FOR="assignsha"; SHAPE_OWED_FOR="mergesha"; SHAPE_RC=0
 TIPS_STR="mergesha assignsha"; reset_stub
 out=$(uniq_gate mergesha basesha 2>&1); rc=$?
 (( rc == 0 )) && ok "2 an assignable collision that version-assign repairs no longer fails the merge commit" \
@@ -70,13 +72,13 @@ out=$(uniq_gate mergesha basesha 2>&1); rc=$?
 grep -q 'DID collide' <<<"$out" \
   && ok "2 ...and the pass states the collision WAS REAL, not a false alarm" \
   || no "2 must not report the collision as never having happened" "$out"
-grep -q 'REPAIRED TIP' <<<"$out" \
-  && ok "2 ...and names WHICH sha it verified, so green is not read as 'the merge commit was clean'" \
-  || no "2 must name the subject it verified" "$out"
+grep -q "repair's own delta" <<<"$out" && grep -q 'not claimed' <<<"$out" \
+  && ok "2 ...and names exactly what it verified AND disclaims what it did not: that the merge commit was ever unique" \
+  || no "2 must name the subject it verified and disclaim the rest" "$out"
 
 # --- 3. THE OVER-CORRECTION GUARD: assignable shape, repair NEVER lands -------
 # This is the arm that keeps the fix from silently recreating DIVE-2118.
-SCAN_CLEAN_FOR=""; SHAPE_OUT="$OWED"; SHAPE_RC=0
+SCAN_CLEAN_FOR=""; SHAPE_OWED_FOR="mergesha"; SHAPE_RC=0
 TIPS_STR="mergesha"; reset_stub
 out=$(uniq_gate mergesha basesha 2>&1); rc=$?
 (( rc == 1 )) && ok "3 an assignable collision that is NEVER repaired still FAILS (the tolerance is not silence)" \
@@ -88,7 +90,7 @@ grep -q 'main is unassigned right now' <<<"$out" \
                  || no "3 wait must be bounded" "polls=$(polls)"
 
 # --- 4. a GENUINE collision (not the assignable shape) still fails immediately -
-SCAN_CLEAN_FOR=""; SHAPE_OUT="$NOTOWED"; SHAPE_RC=0
+SCAN_CLEAN_FOR=""; SHAPE_OWED_FOR=""; SHAPE_RC=0
 TIPS_STR="assignsha"; reset_stub
 out=$(uniq_gate mergesha basesha 2>&1); rc=$?
 (( rc == 1 )) && ok "4 a collision version-assign will NOT repair still fails — the detector keeps its job" \
@@ -99,7 +101,8 @@ out=$(uniq_gate mergesha basesha 2>&1); rc=$?
 # --- 5. UNDETERMINED shape probe must NOT buy silence ------------------------
 # We know there IS a collision; what is unknown is whether a repair is coming. Unknown
 # is not "it will be handled" — same rule as DIVE-2120's bound message.
-SCAN_CLEAN_FOR=""; SHAPE_OUT='version-assign: UNDETERMINED — could not read FIVE_VERSION.'; SHAPE_RC=2
+SCAN_CLEAN_FOR=""; SHAPE_OWED_FOR=""; SHAPE_RC=2
+NOTOWED_SAVE="$NOTOWED"; NOTOWED='version-assign: UNDETERMINED — could not read FIVE_VERSION.'
 TIPS_STR="assignsha"; reset_stub
 out=$(uniq_gate mergesha basesha 2>&1); rc=$?
 (( rc == 1 )) && grep -q 'UNDETERMINED' <<<"$out" \
@@ -108,7 +111,8 @@ out=$(uniq_gate mergesha basesha 2>&1); rc=$?
 
 # --- 6. main moves but the collision persists -> still fails -----------------
 # The repair must be PROVEN by re-scanning, not inferred from "the tip changed".
-SCAN_CLEAN_FOR="somethingelse"; SHAPE_OUT="$OWED"; SHAPE_RC=0
+NOTOWED="$NOTOWED_SAVE"
+SCAN_CLEAN_FOR="somethingelse"; SHAPE_OWED_FOR="mergesha othersha"; SHAPE_RC=0
 TIPS_STR="othersha othersha othersha"; reset_stub
 out=$(uniq_gate mergesha basesha 2>&1); rc=$?
 (( rc == 1 )) && ok "6 main moving is NOT proof of repair — the new tip is re-scanned and still fails if it collides" \


### PR DESCRIPTION
version-uniqueness and version-assign are triggered by the same push and race. Measured on both bundle-changing merges since DIVE-2118 shipped (`186b0e3`, `6fd082e`): the run on the merge commit fails ~18s in while the assigner is still computing the repair; the dispatched run on the assignment commit passes ~7s later. Main self-heals, but **the merge commit keeps a permanently red run**.

Not cosmetic: version-uniqueness is the detector that caught the original DIVE-2118 defect. Red on every healthy merge means you can't tell *'the assigner fixes this in ten seconds'* from *'a real collision needs a human'* without opening the run.

**The fix is not 'ignore the collision'** — a tolerance that doesn't prove the repair happened recreates DIVE-2118 with no red at all, which is worse. `scripts/version-uniqueness-gate.sh` tolerates only the assignable shape, and only after re-scanning main's new tip to prove the repair landed. Unrepaired, non-assignable, and UNDETERMINED all still fail. The pass message states the merge commit DID collide and names which sha was verified.

The shape question runs `version-assign.sh` itself rather than re-deriving the predicate — two copies drift, and the drifting one would be the copy deciding whether to stay quiet.

12 arms, mutation-graded twice (tip-movement-as-proof = arm 6 red; dropping the shape guard = arm 4 red).