### PR TITLE
test(gate-verifier-route): pin the caller identity so the suite is runnable by any agent (DIVE-2190)

### DIFF
--- a/tests/gate_verifier_route_unit.sh
+++ b/tests/gate_verifier_route_unit.sh
@@ -8,7 +8,13 @@ set -uo pipefail
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-vfroute-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
+# DIVE-2190: this harness has no `set -e`, but `fail()` exits the whole script, so a
+# refusal inside any cmd_* call ends the run with the last line on screen being an `ok`
+# and NO summary — a red that looks like a pass that stopped early. Say so, loudly, and
+# without touching the exit status the verdict line set.
+SUMMARY_PRINTED=0
+# shellcheck disable=SC2154  # rc is assigned inside the trap body
+trap 'rc=$?; rm -rf "$TMP"; [[ "$SUMMARY_PRINTED" == 1 ]] || printf "ABORTED - gate_verifier_route_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&2' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
@@ -16,6 +22,18 @@ for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done
+# DIVE-2190: the harness isolates STATE_DIR but the CALLER IDENTITY is ambient — task_actor
+# reads SUDO_USER/USER — while the fixtures hard-code real agent names (maker='dev'). Run this
+# suite as the agent literally named `dev` and the DIVE-2112 self-grading guard fires on step 5's
+# reject for the right reason, killing the run. CI runs as a user matching no fixture, so it is
+# permanently green there. Pin identity the way STATE_DIR is pinned, so WHO runs the suite stops
+# being an input. Wrapping the REAL resolver (rather than reimplementing it) keeps the --from
+# precedence under test instead of under simulation, and keeps the override inside this shell —
+# there is deliberately no env var that could forge an actor in production.
+eval "task_actor_REAL() $(declare -f task_actor | tail -n +2)"
+FIXTURE_ACTOR=fixture-runner   # not a real agent; set per-step to impersonate one on purpose
+task_actor() { USER="agent-${FIXTURE_ACTOR}" SUDO_USER='' task_actor_REAL "$@"; }
+
 STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
 JSON_MODE=1
 mkdir -p "$TASKS_DIR"; set +e
@@ -92,7 +110,10 @@ cmd_task_need DIVE-504 --type=decision --options='A|B' --recommend='A' \
 db "INSERT INTO tasks(ident,title,status,created_by,assignee,verifier,maker_agent,iteration,max_iterations,
       need_type,ask,need_answered_at)
     VALUES('DIVE-505','loop','blocked','dev','dev','main','dev',1,5,'manual','pending human thing',NULL);"
-cmd_task_reject DIVE-505 --feedback='needs another pass' >/dev/null 2>&1
+# DIVE-2190: stdout only. This call can END the harness (cmd_* refusals go through fail()),
+# and `2>&1` sent the one line explaining WHY straight to /dev/null — the failure erased its
+# own reason. Redirect noise, never diagnosis.
+cmd_task_reject DIVE-505 --feedback='needs another pass' >/dev/null
 gate_open=$(db "SELECT CASE WHEN need_type IS NOT NULL AND need_answered_at IS NULL THEN 1 ELSE 0 END FROM tasks WHERE ident='DIVE-505';")
 answered_by=$(db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident='DIVE-505';")
 [[ "$gate_open" == "0" && "$answered_by" == "auto:reject" ]] \
@@ -102,6 +123,26 @@ answered_by=$(db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident='D
   && ok_t "rejected task still bounces to maker (status todo)" \
   || bad_t "rejected task still bounces to maker (status todo)" "status=$(db "SELECT status FROM tasks WHERE ident='DIVE-505';")"
 
+# ---- 6. the identity pin is a pin, not an off switch (DIVE-2190 negative control) ----
+# Step 5 only passes because the actor is NOT the maker. Impersonate the maker on purpose and
+# the DIVE-2112 guard must still refuse — otherwise a pin that silently resolved to "nobody"
+# would look identical to a working one. Subshell: policy_refuse exits, and that exit is the
+# assertion here, not an abort.
+db "INSERT INTO tasks(ident,title,status,created_by,assignee,verifier,maker_agent,iteration,max_iterations,
+      need_type,ask,need_answered_at)
+    VALUES('DIVE-506','loop','blocked','dev','dev','main','dev',1,5,'manual','pending human thing',NULL);"
+FIXTURE_ACTOR=dev
+rj_out=$(cmd_task_reject DIVE-506 --feedback='maker grading itself' 2>&1); rj_rc=$?
+FIXTURE_ACTOR=fixture-runner
+[[ "$rj_rc" != "0" && "$rj_out" == *MAKER* ]] \
+  && ok_t "maker impersonation is still refused (identity pin does not disarm DIVE-2112)" \
+  || bad_t "maker impersonation is still refused" "rc=$rj_rc out=${rj_out//$'\n'/ }"
+[[ "$(db "SELECT status FROM tasks WHERE ident='DIVE-506';")" == "blocked" \
+   && "$(db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident='DIVE-506';")" == "" ]] \
+  && ok_t "refused reject wrote nothing (status and gate untouched)" \
+  || bad_t "refused reject wrote nothing" "status=$(db "SELECT status FROM tasks WHERE ident='DIVE-506';") answered_by=$(db "SELECT need_answered_by FROM tasks WHERE ident='DIVE-506';")"
+
 echo "-----"
 echo "gate_verifier_route_unit: $PASS passed, $FAIL failed"
+SUMMARY_PRINTED=1
 [[ "$FAIL" == "0" ]]


### PR DESCRIPTION
Test-only. The suite was unrunnable by anyone but its author: it failed `rc=5` as `agent-dev` on both identity rails (`USER` and `SUDO_USER`).

Fix pins the caller identity by **wrapping the real `task_actor`** after the source loop — no reimplementation, and no env var that could forge an actor in production. Adds an `ABORTED EXIT` trap so a run that dies mid-way says remaining assertions were **SKIPPED, not passed**, and a step-6 negative control asserting the DIVE-2112 guard still refuses a deliberate maker impersonation and writes nothing.

**Verified independently by main, not taken from the report:** control **9 passed / 0 failed, rc=0** running as `agent-main`; mutation with the identity pin deleted gives **7 passed / 2 failed, rc=1**. So the pin is load-bearing and the harness exits non-zero on failure rather than reporting failures and exiting success (the DIVE-2114 class).

Pushed by main because `agent-olivia` holds no push credential — the structural round-trip, not a review gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
