### PR TITLE
feat(comms): the terse rule now bounds how often you send, and covers agent-to-agent (DIVE-2191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased — feat(comms): the terse rule now bounds HOW OFTEN you send, and covers agent-to-agent (DIVE-2191)
+
+DIVE-1613 ships a terse-comms fragment into every claude agent at create. Measured against one
+day of main's own traffic, it has two holes. It governs SHAPE, not VOLUME — main followed all six
+shape rules 94 times in a day. And it is scoped to human chat, while agent-to-agent was 84
+messages / 32,823 words: 2.2x the word volume of Telegram, on a channel with no rule at all. Every
+a2a word is output tokens for the sender AND input tokens for the receiving model, so it is the
+larger bill by more than 2.2x — and it is the bill the customer pays.
+
+- **A send gate for human chat.** A NEW message — the one that pushes to their phone — is for
+  finished / blocked-on-them / your own error. Everything else edits the message already on screen
+  or goes to the task board. Work-in-progress is not a message. Phrased to compose with the
+  telegram fragment's edit-for-progress rule rather than contradict it.
+- **A fixed a2a shape:** RESULT / EVIDENCE / BLOCKER / NEXT, empty fields dropped. Fixed fields
+  cannot ramble and the receiving model can parse them. Today's internal messages were 390-word
+  essays carrying maybe 60 words of decision.
+- **The verification rails are untouched, and now explicitly carved out**: this cuts the narration,
+  not the checking. Sending work to another agent to verify, and answering as the verifier, is the
+  work — the fragment says so in the same breath, so no agent reads "send less" as "verify less".
+
 ## Unreleased — feat(task): the tier-2 floor says WHY it fired, and a design decision can appeal it on the record instead of by rewording (DIVE-2089)
 
 The T2 category floor reads SUBJECT MATTER as risk and picks the gate's audience from it. dev3

--- a/operational-comms-CLAUDE.md
+++ b/operational-comms-CLAUDE.md
@@ -10,3 +10,31 @@ character demands in the deliverable, be terse in operational chat.
 - A few lines, not paragraphs. No preamble, no throat-clearing, no restating
   the question back.
 - If they want depth, they will ask. Brevity is respect for their time.
+
+## Whether to send at all (human chat)
+
+Shape does not bound volume. Six perfectly terse messages an hour are still
+six interruptions.
+
+- A NEW message — the one that buzzes their phone — is for three things:
+  it is finished, you are blocked ON THEM, or you broke something.
+- Everything else is progress. Edit the message already on screen, or put it
+  on the task board. Work-in-progress is not a message.
+
+## Agent-to-agent: fixed fields, not prose
+
+A word you send another agent is output tokens for you and input tokens for
+them, so it costs roughly double a word a human reads. Use these fields, in
+this order, dropping any that is empty:
+
+    RESULT   — what is now true. One line.
+    EVIDENCE — the command, file:line, PR, or id that proves it.
+    BLOCKER  — what stops you.
+    NEXT     — who does what next.
+
+No greeting, no recap of what they asked, no narration of how you got there.
+If they want the story they can read the task.
+
+This cuts the NARRATION, not the CHECKING. Having another agent verify your
+work, and answering when you are the verifier, is the work — send those, in
+the fields above.


### PR DESCRIPTION
DIVE-1613 ships `operational-comms-CLAUDE.md` into every claude agent at create time. Measured against one day of main's own traffic, it has two holes:

- It governs **shape**, not **volume**. main followed all six shape rules 94 times in a day.
- It is scoped to **human chat**. a2a was 84 messages / 32,823 words — 2.2x Telegram's word volume, on a channel with no rule at all. Every a2a word is output tokens for the sender *and* input tokens for the receiver, so it is the larger bill by more than 2.2x, and it is the bill the customer pays.

## What changed

Content-only, in `operational-comms-CLAUDE.md` (+ CHANGELOG). No `src/` change, so no bundle rebuild.

1. **Send gate (human chat)** — a NEW message (the one that pushes to their phone) is for finished / blocked-on-them / your own error. Everything else edits the message already on screen or goes to the task board. Work-in-progress is not a message.
2. **a2a shape** — `RESULT / EVIDENCE / BLOCKER / NEXT`, empty fields dropped. Fixed fields cannot ramble and the receiving model can parse them.
3. **Verification rails untouched and explicitly carved out** — "this cuts the NARRATION, not the CHECKING", in the same breath, so no agent reads "send less" as "verify less".

## Checked

- Send gate is phrased to **compose with** `telegram-agent-CLAUDE.md`'s "edit the same message for progress; new reply when done or blocked" rather than contradict it — the gate governs which sends are *new messages*.
- No test or fixture asserts this fragment's content (`grep -rn 'operational-comms|Working comms|craft voice' tests/` → no hits).
- Simulated the real append (`preseed_claude_agent`, `src/lib/agent_setup.sh:264`) onto a non-empty per-agent CLAUDE.md — clean blank-line separation, no heading collision.
- Fragment grew 652 → 1784 bytes.

## Known limitation (pre-existing, not introduced here)

The append runs at **create** time only. There is no refresh/backfill path that re-appends fragments to an existing agent's `$HOME/.claude/CLAUDE.md`, so this reaches **new** agents. Same for the DIVE-1613 and DIVE-899 fragments. Worth a follow-up if we want it retroactive on live boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)