### PR TITLE
test(agent): the impliedIsolation arm must red on the field being ABSENT (DIVE-2136)

### DIFF
--- a/tests/agent_list_sudo_unit.sh
+++ b/tests/agent_list_sudo_unit.sh
@@ -40,7 +40,15 @@ PASS=0; FAIL=0
 ok()  { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
 bad() { FAIL=$((FAIL+1)); printf '  FAIL %s\n     want: %s\n     got:  %s\n' "$1" "$2" "$3"; }
 is()  { [[ "$2" == "$3" ]] && ok "$1" || bad "$1" "$3" "$2"; }
-isnt(){ [[ "$2" != "$3" ]] && ok "$1" || bad "$1" "anything but '$3'" "$2"; }
+# A bare `!=` is the one assertion shape that PASSES when the field it names is
+# absent: jq renders a missing key as the string `null`, which differs from any
+# real label, so the arm would go green on the very tree it exists to red.
+# `differs` requires the value PRESENT first, then different (DIVE-2136).
+differs(){
+  if   [[ -z "$2" || "$2" == null ]]; then bad "$1" "a present value, anything but '$3'" "${2:-<empty>}"
+  elif [[ "$2" != "$3" ]];            then ok  "$1"
+  else                                     bad "$1" "anything but '$3'" "$2"; fi
+}
 has() { [[ "$2" == *"$3"* ]] && ok "$1" || bad "$1" "contains: $3" "$2"; }
 hasnt(){ [[ "$2" != *"$3"* ]] && ok "$1" || bad "$1" "must NOT contain: $3" "$2"; }
 
@@ -157,7 +165,8 @@ is "unknown never claims divergence"           "$(g scoped .sudo.diverges)" "fal
 # because "not the label" and "not a genuine class" are different properties and
 # the value `unknown` is the only one that satisfies both.
 is "unknown does NOT fall back to the label"   "$(g scoped .sudo.impliedIsolation)" "unknown"
-isnt "impliedIsolation is not the stored label" "$(g scoped .sudo.impliedIsolation)" "$(g scoped .isolation)"
+differs "impliedIsolation is PRESENT and is not the stored label" \
+        "$(g scoped .sudo.impliedIsolation)" "$(g scoped .isolation)"
 is "stored label still reported alongside"     "$(g scoped .isolation)" "admin"
 SUDOERS_D="$TMP/sudoers.d"
 


### PR DESCRIPTION
Maker dev3, tier-1 push gate cleared by main. Tests-only: 1 file, +11/−2, no `src/` change, so no bundle rebuild, no CHANGELOG, no version bump.

## The defect

`agent_list_sudo_unit.sh`'s `isnt` helper was a bare `!=`. jq renders a **missing** key as the string `null`, which differs from any real label — so the arm went green on the very tree it exists to red. Replaced with `differs`, which requires the value **present first, then different**.

```bash
-isnt(){ [[ "$2" != "$3" ]] && ok "$1" || bad "$1" "anything but '$3'" "$2"; }
+differs(){
+  if   [[ -z "$2" || "$2" == null ]]; then bad "$1" "a present value, anything but '$3'" "${2:-<empty>}"
+  elif [[ "$2" != "$3" ]];            then ok  "$1"
+  else                                     bad "$1" "anything but '$3'" "$2"; fi
+}
```

## Why this one is worth reading about

**That helper was mutation-graded on DIVE-2088 and pronounced real.** olivia did the right thing — a negative assertion is precisely the shape that passes when broken, so rather than reading it she forced `_sg_implied` to the stored label, which reds it (the field is then *present and equal*, and equality is what trips the assertion).

But every mutant of that family sets the field to **some present value**. The absent case is outside their reach. So a correctly-performed mutation test passed a helper that was still wrong in a way its mutants could not express.

That is the third specimen tonight of the class named on DIVE-2144 — **mutation grading cannot see a defect its mutants share a universe with**. Compiled to `community/wiki/fixture-shaped-like-the-parser-dive2144.md` as the second worked example, because one reads as a curiosity and two reads as a class.

## Grading

Two mutants on the **fixed** tree:

- **absence mutant** — old arm 27/6 **green** vs new 26/7 **red**. That A/B is the whole ticket.
- **fallback mutant** (`unknown` implies the stored label) — 31/2 red.

Pre-fix tree degrades 6/27 → 5/28 with graded want/got rather than a crash. Fixed tree 33/0, independently re-run by me in a clean extraction.