### PR TITLE
fix(skills): 5dive-refresh-skills.sh never refreshed 5dive-cli — the skill every agent is provisioned with (DIVE-2160)

### DIFF
--- a/5dive-refresh-skills.sh
+++ b/5dive-refresh-skills.sh
@@ -39,6 +39,14 @@ FIVE_BIN="${FIVE_BIN:-/usr/local/bin/5dive}"
 # newly-added defaults like openagent onto pre-existing boxes.
 DEFAULT_SKILLS=(
   "5dive-ai/skills:openagent"
+  # DIVE-2158: 5dive-cli was MISSING here while being seeded at provisioning
+  # (cmd_agent_create.sh: skills_specs=("5dive-cli")), so every agent carried a
+  # copy that this script could never refresh — the loop below iterates ONLY
+  # DEFAULT_SKILLS, there is no refresh-what-is-installed path. Result: a skill
+  # resync reached the repo and never reached a single agent, silently, while
+  # the maintenance wiki told people to "refresh via 5dive-refresh-skills.sh".
+  # The mechanism was right and the DATA was wrong, which is why nothing failed.
+  "5dive-ai/skills:5dive-cli"
 )
 
 [[ -x "$FIVE_BIN" ]] || { echo "no 5dive at $FIVE_BIN — skipping skills refresh" >&2; exit 0; }


### PR DESCRIPTION
Found by dev2 while resyncing the `5dive-cli` skill to CLI 0.16.30 (DIVE-2157): **the sync landed in `5dive-ai/skills` and would have reached nobody.**

## The gap

`DEFAULT_SKILLS` held only `openagent`, and the loop below it iterates **only that array** — there is no refresh-what-is-installed path:

```bash
DEFAULT_SKILLS=( "5dive-ai/skills:openagent" )
...
for spec in "${DEFAULT_SKILLS[@]}"; do   # <- the entire rollout surface
```

But provisioning **seeds `5dive-cli`** (`src/cmd_agent_create.sh:1256`, `skills_specs=("5dive-cli")`), and I confirmed all seven live agents carry a copy — dev, dev2, dev3, olivia, marketing, community, creative.

So every agent's `5dive-cli` skill was frozen at whatever version it was provisioned with, **permanently**, and no rollout could reach it.

## Why it survived

**Nothing ever failed.** The script exits 0 having refreshed `openagent` and prints `skills refresh done: N re-pulled, 0 failed` — a true statement about the skills it was told to manage. The maintenance wiki meanwhile tells operators a sync is not done until per-user copies update, and to *"refresh via `5dive-refresh-skills.sh`"*.

The mechanism was correct and the **data** was wrong, so a successful refresh and a no-op for `5dive-cli` render identically. The script's own comment even describes the behaviour we wanted — *"Force re-pull every managed default… an existing copy might be stale"* — it just wasn't a managed default.

## Fix

One entry, with the reasoning inline so nobody trims it back as redundant.

## Verified before changing anything

- `5dive-refresh-skills.sh` is repo-tracked and fetched by `install.sh`, so this reaches boxes.
- The claim was checked against the script itself and against `cmd_agent_create.sh`, not taken from the report.
- `bash -n` clean.

**Residual, not fixed here:** the wiki page `five-dive-cli-skill-maintenance.md` implies the refresh script covers this. Once this lands the implication becomes true, so I would rather land the code than edit the page to describe the gap.