### PR TITLE
test(merge-gate): pin the actor so the harness stops grading WHO ran it (DIVE-2114)

### DIFF
--- a/tests/task_deliver_merge_gate_unit.sh
+++ b/tests/task_deliver_merge_gate_unit.sh
@@ -22,6 +22,26 @@ trap 'rm -rf "$TMP"' EXIT
 mkdir -p "$TMP/bin"
 printf '#!/usr/bin/env bash\nexit 1\n' >"$TMP/bin/sudo"
 chmod +x "$TMP/bin/sudo"
+# DIVE-2114/DIVE-2066: PIN THE ACTOR. Tb/Tc call cmd_task_done with no actor, so
+# task_actor() (src/lib/tasks_db.sh) falls through auto_sender_from_sudo — dead
+# here because sudo is stubbed to exit 1 — and lands on the REAL $USER, stripped
+# of an `agent-` prefix. The fixture hardcodes DIVE-201's verifier as `dev`, and
+# DIVE-2007's writer-!=-grader rail refuses anyone else with a DIVE-477 message.
+# Tb/Tc assert on the DIVE-1830 merge-gate text, so they read GREEN only on a box
+# whose $USER strips to literally `dev` and RED everywhere else. That is the same
+# env leak sudo/gh are already stubbed against three lines up — the harness's own
+# greenness depended on who ran it, which makes it a regression detector for
+# nobody. Measured before the pin: 9 passed / 2 failed as both `claude` and
+# `agent-dev2`; the refusal named DIVE-477, not DIVE-1830.
+# BOTH vars, and SUDO_USER is the one that actually bit: task_actor() consults
+# auto_sender_from_sudo() FIRST, which reads $SUDO_USER (validation.sh:73) — so
+# under any `sudo -u X bash tests/...` the invoking agent leaks in and wins
+# before $USER is ever read. DIVE-2066 recorded this as a $USER leak; measured
+# here it is SUDO_USER that dominates, which is why pinning $USER alone changed
+# nothing (still 9/2, actor still resolved to 'main').
+SUDO_USER=agent-dev
+USER=agent-dev
+export SUDO_USER USER
 cat >"$TMP/bin/gh" <<'STUB'
 #!/usr/bin/env bash
 # Minimal stand-in for all three merge-gate calls:


### PR DESCRIPTION
**The ticket's headline premise is wrong, and I could not fix what it described.** `tests/task_deliver_merge_gate_unit.sh` **does** exit non-zero on failure — line 160 is `[[ $FAIL -eq 0 \]\]` as the last command, and it is **byte-identical at `f079f95`, the commit the ticket was filed against**. Measured: bare run `$?=1`; piped to `tail`, `$?=0`. `$?` after a pipeline reports the LAST element, so the `echo $?` in the ticket measured `tail`, not the harness.

**What was real:** the suite had been stuck at **9 passed / 2 failed** because Tb/Tc call `cmd_task_done` with no actor. `task_actor()` falls through to `auto_sender_from_sudo()`, which reads **`$SUDO_USER`** — so under any `sudo -u X bash tests/…` the invoking agent leaks in. DIVE-2007's writer-≠-grader rail then refuses with a **DIVE-477** message while Tb/Tc assert on **DIVE-1830**'s merge-gate text.

**DIVE-2066 recorded this as a `$USER` leak. Measured here, `SUDO_USER` dominates** — it is consulted first, so pinning `$USER` alone changed nothing (still 9/2, actor still resolved to `main`). Both are pinned now.

| | before | after |
|---|---|---|
| as `claude` | 9/2 | **11/0** |
| as `agent-dev2` | 9/2 | **11/0** |
| as `root` | 9/2 | **11/0** |

**The mutation is the point.** Breaking the merge-gate refusal text (`DIVE-1830` → `DIVE-XXXX`) now yields **9/2**. Before the pin the suite read 9/2 *whether or not the gate worked* — a real break and a healthy gate had identical signatures, so it was a regression detector for nothing ([[stubbed-boundary-format-contract]] rule 5: a mutation signature is the set of failing assertion NAMES, not the count).

**Sweep for the same shape across all 162 harnesses: no verified instance.** Two successive regex passes flagged ~80 then 10 candidates; every one I checked guards correctly via an idiom my pattern missed (`[ "$FAIL" -eq 0 ]`, `exit $(( FAIL > 0 ? 1 : 0 ))`, `(( FAIL == 0 ))`, `exit $rc`). **Pattern-matching is the wrong instrument for "does this script fail correctly"** — the right one is execution. I did not complete an execution-based sweep of all 162; that remains open.