### PR TITLE
fix(version-assign): measure the ABSOLUTE property, not a delta an adjacent commit can erase (DIVE-2230)

### DIFF
--- a/scripts/version-assign-push-loop.sh
+++ b/scripts/version-assign-push-loop.sh
@@ -34,11 +34,25 @@ git config user.email 'markounik@gmail.com'
 # scenario this job exists for. So: refetch, recompute against the moved tip, retry,
 # and fail loudly.
 #
-# BASE stays github.event.before across retries, deliberately. If a previous run
-# already assigned, the version HAS moved relative to that base, so the script reports
-# "already moved" and we stop — one version per batch, which is the batching lodar
-# wants. If nobody assigned, we assign once for the whole batch. Both are correct;
-# neither double-bumps.
+# BASE IS NOW INERT (DIVE-2230), and the batching survives it. version-assign.sh no
+# longer decides against the base at all — it compares main's bundle to the bundle
+# recorded at the commit that ASSIGNED the current version, which is an absolute
+# property of the tree and not a delta anyone can launder away. $BEFORE is still
+# passed, and still validated by the script, purely as a truncated-history canary: an
+# unresolvable base means a shallow fetch, and a shallow fetch is what would break the
+# anchor walk.
+#
+# One version per batch still holds, and now holds for a BETTER reason. The loop
+# resets to the freshly-fetched tip before computing, so the assignment it makes
+# covers every merge landed so far. A sibling run then finds the anchor's bundle equal
+# to the tip's and reports nothing owed — not because "the version moved relative to
+# my base", but because main genuinely ships the bundle its version claims.
+#
+# The one deliberate behaviour change: if a further merge lands AFTER that assignment
+# and moves the bundle again, this now assigns a second version instead of stopping.
+# That merge is a real uncovered bundle, and the shared-checkout updater is
+# VERSION-triggered (DIVE-2065) — declining to bump it is not batching, it is the
+# DIVE-2230 debt with a shorter fuse. The tag freeze is on tags; bumps are cheap.
 assigned=""
 for (( try=1; try<=ATTEMPTS; try++ )); do
   git fetch -q origin main

--- a/scripts/version-assign.sh
+++ b/scripts/version-assign.sh
@@ -22,7 +22,37 @@
 # installed-bundle-matches-its-commit selfcheck honest). So this script bumps,
 # and must NEVER create a tag or a GitHub release.
 #
+# DIVE-2230: THE QUESTION IS ABSOLUTE, SO THE BASE IS DERIVED, NEVER PASSED.
+#
+# This script used to compare the bundle at <new-rev> against <base-rev> — the
+# PREVIOUS COMMIT. That asks "did the bundle move in THIS push". The invariant it
+# exists to defend is "does main's bundle match the LAST ASSIGNED VERSION". Those
+# two agree exactly until an assignment fails to land. After that the debt is
+# carried by no one and ERASED by the next unrelated commit, silently and for good.
+#
+# Measured 2026-07-28, three artifacts: run #268 (a2e2009) printed "ASSIGNMENT
+# OWED ... next = 0.16.36" and died on a branch-protection push rejection — loud
+# and correct. Run #271 (0e37bf7), a workflow-only push, then printed "no
+# assignment needed — the bundle is unchanged since a2e2009" and went GREEN, with
+# main's bundle still unassigned. Every run after that was green too. bundle-drift
+# cannot see it either: it compares bundle to SOURCE, and those agree.
+#
+# So the base is now the ANCHOR: the commit that set FIVE_VERSION to its CURRENT
+# value. The bundle recorded there IS the bundle this version shipped, so the
+# comparison answers the absolute question at ANY commit, independent of what the
+# adjacent one did — and one transient push failure can no longer launder itself
+# green. Same wrong-target shape as an anchor pinned to a moving ref (DIVE-2213):
+# the instrument was fine, the thing it was pointed at was not.
+#
+# <base-rev> is still ACCEPTED and still VALIDATED — an unresolvable base means a
+# truncated fetch, and a truncated fetch is exactly what breaks the anchor walk, so
+# it stays as a canary. It is never DECIDED on. A caller cannot reintroduce the
+# delta semantics by passing the wrong thing, which is why version-assign.yml needs
+# no change: its `$before` is now inert.
+#
 # Usage: version-assign.sh <new-rev> [<base-rev>] [--apply]
+#        <base-rev> is a truncated-history canary only; the owed/not-owed decision
+#        is computed against the last ASSIGNED version, never against it.
 # Exit:  0 = no assignment needed (prints why) or assignment computed/applied
 #        2 = could not determine (NOT a pass — never silently skip)
 set -uo pipefail
@@ -41,11 +71,11 @@ if ! git rev-parse --verify --quiet "$NEW" >/dev/null; then
   echo "version-assign: UNDETERMINED — no such rev '$NEW'. This is NOT a pass." >&2; exit 2
 fi
 if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
-  echo "version-assign: UNDETERMINED — no usable base rev '$BASE' (first commit, or a truncated fetch). This is NOT a pass; a bump may be owed and could not be computed." >&2; exit 2
+  echo "version-assign: UNDETERMINED — no usable base rev '$BASE' (first commit, or a truncated fetch). This is NOT a pass; a bump may be owed and could not be computed. The base does not decide anything (DIVE-2230) — it is kept as a truncated-history canary, and a truncated history is what breaks the anchor walk below." >&2; exit 2
 fi
 
-v_new=$(ver_at "$NEW"); v_base=$(ver_at "$BASE")
-s_new=$(sha_at "$NEW"); s_base=$(sha_at "$BASE")
+v_new=$(ver_at "$NEW")
+s_new=$(sha_at "$NEW")
 
 # Fail-open must be LOUD, and the two unreadable causes must not share a message.
 if [[ -z "$v_new" ]]; then
@@ -55,20 +85,53 @@ if [[ -z "$s_new" ]]; then
   echo "version-assign: UNDETERMINED — could not read 5dive.sha256 at '$NEW'. This is NOT a pass." >&2; exit 2
 fi
 
-if [[ "$s_new" == "$s_base" ]]; then
-  echo "version-assign: no assignment needed — the bundle is unchanged since '$BASE' (workflow/doc-only push)."; exit 0
+# THE ANCHOR: walk back over the commits that touched src/header.sh and stop at the
+# first one carrying a DIFFERENT version. The commit after it — the oldest one still
+# carrying $v_new — is where $v_new was assigned. First-parent, because main's trunk
+# is what gets assigned; a merge that changes the version relative to its first
+# parent is itself an assignment and is listed.
+#
+# Walking is the whole point: reading it off the adjacent commit is the bug. The loop
+# normally ends on its first or second iteration (the version moves nearly every
+# release commit), and it is bounded by the history of ONE file.
+ANCHOR=""
+while IFS= read -r c; do
+  [[ -z "$c" ]] && continue
+  if [[ "$(ver_at "$c")" != "$v_new" ]]; then break; fi
+  ANCHOR="$c"
+done < <(git log --first-parent --format=%H "$NEW" -- src/header.sh)
+
+# Never infer an anchor we could not actually see. A shallow clone reaches the end of
+# its grafted history and reports "the version never changed", which is
+# indistinguishable from a genuinely-first version except by asking git whether the
+# history is complete. Guessing here would restore the exact fail-open this ticket is
+# about, one layer down.
+if [[ -z "$ANCHOR" ]]; then
+  echo "version-assign: UNDETERMINED — could not locate the commit that assigned FIVE_VERSION $v_new at '$NEW'. This is NOT a pass; a bump may be owed and could not be computed." >&2; exit 2
 fi
-if [[ "$v_new" != "$v_base" ]]; then
-  echo "version-assign: no assignment needed — the bundle changed AND FIVE_VERSION already moved ($v_base -> $v_new); whoever merged assigned it."; exit 0
+if [[ "$(git rev-parse --is-shallow-repository 2>/dev/null)" == "true" ]] && [[ -z "$(git rev-parse --verify --quiet "${ANCHOR}^" 2>/dev/null)" ]]; then
+  echo "version-assign: UNDETERMINED — the history is SHALLOW and the walk ran off its end at '${ANCHOR:0:12}', so '$v_new' may have been assigned before the graft. This is NOT a pass; fetch with depth 0." >&2; exit 2
 fi
 
-# The bundle moved and the version did not: this is the assignment nobody performed.
+s_anchor=$(sha_at "$ANCHOR")
+if [[ -z "$s_anchor" ]]; then
+  echo "version-assign: UNDETERMINED — could not read 5dive.sha256 at the assignment commit '${ANCHOR:0:12}'. This is NOT a pass." >&2; exit 2
+fi
+
+if [[ "$s_new" == "$s_anchor" ]]; then
+  echo "version-assign: no assignment needed — the bundle is unchanged since $v_new was assigned at ${ANCHOR:0:12}; main ships the bundle its version claims."; exit 0
+fi
+
+# The bundle moved since the version was last assigned, and the version did not
+# follow: this is the assignment nobody performed. Note this is TRUE even when the
+# move happened several commits ago and this push touched nothing — that case is
+# DIVE-2230 itself, and reporting it is the fix.
 if [[ ! "$v_new" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
   echo "version-assign: UNDETERMINED — FIVE_VERSION '$v_new' is not MAJOR.MINOR.PATCH, refusing to guess the successor. This is NOT a pass." >&2; exit 2
 fi
 NEXT="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$(( BASH_REMATCH[3] + 1 ))"
 
-echo "version-assign: ASSIGNMENT OWED — bundle changed ($s_base -> $s_new) with FIVE_VERSION still $v_new."
+echo "version-assign: ASSIGNMENT OWED — bundle changed (${s_anchor:0:16} -> ${s_new:0:16}) since $v_new was assigned at ${ANCHOR:0:12}, with FIVE_VERSION still $v_new."
 echo "version-assign: next = $NEXT"
 (( APPLY )) || { echo "version-assign: --apply not given; nothing written."; exit 0; }
 

--- a/tests/version_assign_unit.sh
+++ b/tests/version_assign_unit.sh
@@ -56,9 +56,14 @@ grep -q 'next = 0.16.20' <<<"$out" && ok "A computes the next patch (0.16.19 -> 
 grep -q 'nothing written' <<<"$out" && ok "A is dry by default — no --apply, no write" || no "A dry" "$out"
 
 # B: version already moved -> nothing owed (the merger did assign it).
+# DIVE-2230 collapsed the two not-owed REASONS into one, because they were both
+# proxies for the same absolute fact: main's bundle is the bundle its version
+# shipped. Here the anchor IS the head commit, so the sha it recorded is the sha at
+# HEAD. The old wording ("FIVE_VERSION already moved") is gone deliberately — it
+# described the delta, which is the thing that could be laundered.
 d=$(mk 0.16.19 aaa 0.16.20 bbb); out=$(run "$d")
-grep -q 'no assignment needed' <<<"$out" && grep -q 'already moved' <<<"$out" \
-  && ok "B version already assigned -> nothing owed" || no "B" "$out"
+grep -q 'no assignment needed' <<<"$out" && grep -q '0.16.20 was assigned at' <<<"$out" \
+  && ok "B version already assigned -> nothing owed, measured against that assignment" || no "B" "$out"
 
 # C: bundle unchanged (workflow/doc-only push) -> exempt.
 d=$(mk 0.16.19 aaa 0.16.19 aaa); out=$(run "$d")
@@ -212,5 +217,100 @@ else
   ok "H BEHAVIOURAL: no tag verb (git tag / gh release / refs/tags / --tags) appears in either shipped file"
 fi
 
-echo; echo "DIVE-2118 version-assign: passed: $P  failed: $F"
+# ---------------------------------------------------------------------------
+# I: DIVE-2230 — THE FAILED ASSIGNMENT MUST NOT LAUNDER ITSELF GREEN.
+#
+# The regression case is NOT "a push fails". Arms A/G already cover that, and the
+# BROKEN implementation passes them: at the failing commit itself the bundle did move
+# in that push, so a delta check and an absolute check agree. The case is "a push
+# fails, THEN an unrelated non-bundle commit lands" — the delta comes back clean, the
+# obligation vanishes, and every subsequent run is green with main unassigned.
+#
+# So this arm is DIFFERENTIAL by construction. It runs the real script AND a mutant
+# that restores the one line of old behaviour (anchor -> BASE), and demands they
+# DISAGREE on the three-commit fixture while AGREEING on the two-commit one. A test
+# that only asserts the real script would pass on an implementation that had merely
+# been reworded.
+mklaunder() { # v/sha at the assignment, then the failed-assign commit, then N doc commits
+  local d="$TMP/launder$RANDOM$RANDOM" i; mkdir -p "$d/src"
+  git -C "$d" init -q -b main; git -C "$d" config user.email t@t; git -C "$d" config user.name t
+  printf 'readonly FIVE_VERSION="0.16.19"\n' > "$d/src/header.sh"; printf 'aaa  5dive\n' > "$d/5dive.sha256"
+  git -C "$d" add -A; git -C "$d" commit -qm "release: assign 0.16.19"
+  # the merge whose assignment FAILED to push: bundle moved, version did not
+  printf 'bbb  5dive\n' > "$d/5dive.sha256"; git -C "$d" add -A; git -C "$d" commit -qm "feat: bundle moves, assignment never landed"
+  for (( i=0; i<${1:-0}; i++ )); do   # unrelated non-bundle pushes (workflow/doc-only)
+    printf 'doc %s\n' "$i" > "$d/README.md"; git -C "$d" add -A; git -C "$d" commit -qm "docs: unrelated"
+  done
+  printf '%s' "$d"; }
+
+# The mutant: one line, restoring exactly the semantics this ticket removed.
+MUT="$TMP/version-assign.mutant.sh"
+sed 's|^s_anchor=$(sha_at "$ANCHOR")$|s_anchor=$(sha_at "$BASE")|' "$S" > "$MUT"
+# CONFIRM THE MUTATION LANDED. A sed that silently matched nothing would make every
+# arm below compare the script against ITSELF and report a confident green.
+if ! cmp -s "$S" "$MUT" && grep -q 's_anchor=$(sha_at "$BASE")' "$MUT"; then
+  ok "I0 CONTROL: the mutant differs from the real script and carries the old base-relative line"
+else
+  no "I0 mutant" "the mutation did not land — every I arm below would be comparing the script to itself"
+fi
+
+# I1 THE FIRST HALF, where broken and fixed AGREE. Both must say OWED; if the mutant
+# were simply broken rather than old, this is where it would show.
+d=$(mklaunder 0)
+real=$( cd "$d" && bash "$S"   HEAD HEAD~1 2>&1 )
+mut=$(  cd "$d" && bash "$MUT" HEAD HEAD~1 2>&1 )
+grep -q 'ASSIGNMENT OWED' <<<"$real" && ok "I1 at the failed-assign commit, the fixed script reports OWED" || no "I1 real" "$real"
+grep -q 'ASSIGNMENT OWED' <<<"$mut"  && ok "I1 CONTROL: and so does the OLD behaviour — this half never discriminated" || no "I1 mut" "$mut"
+
+# I2 THE SECOND HALF — the actual regression. One unrelated doc commit lands on top.
+# Measured on the real repo as runs #268 (loud, correct) then #271 (green, wrong).
+d=$(mklaunder 1)
+real=$( cd "$d" && bash "$S"   HEAD HEAD~1 2>&1 ); rc=$?
+mut=$(  cd "$d" && bash "$MUT" HEAD HEAD~1 2>&1 )
+(( rc == 0 )) && ok "I2 owed-after-a-doc-commit still exits 0 (a finding, not an error)" || no "I2 rc" "$rc: $real"
+grep -q 'ASSIGNMENT OWED' <<<"$real" \
+  && ok "I2 REGRESSION: a doc-only commit ON TOP of a failed assignment still reports the debt" || no "I2 real" "$real"
+grep -q 'next = 0.16.20' <<<"$real" && ok "I2 and still computes the successor it computed before the failure" || no "I2 next" "$real"
+grep -q 'no assignment needed' <<<"$mut" \
+  && ok "I2 DIFFERENTIAL: the OLD behaviour calls the same tree green — this arm discriminates" || no "I2 mut" "$mut"
+
+# I3 the debt survives an ARBITRARY number of unrelated pushes, not just one. The
+# erasure is permanent in the broken version, so a fix that only looked one commit
+# further back would pass I2 and still be wrong.
+d=$(mklaunder 5)
+real=$( cd "$d" && bash "$S" HEAD HEAD~1 2>&1 )
+grep -q 'ASSIGNMENT OWED' <<<"$real" && ok "I3 the debt survives 5 unrelated commits (absolute, not a wider window)" || no "I3" "$real"
+
+# I4 NON-VACUITY. The fix must not answer OWED to everything: once the assignment
+# actually lands, doc commits on top must go quiet. Without this arm, `exit 0 after
+# echoing OWED` would pass I1-I3.
+d=$(mklaunder 1)
+printf 'readonly FIVE_VERSION="0.16.20"\n' > "$d/src/header.sh"   # the assignment lands
+git -C "$d" add -A; git -C "$d" commit -qm "release: assign 0.16.20 at merge"
+printf 'doc after\n' > "$d/README.md"; git -C "$d" add -A; git -C "$d" commit -qm "docs: unrelated"
+real=$( cd "$d" && bash "$S" HEAD HEAD~1 2>&1 ); rc=$?
+(( rc == 0 )) && grep -q 'no assignment needed' <<<"$real" \
+  && ok "I4 NON-VACUITY: once the assignment lands, later doc commits report nothing owed" || no "I4" "$rc: $real"
+grep -q 'assigned at' <<<"$real" \
+  && ok "I4 and names the commit it measured against, so the claim is checkable" || no "I4 anchor named" "$real"
+
+# J: A TRUNCATED HISTORY MUST REFUSE, NOT GUESS. The anchor walk is only as good as
+# the history it can see, and CI checks out with a depth. If the assignment is below
+# the graft, "the version never changed here" is indistinguishable from "this is the
+# first version" — and quietly picking either restores the fail-open one layer down.
+# Depth 2 on purpose: HEAD~1 resolves, so the BASE canary passes and this arm grades
+# the ANCHOR path rather than the pre-existing base check.
+d=$(mklaunder 3)
+sh="$TMP/shallow$RANDOM"
+if git clone -q --depth=2 "file://$d" "$sh" 2>/dev/null; then
+  [[ "$(git -C "$sh" rev-parse --is-shallow-repository)" == "true" ]] \
+    && ok "J CONTROL: the clone really is shallow (otherwise this arm proves nothing)" || no "J control" "not shallow"
+  out=$( cd "$sh" && bash "$S" HEAD HEAD~1 2>&1 ); rc=$?
+  (( rc == 2 )) && ok "J a shallow history exits 2 rather than reporting a clean tree" || no "J rc" "$rc: $out"
+  grep -q 'SHALLOW' <<<"$out" && ok "J and names truncation as the cause, not the version" || no "J msg" "$out"
+else
+  no "J shallow clone could not be created — the arm did NOT run (this is not a pass)"
+fi
+
+echo; echo "DIVE-2118/2230 version-assign: passed: $P  failed: $F"
 [ "$F" -eq 0 ]


### PR DESCRIPTION
## What

`version-assign` compared main's bundle to the bundle at the **previous commit**, which asks *"did the bundle move in THIS push"*. The invariant it exists to defend is *"does main's bundle match the **last assigned version**"*. Those two agree exactly until an assignment fails to land — after that the debt is carried by no one and **erased by the next unrelated commit**, permanently and silently.

Measured on this repo: run **#268** (`a2e2009`) printed `ASSIGNMENT OWED ... next = 0.16.36` and died on a branch-protection push rejection — loud and correct. Run **#271** (`0e37bf7`), a workflow-only push, then printed `no assignment needed — the bundle is unchanged since a2e2009` and went **green**, with main's bundle still unassigned. Every run after that was green too. `bundle-drift` cannot see it either: it compares bundle to SOURCE, and those agree.

This is not a bot that broke and needs a retry. It is **a check measuring a DELTA when the property is ABSOLUTE** — the same wrong-target shape as an anchor pinned to a moving ref (DIVE-2213).

## How

The base is now **derived**: the commit that set `FIVE_VERSION` to its current value, whose recorded `5dive.sha256` *is* the bundle that version shipped. The comparison answers the question at **any** commit, independent of what the adjacent one did, so a transient push failure can no longer launder itself green.

`<base-rev>` is still accepted and still validated, as a **truncated-history canary** — a shallow fetch is precisely what breaks the anchor walk — but it decides nothing. A caller cannot reintroduce the delta semantics by passing the wrong thing, which is why **`.github/workflows/version-assign.yml` needs no change**.

Two fail-opens were closed rather than moved:

- **The derived walk imports its own.** "The version never changed in visible history" is emitted identically by *this is genuinely the first version* and *the history is truncated and the assignment is below the graft*. Guessing either way restores the original defect one layer down, so it asks git whether the history is complete (`rev-parse --is-shallow-repository`) and **refuses** (exit 2) when it is not.
- **The two old "nothing owed" branches collapsed into one.** Both were proxies for the same absolute fact. If the old exemptions had survived the conversion, it would not have been absolute yet.

## The live instance, stated precisely

**main is carrying this debt right now.** `0.17.1` was assigned at `362b975` against bundle `a722b6ee`; main's tip `17eb18c` ships `7af4dd0c`. Two bundle moves landed since (#278, #279) with no assignment, every run green. Pointed at that tip this branch reports `ASSIGNMENT OWED ... next = 0.17.2`; the shipped script reports `no assignment needed`.

**This is prospective harm, not a live customer incident.** Independently checked by @agent-main: the **`v0.17.1` tag ships `a722b6ee`** — the same bundle the assignment named — and boxes install the newest tag, not main HEAD (DIVE-2144). Every published artifact is internally consistent and no install is mismatched. The exposure is that the *next* cut is either blocked by the uniqueness gate or publishes a second artifact under a name already taken.

**Do not hand-assign `0.17.2` before this lands.** The outstanding obligation on main is the only un-fixtured test case this fix will ever get for free; clearing it first leaves the new logic's first production run with nothing to find — which is the exact trap in the ticket's own writeup. @agent-main is holding the assignment until this is on main.

## Grading

The regression case is **not** "a push fails" — the broken implementation passes that, because at the failing commit the delta and the absolute check agree. It is "a push fails, **then** an unrelated non-bundle commit lands".

So arms I1–I4 are differential by construction, against a one-line mutant restoring the old comparison:

- **I0** asserts the mutation actually landed. A `sed` that matched nothing would have every arm below comparing the script to itself and reporting a confident green.
- **I1** asserts **both** implementations report the debt on the first half. A keystone arm that passes on both is not a keystone, and this makes that explicit rather than assumed.
- **I2** asserts they **disagree** on the second half. This is the regression.
- **I3** holds it across five unrelated commits, so a fix that merely widened the window fails.
- **I4** is the non-vacuity arm: once the assignment lands, later doc commits go quiet. Without it, `echo OWED; exit 0` passes I1–I3.
- **J** refuses on a genuinely shallow clone (depth 2 on purpose, so the pre-existing base check passes and the arm grades the *anchor* path).

**36/0 with the fix, 28/8 without it, same harness.** Also green: push-loop 40/0, uniqueness-gate 12/0, bump-guard 21/0, push_unit 78/0.

`scripts/` is not embedded in the bundle, so **no rebuild and no version bump** — 3 files, +194/−17, no `src/`, no `5dive`, no `5dive.sha256`.

## Known residual — DIVE-2264

`version-assign.yml` still exits 0 when `github.event.before` is unusable. Under absolute semantics that skip is a fail-open of the same family, since the question no longer needs `before` at all. Not fixed here: it lives in a `.github/workflows/` file, which `5dive push` cannot ship (DIVE-2262), and the available workaround (the box's `lodar`-scoped `gh` credential) would record a human as editing CI — declined per DIVE-2232. Filed as **DIVE-2264** rather than left in this PR body, because a residual that lives only in a PR body is not tracked.

## Unverified connection, attributed

@agent-olivia notes this may be the silent half of **DIVE-2243** (the host is on `0.16.32` while customers are on `0.17.1`), on the mechanism that `release-cut` never tagged because it counted its own in-progress run, publishing resolves from the newest tag, and `install.sh` has no version comparison. **I did not verify that mechanism** and am not asserting it. One datum that complicates it and is worth someone checking: `v0.17.0` and `v0.17.1` **do** exist as tags, while `0.16.33`–`0.16.36` have none.

Reviewed for scope and shape by @agent-olivia (explicitly against a non-empty diff); blast radius corrected by @agent-main. Neither ran the suite — behaviour is CI's to establish.

Closes DIVE-2230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
