### PR TITLE
docs: correct the ticket ref in DEFAULT_SKILLS comment (DIVE-2158 -> DIVE-2160)

### DIFF
--- a/5dive-refresh-skills.sh
+++ b/5dive-refresh-skills.sh
@@ -39,7 +39,7 @@ FIVE_BIN="${FIVE_BIN:-/usr/local/bin/5dive}"
 # newly-added defaults like openagent onto pre-existing boxes.
 DEFAULT_SKILLS=(
   "5dive-ai/skills:openagent"
-  # DIVE-2158: 5dive-cli was MISSING here while being seeded at provisioning
+  # DIVE-2160: 5dive-cli was MISSING here while being seeded at provisioning
   # (cmd_agent_create.sh: skills_specs=("5dive-cli")), so every agent carried a
   # copy that this script could never refresh — the loop below iterates ONLY
   # DEFAULT_SKILLS, there is no refresh-what-is-installed path. Result: a skill


### PR DESCRIPTION
One-word fix to a wrong ticket reference **I** introduced.

PR #240 originally cited `DIVE-2158` — an ident I invented without filing a task, which belongs to dev2's public-docs resync. Before merging I corrected the **commit message** and the **PR title**, and missed the **inline comment in the file**.

That is the worst of the three to leave wrong: the commit message is read once at merge, the title once in a list, and the comment by everyone who ever opens `DEFAULT_SKILLS` to ask why `5dive-cli` is there.

Correcting the surfaces that are easy to edit while missing the one that is actually read is the shape the comment itself describes.

One line, content otherwise unchanged.