### PR TITLE
test(hb-tier): name the tree, and pin the anchor baseline to a commit (DIVE-2226)

### DIFF
--- a/tests/heartbeat_tier_guard_unmeasured_unit.sh
+++ b/tests/heartbeat_tier_guard_unmeasured_unit.sh
@@ -36,9 +36,11 @@
 #   B. tier_unmeasured() keeps the polarity: unregistered is a MEASUREMENT.
 #   C. The guard block, extracted VERBATIM from src/cmd_heartbeat.sh, decides
 #      correctly under nine causes.
-#   D. ANCHOR: the same harness driving the PRE-FIX block (extracted from
-#      origin/main, not reimplemented here) collapses those causes. Without this
-#      the suite could pass against a guard that never had the bug.
+#   D. ANCHOR: the same harness driving the PRE-FIX block (extracted from a
+#      PINNED commit, not reimplemented here) collapses those causes. Without
+#      this the suite could pass against a guard that never had the bug. The
+#      pin is load-bearing: naming a branch made the anchor compare post-fix to
+#      post-fix the moment this merged. See the PRE_FIX_REF note below.
 #   E. Structural: no decision site re-adds a stderr-swallowed isolation read,
 #      and envelope_tier() is byte-identical to origin/main (DIVE-2210 is a
 #      shipped wire format; this ticket must not move it).
@@ -51,6 +53,17 @@
 # Pure: fixture registries in a tmpdir, no root, no network, no tmux, no db.
 #   bash tests/heartbeat_tier_guard_unmeasured_unit.sh
 set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source.
+# NOTE the absence of `2>/dev/null`. The obvious hardening -- redirect the
+# source's stderr so bash's "No such file" does not litter the log -- also
+# swallows the helper's own stderr line, which IS the payload. That silenced all
+# 210 harnesses at once while every other check in this change stayed green.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
 
 PASS=0; FAIL=0; SKIP=0
@@ -218,13 +231,24 @@ for row in "${CAUSES[@]}"; do
   eq_t "guard/$label" "$want" "$got"
 done
 
-# D. ANCHOR. Same harness, PRE-FIX block taken from origin/main — not retyped
-# here, so this cannot silently agree with my reading of the old code. If the
-# baseline is unavailable, SKIP loudly: an anchor that cannot run must not read
-# as a pass.
+# D. ANCHOR. Same harness, PRE-FIX block taken from a PINNED COMMIT — not
+# retyped here, so this cannot silently agree with my reading of the old code.
+# If the baseline is unavailable, SKIP loudly: an anchor that cannot run must
+# not read as a pass.
+#
+# IT USED TO SAY `origin/main`, AND THAT WAS SELF-INVALIDATING. The moment this
+# fix merged, origin/main BECAME the post-fix tree, so the anchor compared post
+# to post: it reported "pre-fix block only auto-ran on 0/6 unmeasured causes"
+# and "fix did not increase distinguishable decisions (3 -> 3)" — red for a
+# reason that has nothing to do with the code under test, on main, inherited by
+# whoever merged next. A baseline named by a BRANCH moves out from under the
+# claim it anchors; name the COMMIT. (It also explains a count that looked like
+# a disagreement: on a checkout with no reachable baseline these two SKIP, so
+# the same harness honestly reports 36+2 there and 41 here.)
+PRE_FIX_REF="9258ee1"   # main immediately before DIVE-2213 merged (PR #268)
 OLD_SRC="$TMP/old_heartbeat.sh"
-if git rev-parse --verify -q origin/main >/dev/null 2>&1 \
-   && git show origin/main:src/cmd_heartbeat.sh > "$OLD_SRC" 2>/dev/null; then
+if git rev-parse --verify -q "${PRE_FIX_REF}^{commit}" >/dev/null 2>&1 \
+   && git show "${PRE_FIX_REF}:src/cmd_heartbeat.sh" > "$OLD_SRC" 2>/dev/null; then
   if _mk_decider decide_old < <(_extract_guard < "$OLD_SRC"); then
     declare -a OLD_OUT=()
     for row in "${CAUSES[@]}"; do
@@ -260,10 +284,10 @@ if git rev-parse --verify -q origin/main >/dev/null 2>&1 \
       bad_t "fix did not increase distinguishable decisions ($n_old -> $n_new)"
     fi
   else
-    skip_t "ANCHOR: origin/main's cmd_heartbeat.sh has no extractable guard block"
+    skip_t "ANCHOR: ${PRE_FIX_REF}'s cmd_heartbeat.sh has no extractable guard block"
   fi
 else
-  skip_t "ANCHOR: origin/main unavailable (shallow clone?) — pre-fix collapse NOT re-measured here"
+  skip_t "ANCHOR: pinned baseline ${PRE_FIX_REF} unavailable (shallow clone?) — pre-fix collapse NOT re-measured here"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Repairs two reds on `main` (a2e2009), both from `tests/heartbeat_tier_guard_unmeasured_unit.sh`, both merge-order shaped. Test-only: the diff touches no file outside `tests/`, and the bundle is byte-identical.

## 1. The harness named no tree

DIVE-2211 made "every harness names the tree it grades" a **corpus-wide** invariant — `tests/names_the_tree_contract_unit.sh` enumerates `tests/*.sh` rather than a fixed list. #268 was cut and CI'd against a base that predated it, so its green was accurate for its base and stale for main. Two PRs each green in isolation, red on merge.

Measured on a clean `git archive` extract of origin/main: **1 passed, 1 failed**. With the obligation pasted verbatim from CONTRIBUTING (including the deliberate absence of `2>/dev/null`): **2 passed, 0 failed**.

## 2. The anchor baseline was a moving ref

This is mine, and it is the same defect one level up. The anchor took its PRE-FIX guard block from `origin/main` — correct exactly until the fix merged, at which point `origin/main` **became** the post-fix tree and the anchor compared post to post:

    FAIL - ANCHOR is vacuous: pre-fix block only auto-ran on 0/6 unmeasured causes
    FAIL - fix did not increase distinguishable decisions (3 -> 3)

Red on main for a reason unrelated to the code under test, inherited by whoever merges next. Pinned to `9258ee1` (main immediately before #268). A baseline named by a **branch** moves out from under the claim it anchors; name the **commit**.

Note the vacuity guard did its job — it refused to report a pass it could not support. What it could not do was stay meaningful, because its baseline moved.

## The count discrepancy is resolved, and it was environmental

`36 passed / 0 failed / 2 skipped` and `41 passed / 0 failed / 0 skipped` are the same harness in two environments: where the baseline is unreachable, the two anchor arms **SKIP** rather than silently passing. With the pin it reads 41/0/0 in a checkout that can reach `9258ee1`, and a loud SKIP otherwise. Skipped is NOT-REACHED, not green — a skip count must never be read as a pass.

## Not in this PR

`version-assign` is also red on main: it computed `0.16.35 -> 0.16.36` correctly and could not push (`GH006: Protected branch update failed`). Per main: nothing changed under the workflow — the job has been dead ~24h and read green on no-op runs where it had nothing to push. Owned separately; the durable fix is DIVE-2144's tag-based publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)