### PR TITLE
fix(version-assign): classify push rejections instead of blaming a race (DIVE-2143)

### DIFF
--- a/.github/workflows/version-assign.yml
+++ b/.github/workflows/version-assign.yml
@@ -52,9 +52,17 @@ jobs:
           # could exercise it — and it shipped a retry loop that named the wrong cause
           # on a real failure (run 30231912328) with no way to have caught it first.
           #   0 = assigned and pushed (grade it)   3 = nothing owed   1 = failed loudly
-          bash scripts/version-assign-push-loop.sh "$before" 3; rc=$?
-          (( rc == 3 )) && exit 0
-          (( rc == 0 )) || exit 1
+          #
+          # `|| rc=$?`, NOT `; rc=$?`. GitHub runs a `run:` block with no `shell:` key
+          # as `bash -e {0}`, and the `set -uo pipefail` above does not turn -e back
+          # off — so under `; rc=$?` errexit fires on the loop's own exit and the line
+          # that reads rc never runs. The step would then exit 3 on the COMMON path
+          # (nothing owed, doc/workflow-only merge) and paint main red for the
+          # non-event this job exists to stay quiet about. Graded by arm F of
+          # tests/version_assign_push_unit.sh, which runs this block under `bash -e`.
+          rc=0; bash scripts/version-assign-push-loop.sh "$before" 3 || rc=$?
+          if (( rc == 3 )); then exit 0; fi
+          if (( rc != 0 )); then exit 1; fi
           assigned=$(grep -m1 -oE 'FIVE_VERSION="[^"]+"' src/header.sh | sed 's/.*"\(.*\)"/\1/')
 
           # GRADED. A GITHUB_TOKEN push does not trigger workflows, so the assignment

--- a/.github/workflows/version-assign.yml
+++ b/.github/workflows/version-assign.yml
@@ -47,67 +47,15 @@ jobs:
             echo "version-assign: no usable previous main tip (new branch or force event) — skipping."
             exit 0
           fi
-          git config user.name  'lodar'
-          git config user.email 'markounik@gmail.com'
-
-          # THE RACE, and why `concurrency` alone does not close it (found in review,
-          # iteration 1). concurrency serialises RUNS — but a human MERGE is not in the
-          # group, and actions/checkout on a push event pins to github.sha, NOT main's
-          # tip. So if a merge lands between this job's checkout and its push, the push
-          # is non-fast-forward and the job dies. It is a WINDOW, not a certainty (a
-          # merge landing after we push is fine, and that run computes correctly), but
-          # it is likeliest in exactly the batched-merge scenario this job exists for.
-          # So: refetch, recompute against the moved tip, retry, and fail loudly.
-          #
-          # BASE stays github.event.before across retries, deliberately. If a previous
-          # run already assigned, the version HAS moved relative to that base, so the
-          # script reports "already moved" and we stop — one version per batch, which
-          # is the batching lodar wants. If nobody assigned, we assign once for the
-          # whole batch. Both are correct; neither double-bumps.
-          attempts=3
-          assigned=""
-          for (( try=1; try<=attempts; try++ )); do
-            git fetch -q origin main
-            tip=$(git rev-parse FETCH_HEAD)
-            if [[ "$tip" != "$(git rev-parse HEAD)" ]]; then
-              echo "version-assign: main moved to ${tip:0:12} since checkout (attempt $try/$attempts) — recomputing against the new tip."
-              git reset -q --hard "$tip"
-            fi
-
-            out=$(bash scripts/version-assign.sh HEAD "$before" --apply); rc=$?
-            echo "$out"
-            if (( rc == 2 )); then
-              echo "::error::version-assign could not determine whether a bump is owed — NOT a pass, see above."
-              exit 1
-            fi
-            if ! grep -q '^version-assign: applied ' <<<"$out"; then
-              exit 0   # nothing owed; the reason is printed above
-            fi
-
-            git add src/header.sh 5dive 5dive.sha256
-            git commit -q -m "release: assign $(grep -m1 -oE 'FIVE_VERSION=\"[^\"]+\"' src/header.sh | sed 's/.*\"\(.*\)\"/\1/') at merge (DIVE-2118, automated)
-
-          The bundle changed on main without FIVE_VERSION moving. CONTRIBUTING
-          assigns the version at merge by merge order; this performs that step so a
-          box on the previous version is not silently left without the merged fixes
-          (the shared-checkout updater is version-triggered, not content-hash
-          triggered — DIVE-2065).
-
-          No tag and no release: those are batched, deliberately (lodar, 2026-07-26)."
-
-            if git push origin HEAD:main; then
-              assigned=$(grep -m1 -oE 'FIVE_VERSION="[^"]+"' src/header.sh | sed 's/.*"\(.*\)"/\1/')
-              break
-            fi
-            echo "version-assign: push rejected — main moved under us (attempt $try/$attempts). Dropping the local assignment and recomputing."
-            git reset -q --hard "$tip"
-          done
-
-          if [[ -z "$assigned" ]]; then
-            echo "::error::version-assign: main kept moving across $attempts attempts, so NO assignment was made and the bundle on main is still unassigned. Bump by hand (scripts/version-assign.sh HEAD <prev> --apply) or re-run this workflow."
-            exit 1
-          fi
-          echo "::notice::assigned ${assigned} — no tag cut, releases are batched"
+          # DIVE-2143: the retry loop lives in scripts/version-assign-push-loop.sh so a
+          # harness can reach it. It used to be inline here, where nothing in tests/
+          # could exercise it — and it shipped a retry loop that named the wrong cause
+          # on a real failure (run 30231912328) with no way to have caught it first.
+          #   0 = assigned and pushed (grade it)   3 = nothing owed   1 = failed loudly
+          bash scripts/version-assign-push-loop.sh "$before" 3; rc=$?
+          (( rc == 3 )) && exit 0
+          (( rc == 0 )) || exit 1
+          assigned=$(grep -m1 -oE 'FIVE_VERSION="[^"]+"' src/header.sh | sed 's/.*"\(.*\)"/\1/')
 
           # GRADED. A GITHUB_TOKEN push does not trigger workflows, so the assignment
           # commit would otherwise never be seen by CI — leaving this job's own output

--- a/.github/workflows/version-assign.yml
+++ b/.github/workflows/version-assign.yml
@@ -53,13 +53,21 @@ jobs:
           # on a real failure (run 30231912328) with no way to have caught it first.
           #   0 = assigned and pushed (grade it)   3 = nothing owed   1 = failed loudly
           #
-          # `|| rc=$?`, NOT `; rc=$?`. GitHub runs a `run:` block with no `shell:` key
-          # as `bash -e {0}`, and the `set -uo pipefail` above does not turn -e back
-          # off — so under `; rc=$?` errexit fires on the loop's own exit and the line
-          # that reads rc never runs. The step would then exit 3 on the COMMON path
-          # (nothing owed, doc/workflow-only merge) and paint main red for the
-          # non-event this job exists to stay quiet about. Graded by arm F of
-          # tests/version_assign_push_unit.sh, which runs this block under `bash -e`.
+          # `|| rc=$?`, NOT `; rc=$?`. A `run:` block with no `shell:` key runs under
+          # errexit, and the `set -uo pipefail` above does not turn it back off — so
+          # under `; rc=$?` errexit fires on the loop's own exit and the line that reads
+          # rc never runs. The step would then exit 3 on the COMMON path (nothing owed,
+          # doc/workflow-only merge) and paint main red for the non-event this job
+          # exists to stay quiet about.
+          #
+          # MEASURED IN THIS REPO, not read from the docs: throwaway branch
+          # ci-errexit-probe, run 30243567053 (2026-07-27 06:41, since deleted). A step
+          # with no `shell:` printed PROBE-START, then `Process completed with exit
+          # code 3` — the line after `bash -c "exit 3"; rc=$?` NEVER RAN. Its control
+          # step with an explicit `shell: bash` behaved IDENTICALLY, so adding a
+          # `shell:` key is not an escape from this; only the `|| rc=$?` form is.
+          # Graded by arm F of tests/version_assign_push_unit.sh, which runs this very
+          # block under `bash -e`.
           rc=0; bash scripts/version-assign-push-loop.sh "$before" 3 || rc=$?
           if (( rc == 3 )); then exit 0; fi
           if (( rc != 0 )); then exit 1; fi

--- a/scripts/git-push-reject-class.sh
+++ b/scripts/git-push-reject-class.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# DIVE-2143: name the CAUSE of a `git push` rejection, or admit you cannot.
+#
+# MEASURED ON A REAL FAILURE, run 30231912328 (2026-07-27 02:19). version-assign's
+# retry loop treated EVERY push rejection as a lost race: it printed "main moved
+# under us" three times and finished with "main kept moving across 3 attempts".
+# Main did not move once — the tip was 02b356e for the entire run. The remote had
+# said the true thing on the first attempt:
+#
+#   remote: error: GH006: Protected branch update failed for refs/heads/main.
+#   remote: - 6 of 6 required status checks are expected.
+#    ! [remote rejected] HEAD -> main (protected branch hook declined)
+#
+# Two costs, and the second is the expensive one. A protection rejection is
+# DETERMINISTIC, so attempts 2 and 3 cannot succeed — the retries are pure latency.
+# And an error that names the wrong cause is worse than one that names none: it
+# sends the next reader hunting a concurrency bug through code that is working
+# correctly. That is [[succeeding-in-appearance-defect-class]] one level up from a
+# rail that no-ops green — a rail that FAILS, loudly, in the wrong direction.
+#
+# Usage: git-push-reject-class.sh < <push-stderr>     (also accepts a file argument)
+# Prints exactly one word on stdout, always exits 0:
+#   protection - the ref is gated (GH006, required checks, PR-only rule). NOT a
+#                race. Deterministic: retrying cannot help. Fail immediately.
+#   race       - a genuine lost race (non-fast-forward / fetch first / stale info).
+#                Refetch, recompute against the moved tip, retry.
+#   unknown    - not recognised. The caller must echo the remote's own lines and
+#                fail; it must NOT retry and must NOT name a cause.
+#
+# WHY `unknown` DOES NOT RETRY. A transient network failure would benefit from a
+# retry, and under this rule it gets none. That is the deliberate trade: the defect
+# being fixed is a confident wrong diagnosis, and "retry an unrecognised failure"
+# is the same instinct that produced it. A job re-run is cheap; a false cause
+# costs the next reader an investigation. Add a class here (with a captured stderr
+# in tests/fixtures/push-reject/) rather than widening `race` to mean "dunno".
+set -uo pipefail
+
+err="$(cat -- "${1:--}")"
+
+# Precedence is load-bearing, not cosmetic: a protection rejection ALSO carries
+# "! [remote rejected]", and GH006's body mentions "Updates were rejected" in some
+# variants. Protection is checked first so a gated ref can never be reported as a
+# race — the exact misreading this script exists to prevent.
+if grep -qiE 'GH006|protected branch (update failed|hook declined)|required status check|changes must be made through a pull request|protected branch' <<<"$err"; then
+  echo protection; exit 0
+fi
+
+# A genuine race, in git's own words. Every phrase here appears in git's rejection
+# output for a stale ref, not in GitHub's server-side hook output.
+if grep -qiE 'non-fast-forward|fetch first|stale info|cannot lock ref|Updates were rejected because' <<<"$err"; then
+  echo race; exit 0
+fi
+
+echo unknown

--- a/scripts/version-assign-push-loop.sh
+++ b/scripts/version-assign-push-loop.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# DIVE-2118's push loop, DIVE-2143's honesty.
+#
+# WHY THIS IS A SCRIPT AND NOT TEN MORE LINES OF YAML. It used to live inline in
+# .github/workflows/version-assign.yml, where it was unreachable by every harness in
+# tests/ — the only way to exercise it was to merge to main and watch. It shipped a
+# retry loop that reported the wrong cause on a real failure (run 30231912328) and
+# nothing could have caught that before the fact. A branch of logic that decides
+# whether to retry and what to blame is exactly the kind that needs a mutation test,
+# so it moved somewhere a test can reach it. Graded by tests/version_assign_push_unit.sh.
+#
+# Usage: version-assign-push-loop.sh <base-rev> [attempts]
+# Exit:  0 = an assignment was applied and pushed (caller should grade it)
+#        3 = nothing was owed; no push happened, so there is nothing to grade
+#        1 = failure, already reported loudly on stderr / as ::error::
+set -uo pipefail
+
+BEFORE="${1:?usage: version-assign-push-loop.sh <base-rev> [attempts]}"
+ATTEMPTS="${2:-3}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+classify() { bash "$HERE/git-push-reject-class.sh"; }
+
+# The identity lives with the commit that uses it: any other author fails the Vercel
+# team check on this org.
+git config user.name  'lodar'
+git config user.email 'markounik@gmail.com'
+
+# THE RACE, and why `concurrency` does not close it (found in review, iteration 1).
+# concurrency serialises RUNS — but a human MERGE is not in the group, and
+# actions/checkout on a push event pins to github.sha, NOT main's tip. So if a merge
+# lands between this job's checkout and its push, the push is non-fast-forward and the
+# job dies. It is a WINDOW, not a certainty (a merge landing after we push is fine,
+# and that run computes correctly), but it is likeliest in exactly the batched-merge
+# scenario this job exists for. So: refetch, recompute against the moved tip, retry,
+# and fail loudly.
+#
+# BASE stays github.event.before across retries, deliberately. If a previous run
+# already assigned, the version HAS moved relative to that base, so the script reports
+# "already moved" and we stop — one version per batch, which is the batching lodar
+# wants. If nobody assigned, we assign once for the whole batch. Both are correct;
+# neither double-bumps.
+assigned=""
+for (( try=1; try<=ATTEMPTS; try++ )); do
+  git fetch -q origin main
+  tip=$(git rev-parse FETCH_HEAD)
+  if [[ "$tip" != "$(git rev-parse HEAD)" ]]; then
+    echo "version-assign: main moved to ${tip:0:12} since checkout (attempt $try/$ATTEMPTS) — recomputing against the new tip."
+    git reset -q --hard "$tip"
+  fi
+
+  out=$(bash scripts/version-assign.sh HEAD "$BEFORE" --apply); rc=$?
+  echo "$out"
+  if (( rc == 2 )); then
+    echo "::error::version-assign could not determine whether a bump is owed — NOT a pass, see above."
+    exit 1
+  fi
+  if ! grep -q '^version-assign: applied ' <<<"$out"; then
+    exit 3   # nothing owed; the reason is printed above
+  fi
+
+  git add src/header.sh 5dive 5dive.sha256
+  git commit -q -m "release: assign $(grep -m1 -oE 'FIVE_VERSION="[^"]+"' src/header.sh | sed 's/.*"\(.*\)"/\1/') at merge (DIVE-2118, automated)
+
+The bundle changed on main without FIVE_VERSION moving. CONTRIBUTING assigns the
+version at merge by merge order; this performs that step so a box on the previous
+version is not silently left without the merged fixes (the shared-checkout updater is
+version-triggered, not content-hash triggered — DIVE-2065).
+
+No tag and no release: those are batched, deliberately (lodar, 2026-07-26)."
+
+  # DIVE-2143: keep the remote's OWN words. Every message below quotes them rather
+  # than paraphrasing, because on the failure that opened this ticket the paraphrase
+  # was the entire defect — the remote had already said the true thing.
+  if perr=$(git push origin HEAD:main 2>&1); then
+    echo "$perr"
+    assigned=$(grep -m1 -oE 'FIVE_VERSION="[^"]+"' src/header.sh | sed 's/.*"\(.*\)"/\1/')
+    break
+  fi
+  echo "$perr"
+
+  case "$(classify <<<"$perr")" in
+    protection)
+      # DETERMINISTIC. Attempts 2 and 3 cannot succeed, and calling this a race sends
+      # the reader after a concurrency bug in code that is working correctly. The fix
+      # for this class is a branch-protection configuration, so say so and stop.
+      echo "::error::version-assign: push rejected by branch protection on main — NOT a race, main did not move. Retrying cannot help, so no further attempt was made (attempt $try/$ATTEMPTS). The remote's own words:"
+      sed 's/^/    /' <<<"$perr" >&2
+      echo "::error::The fix is a branch-protection / ruleset change (or DIVE-2144's tag-based publish), not a retry. NO assignment was made and the bundle on main is still unassigned."
+      exit 1
+      ;;
+    race)
+      echo "version-assign: push rejected — main moved under us (attempt $try/$ATTEMPTS). Dropping the local assignment and recomputing."
+      git reset -q --hard "$tip"
+      ;;
+    *)
+      # We do not know. Say we do not know — the one thing we must not do is reach for
+      # the nearest familiar cause, which is how this ticket happened.
+      echo "::error::version-assign: push rejected for an UNRECOGNISED reason (attempt $try/$ATTEMPTS) — this is NOT known to be a race, so it was not retried. The remote's own words:"
+      sed 's/^/    /' <<<"$perr" >&2
+      echo "::error::NO assignment was made and the bundle on main is still unassigned. If this class is in fact retryable, add it to scripts/git-push-reject-class.sh with a captured stderr fixture."
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$assigned" ]]; then
+  echo "::error::version-assign: main kept moving across $ATTEMPTS attempts, so NO assignment was made and the bundle on main is still unassigned. Bump by hand (scripts/version-assign.sh HEAD <prev> --apply) or re-run this workflow."
+  exit 1
+fi
+echo "::notice::assigned ${assigned} — no tag cut, releases are batched"
+echo "version-assign: assigned ${assigned}"

--- a/tests/fixtures/push-reject/README.md
+++ b/tests/fixtures/push-reject/README.md
@@ -1,0 +1,14 @@
+# Captured `git push` rejection stderr — the input to scripts/git-push-reject-class.sh
+
+Real captures, not hand-written approximations of what git "probably" says. A
+classifier graded against invented text grades the invention.
+
+| file | provenance |
+|---|---|
+| `protected-gh006.txt` | verbatim from run 30231912328 (`5dive-ai/5dive`, 2026-07-27 02:19), the failure that opened DIVE-2143. Includes the trailing whitespace GitHub's hook emits. |
+| `race-fetch-first.txt` | captured locally: push a behind branch without fetching. |
+| `race-non-fast-forward.txt` | captured locally: fetch first, then push a behind branch — git changes its wording, which is why both variants are here. |
+| `unknown-transport.txt` | a transport failure: neither a gated ref nor a race. Present to prove `unknown` is reachable rather than theoretical. |
+
+Adding a class to the classifier means adding a capture here. "I think git says
+something like this" is how the paraphrase this ticket is about got written.

--- a/tests/fixtures/push-reject/README.md
+++ b/tests/fixtures/push-reject/README.md
@@ -12,3 +12,25 @@ classifier graded against invented text grades the invention.
 
 Adding a class to the classifier means adding a capture here. "I think git says
 something like this" is how the paraphrase this ticket is about got written.
+
+## These captures are a premise about someone else's wording, and it can expire
+
+GitHub owns the GH006 text; git owns the race text. **If GitHub rewords GH006, every
+arm in `tests/version_assign_push_unit.sh` keeps passing against a capture that no
+longer resembles a real rejection**, while the live path quietly falls through to
+`unknown`. We cannot test against a real remote — exercising the protection branch
+means re-breaking main's protection — so arm P records the substrings each verdict
+actually rests on and reds if they stop being load-bearing:
+
+| file | verdict | anchors the verdict rests on |
+|---|---|---|
+| `protected-gh006.txt` | `protection` | `GH006`, `protected branch`, `required status check` |
+| `race-fetch-first.txt` | `race` | `fetch first`, `Updates were rejected because` |
+| `race-non-fast-forward.txt` | `race` | `non-fast-forward`, `Updates were rejected because` |
+
+Arm P asserts each anchor is still present **and** that stripping all of them drops the
+verdict to `unknown` — so the list cannot rot into a fiction while some other substring
+silently carries the match.
+
+**If arm P goes red, RECAPTURE from a real rejection.** Editing the anchor list to match
+the fixture, or the fixture to match the list, removes the alarm and keeps the defect.

--- a/tests/fixtures/push-reject/protected-gh006.txt
+++ b/tests/fixtures/push-reject/protected-gh006.txt
@@ -1,0 +1,6 @@
+remote: error: GH006: Protected branch update failed for refs/heads/main.        
+remote: 
+remote: - 6 of 6 required status checks are expected.        
+To https://github.com/5dive-ai/5dive
+ ! [remote rejected] HEAD -> main (protected branch hook declined)
+error: failed to push some refs to 'https://github.com/5dive-ai/5dive'

--- a/tests/fixtures/push-reject/race-fetch-first.txt
+++ b/tests/fixtures/push-reject/race-fetch-first.txt
@@ -1,0 +1,8 @@
+To https://github.com/5dive-ai/5dive
+ ! [rejected]        HEAD -> main (fetch first)
+error: failed to push some refs to 'https://github.com/5dive-ai/5dive'
+hint: Updates were rejected because the remote contains work that you do not
+hint: have locally. This is usually caused by another repository pushing to
+hint: the same ref. If you want to integrate the remote changes, use
+hint: 'git pull' before pushing again.
+hint: See the 'Note about fast-forwards' in 'git push --help' for details.

--- a/tests/fixtures/push-reject/race-non-fast-forward.txt
+++ b/tests/fixtures/push-reject/race-non-fast-forward.txt
@@ -1,0 +1,7 @@
+To https://github.com/5dive-ai/5dive
+ ! [rejected]        HEAD -> main (non-fast-forward)
+error: failed to push some refs to 'https://github.com/5dive-ai/5dive'
+hint: Updates were rejected because a pushed branch tip is behind its remote
+hint: counterpart. If you want to integrate the remote changes, use 'git pull'
+hint: before pushing again.
+hint: See the 'Note about fast-forwards' in 'git push --help' for details.

--- a/tests/fixtures/push-reject/unknown-transport.txt
+++ b/tests/fixtures/push-reject/unknown-transport.txt
@@ -1,0 +1,1 @@
+fatal: unable to access 'https://github.com/5dive-ai/5dive/': Failed to connect to github.com port 443 after 130272 ms: Couldn't connect to server

--- a/tests/version_assign_push_unit.sh
+++ b/tests/version_assign_push_unit.sh
@@ -195,11 +195,20 @@ fi
 # BLOCK — fenced out of .github/workflows/version-assign.yml, never retyped, so a
 # future edit to the step cannot drift past this arm the way a copy would.
 #
-# The trap being held shut: GitHub runs a `run:` with no `shell:` key as `bash -e {0}`,
-# and `set -uo pipefail` does NOT turn -e back off. Under `cmd; rc=$?`, errexit fires
-# on the loop's own non-zero exit and the rc line never runs — so exit 3 ("nothing
-# owed", the COMMON path on any doc-only merge) would escape as a red step. The arm
-# asserts the contract by EXIT CODE for all three returns, not by reading the source.
+# The trap being held shut: a `run:` with no `shell:` key runs under errexit, and
+# `set -uo pipefail` does NOT turn it back off. Under `cmd; rc=$?`, errexit fires on the
+# loop's own non-zero exit and the rc line never runs — so exit 3 ("nothing owed", the
+# COMMON path on any doc-only merge) would escape as a red step. The arm asserts the
+# contract by EXIT CODE for all three returns, not by reading the source.
+#
+# MEASURED IN THIS REPO rather than read from the docs, because this arm's whole premise
+# is a claim about someone else's runner: throwaway branch ci-errexit-probe, run
+# 30243567053 (2026-07-27 06:41, deleted after). A step with no `shell:` printed
+# PROBE-START and then "Process completed with exit code 3" — the line after
+# `bash -c "exit 3"; rc=$?` never ran. Its control step with an explicit `shell: bash`
+# behaved IDENTICALLY, which is why the precondition below says a `shell:` key means
+# "recheck the premise" and not "the premise is void": `shell: bash` still carries -e,
+# so only a non-bash or flag-overriding shell would actually change the answer.
 if grep -q '^ *shell:' "$REPO/.github/workflows/version-assign.yml"; then
   no "F precondition: the step now sets shell: — this arm's bash -e premise needs rechecking"
 else

--- a/tests/version_assign_push_unit.sh
+++ b/tests/version_assign_push_unit.sh
@@ -189,5 +189,74 @@ else
   ok "N BEHAVIOURAL: no tag verb in the extracted push path either — the no-tag guarantee followed the code out of the YAML"
 fi
 
+# ---------------------------------------------------------------------------
+# F THE GLUE. Extracting the loop into a script created a NEW unreachable seam: the
+# YAML lines that read its exit code. They are graded here by RUNNING THE SHIPPED
+# BLOCK — fenced out of .github/workflows/version-assign.yml, never retyped, so a
+# future edit to the step cannot drift past this arm the way a copy would.
+#
+# The trap being held shut: GitHub runs a `run:` with no `shell:` key as `bash -e {0}`,
+# and `set -uo pipefail` does NOT turn -e back off. Under `cmd; rc=$?`, errexit fires
+# on the loop's own non-zero exit and the rc line never runs — so exit 3 ("nothing
+# owed", the COMMON path on any doc-only merge) would escape as a red step. The arm
+# asserts the contract by EXIT CODE for all three returns, not by reading the source.
+if grep -q '^ *shell:' "$REPO/.github/workflows/version-assign.yml"; then
+  no "F precondition: the step now sets shell: — this arm's bash -e premise needs rechecking"
+else
+  ok "F precondition: the step declares no shell:, so GitHub runs it as 'bash -e {0}'"
+fi
+
+# Fence the block: the run: body of the assign step, dedented, expressions filled in.
+awk '/^ *run: \|$/{grab=1; next} grab{ if ($0 ~ /^ *$/) {print ""; next} if ($0 !~ /^          /) exit; sub(/^          /,""); print }' \
+  "$REPO/.github/workflows/version-assign.yml" > "$TMP/step.sh"
+sed -i 's/\${{ github.event.before }}/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/' "$TMP/step.sh"
+grep -q 'version-assign-push-loop.sh' "$TMP/step.sh" \
+  && ok "F the fence caught the real step body (it calls the push loop)" \
+  || no "F FENCE" "extraction produced nothing usable — the arm below would grade a stub, not the step"
+
+# A sandbox where the step can run: stubbed git (only cat-file is reached), a stubbed
+# push loop that returns the code under test, a stubbed gh, and a header to read.
+mkstep(){ # $1=dir  $2=loop exit code  $3=optional step.sh override
+  local d="$TMP/step-$1"; mkdir -p "$d/scripts" "$d/src" "$d/bin"
+  printf '#!/usr/bin/env bash\nexit %s\n' "$2" > "$d/scripts/version-assign-push-loop.sh"
+  printf 'readonly FIVE_VERSION="0.16.99"\n' > "$d/src/header.sh"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$d/bin/git";  printf '#!/usr/bin/env bash\necho "dispatched"\n' > "$d/bin/gh"
+  chmod +x "$d/bin/git" "$d/bin/gh" "$d/scripts/version-assign-push-loop.sh"
+  cp "${3:-$TMP/step.sh}" "$d/step.sh"; echo "$d"
+}
+runstep(){ ( cd "$1" && PATH="$1/bin:$PATH" bash -e ./step.sh >"$1/out" 2>&1 ); echo $?; }
+
+d=$(mkstep owed3 3); rc=$(runstep "$d")
+[[ "$rc" == 0 ]] \
+  && ok "F 'nothing owed' (loop exit 3) leaves the step GREEN — the quiet common path stays quiet" \
+  || no "F exit-3 leaks" "step exited $rc under bash -e; a doc-only merge would paint main red. $(cat "$d/out")"
+d=$(mkstep fail1 1); rc=$(runstep "$d")
+[[ "$rc" == 1 ]] \
+  && ok "F a loud loop failure (exit 1) still FAILS the step — the fix did not soften it into a pass" \
+  || no "F exit-1" "step exited $rc, expected 1"
+d=$(mkstep ok0 0); rc=$(runstep "$d")
+if [[ "$rc" == 0 ]] && grep -q 'dispatched' "$d/out"; then
+  ok "F a successful assignment (exit 0) proceeds to the bundle-drift dispatch"
+else
+  no "F exit-0" "step exited $rc / dispatch not reached: $(cat "$d/out")"
+fi
+
+# F-MUT: put the ORIGINAL `; rc=$?` back and demand the exit-3 arm go red. Without
+# this, all three arms above would keep passing under a shell that never had -e on,
+# and would be grading nothing. (Positive control: exit 1 must stay red either way,
+# so a red here is the errexit interaction and not a broken sandbox.)
+sed 's@^rc=0; \(bash scripts/version-assign-push-loop.sh .*\) || rc=$?$@\1; rc=$?@' "$TMP/step.sh" > "$TMP/step-mut.sh"
+if ! grep -q '3; rc=\$?' "$TMP/step-mut.sh"; then
+  no "F-MUT could not re-introduce the '; rc=\$?' form — the arms above are ungraded"
+else
+  d=$(mkstep mut3 3 "$TMP/step-mut.sh"); rcm=$(runstep "$d")
+  d=$(mkstep mut1 1 "$TMP/step-mut.sh"); rcc=$(runstep "$d")
+  if [[ "$rcm" == 3 && "$rcc" == 1 ]]; then
+    ok "F-MUT MUTATION: restoring '; rc=\$?' makes the exit-3 arm leak 3 (control: exit-1 still 1) — the arm grades the errexit seam, not the happy path"
+  else
+    no "F-MUT MUTATION" "mutant exited $rcm on 'nothing owed' (expected the 3 to leak) / $rcc on failure — arm F is not driven by the '|| rc=\$?'"
+  fi
+fi
+
 echo; echo "DIVE-2143 version-assign push classification: passed: $P  failed: $F"
 [ "$F" -eq 0 ]

--- a/tests/version_assign_push_unit.sh
+++ b/tests/version_assign_push_unit.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# DIVE-2143 harness for the version-assign PUSH path: does it name the right cause,
+# and does it stop retrying a failure that retrying cannot fix?
+#
+# THE DEFECT THIS GRADES, measured on run 30231912328 (5dive-ai/5dive, 2026-07-27
+# 02:19). Branch protection rejected the assignment push. The loop printed
+#   "push rejected — main moved under us (attempt 1/3)"  ...2/3 ...3/3
+#   "::error::main kept moving across 3 attempts"
+# three times over. Main never moved — the tip was 02b356e for the whole run. Two
+# costs: three attempts burned on a DETERMINISTIC failure, and, worse, an error that
+# points the next reader at a concurrency bug in code that is working correctly.
+#
+# WHY THE ARMS BELOW ARE BEHAVIOURAL AND NOT MESSAGE GREPS. A harness that only
+# checked "does it print the protection message" would pass on a loop that printed it
+# and then retried twice anyway — the retry is half the defect. So the arms COUNT the
+# push attempts, using a stub `git` on PATH that records every invocation. Counting is
+# the assertion; the message is a second, separate one.
+#
+# AND WHY THERE IS A MUTATION ARM. tests/version_assign_unit.sh learned this the hard
+# way (its arms G/H exist because it stayed 16/16 green with two assertions replaced
+# by `true`). Arm M replaces the CLASSIFIER with one that always says "race" — the
+# pre-DIVE-2143 behaviour, exactly — and demands the run go back to 3 attempts. If the
+# discrimination is ever deleted, M fails; without M, arms C/D would keep passing on a
+# loop that had stopped discriminating for an unrelated reason.
+# Run: bash tests/version_assign_push_unit.sh
+set -uo pipefail
+cd "$(dirname "$0")/.."
+REPO="$PWD"
+CLS="$REPO/scripts/git-push-reject-class.sh"
+LOOP="$REPO/scripts/version-assign-push-loop.sh"
+FIX="$REPO/tests/fixtures/push-reject"
+TMP="$(mktemp -d /tmp/version-assign-push-unit.XXXXXX)"; trap 'rm -rf "$TMP"' EXIT
+P=0; F=0
+ok(){ P=$((P+1)); echo "ok   - $1"; }
+no(){ F=$((F+1)); echo "FAIL - $1"; [ -n "${2:-}" ] && echo "   $2"; }
+
+# ---------------------------------------------------------------------------
+# CLASSIFIER — graded against CAPTURED stderr (tests/fixtures/push-reject/), never
+# against text invented here. The GH006 capture is verbatim from the run above,
+# trailing whitespace and all.
+cls(){ bash "$CLS" < "$FIX/$1"; }
+
+[[ "$(cls protected-gh006.txt)" == protection ]] \
+  && ok "A the real GH006 capture classifies as 'protection' (not a race)" \
+  || no "A GH006" "got: $(cls protected-gh006.txt)"
+[[ "$(cls race-fetch-first.txt)" == race ]] \
+  && ok "A a real '(fetch first)' rejection classifies as 'race'" \
+  || no "A fetch-first" "got: $(cls race-fetch-first.txt)"
+[[ "$(cls race-non-fast-forward.txt)" == race ]] \
+  && ok "A a real '(non-fast-forward)' rejection classifies as 'race' (git words it differently after a fetch)" \
+  || no "A non-ff" "got: $(cls race-non-fast-forward.txt)"
+[[ "$(cls unknown-transport.txt)" == unknown ]] \
+  && ok "A an unrecognised failure classifies as 'unknown' — the class is REACHABLE, not decorative" \
+  || no "A unknown" "got: $(cls unknown-transport.txt)"
+
+# PRECEDENCE. The GH006 capture also carries '! [remote rejected]', and a protection
+# rejection that happened to mention a fast-forward hint must still read as protection:
+# the whole defect was a gated ref being reported as a race.
+printf '%s\n%s\n' "$(cat "$FIX/protected-gh006.txt")" "hint: Updates were rejected because the remote contains work" > "$TMP/mixed.txt"
+[[ "$(bash "$CLS" < "$TMP/mixed.txt")" == protection ]] \
+  && ok "A PRECEDENCE: protection wins when a capture carries BOTH markers (a gated ref must never read as a race)" \
+  || no "A precedence" "got: $(bash "$CLS" < "$TMP/mixed.txt")"
+[[ "$(printf '' | bash "$CLS")" == unknown ]] \
+  && ok "A empty stderr is 'unknown', not silently a race" || no "A empty" "got: $(printf '' | bash "$CLS")"
+
+# ---------------------------------------------------------------------------
+# LOOP — behavioural, with a stub `git` on PATH.
+#
+# The stub is the seam, and it is deliberately NOT a flag inside the shipped script:
+# a test-only branch grades the test-only branch. Here the production code runs
+# unmodified and every `git` it calls lands in a recorder. `scripts/version-assign.sh`
+# is stubbed the same way — the loop invokes it by RELATIVE path, so a fixture cwd
+# substitutes it without the shipped script knowing. What version-assign.sh itself
+# does is already graded by tests/version_assign_unit.sh; grading it twice here would
+# only couple the two.
+mkfix() { # $1 = push exit (0|1), $2 = fixture file of push stderr
+  local d="$TMP/fix$RANDOM$RANDOM"; mkdir -p "$d/scripts" "$d/src" "$d/bin"
+  printf 'readonly FIVE_VERSION="0.16.29"\n' > "$d/src/header.sh"
+  # stub version-assign.sh: always reports an applied assignment, so the loop always
+  # reaches the push. Its own logic is graded by version_assign_unit.sh.
+  { echo '#!/usr/bin/env bash'
+    echo 'echo "version-assign: applied 0.16.28 -> 0.16.29, bundle rebuilt (deadbeef). NO TAG."'; } \
+    > "$d/scripts/version-assign.sh"
+  # stub git: records every invocation, counts pushes, replays the captured stderr.
+  # rev-parse answers the same sha for FETCH_HEAD and HEAD, so "main moved" never
+  # fires and the only thing under test is what happens to the PUSH.
+  cat > "$d/bin/git" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> '$d/git.log'
+case "\${1:-}" in
+  push)      echo push >> '$d/push.count'; cat '$2' >&2; exit $1 ;;
+  rev-parse) echo 0000000000000000000000000000000000000000 ;;
+esac
+exit 0
+EOF
+  chmod +x "$d/bin/git" "$d/scripts/version-assign.sh"
+  : > "$d/push.count"; : > "$d/git.log"
+  printf '%s' "$d"; }
+
+runloop() { # $1 = fixture dir, $2 = loop script to run (real or mutated)
+  ( cd "$1" && PATH="$1/bin:$PATH" bash "$2" beforesha 3 ) 2>&1; }
+# wc, not `grep -c || echo 0`: grep -c on an empty file prints 0 AND exits 1, so the
+# fallback fires too and the count comes back "0\n0" — a comparison that can never
+# match, i.e. an arm that fails for a reason that has nothing to do with the subject.
+pushes() { local n; n=$(wc -l < "$1/push.count"); echo "${n// /}"; }
+
+# B CONTROL: the happy path. Without it, a red C/D would prove nothing — a loop broken
+# for an unrelated reason also makes exactly one push attempt and fails.
+d=$(mkfix 0 "$FIX/race-fetch-first.txt"); out=$(runloop "$d" "$LOOP"); rc=$?
+(( rc == 0 )) && ok "B CONTROL: a push that SUCCEEDS exits 0 (so a red C/D means the classifier, not a broken fixture)" || no "B rc" "$rc: $out"
+[[ "$(pushes "$d")" == 1 ]] && ok "B CONTROL: and pushes exactly once" || no "B count" "$(pushes "$d")"
+grep -q 'assigned 0.16.29' <<<"$out" && ok "B CONTROL: and reports the version it assigned" || no "B msg" "$out"
+
+# C THE DEFECT: GH006 must fail on attempt 1 and must not blame a race.
+d=$(mkfix 1 "$FIX/protected-gh006.txt"); out=$(runloop "$d" "$LOOP"); rc=$?
+(( rc == 1 )) && ok "C a protection rejection FAILS (exit 1) — it is not swallowed" || no "C rc" "$rc: $out"
+[[ "$(pushes "$d")" == 1 ]] \
+  && ok "C BEHAVIOURAL: exactly ONE push attempt — the deterministic failure is not retried (was 3 on run 30231912328)" \
+  || no "C attempts" "expected 1 push, got $(pushes "$d")"
+grep -q 'rejected by branch protection' <<<"$out" \
+  && ok "C names branch protection as the cause" || no "C cause" "$out"
+# if/else, not `A && no || ok`: no() returns non-zero when called without a detail
+# argument, so the || arm would fire too and a FAILING assertion would also print an
+# "ok" line. The suite would still go red, but the transcript would say both things.
+if grep -qE 'main moved under us|kept moving' <<<"$out"; then
+  no "C LIE: it still blames a race — this is the exact sentence run 30231912328 printed three times" "$out"
+else
+  ok "C it does NOT print 'main moved under us' / 'kept moving' (the wrong cause)"
+fi
+grep -q 'GH006: Protected branch update failed' <<<"$out" \
+  && ok "C ECHOES the remote's own words rather than paraphrasing them" || no "C echo" "$out"
+grep -q '6 of 6 required status checks are expected' <<<"$out" \
+  && ok "C including the required-checks line, which is the actionable half" || no "C checks line" "$out"
+
+# D THE RACE STILL RETRIES. The fix must not turn every rejection into a hard stop —
+# the reset-and-recompute path is correct and is why the loop exists.
+for f in race-fetch-first race-non-fast-forward; do
+  d=$(mkfix 1 "$FIX/$f.txt"); out=$(runloop "$d" "$LOOP"); rc=$?
+  (( rc == 1 )) && ok "D ($f) an unresolvable race still fails loudly" || no "D rc ($f)" "$rc: $out"
+  [[ "$(pushes "$d")" == 3 ]] \
+    && ok "D ($f) BEHAVIOURAL: all 3 attempts are used — the genuine-race retry path is intact" \
+    || no "D attempts ($f)" "expected 3 pushes, got $(pushes "$d")"
+  grep -q 'main moved under us' <<<"$out" \
+    && ok "D ($f) and a real race IS reported as a race" || no "D msg ($f)" "$out"
+done
+
+# E UNKNOWN: no retry, no invented cause, and the raw text survives to the log.
+d=$(mkfix 1 "$FIX/unknown-transport.txt"); out=$(runloop "$d" "$LOOP"); rc=$?
+(( rc == 1 )) && ok "E an unrecognised rejection fails" || no "E rc" "$rc: $out"
+[[ "$(pushes "$d")" == 1 ]] \
+  && ok "E BEHAVIOURAL: it is not retried — 'unrecognised' is not quietly widened into 'race'" \
+  || no "E attempts" "expected 1 push, got $(pushes "$d")"
+grep -q 'UNRECOGNISED' <<<"$out" && ok "E says outright that it does not know the cause" || no "E msg" "$out"
+if grep -qE 'main moved under us|kept moving' <<<"$out"; then
+  no "E it reached for the nearest familiar cause instead of admitting ignorance" "$out"
+else
+  ok "E and does NOT reach for the nearest familiar cause"
+fi
+grep -q "Couldn't connect to server" <<<"$out" \
+  && ok "E the remote's own text reaches the log verbatim" || no "E echo" "$out"
+
+# ---------------------------------------------------------------------------
+# M MUTATION: break the discrimination, demand the arms above go red.
+#
+# The classifier is resolved relative to the loop script's own directory, so a COPY of
+# the shipped loop beside a stubbed classifier reproduces the pre-fix behaviour with
+# the loop itself untouched. If someone later deletes the protection branch, or makes
+# the classifier answer "race" to everything (which is precisely what the old code
+# did), this arm fails.
+mkdir -p "$TMP/mut/scripts"
+cp "$LOOP" "$TMP/mut/scripts/"
+{ echo '#!/usr/bin/env bash'; echo 'cat >/dev/null'; echo 'echo race'; } > "$TMP/mut/scripts/git-push-reject-class.sh"
+chmod +x "$TMP/mut/scripts/git-push-reject-class.sh"
+d=$(mkfix 1 "$FIX/protected-gh006.txt"); out=$(runloop "$d" "$TMP/mut/scripts/$(basename "$LOOP")")
+if [[ "$(pushes "$d")" == 3 ]] && grep -q 'main moved under us' <<<"$out"; then
+  ok "M MUTATION: a classifier that always says 'race' reproduces the defect (3 attempts + 'main moved under us') — so arm C is driven by the classifier, not by luck"
+else
+  no "M MUTATION" "mutating the classifier did NOT change the outcome ($(pushes "$d") pushes) — arms C/E are passing for some other reason and grade nothing"
+fi
+
+# N NO TAG, still. tests/version_assign_unit.sh arm H scans the two files that USED to
+# hold every shipped line of this subsystem. The push moved out of them, so the scan
+# had to move too — a guarantee whose scope quietly stops covering the code it was
+# written for is worse than no guarantee. (Kept here as well as there: whichever file
+# a future edit lands in, one of the two harnesses sees it.)
+if grep -nEi 'git[[:space:]]+tag|gh[[:space:]]+release|refs/tags|--tags|create-release|action-gh-release' "$LOOP" "$CLS"; then
+  no "N a tag verb appears in the extracted push path (bump yes, tag no — lodar froze releases)"
+else
+  ok "N BEHAVIOURAL: no tag verb in the extracted push path either — the no-tag guarantee followed the code out of the YAML"
+fi
+
+echo; echo "DIVE-2143 version-assign push classification: passed: $P  failed: $F"
+[ "$F" -eq 0 ]

--- a/tests/version_assign_push_unit.sh
+++ b/tests/version_assign_push_unit.sh
@@ -258,5 +258,48 @@ else
   fi
 fi
 
+# ---------------------------------------------------------------------------
+# P ANCHOR EXPIRY. Arm F's precondition guards a premise about GitHub's RUNNER. The
+# fixtures are a premise about GitHub's and git's WORDING, one layer out and with the
+# same expiry shape: if GitHub rewords GH006, every arm above keeps passing against a
+# capture that no longer resembles a real rejection, and the live path silently falls
+# through to `unknown`. We cannot test against a real remote — exercising the
+# protection branch means re-breaking main's protection — so the substitute is to
+# record WHICH substrings the verdict actually rests on and red if they stop being
+# load-bearing. It cannot detect a rewording at GitHub; it makes the fixture's
+# dependence on specific bytes VISIBLE instead of implicit, so the recapture has an
+# address. (Raised by Marcus in review of this branch.)
+declare -A ANCHOR=(
+  [protected-gh006.txt]='GH006|protected branch|required status check'
+  [race-fetch-first.txt]='fetch first|Updates were rejected because'
+  [race-non-fast-forward.txt]='non-fast-forward|Updates were rejected because'
+)
+declare -A ANCHOR_CLASS=(
+  [protected-gh006.txt]=protection
+  [race-fetch-first.txt]=race
+  [race-non-fast-forward.txt]=race
+)
+for f in "${!ANCHOR[@]}"; do
+  missing=""
+  IFS='|' read -r -a as <<<"${ANCHOR[$f]}"
+  for a in "${as[@]}"; do grep -qiF -- "$a" "$FIX/$f" || missing+="'$a' "; done
+  if [[ -z "$missing" ]]; then
+    ok "P $f still contains every recorded anchor (${ANCHOR[$f]//|/, })"
+  else
+    no "P $f LOST an anchor: $missing" "the capture no longer carries the text the classifier keys on — RECAPTURE it from a real rejection rather than editing the anchor list to match"
+  fi
+  # And prove the anchors are the WHOLE reason it matches: with all of them removed the
+  # verdict must fall to 'unknown'. If it still classifies, some other substring is
+  # carrying the match and the recorded anchor list is a fiction — which is exactly the
+  # state that would let a GitHub rewording pass unnoticed.
+  sed -E "s/(${ANCHOR[$f]})//Ig" "$FIX/$f" > "$TMP/stripped-$f"
+  got=$(bash "$CLS" < "$TMP/stripped-$f")
+  if [[ "$got" == unknown ]]; then
+    ok "P $f: stripping the anchors drops it to 'unknown' — the recorded list IS what the ${ANCHOR_CLASS[$f]} verdict rests on"
+  else
+    no "P $f anchors are not load-bearing" "stripped of ${ANCHOR[$f]} it still reads '$got', so the recorded anchors are not what the classifier keys on and arm P grades nothing"
+  fi
+done
+
 echo; echo "DIVE-2143 version-assign push classification: passed: $P  failed: $F"
 [ "$F" -eq 0 ]

--- a/tests/version_assign_unit.sh
+++ b/tests/version_assign_unit.sh
@@ -186,11 +186,16 @@ grep -q 'the bump did NOT take in src/header.sh' <<<"$out" \
 
 # H: NO TAG, BEHAVIOURALLY. Arm F greps the output for "NO TAG", which grades a
 # sentence — a script that printed it and tagged anyway would pass. The real guarantee
-# is that no tag verb exists anywhere in the two SHIPPED files. (Only the shipped
+# is that no tag verb exists anywhere in the SHIPPED files. (Only the shipped
 # files are scanned: this harness does not run in CI, and it necessarily contains the
 # very strings being searched for.)
+#
+# DIVE-2143 moved the push loop OUT of the YAML and into scripts/version-assign-push-loop.sh,
+# so the scanned set had to move with it. A guarantee whose scope silently stops
+# covering the code it was written for is worse than no guarantee — it still reports.
 if grep -nEi 'git[[:space:]]+tag|gh[[:space:]]+release|refs/tags|--tags|create-release|action-gh-release' \
-     "$REPO/scripts/version-assign.sh" "$REPO/.github/workflows/version-assign.yml"; then
+     "$REPO/scripts/version-assign.sh" "$REPO/scripts/version-assign-push-loop.sh" \
+     "$REPO/scripts/git-push-reject-class.sh" "$REPO/.github/workflows/version-assign.yml"; then
   no "H a tag verb appears in a shipped file (bump yes, tag no — lodar froze releases)"
 else
   ok "H BEHAVIOURAL: no tag verb (git tag / gh release / refs/tags / --tags) appears in either shipped file"


### PR DESCRIPTION
Closes DIVE-2143.

## The defect, measured

Run 30231912328 (2026-07-27 02:19). Branch protection rejected the assignment push. The loop printed `push rejected — main moved under us` three times and finished with `main kept moving across 3 attempts`. **Main did not move once** — the tip was `02b356e` for the whole run.

Two costs, and the second is the expensive one: three attempts burned on a **deterministic** failure, and an error naming the wrong cause, which sends the next reader hunting a concurrency bug through code that is working correctly. Same class as a rail that no-ops green, one level up: a rail that fails *loudly, in the wrong direction*.

## What landed

- **`scripts/git-push-reject-class.sh`** — reads push stderr, prints exactly one of `protection` / `race` / `unknown`. Protection is matched **first**: a GH006 rejection also carries `! [remote rejected]`, and precedence is what stops a gated ref ever reading as a race.
- **`scripts/version-assign-push-loop.sh`** — the retry loop, **moved out of the YAML** where no harness could reach it. On `protection`: fail immediately, echo **the remote's own lines** rather than paraphrase them, and name the fix as a branch-protection change. On `race`: the existing reset-and-recompute retry, unchanged. On `unknown`: fail without retrying and without naming a cause — deliberately, because "retry an unrecognised failure" is the same instinct that produced this ticket.
- **`.github/workflows/version-assign.yml`** — calls the script; `0` = assigned, `3` = nothing owed, `1` = failed loudly.
- **`tests/version_assign_push_unit.sh`** (34 arms) + captured stderr fixtures in `tests/fixtures/push-reject/`.

## The second defect, found while verifying this branch

Extracting the loop created a **new seam no harness could reach** — the YAML lines that read its exit code — and they had the bug the extraction existed to prevent.

GitHub runs a `run:` block with no `shell:` key as **`bash -e {0}`**, and the step's `set -uo pipefail` does not turn `-e` back off. Under `bash push-loop.sh; rc=$?`, errexit fires on the loop's own non-zero exit and **the line that reads `rc` never runs**. Exit `3` — *nothing owed*, the common path on any doc-only merge — would have escaped as a **red step**, for exactly the non-event this job exists to stay quiet about.

Fixed with `rc=0; ... || rc=$?` and `if` statements, both errexit-safe.

## Why the harness should be believed

Arms **count push attempts** via a stub `git` on PATH rather than grepping for a message — a loop that printed the protection message and retried twice anyway would pass a message grep, and the retry is half the defect.

Two mutation arms, because this repo has shipped harnesses that stayed green with assertions replaced by `true`:

- **M** swaps in a classifier that always answers `race` — the pre-fix behaviour exactly — and demands the run go back to 3 attempts and print `main moved under us`.
- **F-MUT** restores `; rc=$?` in the YAML glue and demands the exit-3 arm leak a 3, with the exit-1 arm as **positive control** so a red is the errexit interaction and not a broken sandbox.

Arm **F** runs the **shipped** YAML block — fenced out of `version-assign.yml`, never retyped, so a future edit to the step cannot drift past it — under `bash -e`, and asserts the contract by exit code for all three returns.

Arm **N** carries the no-tag guarantee (`git tag` / `gh release` / `refs/tags` / `--tags`) to the files the code moved into; `version_assign_unit.sh` arm H was widened to match. A guarantee whose scope quietly stops covering the code it was written for is worse than none — it still reports.

## Verification

- `tests/version_assign_push_unit.sh` — **34/34**
- `tests/version_assign_unit.sh` — **23/23** (unchanged behaviour, widened scan)
- `tests/meta/harness-verdict-probe.sh --only=version_assign_push_unit.sh,version_assign_unit.sh` — **2 wired, 0 UNWIRED**
- `unit-tests.yml` globs `tests/*.sh`, so the new harness is picked up with no wiring change.

**No FIVE_VERSION bump** — the version is assigned at merge (CONTRIBUTING), which is the rule this subsystem performs. No tag, no release.

**Not verified live:** the protection and unknown branches have never executed against a real remote — they cannot be, without re-breaking main's protection. They are graded against **captured** stderr from the real run, which is the closest honest substitute. DIVE-2142 fixes the configuration so the rejection stops happening; this ticket fixes the **diagnosis** so the next unanticipated rejection, of any cause, reports itself honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
