### PR TITLE
ci(bundle-drift): grade the GENERATED sources and the checksum, not just the bundle (DIVE-2107)

### DIFF
--- a/.github/workflows/bundle-drift.yml
+++ b/.github/workflows/bundle-drift.yml
@@ -21,15 +21,54 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # DIVE-2107: regenerate the GENERATED sources BEFORE building, because the
+      # bundle check below cannot see one level up.
+      #
+      # src/cmd_council.sh is itself generated — src/council/gen_cmd.mjs embeds
+      # engine.mjs + cli.mjs into cmd_council.template.sh. build.sh does NOT run
+      # that generator; it only bundles whatever src/ currently contains. So a
+      # COMMITTED hand-edit of src/cmd_council.sh is faithfully carried into the
+      # bundle, `git diff 5dive` is clean, and every existing check passes: the
+      # canonical .mjs carries nothing, the next gen_cmd.mjs run silently reverts
+      # the change, and the node harnesses (which import engine.mjs) never
+      # exercise it.
+      #
+      # Measured on a committed hand-edit, both directions: build.sh + `git diff
+      # 5dive` stays SILENT; regenerating first reports ` M src/cmd_council.sh`.
+      # The edit must be COMMITTED to reproduce — editing only the working tree
+      # is reverted by the generator and proves nothing.
+      #
+      # Found by olivia verifying DIVE-2103, where iteration 1 did exactly this.
+      # sha256sum-vs-5dive.sha256 and a re-seal both pass on such a commit too,
+      # because they grade the artifact against its OWN recorded checksum and
+      # never against what src produces.
+      - name: Regenerate generated sources
+        run: node src/council/gen_cmd.mjs
+      - name: Fail if a GENERATED source was hand-edited
+        run: |
+          if ! git diff --exit-code src/cmd_council.sh; then
+            echo
+            echo "ERROR: src/cmd_council.sh does not match what its generator produces."
+            echo "It is GENERATED from src/council/{engine,cli}.mjs + cmd_council.template.sh."
+            echo "Edit those, then run: node src/council/gen_cmd.mjs && ./build.sh"
+            echo "Editing src/cmd_council.sh directly is silently reverted by the next build."
+            exit 1
+          fi
       - name: Rebuild bundle from src/
         run: ./build.sh
       - name: Syntax-check the rebuilt bundle
         run: bash -n 5dive
-      - name: Fail if the committed bundle drifted from src/
+      # DIVE-2107: 5dive.sha256 is graded here too. It was previously checked ONLY
+      # by tests/install_checksum_unit.sh in the unit-tests job, so a stale
+      # committed sha surfaced as unit-tests red rather than drift red — and a
+      # green bundle-drift never meant "the sha is consistent". build.sh writes the
+      # sha immediately after the bundle, so if it is dirty here the committed pair
+      # genuinely disagreed.
+      - name: Fail if the committed bundle or its checksum drifted from src/
         run: |
-          if ! git diff --exit-code 5dive; then
+          if ! git diff --exit-code 5dive 5dive.sha256; then
             echo
-            echo "ERROR: the committed 5dive bundle does not match src/."
+            echo "ERROR: the committed 5dive bundle (or 5dive.sha256) does not match src/."
             echo "Run ./build.sh locally and commit the result."
             exit 1
           fi


### PR DESCRIPTION
`build.sh` bundles whatever `src/` contains — it never runs `src/council/gen_cmd.mjs`. So a **committed** hand-edit of the generated `src/cmd_council.sh` rides into the bundle and **every existing check passes**: `git diff 5dive` is clean because the bundle faithfully reflects the (wrong) source, the canonical `.mjs` carries nothing, the next generator run silently reverts it, and the node harnesses that import `engine.mjs` never exercise it. That is exactly what DIVE-2103 iteration 1 did.

**Measured, both directions, on a COMMITTED hand-edit:**
| check | committed hand-edit of the generated source |
|---|---|
| old: `build.sh` + `git diff 5dive` | **SILENT** — the gap |
| new: `gen_cmd.mjs` + `git diff src/cmd_council.sh` | **FIRES** |

**False-positive control (the one that decides whether this is shippable):** on a clean checkout the generator is byte-deterministic — regenerating leaves `src/cmd_council.sh` unchanged and `build.sh` leaves `5dive`/`5dive.sha256` unchanged. Without that, the guard would fire on every PR.

**Also closes a second, separate gap:** the diff now covers `5dive.sha256`. It was previously graded only by `tests/install_checksum_unit.sh` in the *unit-tests* job, so a stale committed sha surfaced as unit-tests red and **a green bundle-drift never implied a consistent sha**.

**Scope:** `src/cmd_council.sh` is the only build-time generated committed source — `gen_cmd.mjs` is the only generator in the repo. `src/cmd_agent_create.sh` matches a "do not edit" grep but that marker is about *runtime-generated sudoers*, not the file itself.

No new required check — this is a step inside the existing `bundle-drift` job, so it changes nothing about which contexts are required and cannot strand an automated writer.