### PR TITLE
ci: a REQUIRED status check must run unconditionally — path filters made tests-only PRs permanently unmergeable (DIVE-2153)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -9,19 +9,19 @@ name: install-smoke
 # confirm `5dive --version` works post-install.
 
 on:
+  # NO `paths:` FILTER ON pull_request — DELIBERATE, DIVE-2153.
+  # `shellcheck` and `docker-install` are REQUIRED status checks on main. A
+  # required context that does not RUN never reports, and GitHub blocks the PR
+  # forever waiting for it — so a path filter here does not skip the check, it
+  # makes a whole class of PR (tests-only, docs-only, workflow-only)
+  # PERMANENTLY UNMERGEABLE. PR #237 was the first casualty.
+  # INVARIANT: if a job is a required context, its trigger must be
+  # unconditional. Cost is ~2 min of CI on PRs that could have skipped it;
+  # the alternative is an unmergeable PR and a human reaching for the admin
+  # bypass, which defeats the gate it was added to enforce.
+  # The `push:` filter below is UNCHANGED — required checks are enforced at the
+  # PR, and main pushes carry the admin bypass.
   pull_request:
-    paths:
-      - 'install.sh'
-      - '5dive'
-      - '5dive-agent-start'
-      - 'src/**'
-      - 'hooks/**'
-      - 'skills/**'
-      - 'systemd/**'
-      - 'docker/Dockerfile'
-      - 'projects-CLAUDE.md'
-      - 'telegram-agent-CLAUDE.md'
-      - '.github/workflows/install-smoke.yml'
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
**Self-inflicted, found by it blocking a real PR.**

`install-smoke.yml` owns `shellcheck` and `docker-install`. Both were made **required contexts** on main earlier tonight (DIVE-2141). Its `pull_request:` trigger is path-filtered and `tests/**` is not in the list — so on a tests-only PR neither job runs, neither context ever reports, and GitHub blocks the PR **forever**, waiting for a check that will never arrive.

PR #237 (tests-only, `+11/−2`) is the first casualty: `test`, `test-installed-host`, `scan`, `check`, `harness-verdict`, `harness-verdict-union`, `selfcheck-union` all **pass**; `shellcheck` and `docker-install` are simply *absent*, and the PR reads `BLOCKED`.

## The invariant

**If a job is a required context, its trigger must be unconditional.**

A path filter on a required check does not *skip* the check — it makes a whole class of PR (tests-only, docs-only, workflow-only) unmergeable. Removing the `pull_request` filter; the `push:` filter is untouched, since required checks are enforced at the PR and main pushes carry the admin bypass.

Cost is ~2 minutes of CI on PRs that could have skipped it (`shellcheck` 1m14s, `docker-install` 1m9s). The alternative is an unmergeable PR and a human reaching for the admin bypass — which defeats the gate it was added to enforce.

## Why this one is worth reading

I compiled this exact failure to `community/wiki/characterize-the-object-before-acting.md` **hours before I built it**:

> A check that can never be reached is worse than no check, because the absent check leaves a visible hole while the unreachable one reports a colour.

along with the review question meant to prevent it — *"what does this guardrail make UNREACHABLE?"* — which I then never asked of the guardrail. Writing the rule is not applying it, and the gap between the two was about four hours.

This is the sixth instance tonight of the same family (absent-vs-forbidden / unreachable-check), across four agents; the count and its bearing on the artifact-over-vigilance argument are logged on DIVE-2152.

## Note on this PR's own CI

This diff touches `.github/workflows/install-smoke.yml`, which **is** in the current path list, so `shellcheck` and `docker-install` trigger here and the required contexts report. This PR can merge under the very filter it removes.