### PR TITLE
DO NOT MERGE YET — install: publish from the newest release TAG, not mutable main HEAD (DIVE-2144)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# DIVE-2144, scope item 4. install.sh is the ONE file that survives the cutover as a
+# mutable-main-to-root path: cmd_selfupdate.sh re-fetches it from raw main on EVERY
+# upgrade and runs it as root via sudo bash. Publishing from a tag does not remove
+# that risk, it CONCENTRATES it — one small file instead of a 47k-line bundle, which
+# is a large improvement and also means a bad merge to this one path is still
+# instantly live on every box. Gate it accordingly. (olivia's finding 4.)
+#
+# WHY @lodar AND NOT A TEAM: the first cut of this file said @5dive-ai/maintainers.
+# That team does not exist — `gh api orgs/5dive-ai/teams` is empty and lodar is the
+# repo's only collaborator. GitHub does not fail a CODEOWNERS entry naming a
+# nonexistent team by refusing the merge; it just never requests the review. The file
+# would have looked like a gate and been a no-op, which is the exact failure class
+# this ticket exists to retire. Name a real owner or name none.
+#
+# CODEOWNERS only REQUESTS review on its own. It becomes a REQUIRED approval when
+# "Require review from Code Owners" is enabled in main's branch protection — a
+# repo-admin setting this file cannot set and does not claim to have set.
+/install.sh            @lodar
+/src/cmd_selfupdate.sh @lodar

--- a/.github/workflows/install-guard.yml
+++ b/.github/workflows/install-guard.yml
@@ -1,0 +1,54 @@
+# DIVE-2144, scope item 4: put the root-path diff in front of a human on every PR.
+#
+# After the tag cutover, install.sh is the only file still fetched from mutable main
+# and executed AS ROOT on every box (cmd_selfupdate.sh re-fetches and runs it on each
+# upgrade). A change to it is live on the whole fleet the moment it merges, with no
+# tag in between. This job does not block that — CODEOWNERS plus branch protection is
+# what blocks it. This job makes it IMPOSSIBLE TO MERGE ONE WITHOUT HAVING SEEN IT:
+# the full diff lands in the job summary, so "I didn't realise that PR touched the
+# root path" stops being available as an explanation.
+name: install-guard
+on:
+  pull_request:
+    paths:
+      - 'install.sh'
+      - 'src/cmd_selfupdate.sh'
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Surface the root-path diff
+        run: |
+          set -uo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          files=$(git diff --name-only "$base" "$head" -- install.sh src/cmd_selfupdate.sh)
+
+          # The path filter above already decided this job should run, so an empty
+          # diff here means the filter and the diff disagree — do not report "clean".
+          if [[ -z "$files" ]]; then
+            echo "::warning::install-guard ran but sees no diff in install.sh or cmd_selfupdate.sh between ${base:0:12} and ${head:0:12}. The path filter and the diff disagree; this is NOT an all-clear."
+            exit 0
+          fi
+
+          {
+            echo "## Root-path change — read this diff"
+            echo
+            echo "This PR changes a file that is fetched from **mutable main** and executed"
+            echo "**as root** on every box during self-update. It goes live on the whole fleet"
+            echo "at merge, with no release tag in between (DIVE-2144)."
+            echo
+            echo "Changed: \`$(tr '\n' ' ' <<<"$files")\`"
+            echo
+            echo '```diff'
+            git diff "$base" "$head" -- install.sh src/cmd_selfupdate.sh
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::warning::This PR modifies the root-execution path ($(tr '\n' ' ' <<<"$files")). It reaches every box at merge, ungated by any tag. Full diff is in the job summary."

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1,0 +1,162 @@
+# DIVE-2144: cut the release tag. This is the PUBLISH ACT.
+#
+# Under DIVE-2144 install.sh resolves the newest release TAG, not main HEAD. That
+# moves publishing off "someone merged" and onto "someone cut a tag" — and a publish
+# act with no owner is a shipping freeze. lodar answered the cadence gate 2026-07-27
+# 05:16, option A: NIGHTLY AUTO-CUT WHEN MAIN CHANGED AND CI IS GREEN, PLUS A MANUAL
+# CUT FOR HOTFIXES. This job is that answer.
+#
+# READ THIS BEFORE EDITING THE TAG NAME OR THE SORT: this job and install.sh's
+# resolve_gh_tag() are ONE RULE IMPLEMENTED TWICE. install.sh accepts only
+# ^v[0-9]+\.[0-9]+\.[0-9]+$ and takes `sort -V | tail -1`. If this job cuts anything
+# that rule would not select, it publishes nothing while reporting success — the tag
+# exists, the release page looks right, and every box keeps installing the older tag.
+# So the ladder below re-implements the SAME filter and the SAME sort, and then
+# ASSERTS the result actually sorts above the incumbent rather than trusting that it
+# does. That assertion is the one that catches a divergence between the two copies.
+#
+# WHAT THIS JOB DOES NOT DO: it does not bump FIVE_VERSION. version-assign.yml owns
+# the bump at merge; this job only publishes a version that already exists on main.
+# The two must not both write versions or they will race for the same number.
+name: release-cut
+on:
+  schedule:
+    # 03:00 UTC. Deliberately an hour ahead of the fleet's 04:00 self-update cron, so
+    # a nightly cut is available to the boxes that same night rather than a day later.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why this cut is being made by hand (hotfix, incident, first cut)'
+        required: true
+        type: string
+
+concurrency:
+  group: release-cut
+  cancel-in-progress: false
+
+jobs:
+  cut:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create the tag and the release
+      checks: read      # read the CI verdict on main's tip
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Cut a release tag if main moved and CI is green on it
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MANUAL_REASON: ${{ inputs.reason }}
+        run: |
+          set -uo pipefail
+
+          sha=$(git rev-parse HEAD)
+          version=$(grep -m1 -oE 'FIVE_VERSION="[^"]+"' src/header.sh | sed 's/.*"\(.*\)"/\1/')
+          if [[ -z "$version" ]]; then
+            echo "::error::could not read FIVE_VERSION from src/header.sh on main — refusing to cut."
+            exit 1
+          fi
+          tag="v${version}"
+          echo "main tip ${sha:0:12} carries FIVE_VERSION=${version} -> candidate tag ${tag}"
+
+          # --- the incumbent, resolved by install.sh's OWN rule -------------------
+          # Same filter and same `sort -V` as resolve_gh_tag(). If these two ever
+          # disagree, the assertion further down is what surfaces it.
+          git fetch -q --tags origin
+          incumbent=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          echo "incumbent published tag (install.sh's rule): ${incumbent:-<none>}"
+
+          # --- has main actually moved? ------------------------------------------
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            existing=$(git rev-list -n1 "refs/tags/${tag}")
+            if [[ "$existing" == "$sha" ]]; then
+              echo "::notice::${tag} already points at main's tip ${sha:0:12} — main has not moved since the last cut. Nothing to publish."
+              exit 0
+            fi
+            # A version published against one tree and now claimed by another is the
+            # DIVE-2118 failure class. Never move a published tag: boxes that already
+            # took it would silently receive different bytes under a version they
+            # already have, and nothing downstream would ever ask again.
+            echo "::error::${tag} EXISTS at ${existing:0:12} but main's tip is ${sha:0:12}. A published version is being claimed by a second tree. NOT re-pointing the tag. Bump FIVE_VERSION on main (scripts/version-assign.sh) so the new tree gets its own version."
+            exit 1
+          fi
+
+          # --- CI verdict on THAT EXACT SHA, and it must be non-vacuous ----------
+          # "no failing checks" is satisfied by "no checks at all", which is exactly
+          # the state a GITHUB_TOKEN push leaves behind (token pushes do not trigger
+          # workflows — see version-assign.yml). Treating that as green would publish
+          # an ungraded tree at precisely the moment our grading is broken, which is
+          # the failure this whole ticket exists to retire. So: count first.
+          runs=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/commits/${sha}/check-runs" \
+                   --jq '.check_runs[] | [.name, .status, (.conclusion // "pending")] | @tsv' 2>/dev/null)
+          # >>> DIVE-2144 release-cut guard block (extracted verbatim by tests/release_cut_guards_unit.sh)
+          total=$(printf '%s' "$runs" | grep -c . || true)
+
+          if (( total == 0 )); then
+            echo "::error::CI NOT REACHED on ${sha:0:12} — ZERO check-runs exist for this commit, which is NOT the same as green. Refusing to cut ${tag}. (A GITHUB_TOKEN push does not trigger workflows; dispatch bundle-drift against main, let it complete, then re-run this job.)"
+            exit 1
+          fi
+
+          incomplete=$(awk -F'\t' '$2 != "completed"' <<<"$runs")
+          bad=$(awk -F'\t' '$3 != "success" && $3 != "skipped" && $3 != "neutral"' <<<"$runs" | awk -F'\t' '$2 == "completed"')
+
+          echo "CI on ${sha:0:12}: ${total} check-run(s)"
+          printf '%s\n' "$runs" | sed 's/^/  /'
+
+          if [[ -n "$incomplete" ]]; then
+            echo "::error::CI still IN FLIGHT on ${sha:0:12} — refusing to cut ${tag}. Unfinished:"
+            printf '%s\n' "$incomplete" | sed 's/^/  /'
+            exit 1
+          fi
+          if [[ -n "$bad" ]]; then
+            echo "::error::CI is RED on ${sha:0:12} — refusing to cut ${tag}. Failing:"
+            printf '%s\n' "$bad" | sed 's/^/  /'
+            exit 1
+          fi
+          echo "CI green on ${sha:0:12}: ${total}/${total} completed, none failing."
+          # <<< DIVE-2144 release-cut guard block
+
+          # --- the candidate must WIN install.sh's sort, not merely exist ---------
+          # Without this, a cut that is lexically fine but version-sorts BELOW the
+          # incumbent succeeds, exits 0, and publishes precisely nothing. The tag page
+          # would show it; no box would ever install it.
+          # Note the tie: `sort -V | tail -1` returns its LAST input when the two are
+          # equal, so a naive `winner != tag` check passes a tie. That is unreachable
+          # here (the tag-exists branch above already returned), but a guard that is
+          # correct only because of a precondition somewhere else stops being correct
+          # the moment someone reorders the steps. Reject `<=`, not `<`.
+          # >>> DIVE-2144 sort-assertion block (extracted verbatim by tests/release_cut_guards_unit.sh)
+          if [[ -n "$incumbent" ]]; then
+            winner=$(printf '%s\n%s\n' "$incumbent" "$tag" | sort -V | tail -1)
+            if [[ "$winner" != "$tag" || "$tag" == "$incumbent" ]]; then
+              echo "::error::${tag} does NOT sort above the incumbent ${incumbent} under 'sort -V', so install.sh would keep resolving ${incumbent} and this cut would publish NOTHING while succeeding. Refusing."
+              exit 1
+            fi
+          fi
+          # <<< DIVE-2144 sort-assertion block
+
+          # --- publish -----------------------------------------------------------
+          note="nightly auto-cut: main changed and CI is green (lodar 2026-07-27, cadence option A)"
+          [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]] && note="manual cut: ${MANUAL_REASON}"
+
+          git config user.name  'lodar'
+          git config user.email 'markounik@gmail.com'
+          git tag -a "$tag" "$sha" -m "${tag} — ${note}
+
+          Publishes ${sha} as the tree every box installs (DIVE-2144). CI green on
+          this exact sha: ${total} completed check-runs, none failing."
+          if ! git push origin "refs/tags/${tag}"; then
+            echo "::error::tag push rejected — ${tag} was NOT published. Nothing changed for any box; they keep installing ${incumbent:-the previous tag}."
+            exit 1
+          fi
+
+          gh release create "$tag" --title "$tag" --target "$sha" --notes "${note}
+
+          Installed by every box via install.sh's tag resolver (DIVE-2144). Previous published tag: ${incumbent:-none}." \
+            || echo "::warning::THE TAG IS PUBLISHED and boxes will take ${tag} — only the release PAGE failed to create. Not an error in the publish; create the release by hand if you want the notes."
+
+          echo "::notice::published ${tag} at ${sha:0:12} (was ${incumbent:-none}) — this is what every box now installs"

--- a/install.sh
+++ b/install.sh
@@ -35,24 +35,82 @@ fi
 # is the thing that is unfixable at the client, and a pinned tree cannot be
 # inconsistent. The guard itself stays exactly as strict as it was.
 #
-# Prints the sha on stdout, or fails if it cannot resolve one (the caller then
-# falls back to /main, and the mismatch message says which case it is in).
-resolve_gh_sha() {
-  local sha=""
+# DIVE-2144: WHAT we resolve changed, and it is the whole point of that ticket.
+# It used to be the tip of `main`, which made merging identical to publishing:
+# an unreviewed merge was live on every box within one self-update, and the
+# version-assign commit sat on the customer critical path (DIVE-2118/2141/2142).
+# Now it is the newest RELEASE TAG. Cutting a tag becomes the publish act;
+# merging only stages. The pin mechanism below is unchanged — same ladder, same
+# raw/<sha>/ fetch, same DIVE-1977 consistency property — only its INPUT moved.
+#
+# Two ways to get this wrong, both measured on the real 285-tag repo, both of
+# which succeed loudly-plausibly rather than failing:
+#
+#   LEXICAL SORT. `sort | tail -1` — the form almost everyone writes — returns
+#   v0.9.9, not v0.15.34. That ships a six-minor-version DOWNGRADE to every box
+#   while exiting 0 with a real tag name in the log. Nothing downstream catches
+#   it: the sha is valid, the tree is consistent, the pin is honest. Version-sort
+#   (`sort -V`) is load-bearing, not tidiness. tests/install_pin_sha_unit.sh
+#   proves it by mutation.
+#
+#   FAILING OPEN TO /main. The old block fell back to the mutable ref when
+#   nothing resolved. Keeping that here would invert its meaning: pre-2144 the
+#   fallback was a PIN failure (same content, unpinned, risk = inconsistency);
+#   post-2144 the identical line is a POLICY failure (DIFFERENT, ungated content
+#   shipped as root). And "no tag resolves" is not a random event — it correlates
+#   with tags deleted, release process broken, incident in progress. So we fail
+#   CLOSED, which is a no-op, not a brick: the box keeps the CLI it already has,
+#   exactly as it does every hour nothing is published. Two explicit valves out
+#   already exist and the error names both — GH_SHA (pin a tree directly) and
+#   REPO (override the source entirely).
+
+# Newest release tag name (e.g. v0.15.34) on stdout, or return 1.
+resolve_gh_tag() {
+  local tags=""
   # git ls-remote is exact and carries no API rate limit. A brand-new box may
   # not have git yet — this script is what apt-installs it — so this is the
   # normal path on every re-install and self-update, not on the first one.
   if command -v git >/dev/null 2>&1; then
-    sha="$(git ls-remote "https://github.com/$GH_ORG/5dive.git" main 2>/dev/null | awk 'NR==1 {print $1}')" || sha=""
+    tags="$(git ls-remote --tags --refs "https://github.com/$GH_ORG/5dive.git" 'v*' 2>/dev/null \
+      | sed -n 's#.*refs/tags/##p')" || tags=""
+  fi
+  # First-install fallback: the tags atom feed. Unauthenticated, and not subject
+  # to the 60/hr api.github.com limit a NAT'd fleet would share.
+  if [[ -z "$tags" ]]; then
+    tags="$(curl -fsSL --max-time 10 "https://github.com/$GH_ORG/5dive/tags.atom" 2>/dev/null \
+      | sed -n 's#.*<title>[[:space:]]*\(v[0-9][^<]*\)</title>.*#\1#p')" || tags=""
+  fi
+  # Last resort before giving up on resolving a tag altogether.
+  if [[ -z "$tags" ]]; then
+    tags="$(curl -fsSL --max-time 10 "https://api.github.com/repos/$GH_ORG/5dive/tags?per_page=100" 2>/dev/null \
+      | sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\(v[0-9][^"]*\)".*/\1/p')" || tags=""
+  fi
+  [[ -n "$tags" ]] || return 1
+  # `sort -V`, never `sort` — see the LEXICAL SORT note above. The regex also
+  # drops anything that is not a plain vMAJOR.MINOR.PATCH release tag, so a
+  # `v1.0.0-rc1` or a `nightly` can never become the thing every box installs.
+  local newest
+  newest="$(printf '%s\n' "$tags" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)"
+  [[ -n "$newest" ]] || return 1
+  printf '%s\n' "$newest"
+}
+
+# Commit sha for tag $1 on stdout, or return 1. Same three-rung ladder.
+resolve_gh_sha() {
+  local tag="$1" sha="" out=""
+  if command -v git >/dev/null 2>&1; then
+    # An ANNOTATED tag's own sha is the tag object, which raw.githubusercontent
+    # does not serve — the `^{}` peel is the commit. 97 of our tags are
+    # annotated, so preferring the peeled line is required, not defensive.
+    out="$(git ls-remote --tags "https://github.com/$GH_ORG/5dive.git" "refs/tags/$tag" "refs/tags/$tag^{}" 2>/dev/null)" || out=""
+    sha="$(printf '%s\n' "$out" | awk '$2 ~ /\^\{\}$/ {print $1; exit}')"
+    [[ -n "$sha" ]] || sha="$(printf '%s\n' "$out" | awk 'NR==1 {print $1}')"
     if [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then printf '%s\n' "$sha"; return 0; fi
   fi
-  # First-install fallback: the commits atom feed. Unauthenticated, and not
-  # subject to the 60/hr api.github.com limit a NAT'd fleet would share.
-  sha="$(curl -fsSL --max-time 10 "https://github.com/$GH_ORG/5dive/commits/main.atom" 2>/dev/null \
+  sha="$(curl -fsSL --max-time 10 "https://github.com/$GH_ORG/5dive/commits/$tag.atom" 2>/dev/null \
     | sed -n 's#.*Grit::Commit/\([0-9a-f]\{40\}\).*#\1#p' | head -1)" || sha=""
   if [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then printf '%s\n' "$sha"; return 0; fi
-  # Last resort before giving up on pinning altogether.
-  sha="$(curl -fsSL --max-time 10 "https://api.github.com/repos/$GH_ORG/5dive/commits/main" 2>/dev/null \
+  sha="$(curl -fsSL --max-time 10 "https://api.github.com/repos/$GH_ORG/5dive/commits/$tag" 2>/dev/null \
     | sed -n 's/.*"sha"[[:space:]]*:[[:space:]]*"\([0-9a-f]\{40\}\)".*/\1/p' | head -1)" || sha=""
   if [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then printf '%s\n' "$sha"; return 0; fi
   return 1
@@ -63,14 +121,39 @@ resolve_gh_sha() {
 # `file://` bundle of the working tree) — an explicit REPO is never re-pinned,
 # because we can't vouch for a foreign mirror's internal consistency. GH_SHA
 # pins the tree directly, skipping resolution (CI wanting a PR head, rollbacks).
+# Both are the documented ways OUT of the tag rail, and the fail-closed errors
+# below name them, so an operator leaves the guarantee by choosing to rather
+# than by being moved out of it silently.
 GH_PINNED_SHA="${GH_SHA:-}"
-if [[ -z "${REPO:-}" ]]; then
-  [[ -n "$GH_PINNED_SHA" ]] || GH_PINNED_SHA="$(resolve_gh_sha || true)"
-  if [[ -n "$GH_PINNED_SHA" ]]; then
-    REPO="https://raw.githubusercontent.com/$GH_ORG/5dive/$GH_PINNED_SHA"
-  else
-    REPO="https://raw.githubusercontent.com/$GH_ORG/5dive/main"
+GH_PINNED_TAG=""
+if [[ "${1:-}" == "--uninstall" ]]; then
+  # Uninstall downloads nothing, so it must never be gated on the release rail
+  # being healthy. Failing closed here would be a brick in the one direction
+  # fail-closed exists to prevent: "we cannot publish right now" must not become
+  # "you cannot remove what we already installed".
+  REPO="${REPO:-}"
+  GH_PINNED_SHA=""
+elif [[ -z "${REPO:-}" ]]; then
+  if [[ -z "$GH_PINNED_SHA" ]]; then
+    GH_PINNED_TAG="$(resolve_gh_tag || true)"
+    if [[ -z "$GH_PINNED_TAG" ]]; then
+      # Distinct and greppable on purpose: this must never read like the ordinary
+      # "pinned to <tag>" line, and must never be a silent `|| true` into main.
+      printf 'error: 5dive install: NO RELEASE TAG RESOLVED — refusing to install from ungated main.\n' >&2
+      printf '       Nothing was changed; if 5dive is already installed it keeps running the version it has.\n' >&2
+      printf '       Retry later, or choose a source explicitly:\n' >&2
+      printf '         GH_SHA=<40-hex commit>   pin one tree directly (rollback, CI, a PR head)\n' >&2
+      printf '         REPO=<base url>          install from a mirror or an offline bundle\n' >&2
+      exit 1
+    fi
+    GH_PINNED_SHA="$(resolve_gh_sha "$GH_PINNED_TAG" || true)"
+    if [[ -z "$GH_PINNED_SHA" ]]; then
+      printf 'error: 5dive install: RELEASE TAG %s RESOLVED BUT ITS COMMIT DID NOT — refusing to install from ungated main.\n' "$GH_PINNED_TAG" >&2
+      printf '       Nothing was changed. Retry later, or set GH_SHA=<40-hex commit> / REPO=<base url> explicitly.\n' >&2
+      exit 1
+    fi
   fi
+  REPO="https://raw.githubusercontent.com/$GH_ORG/5dive/$GH_PINNED_SHA"
 else
   GH_PINNED_SHA=""
 fi

--- a/install.sh
+++ b/install.sh
@@ -75,10 +75,12 @@ resolve_gh_tag() {
       | sed -n 's#.*refs/tags/##p')" || tags=""
   fi
   # First-install fallback: the tags atom feed. Unauthenticated, and not subject
-  # to the 60/hr api.github.com limit a NAT'd fleet would share.
+  # to the 60/hr api.github.com limit a NAT'd fleet would share. Parse the
+  # <id> — NOT the <title>, which carries a human release headline after the tag
+  # ("v0.15.34 — task set-body") and matches nothing on the real feed.
   if [[ -z "$tags" ]]; then
     tags="$(curl -fsSL --max-time 10 "https://github.com/$GH_ORG/5dive/tags.atom" 2>/dev/null \
-      | sed -n 's#.*<title>[[:space:]]*\(v[0-9][^<]*\)</title>.*#\1#p')" || tags=""
+      | sed -n 's#.*<id>tag:github.com,[0-9]*:Repository/[0-9]*/\([^<]*\)</id>.*#\1#p')" || tags=""
   fi
   # Last resort before giving up on resolving a tag altogether.
   if [[ -z "$tags" ]]; then

--- a/tests/install_pin_sha_unit.sh
+++ b/tests/install_pin_sha_unit.sh
@@ -75,7 +75,7 @@ git_stub='case "$*" in
 esac'
 # curl: tags.atom lists both tags; commits/<tag>.atom yields that tag's commit.
 atom_stub='case "$*" in
-  *tags.atom*) printf "<entry><title>'"$TAG_OLD"'</title></entry>\n<entry><title>'"$TAG_NEW"'</title></entry>\n" ;;
+  *tags.atom*) printf "<id>tag:github.com,2008:Repository/1239570688/'"$TAG_OLD"'</id>\n<title>'"$TAG_OLD"' — a release headline</title>\n<id>tag:github.com,2008:Repository/1239570688/'"$TAG_NEW"'</id>\n<title>'"$TAG_NEW"' — a release headline</title>\n" ;;
   *commits/'"$TAG_NEW"'.atom*) printf "<id>tag:github.com,2008:Grit::Commit/'"$SHA_NEW"'</id>\n" ;;
   *commits/'"$TAG_OLD"'.atom*) printf "<id>tag:github.com,2008:Grit::Commit/'"$SHA_OLD"'</id>\n" ;;
   *) exit 22 ;;

--- a/tests/install_pin_sha_unit.sh
+++ b/tests/install_pin_sha_unit.sh
@@ -5,6 +5,14 @@
 # release, which fails the checksum guard with a tamper-shaped message on an
 # unattended nightly self-update.
 #
+# DIVE-2144: and the sha it pins must come from the newest RELEASE TAG, not from
+# the tip of main. Merging must stage; cutting a tag must publish. Two failure
+# modes here succeed-in-appearance rather than erroring, so both are asserted by
+# MUTATION at the bottom of this file rather than by a happy-path check alone:
+#   (a) resolving main instead of a tag  — publishes every unreviewed merge
+#   (b) `sort` instead of `sort -V`      — resolves v0.9.9 as "newest" and ships
+#                                          every box a six-minor DOWNGRADE, exit 0
+#
 # Hermetic by construction: the pin-resolution block is extracted verbatim from
 # install.sh and run against STUBBED git/curl on PATH, so this harness makes no
 # network calls and asserts the real shipped code, not a paraphrase of it.
@@ -14,98 +22,161 @@ PASS=0; FAIL=0
 ok_t(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t(){ FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 
-SHA_A="1111111111111111111111111111111111111111"
-SHA_B="2222222222222222222222222222222222222222"
-SHA_C="3333333333333333333333333333333333333333"
+# TAG_OLD sorts LEXICALLY ABOVE TAG_NEW ("9" > "1"), which is the real shape of
+# the repo: `sort | tail -1` over its 285 tags returns v0.9.9, `sort -V` returns
+# v0.15.34. Every tag-resolution case below would pass under a lexical sort if
+# the fixtures did not straddle that boundary.
+TAG_NEW="v0.15.34"
+TAG_OLD="v0.9.9"
+SHA_NEW="1111111111111111111111111111111111111111"
+SHA_OLD="2222222222222222222222222222222222222222"
+SHA_TAGOBJ="9999999999999999999999999999999999999999"   # annotated tag OBJECT — raw/ does not serve it
+SHA_DIRECT="3333333333333333333333333333333333333333"
 
 block="$(sed -n '/^# >>> DIVE-1977 pin-resolution block/,/^# <<< DIVE-1977 pin-resolution block/p' install.sh)"
-if [[ -n "$block" ]] && grep -q 'resolve_gh_sha()' <<<"$block"; then
+if [[ -n "$block" ]] && grep -q 'resolve_gh_sha()' <<<"$block" && grep -q 'resolve_gh_tag()' <<<"$block"; then
   ok_t "pin-resolution block is extractable from install.sh"
 else
-  bad_t "pin-resolution block missing" "markers '# >>> / # <<< DIVE-1977 pin-resolution block' not found in install.sh"
+  bad_t "pin-resolution block missing" "markers '# >>> / # <<< DIVE-1977 pin-resolution block' (with resolve_gh_tag + resolve_gh_sha) not found in install.sh"
   echo; echo "$PASS passed, $FAIL failed"; exit 1
 fi
 
-# Run the extracted block under install.sh's real flags (`set -euo pipefail`,
-# line 6) with $1/$2 as the git/curl stub behaviour, and echo the resolved
-# REPO + GH_PINNED_SHA. Stubs shadow the real binaries via PATH.
-run_block() { # $1=git stub body ('' = git absent)  $2=curl stub body
-  local stubs; stubs="$(mktemp -d)"
-  if [[ -n "$1" ]]; then printf '#!/usr/bin/env bash\n%s\n' "$1" > "$stubs/git"; chmod +x "$stubs/git"; fi
-  printf '#!/usr/bin/env bash\n%s\n' "$2" > "$stubs/curl"; chmod +x "$stubs/curl"
-  # PATH is stubs-first but keeps the real tools the block needs (awk/sed/head).
-  # A stub that exits nonzero stands in for "git present but can't resolve" and
-  # for "git absent" alike: both leave $sha empty and must fall through.
-  env -i PATH="$stubs:/usr/bin:/bin" GH_ORG="testorg" \
-    ${3+REPO="$3"} ${4+GH_SHA="$4"} \
+# Run an extracted block under install.sh's real flags (`set -euo pipefail`,
+# line 6) with $2/$3 as the git/curl stub behaviour, and echo the resolved
+# REPO + GH_PINNED_SHA. Stubs shadow the real binaries via PATH. stdout and
+# stderr are BOTH captured (the fail-closed cases assert on stderr) and the exit
+# status is appended as RC=<n>.
+run_block_with() { # $1=block  $2=git stub  $3=curl stub  [$4=REPO] [$5=GH_SHA] [$6=argv1]
+  local blk="$1" stubs out rc; stubs="$(mktemp -d)"
+  if [[ -n "$2" ]]; then printf '#!/usr/bin/env bash\n%s\n' "$2" > "$stubs/git"; chmod +x "$stubs/git"; fi
+  printf '#!/usr/bin/env bash\n%s\n' "$3" > "$stubs/curl"; chmod +x "$stubs/curl"
+  # PATH is stubs-first but keeps the real tools the block needs (awk/sed/head/
+  # grep/sort). A stub that exits nonzero stands in for "git present but can't
+  # resolve" and for "git absent" alike: both leave the ladder empty.
+  out="$(env -i PATH="$stubs:/usr/bin:/bin" GH_ORG="testorg" \
+    ${4+REPO="$4"} ${5+GH_SHA="$5"} \
     bash -c "set -euo pipefail
-$block
-printf 'REPO=%s\nPIN=%s\n' \"\$REPO\" \"\$GH_PINNED_SHA\"" 2>/dev/null
-  local rc=$?; rm -rf "$stubs"; return $rc
+$blk
+printf 'REPO=%s\nPIN=%s\n' \"\$REPO\" \"\$GH_PINNED_SHA\"" install.sh ${6:+"$6"} 2>&1)"
+  rc=$?
+  rm -rf "$stubs"
+  printf '%s\nRC=%s\n' "$out" "$rc"
+}
+run_block() { run_block_with "$block" "$@"; }
+
+# --- stubs -------------------------------------------------------------------
+# git: the tag LIST query carries --refs; the per-tag sha query does not.
+# TAG_NEW is annotated (tag object + ^{} peel), TAG_OLD is lightweight.
+git_stub='case "$*" in
+  *--refs*) printf "aaaaaaa\trefs/tags/'"$TAG_OLD"'\nbbbbbbb\trefs/tags/'"$TAG_NEW"'\n" ;;
+  *"refs/tags/'"$TAG_NEW"'"*) printf "'"$SHA_TAGOBJ"'\trefs/tags/'"$TAG_NEW"'\n'"$SHA_NEW"'\trefs/tags/'"$TAG_NEW"'^{}\n" ;;
+  *"refs/tags/'"$TAG_OLD"'"*) printf "'"$SHA_OLD"'\trefs/tags/'"$TAG_OLD"'\n" ;;
+  *) exit 1 ;;
+esac'
+# curl: tags.atom lists both tags; commits/<tag>.atom yields that tag's commit.
+atom_stub='case "$*" in
+  *tags.atom*) printf "<entry><title>'"$TAG_OLD"'</title></entry>\n<entry><title>'"$TAG_NEW"'</title></entry>\n" ;;
+  *commits/'"$TAG_NEW"'.atom*) printf "<id>tag:github.com,2008:Grit::Commit/'"$SHA_NEW"'</id>\n" ;;
+  *commits/'"$TAG_OLD"'.atom*) printf "<id>tag:github.com,2008:Grit::Commit/'"$SHA_OLD"'</id>\n" ;;
+  *) exit 22 ;;
+esac'
+# curl: api.github.com only — the last rung of both ladders.
+api_stub='case "$*" in
+  *api.github.com*/tags*) printf "{\"name\": \"'"$TAG_OLD"'\"}\n{\"name\": \"'"$TAG_NEW"'\"}\n" ;;
+  *api.github.com*commits/'"$TAG_NEW"'*) printf "{\"sha\": \"'"$SHA_NEW"'\", \"commit\": {}}\n" ;;
+  *api.github.com*commits/'"$TAG_OLD"'*) printf "{\"sha\": \"'"$SHA_OLD"'\", \"commit\": {}}\n" ;;
+  *) exit 22 ;;
+esac'
+
+# The tag-rail property, factored out so the mutants below are graded by the
+# SAME assertion the real block is graded by.
+pins_newest_tag() { # $1=block ; 0 = REPO pinned to the newest tag's commit sha
+  local out; out="$(run_block_with "$1" "$git_stub" "exit 22")"
+  [[ "$out" == *"REPO=https://raw.githubusercontent.com/testorg/5dive/$SHA_NEW"* && "$out" == *"PIN=$SHA_NEW"* ]]
 }
 
-# 1. git ls-remote resolves → REPO pinned to that sha, not to /main.
-out="$(run_block "printf '$SHA_A\trefs/heads/main\n'" "exit 22")"
-if [[ "$out" == *"REPO=https://raw.githubusercontent.com/testorg/5dive/$SHA_A"* && "$out" == *"PIN=$SHA_A"* ]]; then
-  ok_t "git ls-remote sha pins REPO to raw/<sha>"
+# 1. git resolves → REPO pinned to the NEWEST tag's commit, version-sorted, and
+#    peeled through the annotated tag object.
+if pins_newest_tag "$block"; then
+  ok_t "git ls-remote pins REPO to the newest release tag's commit ($TAG_NEW, not $TAG_OLD, not main)"
 else
-  bad_t "git ls-remote sha did not pin REPO" "got: ${out//$'\n'/ | }"
+  bad_t "newest release tag did not pin REPO" "got: $(run_block "$git_stub" "exit 22" | tr '\n' '|')"
 fi
 
-# 2. git absent/broken → atom feed fallback pins.
-atom_stub='case "$*" in
-  *commits/main.atom*) printf "<entry><id>tag:github.com,2008:Grit::Commit/'"$SHA_B"'</id></entry>\n" ;;
-  *) exit 22 ;;
-esac'
+# 2. git absent/broken → tags.atom + commits/<tag>.atom fallback pins the same tag.
 out="$(run_block "exit 1" "$atom_stub")"
-if [[ "$out" == *"PIN=$SHA_B"* ]]; then
-  ok_t "atom-feed fallback pins when git can't resolve (fresh box, git not installed yet)"
+if [[ "$out" == *"PIN=$SHA_NEW"* ]]; then
+  ok_t "atom-feed fallback resolves the same newest tag (fresh box, git not installed yet)"
 else
-  bad_t "atom-feed fallback did not pin" "got: ${out//$'\n'/ | }"
+  bad_t "atom-feed fallback did not pin the newest tag" "got: ${out//$'\n'/ | }"
 fi
 
-# 3. git + atom both fail → api.github.com last resort pins.
-api_stub='case "$*" in
-  *api.github.com*) printf "{\"sha\": \"'"$SHA_C"'\", \"commit\": {}}\n" ;;
-  *) exit 22 ;;
-esac'
+# 3. git + atom both fail → api.github.com last resort pins the same tag.
 out="$(run_block "exit 1" "$api_stub")"
-if [[ "$out" == *"PIN=$SHA_C"* ]]; then
-  ok_t "api.github.com is the last-resort pin"
+if [[ "$out" == *"PIN=$SHA_NEW"* ]]; then
+  ok_t "api.github.com is the last-resort tag resolver"
 else
-  bad_t "api.github.com fallback did not pin" "got: ${out//$'\n'/ | }"
+  bad_t "api.github.com fallback did not pin the newest tag" "got: ${out//$'\n'/ | }"
 fi
 
-# 4. NOTHING resolves → fall back to /main, and say so via an empty pin. The
-#    install must still proceed (never harden into a brick), and the mismatch
-#    branch keys off the empty pin to soften its wording.
+# 4. DIVE-2144: NO TAG RESOLVES → FAIL CLOSED. Never fall back to ungated main.
+#    This is a no-op, not a brick: an installed box keeps the CLI it has, which
+#    is where it already was. The error must name both explicit valves out
+#    (GH_SHA, REPO) so an operator leaves the guarantee by choosing to.
 out="$(run_block "exit 1" "exit 22")"
-if [[ "$out" == *"REPO=https://raw.githubusercontent.com/testorg/5dive/main"* ]] \
-   && [[ "$(sed -n 's/^PIN=//p' <<<"$out")" == "" ]]; then
-  ok_t "unresolvable sha falls back to /main with an empty pin (no brick)"
+if [[ "$out" != *"REPO=https"* ]] && [[ "$out" == *"RC=1"* ]] \
+   && [[ "$out" == *"NO RELEASE TAG RESOLVED"* ]] \
+   && [[ "$out" == *"GH_SHA"* && "$out" == *"REPO=<base url>"* ]]; then
+  ok_t "no tag resolvable fails CLOSED, naming GH_SHA and REPO — never falls back to /main"
 else
-  bad_t "unresolvable-sha fallback wrong" "got: ${out//$'\n'/ | }"
+  bad_t "unresolvable tag did not fail closed" "got: ${out//$'\n'/ | }"
 fi
 
-# 5. A caller-supplied REPO (offline smoke bundle, enterprise mirror) is never
-#    re-pinned and never claims a pin.
-out="$(run_block "printf '$SHA_A\trefs/heads/main\n'" "exit 22" "file:///opt/5dive-bundle")"
-if [[ "$out" == *"REPO=file:///opt/5dive-bundle"* && "$out" != *"PIN=$SHA_A"* ]]; then
-  ok_t "explicit REPO override is untouched and claims no pin"
+# 5. Tag resolves but its commit does not → also fail closed, and say which tag.
+half_stub='case "$*" in
+  *--refs*) printf "bbbbbbb\trefs/tags/'"$TAG_NEW"'\n" ;;
+  *) exit 1 ;;
+esac'
+out="$(run_block "$half_stub" "exit 22")"
+if [[ "$out" != *"REPO=https"* ]] && [[ "$out" == *"RC=1"* ]] && [[ "$out" == *"$TAG_NEW RESOLVED BUT ITS COMMIT DID NOT"* ]]; then
+  ok_t "tag-without-commit fails closed and names the tag"
 else
-  bad_t "explicit REPO override was clobbered or falsely claimed a pin" "got: ${out//$'\n'/ | }"
+  bad_t "tag-without-commit did not fail closed" "got: ${out//$'\n'/ | }"
 fi
 
-# 6. GH_SHA pins directly with zero resolution (works with no git and no network).
-out="$(run_block "exit 1" "exit 22" "" "$SHA_C")"
-if [[ "$out" == *"REPO=https://raw.githubusercontent.com/testorg/5dive/$SHA_C"* && "$out" == *"PIN=$SHA_C"* ]]; then
-  ok_t "GH_SHA pins directly without any resolution"
+# 6. A lightweight (unannotated) tag has no ^{} peel — its own sha IS the commit.
+light_stub='case "$*" in
+  *--refs*) printf "aaaaaaa\trefs/tags/'"$TAG_OLD"'\n" ;;
+  *"refs/tags/'"$TAG_OLD"'"*) printf "'"$SHA_OLD"'\trefs/tags/'"$TAG_OLD"'\n" ;;
+  *) exit 1 ;;
+esac'
+out="$(run_block "$light_stub" "exit 22")"
+if [[ "$out" == *"PIN=$SHA_OLD"* ]]; then
+  ok_t "lightweight tag pins its own sha (no ^{} peel to prefer)"
+else
+  bad_t "lightweight tag did not pin" "got: ${out//$'\n'/ | }"
+fi
+
+# 7. A caller-supplied REPO (offline smoke bundle, enterprise mirror) is never
+#    re-pinned, never claims a pin, and is NOT subject to the tag rail — the
+#    offline install-smoke must keep working with no tags in sight.
+out="$(run_block "exit 1" "exit 22" "file:///opt/5dive-bundle")"
+if [[ "$out" == *"REPO=file:///opt/5dive-bundle"* && "$out" == *"PIN="$'\n'* && "$out" == *"RC=0"* ]]; then
+  ok_t "explicit REPO override is untouched, claims no pin, and survives an unresolvable tag"
+else
+  bad_t "explicit REPO override was clobbered, falsely claimed a pin, or was failed closed" "got: ${out//$'\n'/ | }"
+fi
+
+# 8. GH_SHA pins directly with zero resolution (works with no git and no network).
+out="$(run_block "exit 1" "exit 22" "" "$SHA_DIRECT")"
+if [[ "$out" == *"REPO=https://raw.githubusercontent.com/testorg/5dive/$SHA_DIRECT"* && "$out" == *"PIN=$SHA_DIRECT"* ]]; then
+  ok_t "GH_SHA pins directly without any resolution (rollback / CI / air-gap valve)"
 else
   bad_t "GH_SHA did not pin" "got: ${out//$'\n'/ | }"
 fi
-# (case 6 passes REPO="" explicitly — assert the empty override is treated as unset)
+# (case 8 passes REPO="" explicitly — assert the empty override is treated as unset)
 
-# 7. The bundle and its checksum must be fetched from the SAME base. A future
+# 9. The bundle and its checksum must be fetched from the SAME base. A future
 #    edit that reintroduces a hardcoded /main URL for either one re-opens the race.
 if grep -nE '^\s*(curl .*|_want="\$\(curl .*)"?https://raw\.githubusercontent\.com/[^"]*/main/5dive' install.sh; then
   bad_t "a fetch of the bundle or its sha256 hardcodes the mutable /main ref" "must go through \$REPO"
@@ -113,8 +184,8 @@ else
   ok_t "bundle + sha256 are both fetched through \$REPO (one pinned base)"
 fi
 
-# 8. The guard is NOT weakened — mismatch is still fatal — but the message no
-#    longer collapses cache skew into tampering.
+# 10. The guard is NOT weakened — mismatch is still fatal — but the message no
+#     longer collapses cache skew into tampering.
 if grep -q 'checksum mismatch' install.sh && grep -cq 'die "5dive bundle checksum mismatch' install.sh; then
   ok_t "mismatch is still fatal (die), guard not weakened"
 else
@@ -128,5 +199,39 @@ else
   bad_t "mismatch message still collapses stale-mirror into tampering" \
     "pinned-branch=$pinned_msg skew-branch=$skew_msg (want >=1 each)"
 fi
+
+# 11. --uninstall must NOT be gated on the release rail. Fail-closed exists to
+#     stop us publishing ungated code, not to trap a box with software it wants
+#     to remove: "we cannot publish right now" must never become "you cannot
+#     uninstall". Total-failure stubs + --uninstall must still exit 0.
+out="$(run_block_with "$block" "exit 1" "exit 22" "" "" "--uninstall")"
+if [[ "$out" == *"RC=0"* ]] && [[ "$out" != *"NO RELEASE TAG RESOLVED"* ]]; then
+  ok_t "--uninstall is not gated on tag resolution (fail-closed never traps a removal)"
+else
+  bad_t "--uninstall was blocked by the tag rail" "got: ${out//$'\n'/ | }"
+fi
+
+# --- NON-VACUITY: the two ways to get DIVE-2144 wrong must both go RED --------
+# An instrument that only distinguishes tag-from-main has graded HALF the change:
+# it passes happily while the resolver returns the WRONG tag. Both mutants are
+# sed edits on the REAL extracted block, and each mutation is asserted to have
+# actually changed something first — a mutant that failed to apply grades green
+# for the same reason a passing test does, which is exactly the trap.
+mutant_red() { # $1=label  $2=sed expr
+  local mutant; mutant="$(sed "$2" <<<"$block")"
+  if [[ "$mutant" == "$block" ]]; then
+    bad_t "mutation '$1' did not apply" "sed '$2' changed nothing — the arm is vacuous, not passing"
+    return
+  fi
+  if pins_newest_tag "$mutant"; then
+    bad_t "mutation '$1' still passes" "the tag assertion cannot detect this bug"
+  else
+    ok_t "mutation '$1' is caught (assertion is non-vacuous)"
+  fi
+}
+# (a) publish from mutable main, i.e. the pre-2144 behaviour this ticket retires.
+mutant_red "pins main instead of the tag" 's#/5dive/\$GH_PINNED_SHA#/5dive/main#'
+# (b) lexical sort — resolves v0.9.9 as "newest" and ships a downgrade, exit 0.
+mutant_red "lexical sort picks v0.9.9 as newest" 's/sort -V/sort/'
 
 echo; echo "$PASS passed, $FAIL failed"; [[ $FAIL -eq 0 ]]

--- a/tests/release_cut_guards_unit.sh
+++ b/tests/release_cut_guards_unit.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# DIVE-2144 — grade the two guards in .github/workflows/release-cut.yml.
+#
+# SHAPE, and it is deliberate (same as tests/install_pin_sha_unit.sh): this extracts
+# the guard blocks VERBATIM from the shipped workflow by fence marker and runs those
+# bytes. It does not re-implement them. A harness that re-implements the logic it
+# grades is internally consistent and externally silent — it agrees with itself while
+# the shipped file does something else. See community/wiki/fixture-shaped-like-the-parser-dive2144.md.
+#
+# WHAT THESE GUARDS ARE FOR: this workflow decides whether to PUBLISH. Both of its
+# failure modes succeed and exit 0 —
+#   (1) "no failing checks" is satisfied by "no checks at all", so an ungraded tree
+#       publishes at exactly the moment grading is broken;
+#   (2) a tag that does not win install.sh's `sort -V` publishes NOTHING while the
+#       release page looks correct.
+# Neither is visible downstream, which is why they are asserted here.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+WF=.github/workflows/release-cut.yml
+pass=0; fail=0
+ok(){ if [[ "$2" == "$3" ]]; then pass=$((pass+1)); echo "ok   - $1"; else fail=$((fail+1)); echo "FAIL - $1: got '$2' want '$3'"; fi; }
+
+# Extract a fenced block verbatim and strip the workflow's 10-space run: indent.
+extract(){ # $1 = fence name
+  sed -n "/# >>> DIVE-2144 $1/,/# <<< DIVE-2144 $1/p" "$WF" \
+    | sed '1d;$d' | sed 's/^          //'
+}
+
+GUARD=$(extract 'release-cut guard block')
+SORTA=$(extract 'sort-assertion block')
+[[ -n "$GUARD" && -n "$SORTA" ]] || { echo "FAIL - could not extract the fenced blocks from $WF"; exit 1; }
+
+# --- harness: run the extracted bytes against a fixture -----------------------
+verdict(){ # $1 = check-runs TSV ; echoes NOT-REACHED|IN-FLIGHT|RED|GREEN
+  local out rc
+  out=$(runs="$1" sha=deadbeefcafe tag=v9.9.9 bash -c "
+    set -uo pipefail
+    $GUARD
+  " 2>&1); rc=$?
+  if (( rc != 0 )); then
+    grep -q 'CI NOT REACHED'   <<<"$out" && { echo NOT-REACHED; return; }
+    grep -q 'CI still IN FLIGHT'<<<"$out" && { echo IN-FLIGHT;   return; }
+    grep -q 'CI is RED'         <<<"$out" && { echo RED;         return; }
+    echo "OTHER-FAIL:$out"; return
+  fi
+  grep -q 'CI green on' <<<"$out" && echo GREEN || echo "OTHER-OK:$out"
+}
+cut_decision(){ # $1 = incumbent, $2 = candidate ; echoes CUT|REFUSE
+  incumbent="$1" tag="$2" bash -c "set -uo pipefail; $SORTA" >/dev/null 2>&1 && echo CUT || echo REFUSE
+}
+
+echo "== guard A: the CI verdict must never read absence as green =="
+ok "ZERO check-runs -> NOT-REACHED, not GREEN"  "$(verdict "")" "NOT-REACHED"
+ok "all success -> GREEN"                       "$(verdict "$(printf 'test\tcompleted\tsuccess\nscan\tcompleted\tsuccess')")" "GREEN"
+ok "skipped and neutral count as green"         "$(verdict "$(printf 'test\tcompleted\tsuccess\nhook\tcompleted\tskipped\nx\tcompleted\tneutral')")" "GREEN"
+ok "one failure -> RED"                         "$(verdict "$(printf 'test\tcompleted\tsuccess\nscan\tcompleted\tfailure')")" "RED"
+ok "cancelled -> RED"                           "$(verdict "$(printf 'test\tcompleted\tcancelled')")" "RED"
+ok "timed_out -> RED"                           "$(verdict "$(printf 'test\tcompleted\ttimed_out')")" "RED"
+ok "still in_progress -> IN-FLIGHT, not GREEN"  "$(verdict "$(printf 'test\tin_progress\tpending\nscan\tcompleted\tsuccess')")" "IN-FLIGHT"
+ok "queued -> IN-FLIGHT"                        "$(verdict "$(printf 'test\tqueued\tpending')")" "IN-FLIGHT"
+
+echo "== guard B: the candidate must WIN install.sh's sort, not merely exist =="
+ok "v0.16.32 over v0.15.34 -> CUT"              "$(cut_decision v0.15.34 v0.16.32)" "CUT"
+ok "no incumbent -> CUT"                        "$(cut_decision '' v0.16.32)"       "CUT"
+ok "v0.9.9 under v0.15.34 -> REFUSE"            "$(cut_decision v0.15.34 v0.9.9)"   "REFUSE"
+ok "equal -> REFUSE (never re-point a tag)"     "$(cut_decision v0.16.32 v0.16.32)" "REFUSE"
+
+echo "== guard C: the cutter's incumbent rule agrees with install.sh's shipped one =="
+# install.sh's resolve_gh_tag and this workflow are one rule implemented twice. If
+# they diverge, the cutter publishes a tag the installer will not select.
+inst_rule=$(grep -oE "grep -E '\^v\[0-9\]\+\\\\\.\[0-9\]\+\\\\\.\[0-9\]\+\\\$'" install.sh | head -1)
+ok "install.sh still filters ^v<n>.<n>.<n>$"    "$([[ -n "$inst_rule" ]] && echo yes || echo no)" "yes"
+ok "install.sh still sorts with sort -V"        "$(grep -c 'sort -V' install.sh | awk '{print ($1>0)?"yes":"no"}')" "yes"
+ok "the workflow sorts with sort -V too"        "$(grep -c 'sort -V' "$WF" | awk '$1>0{print "yes"}')" "yes"
+
+echo "== non-vacuity: each guard must RED when mutated =="
+mutate(){ # $1 = sed expr applied to the extracted block var named by $2
+  local expr="$1" var="$2" before after
+  before="${!var}"
+  after=$(sed "$expr" <<<"$before")
+  [[ "$after" == "$before" ]] && { echo "FAIL - mutation '$expr' did not apply (arm is VACUOUS)"; fail=$((fail+1)); return 1; }
+  printf '%s' "$after"
+}
+
+# (a) drop the zero-check: absence must stop reading as green
+if m=$(mutate 's/if (( total == 0 )); then/if false; then/' GUARD); then
+  GUARD_SAVE="$GUARD"; GUARD="$m"
+  ok "MUTANT drop zero-check: empty runs no longer NOT-REACHED" \
+     "$([[ "$(verdict "")" == "NOT-REACHED" ]] && echo caught-nothing || echo mutant-detected)" "mutant-detected"
+  GUARD="$GUARD_SAVE"
+fi
+# (b) drop the in-flight arm: a running check must stop reading as green
+if m=$(mutate '/incomplete=\$(awk/s/\$2 != "completed"/1==0/' GUARD); then
+  GUARD_SAVE="$GUARD"; GUARD="$m"
+  ok "MUTANT drop in-flight arm: running check no longer IN-FLIGHT" \
+     "$([[ "$(verdict "$(printf 'test\tin_progress\tpending')")" == "IN-FLIGHT" ]] && echo caught-nothing || echo mutant-detected)" "mutant-detected"
+  GUARD="$GUARD_SAVE"
+fi
+# (c) lexical sort: this is olivia's measured v0.9.9 downgrade, in the cutter
+if m=$(mutate 's/sort -V/sort/' SORTA); then
+  SORTA_SAVE="$SORTA"; SORTA="$m"
+  ok "MUTANT lexical sort: v0.9.9 stops being refused" \
+     "$(cut_decision v0.15.34 v0.9.9)" "CUT"
+  SORTA="$SORTA_SAVE"
+fi
+
+echo
+echo "$pass passed, $fail failed"
+exit $(( fail > 0 ))


### PR DESCRIPTION
Draft on purpose. The code is done and green; **merging it today ships a downgrade.**

## What changed

`install.sh` resolved the tip of `main` and pinned every asset to that sha, so merging *was* publishing — an unreviewed merge went live on every box within one self-update, and the version-assign commit sat on the customer critical path (DIVE-2118 → 2141 → 2142).

The pin **mechanism** is untouched: same three-rung ladder (git ls-remote → atom feed → api.github.com), same `raw/<sha>/` fetch, same DIVE-1977 one-consistent-tree property. Only its **input** moved.

- `resolve_gh_tag()` — newest release tag, version-sorted, `^v[0-9]+\.[0-9]+\.[0-9]+$` only (a `v1.0.0-rc1` or a `nightly` can never become the thing every box installs).
- `resolve_gh_sha()` — peels that tag to a commit. 97 of our 285 tags are annotated, and raw.githubusercontent does not serve a tag *object*, so the `^{}` peel is required, not defensive.

## Two footguns closed, both of which succeed-in-appearance

**Lexical sort.** Measured on the real repo: `sort | tail -1` returns `v0.9.9`; `sort -V` returns `v0.15.34`. The naive form ships a six-minor-version **downgrade** to every box while exiting 0 with a real tag name in the log. Nothing downstream catches it — the sha is valid, the tree is consistent, the pin is honest.

**Fail-open to `/main`.** The old block fell back to the mutable ref. Kept here, that identical line would invert meaning: pre-2144 it was a *pin* failure (same content, unpinned, risk = inconsistency); post-2144 it is a *policy* failure (different, ungated content executed as root) — and "no tag resolves" is not random, it correlates with tags deleted / release process broken / incident in progress. Now fails **closed**, which is a no-op rather than a brick: the box keeps the CLI it already has, exactly as it does every hour nothing is published. The error is loud and greppable and names both explicit valves out, `GH_SHA` and `REPO`.

`--uninstall` is exempt — it fetches nothing, and "we cannot publish right now" must not become "you cannot remove what we installed."

## How it was checked

- `tests/install_pin_sha_unit.sh` — **15/15 green**, still hermetic (stubbed `git`/`curl`, no network) and still extracting the shipped block verbatim rather than a paraphrase.
- **Non-vacuity by mutation on the real block**, both arms required by review: pinning `main` instead of the tag → RED; `sort` instead of `sort -V` → RED. Each mutant asserts its sed actually applied, so an arm that fails to mutate is reported as vacuous instead of grading green.
- Live resolution against the real repo: `v0.15.34` → `a3015ae87586027e97ff0a5e627f9b3192296a84`, and `raw/<that sha>/install.sh` → 200.
- `shellcheck -S error` clean; `bash -n` clean.

## Why this is a draft

Newest tag is **v0.15.34**; `main` is at **0.16.29**. Merging before a tag is cut points every box at a 30-version-old tree. The release freeze of 2026-07-26 ("bump yes, tag no") was sound tagging hygiene while publish came from main — under this PR the same unchanged decision silently becomes the **publish cadence**. That is lodar's call, not an engineering one, and it is gated on DIVE-2144.

Merge only after: (1) the cadence answer, and (2) a tag cut at or above current main.

Still open in the ticket, deliberately out of this PR: gating `install.sh` itself (required review + per-PR diff check — post-cutover it is the only mutable-main-to-root path left), and retiring the DIVE-2118 version-assign performer.