### PR TITLE
git: generated files must never be content-merged — regenerate them (DIVE-2250)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,33 @@
+# DIVE-2250 — GENERATED FILES MUST NEVER BE MERGED. REGENERATE THEM.
+#
+# `-merge` unsets the merge attribute, which makes git refuse a content merge and
+# leave the path UNMERGED (index stages 1/2/3, `UU` in status) instead of running a
+# three-way TEXT merge over it.
+#
+# WHY: `5dive` is a ~49,500-line file produced by ./build.sh from src/*.sh. To git it
+# was an ordinary text file — `git check-attr merge -- 5dive` reported `unspecified` —
+# so any merge where both sides had rebuilt it ran a line-level merge and REPORTED
+# SUCCESS, producing a bundle that no src/ tree ever generated. Measured live on
+# 2026-07-27: merging main into a branch raised exactly ONE conflict, 5dive.sha256,
+# while the bundle itself stitched silently. install.sh fetches the bundle directly,
+# so that artifact is customer-facing.
+#
+# The only thing that was catching this is an ACCIDENT, not a guard: 5dive.sha256 is a
+# single 64-hex line, so two rebuilt branches always collide on that one line. Give
+# that file a header and the collision stops and a stitched bundle ships with no local
+# signal at all until bundle-drift runs, which is after push.
+#
+# ── READ THIS AT CONFLICT TIME ────────────────────────────────────────────────
+# When one of these paths conflicts, THE WORKTREE FILE WILL LOOK COMPLETELY NORMAL.
+# There are NO conflict markers in it — `-merge` leaves OUR version verbatim.
+# Measured: index UU, worktree == ours, 0 occurrences of <<<<<<< or >>>>>>>.
+# So `git add` is the natural next move and it silently commits a STALE bundle.
+#
+#   DO NOT edit these files. DO NOT `git add` them as-is.
+#   REGENERATE:  ./build.sh   then  git add 5dive 5dive.sha256
+#
+# "Resolve the conflict" is the wrong instruction here and this comment deliberately
+# does not use those words: there is nothing in the file to resolve.
+# ──────────────────────────────────────────────────────────────────────────────
+5dive              -merge
+src/cmd_council.sh -merge

--- a/tests/gitattributes_generated_merge_unit.sh
+++ b/tests/gitattributes_generated_merge_unit.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# DIVE-2250 — generated files must never be content-merged by git.
+#
+# WHAT THIS GRADES, and why it is shaped this way:
+#   (a) the SHIPPED .gitattributes, read through `git check-attr`, not the existence
+#       of the file. A .gitattributes that is present but whose pattern does not match
+#       is exactly the vacuous control this repo keeps finding
+#       (community/wiki/a-vacuously-passing-control-is-invisible-in-a-failure-list.md).
+#   (b) the EFFECT, by running a real merge in a throwaway repo that uses the REAL
+#       shipped .gitattributes — copied in, never reimplemented.
+#
+# THE ASSERTION IS "UNMERGED", NEVER "HAS CONFLICT MARKERS" (dev, measured 2026-07-28):
+# with `-merge`, git leaves the index at stages 1/2/3 (`UU`) but writes OUR version to
+# the worktree VERBATIM — zero <<<<<<< or >>>>>>>. A marker-based assertion would be
+# green against a broken implementation AND green against a correct one, i.e. it would
+# grade nothing. Measured in a throwaway repo: UU, worktree == ours, 0 markers.
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+REPO_ROOT=$PWD
+pass=0; fail=0
+ok(){ pass=$((pass+1)); echo "ok   - $1"; }
+bad(){ fail=$((fail+1)); echo "FAIL - $1: $2"; }
+
+# --- (a) the shipped attribute, via check-attr -------------------------------
+for f in 5dive src/cmd_council.sh; do
+  got=$(git check-attr merge -- "$f" 2>/dev/null | sed 's/.*merge: //')
+  [[ "$got" == "unset" ]] && ok "check-attr says merge is unset for $f" \
+                          || bad "merge must be unset for $f" "got '$got'"
+done
+# 5dive.sha256 is DELIBERATELY left mergeable: it is one 64-hex line, so any two
+# rebuilt branches always collide on it and the markers there are informative (you
+# can read both hashes). Pinned so a later "tidy up" does not silently change it.
+got=$(git check-attr merge -- 5dive.sha256 2>/dev/null | sed 's/.*merge: //')
+[[ "$got" == "unspecified" ]] && ok "5dive.sha256 stays mergeable on purpose (its conflict is readable)" \
+                              || bad "5dive.sha256 attribute changed" "got '$got'"
+
+# --- (b) the effect, in a throwaway repo using the SHIPPED .gitattributes -----
+# The scenario is the REAL hazard, not the easy one: two branches edit DIFFERENT
+# regions of a large generated file. That is what git text-merges silently today.
+scenario() { # $1 = "with-attrs" | "without-attrs" ; echoes UNMERGED|MERGED-SILENTLY
+  local mode="$1" t; t=$(mktemp -d /tmp/gitattr-unit.XXXXXX) || return 1
+  ( set -e; cd "$t"; git init -q .; git config user.email t@t; git config user.name t
+    [[ "$mode" == "with-attrs" ]] && cp "$REPO_ROOT/.gitattributes" .
+    seq 1 400 > 5dive; git add -A; git commit -qm base
+    git checkout -qb side; sed -i '390s/.*/THEIR-EDIT/' 5dive; git commit -qam theirs
+    git checkout -q -; sed -i '10s/.*/OUR-EDIT/' 5dive; git commit -qam ours
+    git merge side >/dev/null 2>&1 || true
+    if [[ -n "$(git ls-files -u -- 5dive)" ]]; then echo UNMERGED; else echo MERGED-SILENTLY; fi
+  ); rm -rf "$t"
+}
+r=$(scenario with-attrs)
+[[ "$r" == "UNMERGED" ]] && ok "a two-region concurrent edit leaves the bundle UNMERGED (git refuses to stitch it)" \
+                         || bad "the attribute must stop the content merge" "got '$r'"
+# TWO-SIDED: without the shipped file the SAME scenario stitches silently. Without
+# this arm the test passes on a git that refuses everything, and proves nothing about
+# our .gitattributes.
+r=$(scenario without-attrs)
+[[ "$r" == "MERGED-SILENTLY" ]] && ok "and without it git DOES stitch the same edit silently (the hazard is real, arm is not vacuous)" \
+                                || bad "control must show a silent stitch" "got '$r'"
+
+printf '\ngitattributes-generated-merge: %s passed, %s failed\n' "$pass" "$fail"
+[[ $fail -eq 0 ]]

--- a/tests/gitattributes_generated_merge_unit.sh
+++ b/tests/gitattributes_generated_merge_unit.sh
@@ -39,26 +39,39 @@ got=$(git check-attr merge -- 5dive.sha256 2>/dev/null | sed 's/.*merge: //')
 # --- (b) the effect, in a throwaway repo using the SHIPPED .gitattributes -----
 # The scenario is the REAL hazard, not the easy one: two branches edit DIFFERENT
 # regions of a large generated file. That is what git text-merges silently today.
-scenario() { # $1 = "with-attrs" | "without-attrs" ; echoes UNMERGED|MERGED-SILENTLY
-  local mode="$1" t; t=$(mktemp -d /tmp/gitattr-unit.XXXXXX) || return 1
+#
+# PARAMETERISED OVER EVERY GUARDED PATH (dev's push-back, DIVE-2250): an earlier
+# version ran the effect arm and both mutations against `5dive` only, so
+# src/cmd_council.sh shipped with a check-attr assertion and NO demonstrated effect —
+# green-looking, and exposed to exactly the present-but-does-not-bind case the
+# mutations exist to catch. It is not a hypothetical difference: a gitattributes
+# pattern CONTAINING A SLASH is anchored to the .gitattributes directory while a
+# bare name matches at any depth, so the two entries take different code paths in
+# git's matcher. And per DIVE-2185 the bundle eventually leaves git entirely, which
+# makes cmd_council.sh the entry with PERMANENT value — i.e. the longest-lived arm
+# was the uncovered one.
+scenario() { # $1 = with-attrs|without-attrs, $2 = guarded path ; echoes UNMERGED|MERGED-SILENTLY
+  local mode="$1" path="$2" t; t=$(mktemp -d /tmp/gitattr-unit.XXXXXX) || return 1
   ( set -e; cd "$t"; git init -q .; git config user.email t@t; git config user.name t
     [[ "$mode" == "with-attrs" ]] && cp "$REPO_ROOT/.gitattributes" .
-    seq 1 400 > 5dive; git add -A; git commit -qm base
-    git checkout -qb side; sed -i '390s/.*/THEIR-EDIT/' 5dive; git commit -qam theirs
-    git checkout -q -; sed -i '10s/.*/OUR-EDIT/' 5dive; git commit -qam ours
+    mkdir -p "$(dirname "$path")"
+    seq 1 400 > "$path"; git add -A; git commit -qm base
+    git checkout -qb side; sed -i '390s/.*/THEIR-EDIT/' "$path"; git commit -qam theirs
+    git checkout -q -; sed -i '10s/.*/OUR-EDIT/' "$path"; git commit -qam ours
     git merge side >/dev/null 2>&1 || true
-    if [[ -n "$(git ls-files -u -- 5dive)" ]]; then echo UNMERGED; else echo MERGED-SILENTLY; fi
+    if [[ -n "$(git ls-files -u -- "$path")" ]]; then echo UNMERGED; else echo MERGED-SILENTLY; fi
   ); rm -rf "$t"
 }
-r=$(scenario with-attrs)
-[[ "$r" == "UNMERGED" ]] && ok "a two-region concurrent edit leaves the bundle UNMERGED (git refuses to stitch it)" \
-                         || bad "the attribute must stop the content merge" "got '$r'"
-# TWO-SIDED: without the shipped file the SAME scenario stitches silently. Without
-# this arm the test passes on a git that refuses everything, and proves nothing about
-# our .gitattributes.
-r=$(scenario without-attrs)
-[[ "$r" == "MERGED-SILENTLY" ]] && ok "and without it git DOES stitch the same edit silently (the hazard is real, arm is not vacuous)" \
-                                || bad "control must show a silent stitch" "got '$r'"
+for gp in 5dive src/cmd_council.sh; do
+  r=$(scenario with-attrs "$gp")
+  [[ "$r" == "UNMERGED" ]] && ok "a two-region concurrent edit leaves $gp UNMERGED (git refuses to stitch it)" \
+                           || bad "the attribute must stop the content merge for $gp" "got '$r'"
+  # TWO-SIDED: without the shipped file the SAME edit stitches silently. Without this
+  # arm the suite passes on a git that refuses everything and says nothing about OUR file.
+  r=$(scenario without-attrs "$gp")
+  [[ "$r" == "MERGED-SILENTLY" ]] && ok "and without it git DOES stitch $gp silently (the hazard is real, arm is not vacuous)" \
+                                  || bad "control must show a silent stitch for $gp" "got '$r'"
+done
 
 printf '\ngitattributes-generated-merge: %s passed, %s failed\n' "$pass" "$fail"
 [[ $fail -eq 0 ]]


### PR DESCRIPTION
No `.gitattributes` existed, so git three-way TEXT merged the 49.5k-line generated bundle and reported success — producing a bundle no src/ tree ever built. The only thing catching it was an accident: `5dive.sha256` is one line so it always collides.

Adds `5dive -merge` and `src/cmd_council.sh -merge`.

**Measured caveat that shapes the fix:** with `-merge` the index goes UU but the worktree holds OUR version with **zero conflict markers**, so `git add` silently commits a stale bundle. The comment therefore says REGENERATE and never says "resolve". Test asserts UNMERGED via `git ls-files -u`, never markers — a marker assertion would grade nothing here.

Two-sided + mutation-graded (delete the file → 2/3; break the pattern → 3/2 with MERGED-SILENTLY).

DIVE-2250