### PR TITLE
test: pin baselines to commits, and make CI deep enough to resolve them (DIVE-2229)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      # DIVE-2229: fetch-depth is load-bearing, not hygiene. actions/checkout@v4
+      # defaults to depth 1, and the harnesses below anchor "what this code did
+      # BEFORE" to pinned commits. At depth 1 none of those commits are present,
+      # so every one of those arms was NOT-REACHED in the only environment that
+      # gates a merge — measured on a true depth-1 clone: 36 passed, 0 failed,
+      # 2 SKIPPED, against 41/0/0 on a full checkout. That had been true since
+      # this workflow was written; a skip count is not a green count.
       - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
       - name: Run unit harnesses
         run: |
           rc=0
@@ -49,7 +57,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
+      # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
       - name: Every harness must be able to FAIL
         run: |
           bash tests/meta/harness-verdict-probe.sh --assume-clean \
@@ -81,7 +91,9 @@ jobs:
   test-installed-host:
     runs-on: ubuntu-latest
     steps:
+      # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
       - name: Simulate a box with 5dive installed
         run: |
           # live state dir + gate-proof enforcement flipped ON (as on the
@@ -166,7 +178,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [harness-verdict, test-installed-host]
     steps:
+      # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
       - uses: actions/download-artifact@v4
         with: { pattern: probe-*, merge-multiple: true }
       # The union script fails closed on a missing, headerless, or different-corpus
@@ -188,7 +202,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [harness-verdict, test-installed-host]
     steps:
+      # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
       - uses: actions/download-artifact@v4
         with: { pattern: selfcheck-*, merge-multiple: true }
       # Fails closed on a missing, headerless, different-corpus or

--- a/tests/baseline_pin_unit.sh
+++ b/tests/baseline_pin_unit.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# DIVE-2229 unit: a test baseline must name a COMMIT, and it must RESOLVE in the
+# environment that gates the merge.
+#
+# THE CLASS. Two harnesses took their "before" from `origin/main`. That ref is
+# correct exactly until the fix merges — after which origin/main IS the post-fix
+# tree, and the anchor compares post to post:
+#
+#   - on a DID-CHANGE assertion it goes red on main for a reason unrelated to the
+#     code under test (measured: "fix did not increase distinguishable decisions
+#     (3 -> 3)" on heartbeat_tier_guard_unmeasured_unit.sh after DIVE-2213);
+#   - on a MUST-NOT-CHANGE assertion it goes VACUOUS-PASS and never announces
+#     itself. `envelope_tier() is byte-identical to origin/main` was the arm
+#     olivia cited as proof DIVE-2210's wire format was unmoved, and by then it
+#     was comparing a file to itself.
+#
+# The second half is independent and hits the FIX too: `actions/checkout@v4`
+# defaults to depth 1, and neither a branch ref nor a pinned commit resolves in a
+# depth-1 tree. On a true depth-1 clone the suite read 36 passed, 0 failed,
+# 2 SKIPPED where a full checkout reads 41/0/0 — so those arms had never once run
+# in CI, and every past green there was 36+2. A skip is NOT-REACHED, not green.
+# Fixing only the pin leaves the anchors decisive on a laptop, which is the one
+# place they gate nothing; fixing only the depth leaves them vacuous everywhere.
+#
+# ENUMERATED BY TARGET, NOT BY PATTERN. `git grep -l origin/main tests/` returns
+# 9 files, and 7 of them are not instances: comments, and harnesses that build a
+# THROWAWAY repo and legitimately `git update-ref refs/remotes/origin/main` in
+# it. Fencing all 9 would have "fixed" seven non-bugs and taught the next reader
+# that the shape is the rule. The rule is: a git read that resolves a ref against
+# THIS repository, where the ref is a BRANCH.
+#
+# Isolated: reads files, runs git only against fixtures it creates. No root, no
+# network, never the live tasks.db.
+#   bash tests/baseline_pin_unit.sh
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; [[ -n "${2:-}" ]] && printf '       %s\n' "$2"; return 0; }
+
+TMP="$(mktemp -d /tmp/baseline-pin.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+WF=".github/workflows/unit-tests.yml"
+
+# ---------------------------------------------------------------------------
+# The detector. One function, used on the real corpus AND on synthetic fixtures,
+# so the mutation arm below grades the SAME code the verdict arms use.
+#
+# A line is an instance when it reads a blob/tree out of THIS repo (`git show`,
+# `git rev-parse`, `git diff`, `git log`, `git merge-base`) naming a BRANCH ref.
+# `git -C <somewhere>` is excluded by construction: that is a throwaway fixture
+# repo, and its refs are ones the harness just wrote itself.
+# ---------------------------------------------------------------------------
+branch_baselines() {   # <file> -> matching "line:text", empty if clean
+  grep -nE '(^|[^-])git (show|rev-parse|diff|log|merge-base)[^|;&]*(origin/(main|master)|FETCH_HEAD)' "$1" \
+    | grep -v 'git -C' \
+    | grep -vE '^\s*[0-9]+:\s*#'
+}
+
+# --- Arm A: the detector FIRES on the shape (liveness). Without this, arm B's
+#     "no file matched" is equally consistent with a detector that matches
+#     nothing at all — the exact vacuity this ticket is about.
+# The fixture is ASSEMBLED, never written literally, because this file is itself
+# inside the corpus arm B sweeps: a literal `git show origin/<branch>` here would
+# make the harness its own only offender. Excluding this file from the sweep
+# instead would carve out the one place a real instance could then hide.
+_B="ma""in"
+printf '#!/usr/bin/env bash\nold="$(git show origin/%s:src/lib/registry.sh)"\n' "$_B" > "$TMP/positive.sh"
+if [[ -n "$(branch_baselines "$TMP/positive.sh")" ]]; then
+  ok_t "detector FIRES on a synthetic \`git show origin/${_B}:<path>\` — arm B is a real measurement"
+else
+  bad_t "detector is DEAD" "it did not match the canonical instance, so 'no harness matched' below would be vacuous"
+fi
+
+# --- Arm A2: and it does NOT fire on the two legitimate shapes, or the fence is
+#     a nuisance that the next author will disable rather than obey.
+{ printf '#!/usr/bin/env bash\n'
+  printf '# a comment mentioning git show origin/%s is not an instance\n' "$_B"
+  printf 'git -C "$REPO3" update-ref refs/remotes/origin/%s %s\n' "$_B" "$_B"
+  printf 'git -C "$REPO3" show origin/%s:f\n' "$_B"
+} > "$TMP/negative.sh"
+if [[ -z "$(branch_baselines "$TMP/negative.sh")" ]]; then
+  ok_t "detector is SILENT on comments and on throwaway-repo \`git -C\` refs — enumerated by target, not by pattern"
+else
+  bad_t "detector over-matches" "$(branch_baselines "$TMP/negative.sh")"
+fi
+
+# --- Arm B: the corpus. Non-vacuity first: a scan of zero files passes trivially.
+mapfile -t CORPUS < <(ls tests/*.sh tests/lib/*.sh 2>/dev/null)
+if (( ${#CORPUS[@]} >= 20 )); then
+  ok_t "scanned ${#CORPUS[@]} harness files — the sweep below has a denominator"
+else
+  bad_t "corpus is too small to be the real one" "found ${#CORPUS[@]} files under tests/; a near-empty sweep cannot support 'none of them'"
+fi
+offenders=""
+for f in "${CORPUS[@]}"; do
+  hits="$(branch_baselines "$f")"
+  [[ -n "$hits" ]] && offenders="${offenders}${f}: ${hits}"$'\n'
+done
+if [[ -z "$offenders" ]]; then
+  ok_t "no harness derives a baseline from a BRANCH ref against this repo (pin the commit — tests/lib/pinned_baseline.sh)"
+else
+  bad_t "a baseline is named by a branch, so it moves when the fix merges" "$offenders"
+fi
+
+# --- Arm C: the pins that exist must be real commits AND must not be the tip.
+#     A pin that happens to equal current HEAD is a moving baseline wearing a
+#     sha, and it is what you get by pinning during the merge that lands it.
+head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
+pins="$(grep -rhoE '^[A-Z_]*REF="[0-9a-f]{7,40}"' tests/*.sh | grep -oE '[0-9a-f]{7,40}' | sort -u)"
+if [[ -n "$pins" ]]; then
+  ok_t "harnesses declare $(wc -w <<<"$pins") pinned baseline commit(s)"
+  for p in $pins; do
+    # AN ABBREVIATED PIN KILLS THE FALLBACK. `git fetch origin e32fab8` is
+    # rejected with "couldn't find remote ref" — a remote will serve a full
+    # object name and nothing shorter. So a 7-char pin leaves
+    # pinned_baseline.sh's shallow-tree recovery as DEAD CODE: the arm reds on
+    # every shallow checkout while reading, on a full one, exactly as it should.
+    # Found by running the fallback, not by reading it.
+    if (( ${#p} != 40 )); then
+      bad_t "pinned baseline $p is abbreviated (${#p} chars)" "the shallow-tree fetch in tests/lib/pinned_baseline.sh cannot ask a remote for an abbreviated sha, so the recovery path never runs; use the full 40-char object name"
+      continue
+    fi
+    if ! git rev-parse --verify -q "${p}^{commit}" >/dev/null 2>&1; then
+      # Not a failure of the PIN — a shallow tree cannot see it. Arm D owns that.
+      printf '#    pin %s not present in this (possibly shallow) checkout\n' "$p"
+      continue
+    fi
+    if [[ "$(git rev-parse "$p")" == "$head_sha" ]]; then
+      bad_t "pinned baseline $p IS HEAD" "comparing the tree to itself; pick the commit BEFORE the change under test"
+    else
+      ok_t "pin $p resolves to a commit that is not HEAD"
+    fi
+  done
+else
+  bad_t "no pinned baselines found" "the two harnesses this ticket repaired should declare *_REF=\"<sha>\"; the grep found none, so this arm is scanning the wrong thing"
+fi
+
+# --- Arm D: the CI half. Every checkout in the workflow that runs the suite must
+#     ask for full history, or the pins above resolve nowhere that gates a merge.
+if [[ -f "$WF" ]]; then
+  n_checkout="$(grep -c 'uses: actions/checkout@' "$WF")"
+  n_depth="$(grep -c 'fetch-depth: 0' "$WF")"
+  if (( n_checkout > 0 )); then
+    ok_t "$WF has $n_checkout checkout step(s) to account for"
+  else
+    bad_t "no checkout steps found in $WF" "the parse is wrong, not the workflow"
+  fi
+  if (( n_depth >= n_checkout && n_checkout > 0 )); then
+    ok_t "every checkout in $WF sets fetch-depth: 0 ($n_depth/$n_checkout) — pinned baselines resolve where the merge is gated"
+  else
+    bad_t "a checkout in $WF is depth-1" "$n_depth of $n_checkout steps set fetch-depth: 0; at depth 1 no pinned commit resolves and the baseline arms report NOT-REACHED, which reads as green"
+  fi
+else
+  bad_t "$WF is missing" "the CI half of this ticket cannot be asserted"
+fi
+
+# --- Arm E: the helper must FAIL CLOSED. An unresolvable pin returning success
+#     (or an empty file that compares equal to an empty extraction) is how this
+#     whole class re-enters through its own fix.
+if . tests/lib/pinned_baseline.sh 2>/dev/null; then
+  ok_t "tests/lib/pinned_baseline.sh is sourceable"
+  if pinned_blob "0000000000000000000000000000000000000000" src/cmd_task.sh "$TMP/nope" 2>/dev/null; then
+    bad_t "pinned_blob reported SUCCESS for an unresolvable commit" "callers would compare against whatever it left behind"
+  else
+    ok_t "pinned_blob REFUSES an unresolvable commit (non-zero, no output file)"
+  fi
+  [[ ! -e "$TMP/nope" ]] \
+    && ok_t "pinned_blob left no partial file behind on refusal" \
+    || bad_t "pinned_blob wrote a file it could not fill" "$(wc -c < "$TMP/nope") bytes at $TMP/nope"
+  # A resolvable commit with a path that does not exist there is a DIFFERENT
+  # failure and must not be laundered into "baseline unavailable".
+  if pinned_blob HEAD "no/such/path/at/all.sh" "$TMP/nopath" 2>/dev/null; then
+    bad_t "pinned_blob reported SUCCESS for a missing path at a resolvable ref" "an empty baseline compares equal to an empty extraction"
+  else
+    ok_t "pinned_blob REFUSES a missing path at a resolvable ref"
+  fi
+
+  # --- Arm E2: AN EMPTY DIFF IS NOT A CLEAN DIFF. olivia's scope check on this
+  #     very branch ran `git diff --name-only origin/main...origin/<branch>`
+  #     before the branch was pushed, got nothing, and its out-of-scope grep
+  #     reported "none out of scope — claim HOLDS". A comparison against a ref
+  #     that is not there announces SUCCESS rather than ABSENCE. Measure the
+  #     naive form failing, then the guarded form refusing, in one arm — the
+  #     mutation is differential or it proves nothing.
+  ABSENT="dead0dead0dead0dead0dead0dead0dead0dead0"
+  naive="$(git diff --name-only "$ABSENT" 2>/dev/null | grep -vE '^(tests/|\.github/)' || true)"
+  if [[ -z "$naive" ]]; then
+    ok_t "REPRODUCED: an out-of-scope filter over a diff against an absent ref reports CLEAN on zero evidence"
+  else
+    bad_t "could not reproduce the empty-diff vacuity" "the naive form returned '$naive' — this arm is grading something else and its verdict below is not about the defect"
+  fi
+  if pinned_diff "$ABSENT" --name-only >/dev/null 2>&1; then
+    bad_t "pinned_diff reported SUCCESS against an absent ref" "callers would read its empty output as 'nothing out of scope'"
+  else
+    ok_t "pinned_diff REFUSES an absent ref instead of returning an empty diff that satisfies every filter"
+  fi
+else
+  bad_t "tests/lib/pinned_baseline.sh not sourceable" "the shared fail-closed resolver is the fix; without it each caller re-invents the skip"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/heartbeat_tier_guard_unmeasured_unit.sh
+++ b/tests/heartbeat_tier_guard_unmeasured_unit.sh
@@ -64,11 +64,19 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+# DIVE-2229: pinned-commit baselines, fail-closed. Same no-2>/dev/null rule.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/pinned_baseline.sh" \
+  || printf 'pinned baseline helper: UNRESOLVED (tests/lib/pinned_baseline.sh not reachable)\n' >&2
 cd "$(dirname "$0")/.."
 
 PASS=0; FAIL=0; SKIP=0
 ok_t()   { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
-bad_t()  { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+# DIVE-2229: $2 used to be DROPPED here, so a caller that carefully explained WHY
+# an arm failed printed only its headline. Found by reading the offline run's
+# actual output rather than the call site — the message was written, passed, and
+# swallowed. Second line only when there is one, so the 40 single-arg callers
+# above are unchanged.
+bad_t()  { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; [[ -n "${2:-}" ]] && printf '       %s\n' "$2"; return 0; }
 skip_t() { SKIP=$((SKIP+1)); printf 'SKIP - %s\n' "$1"; }
 eq_t()   { if [[ "$2" == "$3" ]]; then ok_t "$1"; else bad_t "$1 (expected '$2', got '$3')"; fi; }
 
@@ -245,10 +253,17 @@ done
 # claim it anchors; name the COMMIT. (It also explains a count that looked like
 # a disagreement: on a checkout with no reachable baseline these two SKIP, so
 # the same harness honestly reports 36+2 there and 41 here.)
-PRE_FIX_REF="9258ee1"   # main immediately before DIVE-2213 merged (PR #268)
+PRE_FIX_REF="9258ee1ae81b6e96210d0af026f2f3a4a556a518"   # main immediately before DIVE-2213 merged (PR #268)
+# FULL 40 chars, deliberately: `git fetch origin <abbrev>` is rejected with
+# "couldn't find remote ref", so an abbreviated pin makes the shallow-tree
+# fallback in pinned_baseline.sh DEAD CODE and every shallow box reds. Measured.
 OLD_SRC="$TMP/old_heartbeat.sh"
-if git rev-parse --verify -q "${PRE_FIX_REF}^{commit}" >/dev/null 2>&1 \
-   && git show "${PRE_FIX_REF}:src/cmd_heartbeat.sh" > "$OLD_SRC" 2>/dev/null; then
+# DIVE-2229: pinning fixed the ref but left the OTHER half — in a depth-1 CI
+# checkout the pinned commit is not present, this went `skip`, and a skip reads
+# as green to everyone quoting the tally. It now FETCHES that one commit and
+# REDS if it still cannot get it, because "the anchor did not run" and "the
+# anchor passed" must never print the same colour.
+if pinned_blob "$PRE_FIX_REF" src/cmd_heartbeat.sh "$OLD_SRC"; then
   if _mk_decider decide_old < <(_extract_guard < "$OLD_SRC"); then
     declare -a OLD_OUT=()
     for row in "${CAUSES[@]}"; do
@@ -287,7 +302,7 @@ if git rev-parse --verify -q "${PRE_FIX_REF}^{commit}" >/dev/null 2>&1 \
     skip_t "ANCHOR: ${PRE_FIX_REF}'s cmd_heartbeat.sh has no extractable guard block"
   fi
 else
-  skip_t "ANCHOR: pinned baseline ${PRE_FIX_REF} unavailable (shallow clone?) — pre-fix collapse NOT re-measured here"
+  bad_t "ANCHOR: pre-fix collapse NOT re-measured" "$(pinned_unavailable_msg "$PRE_FIX_REF")"
 fi
 
 # ---------------------------------------------------------------------------
@@ -306,12 +321,36 @@ fi
 
 # DIVE-2210's envelope_tier() is a shipped wire format that olivia verified.
 # This ticket adds a sibling; it must not edit it.
-if git rev-parse --verify -q origin/main >/dev/null 2>&1; then
-  old_et="$(git show origin/main:src/lib/registry.sh 2>/dev/null | awk '/^envelope_tier\(\) \{$/ { on=1 } on { print } on && $0 == "}" { exit }')"
-  new_et="$(awk '/^envelope_tier\(\) \{$/ { on=1 } on { print } on && $0 == "}" { exit }' src/lib/registry.sh)"
-  eq_t "envelope_tier() is byte-identical to origin/main (DIVE-2210 untouched)" "$old_et" "$new_et"
+#
+# DIVE-2229 — THIS ARM WAS THE VACUOUS ONE, and it is the arm olivia cited as
+# proof DIVE-2210's wire format was unmoved. It compared against `origin/main`,
+# so once DIVE-2213 merged it was comparing main's registry.sh to main's
+# registry.sh: a must-not-change assertion whose two sides are the same file
+# cannot fail. It does not go red when it stops meaning anything — it goes `ok`
+# forever. Worse, in a `clone --depth=1 --branch main` the ref RESOLVES (to HEAD),
+# so "did origin/main resolve?" never detected it either.
+#
+# e32fab8 is the commit that SHIPPED envelope_tier() for DIVE-2210 — the exact
+# bytes olivia verified — so the pin is what the sentence already claimed to be
+# comparing against, and it is immutable.
+ENVELOPE_TIER_REF="e32fab8e39d9382453f4d1ea680e97f2e386767b"   # DIVE-2210 (full sha: fetchable)
+OLD_REG="$TMP/old_registry.sh"
+_extract_et() { awk '/^envelope_tier\(\) \{$/ { on=1 } on { print } on && $0 == "}" { exit }'; }
+if pinned_blob "$ENVELOPE_TIER_REF" src/lib/registry.sh "$OLD_REG"; then
+  old_et="$(_extract_et < "$OLD_REG")"
+  new_et="$(_extract_et < src/lib/registry.sh)"
+  # NON-VACUITY, asserted and not assumed. Both sides are produced by the same
+  # awk range, so a rename of envelope_tier() empties BOTH and eq_t goes green on
+  # a function that no longer exists. The equality below is only worth reading
+  # after this line has established there is something to compare.
+  if [[ -n "$old_et" && -n "$new_et" ]]; then
+    ok_t "envelope_tier() is extractable on BOTH sides ($(wc -l <<<"$old_et") / $(wc -l <<<"$new_et") lines) — the equality below is non-vacuous"
+    eq_t "envelope_tier() is byte-identical to ${ENVELOPE_TIER_REF} (DIVE-2210 untouched)" "$old_et" "$new_et"
+  else
+    bad_t "envelope_tier() drift check is VACUOUS" "extracted ${#old_et} bytes at ${ENVELOPE_TIER_REF} and ${#new_et} bytes here — an empty side makes byte-equality meaningless; the function was renamed, moved out of src/lib/registry.sh, or its opening line no longer matches the extractor"
+  fi
 else
-  skip_t "envelope_tier() drift check (origin/main unavailable)"
+  bad_t "envelope_tier() drift check did NOT run" "$(pinned_unavailable_msg "$ENVELOPE_TIER_REF")"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/lib/pinned_baseline.sh
+++ b/tests/lib/pinned_baseline.sh
@@ -1,0 +1,105 @@
+# shellcheck shell=bash
+# PIN THE BASELINE TO A COMMIT, AND MAKE FAILURE TO RESOLVE IT LOUD. (DIVE-2229.)
+#
+# THE DEFECT THIS CLOSES, both halves of it.
+#
+# 1. A BASELINE NAMED BY A BRANCH MOVES OUT FROM UNDER THE CLAIM.  An anchor
+#    that reads its "before" from `origin/main` is correct exactly until the fix
+#    merges -- then origin/main IS the post-fix tree and the anchor compares post
+#    to post.  On a "did the fix change anything" assertion that goes RED on main
+#    for a reason unrelated to the code under test (measured on
+#    heartbeat_tier_guard_unmeasured_unit.sh after DIVE-2213: "3 -> 3
+#    distinguishable decisions").  On a MUST-NOT-CHANGE assertion
+#    (`X is byte-identical to origin/main`) it is worse: it goes VACUOUS-PASS and
+#    never announces itself again.  The second is the dangerous one, because the
+#    log still reads `ok`.
+#
+# 2. THE COMPARISON MAY NEVER RUN WHERE IT GATES.  `actions/checkout@v4` with no
+#    `fetch-depth` is depth 1.  What that does to a branch-named baseline depends
+#    on how the shallow tree was made, and BOTH outcomes are wrong:
+#      - PR checkout (fetch of refs/pull/N/merge, no refs/remotes/origin/main):
+#        the ref does not resolve, and a harness that treats that as `skip`
+#        reports NOT-REACHED while a reader counts it as green.
+#      - `git clone --depth=1 --branch main`: refs/remotes/origin/main EXISTS and
+#        points at the same commit as HEAD, so `git show origin/main:<path>` hands
+#        back the WORKING TREE'S OWN CONTENT.  Every byte-identical assertion
+#        passes, having compared a file to itself.  No skip, no red, no signal.
+#    So "does origin/main resolve?" is not even a reliable detector of the
+#    problem -- it can resolve and still be meaningless.  Pin the commit.
+#
+# THE CONTRACT.  `pinned_blob <ref> <path> <outfile>` writes the blob at
+# <ref>:<path> to <outfile> and returns 0, or returns non-zero having written
+# nothing.  It never reports success against a tree it did not resolve, and it
+# never silently substitutes HEAD.
+#
+# WHY IT FETCHES, AND WHY THE FETCH IS BOUNDED.  A shallow clone legitimately
+# lacks the pinned commit, and refusing to try turns a solvable condition into a
+# permanent skip -- which is the second half of the defect above.  So it asks the
+# remote for exactly that one commit at depth 1 (GitHub serves reachable SHAs).
+# It does NOT deepen the whole history: the cost of the fallback must not scale
+# with the repo, or CI will be tempted to remove it again.
+#
+# WHY CALLERS MUST NOT `skip` ON FAILURE.  A skip count is NOT-REACHED, not
+# green, and these are exactly the assertions nobody re-checks by hand.  Every
+# caller in tests/ treats an unresolvable pin as a FAILURE and says so in the
+# message.  The workflow guarantees it resolves (`fetch-depth: 0`); a developer
+# box with a network can fetch it; a box with neither has not run the check and
+# must not be told it passed.  tests/baseline_pin_unit.sh fences both halves.
+
+# Resolve <ref> to a commit in THIS repository, fetching it once if absent.
+# Prints nothing. Returns 0 if the commit is present afterwards.
+pinned_commit_available() {
+  local ref="$1"
+  git rev-parse --verify -q "${ref}^{commit}" >/dev/null 2>&1 && return 0
+  # Bounded, targeted: this one commit, depth 1, no history deepening.
+  git fetch --depth=1 origin "$ref" >/dev/null 2>&1 || return 1
+  git rev-parse --verify -q "${ref}^{commit}" >/dev/null 2>&1
+}
+
+# pinned_blob <ref> <path> <outfile>
+# On success <outfile> holds <ref>:<path>. On failure <outfile> is not created
+# and the return status is non-zero -- callers MUST red, not skip.
+pinned_blob() {
+  local ref="$1" path="$2" out="$3"
+  pinned_commit_available "$ref" || return 1
+  # A missing PATH at a resolvable REF is a different failure (the file moved),
+  # and it must not be laundered into "baseline unavailable" either.
+  git show "${ref}:${path}" > "${out}.part" 2>/dev/null || { rm -f "${out}.part"; return 1; }
+  # An empty baseline blob compares equal to an empty extraction, which is the
+  # vacuous-pass this file exists to prevent. Treat it as unresolved.
+  [[ -s "${out}.part" ]] || { rm -f "${out}.part"; return 1; }
+  mv "${out}.part" "$out"
+}
+
+# pinned_unavailable_msg <ref> -- the message every caller shares, so the reason
+# a load-bearing arm did not run is stated the same way everywhere.
+#
+# RED AND DECLINED MUST STAY DISTINGUISHABLE TO A READER. Turning the old skip
+# into a failure is right -- a skip reads as green in the tally -- but a failure
+# that reads like an ordinary assertion sends the next person into src/ looking
+# for a defect that is not there. The model in this corpus is
+# org_write_authz_unit.sh, which says out loud that the SUITE cannot be exercised
+# in this environment; the counter-examples are the harnesses that go red under
+# root with ordinary assertion text and leave you unable to tell a broken product
+# from a wrong environment. The person who hits this line is offline, in a hurry,
+# and must be told in the first clause that the ENVIRONMENT is the cause.
+pinned_unavailable_msg() {
+  printf 'PRECONDITION NOT MET (environment, not a product defect): this box cannot see the pinned baseline commit %s. The tree is shallow and the single-commit fetch fallback did not reach a remote -- offline, or a CI checkout without fetch-depth:0. NOTHING IS WRONG WITH src/ ON THE STRENGTH OF THIS LINE; the comparison simply did not run, and it is reported red rather than skipped because a skip is counted as green by every reader of the tally. To exercise it: deepen the checkout (git fetch --depth=1 origin %s, or fetch-depth: 0 in the workflow) and re-run.' "$1" "$1"
+}
+
+# pinned_diff <ref> [<git-diff-args>...] -- a diff against a PINNED ref that
+# refuses instead of returning empty when the ref is not there.
+#
+# WHY THIS EXISTS (olivia, DIVE-2229 review): her scope check ran
+# `git diff --name-only origin/main...origin/<branch> | grep -vE <allowed>` and
+# printed "none out of scope -- claim HOLDS". The branch had not been pushed, so
+# the diff was EMPTY, and an empty diff satisfies an out-of-scope filter
+# perfectly. A comparison against a ref that is not there announced SUCCESS
+# rather than ABSENCE -- the same defect this file exists to close, one level up,
+# and it fooled the verifier of the ticket about it. An empty result set is not
+# evidence; it is the shape a missing input takes.
+pinned_diff() {
+  local ref="$1"; shift
+  pinned_commit_available "$ref" || return 1
+  git diff "$@" "$ref" 2>/dev/null || return 1
+}

--- a/tests/policy_refusals_unit.sh
+++ b/tests/policy_refusals_unit.sh
@@ -29,6 +29,9 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+# DIVE-2229: pinned-commit baselines, fail-closed. Same no-2>/dev/null rule.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/pinned_baseline.sh" \
+  || printf 'pinned baseline helper: UNRESOLVED (tests/lib/pinned_baseline.sh not reachable)\n' >&2
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/policy-refusals.XXXXXX)"
@@ -160,15 +163,21 @@ DUPES="$(grep -oE 'policy_refuse "[^"]+" [a-z0-9-]+' src/cmd_task.sh | awk '{pri
 #     an unrelated environmental reason on this host, so it never reached the
 #     assertion. Compare every instrumented site against the code it had on
 #     origin/main — the only source of truth for "what it used to do".
-# Do not merely CHECK for origin/main — try to obtain it. A shallow CI checkout
-# legitimately lacks it, and the old code turned that into a silent `ok`.
-if ! git rev-parse --verify origin/main >/dev/null 2>&1; then
-  git fetch --depth=1 origin main >/dev/null 2>&1 || true
-fi
-if git rev-parse --verify origin/main >/dev/null 2>&1 || git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
-  MAIN_REF=origin/main
-  git rev-parse --verify origin/main >/dev/null 2>&1 || MAIN_REF=FETCH_HEAD
-  git show "${MAIN_REF}:src/cmd_task.sh" > "$TMP/orig_task.sh" 2>/dev/null
+# Do not merely CHECK for the baseline — try to obtain it. A shallow CI checkout
+# legitimately lacks it, and the oldest version of this code turned that into a
+# silent `ok`.
+#
+# DIVE-2229 — but "obtain origin/main" was still the wrong target. `origin/main`
+# and its `FETCH_HEAD` fallback both name the CURRENT tip, so once this
+# instrumentation merged the comparison read the post-instrumentation file and
+# asked whether it matched itself. The question this arm exists to answer is
+# "what did these sites do BEFORE they were instrumented", and only a commit can
+# answer that. e142832 is main immediately before da303e9 (DIVE-1922, PR #156)
+# introduced policy_refuse at all, so it is the last tree in which every one of
+# these sites still called `fail` directly — checked non-vacuous: it carries
+# fail "$E_AUTH_REQUIRED" (7), fail "$E_CONFLICT" (12) and fail "$E_USAGE" (73).
+PRE_INSTRUMENT_REF="e14283209d022c16034f4a4679d0a46463ddd8f3"   # before DIVE-1922 (PR #156)
+if pinned_blob "$PRE_INSTRUMENT_REF" src/cmd_task.sh "$TMP/orig_task.sh"; then
   drift=0
   while read -r code slug; do
     # the message is unchanged by instrumentation, so match the site by its slug's
@@ -185,22 +194,32 @@ if git rev-parse --verify origin/main >/dev/null 2>&1 || git rev-parse --verify 
   grep -q 'local code="\$1"' src/lib/tasks_db.sh \
     && ok_t "policy_refuse takes the exit code as a PARAMETER, so instrumenting preserves behaviour" \
     || bad_t "hardcoded exit code" "policy_refuse forces one code onto every site it instruments"
-  # Every code still in use must be one origin/main actually used at a refusal.
+  # Every code still in use must be one the pre-instrumentation tree actually
+  # used at a refusal.
+  #
+  # NON-VACUITY FIRST: the loop below is a series of "is this code present in the
+  # baseline file" greps, and an EMPTY baseline file answers no to all of them —
+  # which reds, so that direction is safe — but a baseline that simply contains
+  # no `fail "$E_..."` at all would make a green here mean nothing. Establish the
+  # denominator before reading the verdict.
+  base_fails="$(grep -cF 'fail "$E_' "$TMP/orig_task.sh" || true)"
+  [[ "${base_fails:-0}" -gt 0 ]] \
+    && ok_t "baseline ${PRE_INSTRUMENT_REF}:src/cmd_task.sh carries $base_fails direct fail sites — the subset check below has a denominator" \
+    || bad_t "baseline carries NO direct fail sites" "${PRE_INSTRUMENT_REF}:src/cmd_task.sh has no \`fail \"\$E_…\"\` at all, so 'every code existed at a refusal there' cannot be answered — the pin is wrong or the file moved"
   unknown=""
   for c in $(grep -oE 'policy_refuse "\$E_[A-Z_]+"' src/cmd_task.sh | grep -oE 'E_[A-Z_]+' | sort -u); do
-    grep -q "fail \"\$${c}\"" "$TMP/orig_task.sh" || unknown="$unknown $c"
+    grep -qF "fail \"\$${c}\"" "$TMP/orig_task.sh" || unknown="$unknown $c"
   done
   [[ -z "$unknown" ]] \
-    && ok_t "every exit code used by an instrumented site existed at a refusal on origin/main" \
+    && ok_t "every exit code used by an instrumented site existed at a refusal at ${PRE_INSTRUMENT_REF} (pre-instrumentation)" \
     || bad_t "invented exit code" "$unknown"
 else
-  # NOT ok_t. This comparison is the only thing standing between "telemetry was
-  # added" and "telemetry silently changed three exit codes", which is a defect
-  # this ticket already shipped once. Counting a skip as a pass is how a suite
-  # reports green while its load-bearing assertion never ran, so it is a FAILURE
-  # here — CI always has origin/main, and a developer box that does not can fetch.
-  bad_t "origin/main unreachable — the behaviour-preservation comparison did NOT run" \
-        "a fetch was attempted and failed; this assertion is not optional"
+  # NOT ok_t, and NOT skip_t. This comparison is the only thing standing between
+  # "telemetry was added" and "telemetry silently changed three exit codes",
+  # which is a defect this ticket already shipped once. Counting a skip as a pass
+  # is how a suite reports green while its load-bearing assertion never ran.
+  bad_t "the behaviour-preservation comparison did NOT run" \
+        "$(pinned_unavailable_msg "$PRE_INSTRUMENT_REF")"
 fi
 
 # --- Case 5: policy_refuse is reserved for POLICY refusals. If it ever spreads


### PR DESCRIPTION
Two independent defects, one class. Fixing either alone leaves the anchors worthless.

**A. A baseline named by a BRANCH moves out from under its claim.** `origin/main` is the pre-fix tree only until the fix merges. On a *did-change* assertion it then reds on main for a reason unrelated to the code under test (DIVE-2213 left exactly that: `3 -> 3 distinguishable decisions`). On a **must-not-change** assertion it is worse: it goes VACUOUS-PASS and never announces itself again. `envelope_tier() is byte-identical to origin/main` is the arm olivia cited as proof DIVE-2210's wire format was unmoved, and by then it was comparing main's `registry.sh` to itself.

**B. The comparisons never ran where they gate.** `actions/checkout@v4` defaults to depth 1. Measured on a true depth-1 clone: **36 passed, 0 failed, 2 SKIPPED**, against 41/0/0 on a full checkout. Both baseline arms had been NOT-REACHED in CI since this workflow was written, so every past green there was 36+2. A skip is NOT-REACHED, not green.

### Enumerated by TARGET, not by pattern
`git grep -l origin/main tests/` returns **9** files; **2** are instances. The other 7 are comments, or harnesses that build a *throwaway* repo and legitimately `update-ref refs/remotes/origin/main` inside it. The rule is: *a git read that resolves a BRANCH ref against THIS repository.* The ticket's "8 harnesses" and a reviewer's independent "3" were both container-counting.

The two are **not symmetric**: `policy_refusals_unit` had a `FETCH_HEAD` fallback that partly self-healed; `heartbeat_tier_guard_unmeasured_unit:309` had a bare `rev-parse` guard, so an absent ref skipped in silence and a *present* ref compared the fix against itself.

### What changed
- **`tests/lib/pinned_baseline.sh`** (new) — resolve a pinned COMMIT, with a bounded single-commit fetch when a shallow tree lacks it, and REFUSE otherwise. Never a partial file, never an empty blob, never success against a tree it did not resolve. Callers red rather than skip. Its refusal message names the **environment** as the cause in the first clause, so an offline reader is not sent hunting in `src/`.
- **`heartbeat_tier_guard_unmeasured_unit.sh`** — `envelope_tier()` pinned to `e32fab8` (the commit that shipped DIVE-2210), plus a **non-vacuity arm**: both sides come from one `awk` range, so a rename empties both and byte-equality passes on a function that no longer exists. Its `bad_t` was **dropping its second argument**, so every explanation any caller ever wrote there was swallowed — fixed.
- **`policy_refusals_unit.sh`** — pinned to `e142832`, main immediately before DIVE-1922 introduced `policy_refuse` at all: the last tree where those sites still called `fail` directly. Non-vacuity arm asserts the baseline carries 133 direct fail sites before the subset check is read.
- Pins are **full 40-char object names**: a remote will not serve an abbreviated sha (`couldn't find remote ref`), which had made the fetch fallback dead code. Found by running it, not by reading it.
- **`.github/workflows/unit-tests.yml`** — `fetch-depth: 0` on all five checkouts.
- **`tests/baseline_pin_unit.sh`** (new) — fences the class. No harness may baseline off a branch ref; no pin may be abbreviated or equal HEAD; every checkout must be deep. Arm A proves the detector FIRES before arm B's "none found" is read as green. Arm E2 reproduces a reviewer's own empty-diff vacuity (a scope check against an unpushed ref reported "none out of scope" from zero evidence) and shows `pinned_diff` refusing where a bare `git diff` returns a filter-satisfying empty.

### Evidence
| environment | before | after |
|---|---|---|
| full checkout | 41/0/0 | **42 passed, 0 failed, 0 skipped** (+ 18/0 policy, 16/0 new fence) |
| depth-1, remote reachable | 36/0/**2 skipped** | **42/0/0** (fallback recovers) |
| depth-1, offline | 36/0/**2 skipped** | **36 passed, 2 FAILED, 0 skipped** — the skips *convert* rather than disappear, each naming the environment as the cause |

`harness-verdict-probe`: 3 wired, 0 unwired, 0 not-reached. Full suite 218 green. PII scan clean.

Re-pinned and re-checked: `envelope_tier()` at `e32fab8` is byte-identical to the current tree, so the DIVE-2213 byte-identity conclusion is **supported** — no wire-format regression, now proven by a comparison that can actually fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
