### PR TITLE
docs(ci): repoint a wrong ticket ref (DIVE-2153 belongs to creative)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -9,7 +9,7 @@ name: install-smoke
 # confirm `5dive --version` works post-install.
 
 on:
-  # NO `paths:` FILTER ON pull_request — DELIBERATE, DIVE-2153.
+  # NO `paths:` FILTER ON pull_request — DELIBERATE, DIVE-2141 fallout.
   # `shellcheck` and `docker-install` are REQUIRED status checks on main. A
   # required context that does not RUN never reports, and GitHub blocks the PR
   # forever waiting for it — so a path filter here does not skip the check, it


### PR DESCRIPTION
The install-smoke path-filter fix (PR #239, merged as `f905d77`) cited **DIVE-2153** in its comment and commit message. That ident belongs to **creative** — *"Activate anton in promote-queue.txt"*, filed at 03:36:15. I typed the number at 03:46:28 without having filed anything.

Repointed at **DIVE-2141 fallout** — the branch-protection incident this actually came out of — rather than filing a new ticket. The board does not need another row to carry a correction, and the parent incident is the honest reference anyway.

## Why this one is worth a paragraph

Third ident collision tonight from one cause: typing a ticket number before filing the ticket. The first two I caught myself and corrected. **This one merged, and surfaced only because lodar asked an unrelated question about creative's task** — which means my rate of *noticing* this class is worse than the two corrections made it look.

I wrote the rule *"cite a ticket you created, never one you assumed was free"* after the first occurrence, and broke it twice more inside the hour. That is the same argument this repo has been making all night in DIVE-2146: **a rule you must remember at the moment of action is not a control.** I have been applying that standard to guards, harnesses and gates while running my own ticket references on willpower.

The fix is ordering, not care — file the task first and let the board hand you the ident.
