### PR TITLE
DIVE-2233 item 2: make the tier-2 hard human floor a property instead of a label

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -4950,6 +4950,51 @@ cmd_task_need() {
   # SET below overwrites need_type/ask/tier. Without the archive the previous
   # gate leaves nothing but a stale answerer; without the reset the incoming
   # gate wears that answerer's identity, uid and signature (DIVE-2094).
+  # DIVE-2233 item 2 — mint the per-gate human nonce BEFORE the gate is persisted, and
+  # refuse to persist it at all if a tier-2 gate cannot arm itself.
+  #
+  # ORDERING IS THE WHOLE FIX, and getting it wrong was worse than not fixing it. The
+  # refusal originally sat after this UPDATE, so a mint failure aborted the command
+  # having ALREADY written need_type/ask/tier — leaving exactly the half-armed tier-2
+  # gate it refuses to create, while telling the caller it had failed. Caught by arm M2
+  # of gate_t2_nonce_proof_unit ("no half-filed gate is left behind"), which is the arm
+  # I nearly did not write because the refusal "obviously" prevented the state.
+  #
+  # WHY IT MUST FAIL CLOSED. An empty mint used to be silent: no UPDATE, hash NULL, gate
+  # files normally, no warning and no audit row — indistinguishable from a properly
+  # minted gate. Survivable while nothing read the column; NOT survivable once the
+  # tier-2 floor treats a NULL hash as "skip the check", because then a box with a
+  # broken RNG has no floor while every gate on it still LOOKS protected. That is
+  # DIVE-2131 restated. `_human_nonce_verify` already fails closed on a missing hash;
+  # the floor inverted that into a fail-open by skipping, so the refusal belongs HERE,
+  # where the absence is created, not there, where it is only observed.
+  #
+  # Scoped to tier 2 deliberately: for the other human types a NULL hash still means
+  # what it always meant and DIVE-916's verify path fails closed on it unchanged, so
+  # widening this would break gate filing for no security gain. With the /dev/urandom
+  # fallback in `_human_nonce_mint`, reaching this refusal means both the CSPRNG and
+  # openssl are gone — a broken box, not a routine one.
+  # DIVE-2365 (rebase onto DIVE-2356): the condition is "hard-human TYPE **or**
+  # tier>=2", NOT `tier == "2"`. This branch and the persist site below were written
+  # against different mint conditions on two branches; a string compare misses tier
+  # 3+, so the arm-or-refuse decision would cover a NARROWER set than the floor it
+  # exists to protect — the fail-open this commit closes, reintroduced one tier up.
+  # `_t2` is what the refusal keys on, so it tracks the tier arm alone: a hard-human
+  # type at tier 0/1 still files on an empty mint exactly as it always did.
+  local human_nonce="" _mint_nonce=0 _t2=0
+  case "$type" in approval|secret|manual|access) _mint_nonce=1 ;; esac
+  [[ "${tier:-}" =~ ^[0-9]+$ ]] && (( tier >= 2 )) && { _mint_nonce=1; _t2=1; }
+  (( _mint_nonce )) && human_nonce=$(_human_nonce_mint)
+  if (( _t2 )) && [[ -z "$human_nonce" ]]; then
+    # DIVE-2054: DELIBERATELY UNFENCED — a hard gate that could not arm itself is a
+    # fleet-health event, and it must leave evidence even though the caller is told.
+    audit_log "task need nonce-mint-failed" error 0 -- \
+      "task=$ident" "type=$type" "tier=$tier" \
+      "reason=could not mint a per-gate human nonce (openssl and /dev/urandom both unusable)" \
+      2>/dev/null || true
+    fail "$E_GENERIC" "$ident: refusing to file a tier-2 gate that cannot mint its own human proof — openssl and /dev/urandom are both unusable on this box, so the tier-2 human floor could not be enforced on it. Filing it anyway would create a gate that LOOKS hard-gated and is not (DIVE-2131). Fix the box's RNG, or file this at a lower --tier if it genuinely is not a human-only call."
+  fi
+
   db "BEGIN IMMEDIATE;
       $(_gate_archive_and_clear_sql file "id=${id}")
       UPDATE tasks
@@ -5424,14 +5469,11 @@ cmd_task_need() {
   # HAVE a nonce (S16), so every gate already in flight keeps clearing. See the
   # ORDERING note above — refuse-on-NULL waits for tier-2 decisions to accumulate
   # nonces in the wild.
-  local human_nonce="" _mint_nonce=0
-  case "$type" in approval|secret|manual|access) _mint_nonce=1 ;; esac
-  [[ "${tier:-}" =~ ^[0-9]+$ ]] && (( tier >= 2 )) && _mint_nonce=1
-  if (( _mint_nonce )); then
-    human_nonce=$(_human_nonce_mint)
-    [[ -n "$human_nonce" ]] \
-      && db "UPDATE tasks SET human_nonce_hash=$(sqlq "$(_human_nonce_sha "$human_nonce")") WHERE id=${id};"
-  fi
+  # THE MINT ITSELF HAS MOVED UP (DIVE-2054 ordering fix, above the first tasks UPDATE):
+  # a tier-2 gate that cannot arm itself must refuse BEFORE any row is written, not after.
+  # Only the persist survives here.
+  [[ -n "$human_nonce" ]] \
+    && db "UPDATE tasks SET human_nonce_hash=$(sqlq "$(_human_nonce_sha "$human_nonce")") WHERE id=${id};"
   # DIVE-1927: rc 3 = filed and answerable, but NOBODY was pinged. The gate always
   # stands — the dashboard "Needs you" card, `task inbox` and `task answer` need no
   # channel, and a headless/solo/CI box answers gates exactly that way. What must

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -5408,14 +5408,22 @@ cmd_task_need() {
   # If you are here to add a nonce mint somewhere new: check what it does to the
   # ledger before you assume it is a no-op. This one was assumed to be.
   #
-  # NOT DONE HERE, on purpose: the minted nonce is not yet reachable by a decision
-  # TAP. `_task_gate_reply_markup` appends `:${nonce}` to callback_data for
-  # approval/secret/manual but not for the decision option buttons, and
-  # telegram-pi's parser is `^tna:(\d+):(.+)$` (greedy) — appending there would
-  # swallow the nonce into the option token and break decision taps on pi
-  # runtimes. That is a plugin-side fix (all four TNA_RE variants) and its own
-  # ticket; until it lands the hash is at-rest evidence only, which is exactly
-  # and only what the refuse-on-NULL rule needs.
+  # THE EMIT HALF NOW LANDS ALONGSIDE THIS (DIVE-2233 item 2). An earlier draft of
+  # this comment said the nonce was "not yet reachable by a decision TAP" and
+  # deferred it as a plugin-side ticket. `_task_gate_reply_markup` now appends
+  # `:${nonce}` to the decision option buttons too, and the answer path verifies it
+  # (see the tier-2 floor in cmd_task_answer). What made that safe rather than a
+  # plugin break is graded in gate_t2_nonce_proof_unit S12b/S12e: the DEPLOYED
+  # TNA_RE accepts the wider callback_data unchanged, and the fork scan reads each
+  # tna.ts variant's OWN on-disk regex rather than assuming. Two forks (opencode,
+  # pi) still parse the option token greedily and would swallow the nonce — they
+  # are named, fenced by that arm, and tracked, not silently shipped past.
+  #
+  # STILL NOT DONE HERE, and this is the part that must stay undone: refuse a
+  # tier-2 answer whose human_nonce_hash IS NULL. The floor is scoped to gates that
+  # HAVE a nonce (S16), so every gate already in flight keeps clearing. See the
+  # ORDERING note above — refuse-on-NULL waits for tier-2 decisions to accumulate
+  # nonces in the wild.
   local human_nonce="" _mint_nonce=0
   case "$type" in approval|secret|manual|access) _mint_nonce=1 ;; esac
   [[ "${tier:-}" =~ ^[0-9]+$ ]] && (( tier >= 2 )) && _mint_nonce=1
@@ -6215,14 +6223,26 @@ _task_gate_reply_markup() { # <row_id> <type> <options> <recommend> <nonce> <cha
   local reply_markup=""
   if [[ "$channel_type" =~ ^(claude|codex|grok|antigravity)$ ]]; then
     if [[ "$need_type" == "decision" && -n "$options" ]]; then
-      reply_markup=$(printf '%s' "$options" | jq -Rc --arg id "$numid" --arg r "$recommend" --arg p "$label" '
+      # DIVE-2233: the decision buttons now carry the per-gate nonce suffix too, exactly
+      # like approval/secret/manual. This is what makes a tier-2 decision tap PROVABLE
+      # rather than merely asserted — the raw nonce goes into callback_data, which the
+      # agent LLM never sees, and comes back as --human-proof.
+      #
+      # NO PLUGIN CHANGE IS NEEDED, and that is a measured fact, not an assumption: the
+      # deployed contract is `TNA_RE = /^tna:(\d+):([^:]+)(?::([0-9a-f]{32}))?$/`, whose
+      # nonce group is generic over the token — it was never conditioned on the gate type.
+      # Verified against the INSTALLED artifacts (telegram 0.5.35 and 0.5.36 under
+      # ~/.claude/plugins/cache), not just the plugins repo. The emitter here was the only
+      # type-conditional half of the contract. `$np` is empty for gates that mint no nonce,
+      # so the callback_data is byte-identical to today's for every one of them.
+      reply_markup=$(printf '%s' "$options" | jq -Rc --arg id "$numid" --arg r "$recommend" --arg p "$label" --arg np "$np" '
         ($r | gsub("^\\s+|\\s+$"; "")) as $rr
         | [ split("|")[] | gsub("^\\s+|\\s+$"; "") | select(length > 0) ] as $o
         | ($o | to_entries
            | sort_by(.value == $rr and ($rr|length)>0 | not)
            | reduce .[] as $e ({rows: [], cur: [], w: 0};
                (($e.value | length) + (if $e.value == $rr and ($rr|length)>0 then 2 else 0 end)) as $len
-               | {text: ($p + (if $e.value == $rr and ($rr|length)>0 then "⭐ " + $e.value else $e.value end)), callback_data: ("tna:" + $id + ":" + ($e.key | tostring))} as $btn
+               | {text: ($p + (if $e.value == $rr and ($rr|length)>0 then "⭐ " + $e.value else $e.value end)), callback_data: ("tna:" + $id + ":" + ($e.key | tostring) + $np)} as $btn
                | if (.cur | length) > 0 and ((.cur | length) >= 3 or (.w + $len + 2) > 24)
                  then {rows: (.rows + [.cur]), cur: [$btn], w: $len}
                  else {rows: .rows, cur: (.cur + [$btn]), w: (.w + $len + 2)}
@@ -7410,6 +7430,49 @@ cmd_task_answer() {
       "task=$ident" "type=$nt" "tier=$gtier" "reason=non-human answer on tier-2 floor" \
       "human=$human" "caller=$_caller3" "sudo_uid=${SUDO_UID:-}"
     fail "$E_AUTH_REQUIRED" "$ident is a tier-2 human gate ($nt) — only a human can clear it, so an agent answer is refused. Tap the button in Telegram or use the dashboard. (If the tier-2 floor over-fired on this gate, re-file it at a lower --tier.)"
+  fi
+
+  # DIVE-2233 (second item) — THE TIER-2 HUMAN CLAIM MUST BE PROVED, NOT ASSERTED.
+  #
+  # The floor above only fires when `--human` was NOT passed. That is the entire hole:
+  # every guard on a tier-2 gate is downstream of a flag, and `--human` is a plain CLI
+  # flag any agent that can `sudo` can pass. The gate that closed DIVE-2131 is the
+  # worked example — a tier-2 hard gate whose row recorded need_answered_uid=1004
+  # (agent-main, the plugin's own uid) and human_nonce_hash NULL. Nothing in that row is
+  # non-forgeable. "Hard human floor" was a label on it, not a property of it.
+  #
+  # So when a tier-2 gate HAS a minted nonce, a `--human` answer must carry one of the
+  # two DIVE-916 evidence forms — the per-gate nonce (the tap; its SUDO_UID is the
+  # spawning agent, which is why the nonce exists) or a non-agent SUDO_UID (dashboard
+  # exec, human-on-box login). Both are things an agent cannot produce for itself.
+  #
+  # SCOPED TO "HAS A NONCE" ON PURPOSE, and this is the compatibility hinge rather than
+  # timidity: before this change, tier-2 decision/access gates minted nothing, so a gate
+  # filed by the old code and answered by the new code has no hash to check. Demanding
+  # evidence there would reject real human taps on every gate already in flight — and
+  # those taps genuinely cannot comply, because the button they are attached to was
+  # rendered without a nonce in its callback_data. `human_nonce_hash` non-empty is the
+  # exact, per-row witness that this gate's buttons CAN carry proof.
+  #
+  # Runs under `_gate_proof_enforced` for the same rollout envelope as every other
+  # evidence rule (enforce is ON fleet-wide since DIVE-950).
+  if [[ "$gtier" == "2" ]] && (( human )) && _gate_proof_enforced; then
+    local _t2_hash; _t2_hash=$(db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE id=${id};")
+    if [[ -n "$_t2_hash" ]]; then
+      local _t2_hp=0 _t2_su=0
+      [[ -n "$human_proof" ]] && _human_nonce_verify "$id" "$human_proof" && _t2_hp=1
+      _gate_sudo_uid_nonagent && _t2_su=1
+      local _t2_caller; _t2_caller=$(id -un 2>/dev/null || echo '?')
+      # DIVE-2054: the nonce being scored is task-store state for $ident — fenced.
+      _task_store_audit_log "task answer t2-human-evidence" \
+        "$([[ $(( _t2_hp || _t2_su )) -eq 1 ]] && echo ok || echo error)" 0 -- \
+        "task=$ident" "type=$nt" "tier=$gtier" "nonce_valid=$_t2_hp" "sudo_nonagent=$_t2_su" \
+        "human_proof=$([[ -n "$human_proof" ]] && echo present || echo absent)" \
+        "caller=$_t2_caller" "sudo_uid=${SUDO_UID:-}" 2>/dev/null || true
+      if (( ! _t2_hp && ! _t2_su )); then
+        fail "$E_AUTH_REQUIRED" "$ident is a tier-2 human gate ($nt) and the --human claim is unproven: no valid per-gate proof and no non-agent SUDO_UID. Tap the button in Telegram (it carries the proof) or answer from the dashboard. A bare 'sudo 5dive task answer --human' is exactly the forge this refuses."
+      fi
+    fi
   fi
 
   # Who resumes: the agent that hit the gate (assignee), else the creator.

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -1697,8 +1697,32 @@ _human_nonce_sha() {
 
 # Mint a fresh nonce. 16 bytes = 32 hex chars: unguessable, and short enough that
 # `tna:<numid>:<action>:<nonce>` stays under Telegram's 64-byte callback cap.
-# Echoes the RAW nonce on stdout (caller stores only its hash).
-_human_nonce_mint() { openssl rand -hex 16 2>/dev/null; }
+# Echoes the RAW nonce on stdout (caller stores only its hash). rc 0 only when a
+# well-formed nonce was actually produced.
+#
+# DIVE-2233 item 2 (found by Marcus on the pre-merge read): this used to be a bare
+# `openssl rand -hex 16 2>/dev/null` — stderr suppressed, rc unchecked. A missing or
+# broken openssl therefore returned EMPTY, the caller's `[[ -n $human_nonce ]] &&`
+# skipped the UPDATE, and the gate filed with human_nonce_hash NULL and nothing
+# anywhere saying so. That was harmless while nothing read the column; it stopped
+# being harmless at the commit that made NULL mean "skip the tier-2 floor". An
+# inherited silent-empty becomes a security property at the moment something starts
+# reading it, and that is the commit that owes it a voice.
+#
+# Two changes: a FALLBACK so a single missing tool cannot disarm the floor, and an
+# rc so the caller can refuse rather than guess. /dev/urandom is the kernel CSPRNG —
+# the same source openssl seeds from — so the fallback is not a weaker nonce, and it
+# is present on every box we run on. The result is validated either way: a truncated
+# read that yields 12 hex chars must not pass as a nonce.
+_human_nonce_mint() {
+  local n=""
+  n=$(openssl rand -hex 16 2>/dev/null) || n=""
+  if [[ ! "$n" =~ ^[0-9a-f]{32}$ ]]; then
+    n=$(od -An -tx1 -N16 /dev/urandom 2>/dev/null | tr -d ' \n')
+  fi
+  [[ "$n" =~ ^[0-9a-f]{32}$ ]] || return 1
+  printf '%s' "$n"
+}
 
 # Verify a presented nonce against the stored hash for task <id>. 0 = match.
 # Fails closed on a gate with no stored hash (legacy row / non-human gate) or an

--- a/tests/gate_t2_nonce_proof_unit.sh
+++ b/tests/gate_t2_nonce_proof_unit.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# DIVE-2233 ITEM 2 — the tier-2 human claim, proved instead of asserted.
+#
+# Cut onto its own branch at Marcus's direction, and the reason is the point: the tier-2
+# "hard human floor" is currently a LABEL. The gate that closed DIVE-2131 recorded
+# need_answered_uid=1004 (the plugin's own uid) and human_nonce_hash NULL — a tier-2 hard
+# gate closed with no non-forgeable principal. The floor only ever fired when `--human` was
+# ABSENT, and `--human` is a flag any agent that can sudo simply passes.
+#
+# This ships INDEPENDENTLY of the sealed gate-clear (item 1 / phase 3): it touches no
+# constitution key and waits on no council motion. A live floor that is decorative must not
+# wait on governance it does not depend on.
+#
+# THREE PARTS. Tier 2 now mints a per-gate nonce for EVERY type (it skipped `decision`);
+# the decision buttons CARRY it in callback_data; and a `--human` answer on a nonce-bearing
+# tier-2 gate must produce that nonce or a non-agent SUDO_UID. Scoped to gates that HAVE a
+# nonce, which is the compatibility hinge rather than timidity — a gate filed by the old
+# code has no hash to check, and demanding evidence there would reject real taps on every
+# gate already in flight, whose buttons were rendered without a nonce to carry.
+#
+# Run: bash tests/gate_t2_nonce_proof_unit.sh (no root, no network).
+
+# DIVE-2211: name the tree this harness grades. NOTE the absence of `2>/dev/null` —
+# redirecting the source's stderr also swallows the helper's own stderr line, which IS
+# the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/gate-t2-nonce-proof.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# STATE_DIR must be set BEFORE cmd_council.sh is sourced (COUNCIL_DIR/COUNCIL_LINEAGE are
+# source-time globals derived from it).
+STATE_DIR="$TMP"
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh cmd_task.sh cmd_council.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+# cmd_council.sh LAST, matching the production bundle order (CNCL-14). Sourcing it is not
+# convenience: the anchor lives in those council helpers, and a harness that stubbed them
+# would be grading its own stubs.
+COUNCIL_DIR="$STATE_DIR/council"; COUNCIL_LINEAGE="$COUNCIL_DIR/lineage.jsonl"
+TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+GATE_PROOF_KEY="$STATE_DIR/gate-proof.key"
+GATE_PROOF_ENFORCE="$STATE_DIR/gate-proof.enforce"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"; set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+tasks_db_init
+
+AUDIT_FILE="$TMP/audit"; : > "$AUDIT_FILE"
+audit_log() { printf '%s\n' "$*" >> "$AUDIT_FILE"; }
+_af_reset() { : > "$AUDIT_FILE"; }
+_af()       { cat "$AUDIT_FILE" 2>/dev/null; }
+# Capture the RAW nonce cmd_task_need hands to the notifier ($8). This is the only place
+# it is ever exposed — it is deliberately never printed to stdout, so the filing agent
+# cannot see it. The item-2 arms need it to simulate a real tap.
+NONCE_FILE="$TMP/nonce"; : > "$NONCE_FILE"
+task_need_notify() { printf '%s' "${8:-}" > "$NONCE_FILE"; return 0; }
+last_nonce() { cat "$NONCE_FILE" 2>/dev/null; }
+# The task-store audit fence (DIVE-2054) checks the store is production; this harness is
+# isolated, so open it or every row is withheld and the audit assertions pass vacuously.
+_task_human_send_allowed() { return 0; }
+
+# Only `id -un` is stubbed. _gate_authenticated_actor, _gate_route_reviewer,
+# _task_resolve_coordinator and the whole _council_* chain run for real — THEY decide.
+FAKE_CALLER="agent-marcus"
+id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+
+# Org chart: marcus is the lead, dev reports to marcus.
+db "INSERT INTO agents_org (name, role, reports_to) VALUES ('marcus','coordinator',NULL);"
+db "INSERT INTO agents_org (name, role, reports_to) VALUES ('dev','builder','marcus');"
+[[ "$(_gate_route_reviewer dev)" == "marcus" ]] \
+  || { printf 'FAIL - harness precondition: routing did not resolve dev -> marcus\n'; exit 1; }
+
+# --- the ANCHOR -----------------------------------------------------------------------
+# `constitution_yaml <clear_leads csv> [eng_lead]` — writes the strict shape the node-free
+# reader supports. NO `hard_gates:` key on purpose: absent keeps the SHIPPED defaults, so
+# the tier-2 floor these arms lean on behaves exactly as in production. A trimmed
+# hard_gates block would silently narrow the floor and green the T2 arms for the wrong
+# reason (DIVE-2099's own lesson).
+constitution_yaml() {
+  local leads="${1:-}" eng="${2:-}" n
+  printf 'ship:\ncomms:\n'
+  if [[ -n "$leads" || -n "$eng" ]]; then
+    printf 'authority:\n'
+    [[ -n "$eng" ]] && printf '  eng_approval_lead: %s\n' "$eng"
+    if [[ -n "$leads" ]]; then
+      printf '  gate_clear_leads:\n'
+      IFS=, read -ra _ls <<< "$leads"
+      for n in "${_ls[@]}"; do printf '    - %s\n' "$n"; done
+    fi
+  fi
+  return 0
+}
+write_constitution() { mkdir -p "$STATE_DIR"; printf '%s' "$1" > "$STATE_DIR/constitution.yaml"; }
+seal_constitution()  { # seal whatever bytes are on disk RIGHT NOW
+  mkdir -p "$COUNCIL_DIR"
+  printf '{"seq":1,"record":{"constitutionDigest":"%s"}}\n' \
+    "$(sha256sum < "$STATE_DIR/constitution.yaml" | awk '{print $1}')" > "$COUNCIL_LINEAGE"
+}
+unseal() { rm -f "$COUNCIL_LINEAGE"; }
+anchor_to() { write_constitution "$(constitution_yaml "$1" "${2:-}")"; seal_constitution; }
+
+seed_task() { db "INSERT INTO tasks (ident, title, status, created_by, assignee) VALUES ('$1',$(sqlq "${2:-t}"),'todo','dev','dev');"; }
+answered()  { db "SELECT CASE WHEN need_answered_at IS NULL THEN 'open' ELSE 'closed' END FROM tasks WHERE ident='$1';"; }
+provof()    { db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident='$1';"; }
+tierof()    { db "SELECT COALESCE(tier,'') FROM tasks WHERE ident='$1';"; }
+revof()     { db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='$1';"; }
+hashof()    { db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE ident='$1';"; }
+setrev()    { db "UPDATE tasks SET routed_reviewer=$(sqlq "$2") WHERE ident='$1';"; }
+
+export SUDO_UID=1234          # agent-ish uid: NOT the non-agent human-evidence form
+touch "$GATE_PROOF_ENFORCE"   # enforcement ON — the human-only floor is live
+
+# A routed tier-1 approval owned by dev, routed to $1. Returns the ident.
+mk_routed() { # <ident> <reviewer>
+  seed_task "$1" "delegated push for the retry backoff fix"
+  cmd_task_need "$1" --type=approval --tier=1 \
+    --ask="approve delegated push for review of branch fix-retry-backoff" --from=dev >/dev/null 2>&1
+  setrev "$1" "$2"
+}
+
+# ======================================================================================
+
+# ITEM 2 — the tier-2 nonce: mint, EMIT, verify
+# ======================================================================================
+
+anchor_to marcus
+
+# --------------------------------------------------------------------------------------
+# S10 MINT. A tier-2 `decision` — the exact shape of the gate that closed DIVE-2131 —
+#     now mints a per-gate nonce. Before this change the mint was type-conditional and
+#     `decision` got nothing, so its answer row had no non-forgeable field at all.
+# --------------------------------------------------------------------------------------
+seed_task DIVE-506 "pick the rollout order"
+cmd_task_need DIVE-506 --type=decision --tier=2 --options="A|B" --recommend=A \
+  --ask="which rollout order" --from=dev >/dev/null 2>&1
+[[ "$(tierof DIVE-506)" == "2" && -n "$(hashof DIVE-506)" ]] \
+  && ok_t "S10 a tier-2 DECISION now mints a per-gate nonce (it minted none before)" \
+  || bad_t "S10 t2 decision mints" "tier=$(tierof DIVE-506) hash='$(hashof DIVE-506)'"
+T2_NONCE="$(last_nonce)"
+[[ "$T2_NONCE" =~ ^[0-9a-f]{32}$ ]] \
+  && ok_t "S10b the raw nonce reaches the notifier in the shape the deployed regex accepts" \
+  || bad_t "S10b nonce shape" "'$T2_NONCE'"
+
+# --------------------------------------------------------------------------------------
+# S11 TIER 1 IS UNCHANGED. The mint widened to tier 2 only; a tier-1 decision must still
+#     mint nothing, or every ordinary agent-clearable gate just grew a human floor.
+# --------------------------------------------------------------------------------------
+seed_task DIVE-507 "pick the rollout order"
+cmd_task_need DIVE-507 --type=decision --tier=1 --options="A|B" \
+  --ask="which rollout order" --from=dev >/dev/null 2>&1
+[[ -z "$(hashof DIVE-507)" ]] \
+  && ok_t "S11 a tier-1 decision still mints NO nonce (the widening is tier-scoped)" \
+  || bad_t "S11 t1 mints nothing" "hash='$(hashof DIVE-507)'"
+
+# --------------------------------------------------------------------------------------
+# S12 EMIT — the half that makes verification possible at all. The decision buttons must
+#     carry the nonce in callback_data, and the result must match the DEPLOYED contract
+#     `TNA_RE = /^tna:(\d+):([^:]+)(?::([0-9a-f]{32}))?$/` (verified against the installed
+#     telegram 0.5.35/0.5.36 artifacts, not just the plugins repo). Asserting our own
+#     emitter against our own idea of the format would prove nothing — the regex literal
+#     below is COPIED from the deployed plugin.
+# --------------------------------------------------------------------------------------
+TNA_RE_DEPLOYED='^tna:[0-9]+:[^:]+(:[0-9a-f]{32})?$'
+mk=$(_task_gate_reply_markup 42 decision "A|B" "A" "$T2_NONCE" claude)
+cb=$(printf '%s' "$mk" | jq -r '.inline_keyboard[0][0].callback_data')
+[[ "$cb" == *":$T2_NONCE" ]] \
+  && ok_t "S12 the DECISION callback_data now carries the nonce (it did not before)" \
+  || bad_t "S12 decision emits nonce" "cb='$cb'"
+[[ "$cb" =~ $TNA_RE_DEPLOYED ]] \
+  && ok_t "S12b it still matches the DEPLOYED TNA_RE — no plugin change required" \
+  || bad_t "S12b deployed regex match" "cb='$cb'"
+(( ${#cb} <= 64 )) \
+  && ok_t "S12c callback_data stays inside Telegram's 64-byte cap (${#cb} bytes)" \
+  || bad_t "S12c callback cap" "${#cb} bytes: $cb"
+mk0=$(_task_gate_reply_markup 42 decision "A|B" "A" "" claude)
+cb0=$(printf '%s' "$mk0" | jq -r '.inline_keyboard[0][0].callback_data')
+[[ "$cb0" == "tna:42:0" ]] \
+  && ok_t "S12d a gate with NO nonce emits byte-identical callback_data to today's" \
+  || bad_t "S12d no-nonce unchanged" "cb0='$cb0'"
+
+# --------------------------------------------------------------------------------------
+# S12e THE FENCE (DIVE-2233). S12b above grades a literal TRANSCRIBED from one plugin. A
+#      copy cannot detect the case that actually bites: a FORK whose regex differs. It
+#      does. telegram / -codex / -grok / -agy / -qwen carry the optional nonce group, but
+#      telegram-opencode and telegram-pi still use the pre-DIVE-916 `/^tna:(\d+):(.+)$/`,
+#      whose group 2 is GREEDY — it swallows ":<nonce>" into the token, and a decision
+#      then resolves `opts[Number("0:<nonce>")]` = opts[NaN] = undefined = 'invalid'. The
+#      tap is silently dropped. (Those two forks are already broken TODAY for approval /
+#      secret / manual, which have carried the suffix since DIVE-916; this change would
+#      extend it to `decision`, the last type still working there. No agent is currently
+#      exposed — `5dive agent list` shows the only opencode agent with CHANNELS=none and
+#      no pi agents — so the harm is prospective, not live.)
+#
+#      So this arm enumerates the real ARTIFACTS instead of trusting the transcription,
+#      and pins the laggards as a KNOWN set. A new fork going greedy reds here; a laggard
+#      being FIXED also reds, which is the nudge to shrink the list. The plugins tree is
+#      not present on a bare CI checkout, so its absence SKIPS LOUDLY — a silent skip
+#      would make this fence indistinguishable from a fence that passed.
+PLUG=""
+for _p in /home/claude/projects/5dive/5dive-plugins/plugins \
+          "$HOME/.claude/plugins/marketplaces/5dive-plugins/plugins"; do
+  [[ -d "$_p" ]] && { PLUG="$_p"; break; }
+done
+if [[ -z "$PLUG" ]]; then
+  printf 'SKIP - S12e fork-regex fence: no 5dive-plugins tree reachable (NOT a pass)\n'
+else
+  _greedy=""; _tolerant=""
+  for _f in "$PLUG"/telegram*/tna.ts; do
+    [[ -f "$_f" ]] || continue
+    _re=$(grep -h 'export const TNA_RE' "$_f" 2>/dev/null)
+    [[ -n "$_re" ]] || continue
+    if [[ "$_re" == *'[0-9a-f]{32}'* ]]; then _tolerant+=" $(basename "$(dirname "$_f")")"
+    else                                      _greedy+=" $(basename "$(dirname "$_f")")"; fi
+  done
+  # Non-vacuity: the scan must actually have found forks, or "no greedy forks" is a lie.
+  [[ -n "$_tolerant" ]] \
+    && ok_t "S12e precond: the fork scan reached real tna.ts artifacts ($(echo $_tolerant | wc -w) nonce-tolerant)" \
+    || bad_t "S12e scan found nothing" "PLUG=$PLUG"
+  [[ "$(echo $_greedy | tr ' ' '\n' | sort | tr '\n' ' ')" == "telegram-opencode telegram-pi " ]] \
+    && ok_t "S12e the greedy-token forks are EXACTLY the two known laggards (opencode, pi)" \
+    || bad_t "S12e laggard set changed" "greedy='$_greedy' — a new fork drifted, or one was fixed; update the list"
+  # And the emitted value must satisfy every TOLERANT fork's OWN regex, read from disk.
+  _bad=""
+  for _f in "$PLUG"/telegram*/tna.ts; do
+    [[ -f "$_f" ]] || continue
+    _re=$(grep -h 'export const TNA_RE' "$_f" 2>/dev/null); [[ "$_re" == *'[0-9a-f]{32}'* ]] || continue
+    node -e 'const m=process.argv[1].match(/\/(\^.*\$)\//);if(!m)process.exit(2);process.exit(new RegExp(m[1]).test(process.argv[2])?0:1)' \
+      "$_re" "$cb" 2>/dev/null || _bad+=" $(basename "$(dirname "$_f")")"
+  done
+  [[ -z "$_bad" ]] \
+    && ok_t "S12e the emitted callback satisfies each tolerant fork's OWN on-disk regex" \
+    || bad_t "S12e a tolerant fork rejects our callback" "rejected by:$_bad cb='$cb'"
+fi
+
+# --------------------------------------------------------------------------------------
+# S13 VERIFY — THE DIVE-2131 FORGE. A bare `--human` on a tier-2 gate that HAS a nonce,
+#     from an agent-ish SUDO_UID and with no proof, is exactly the answer that closed
+#     DIVE-2131 with need_answered_uid=1004 and human_nonce_hash NULL. It is now REFUSED.
+# --------------------------------------------------------------------------------------
+FAKE_CALLER="agent-main"
+out=$(cmd_task_answer DIVE-506 --value=A --from=main --human 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-506)" == "open" ]] \
+  && ok_t "S13 THE FORGE IS DEAD: bare --human on a nonce-bearing tier-2 gate is refused" \
+  || bad_t "S13 forge refused" "rc=$rc state=$(answered DIVE-506) out=$out"
+
+# --------------------------------------------------------------------------------------
+# S14 NON-VACUITY FOR S13: the SAME gate, SAME caller, SAME uid, plus the real nonce —
+#     clears. Without this, an implementation that rejects every tier-2 human answer
+#     would pass S13 while having broken the tap entirely.
+# --------------------------------------------------------------------------------------
+out=$(cmd_task_answer DIVE-506 --value=A --from=main --human --human-proof="$T2_NONCE" 2>&1); rc=$?
+[[ $rc -eq 0 && "$(answered DIVE-506)" == "closed" ]] \
+  && ok_t "S14 the REAL TAP (same caller + the nonce) clears — only the proof differs" \
+  || bad_t "S14 real tap clears" "rc=$rc state=$(answered DIVE-506) out=$out"
+
+# --------------------------------------------------------------------------------------
+# S15 THE OTHER EVIDENCE FORM. A non-agent SUDO_UID (dashboard exec / human-on-box) also
+#     clears, with no nonce — the two DIVE-916 forms stay EQUIVALENT and are never
+#     double-gated (DIVE-525).
+#     `_gate_is_root` is stubbed here and ONLY here. It is the seam DIVE-1401 put in for
+#     exactly this: `_gate_sudo_uid_nonagent` reads SUDO_UID only in its root branch, and
+#     this harness runs unprivileged, so without the seam it falls to `id -u` = the agent
+#     running the suite and the arm can never reach the branch it is meant to grade. The
+#     resolver itself is NOT stubbed — SUDO_UID=0 still has to survive the real
+#     getent/agent-* check inside it.
+# --------------------------------------------------------------------------------------
+seed_task DIVE-508 "pick the rollout order"
+cmd_task_need DIVE-508 --type=decision --tier=2 --options="A|B" \
+  --ask="which rollout order" --from=dev >/dev/null 2>&1
+SAVED_UID="$SUDO_UID"; export SUDO_UID=0   # root: a real, non-agent uid
+_gate_is_root() { return 0; }
+_gate_sudo_uid_nonagent \
+  && ok_t "S15 precond: the real resolver accepts SUDO_UID=0 as non-agent evidence" \
+  || bad_t "S15 precond" "_gate_sudo_uid_nonagent refused SUDO_UID=0 under the root seam"
+out=$(cmd_task_answer DIVE-508 --value=A --from=main --human 2>&1); rc=$?
+_gate_is_root() { [[ $EUID -eq 0 ]]; }     # restore production behaviour immediately
+export SUDO_UID="$SAVED_UID"
+[[ $rc -eq 0 && "$(answered DIVE-508)" == "closed" ]] \
+  && ok_t "S15 a non-agent SUDO_UID still clears with no nonce (forms stay equivalent)" \
+  || bad_t "S15 sudo_uid form" "rc=$rc state=$(answered DIVE-508) out=$out"
+
+# --------------------------------------------------------------------------------------
+# S16 THE COMPATIBILITY HINGE. A tier-2 gate filed by the OLD code has no stored hash, and
+#     its already-rendered buttons physically cannot carry a proof. Demanding evidence
+#     there would reject real human taps on every gate in flight at deploy time. So a
+#     no-hash tier-2 gate keeps clearing on provenance. This arm is why the rule is scoped
+#     to "has a nonce" rather than to the tier.
+# --------------------------------------------------------------------------------------
+seed_task DIVE-509 "pick the rollout order"
+cmd_task_need DIVE-509 --type=decision --tier=2 --options="A|B" \
+  --ask="which rollout order" --from=dev >/dev/null 2>&1
+db "UPDATE tasks SET human_nonce_hash=NULL WHERE ident='DIVE-509';"   # the pre-fix row shape
+out=$(cmd_task_answer DIVE-509 --value=A --from=main --human 2>&1); rc=$?
+[[ $rc -eq 0 && "$(answered DIVE-509)" == "closed" ]] \
+  && ok_t "S16 a legacy tier-2 gate with NO minted nonce still clears (in-flight taps live)" \
+  || bad_t "S16 legacy compat" "rc=$rc state=$(answered DIVE-509) out=$out"
+
+# --------------------------------------------------------------------------------------
+# S17 A WRONG nonce is not a nonce. Guards against a verifier that checks presence rather
+#     than value.
+# --------------------------------------------------------------------------------------
+seed_task DIVE-510 "pick the rollout order"
+cmd_task_need DIVE-510 --type=decision --tier=2 --options="A|B" \
+  --ask="which rollout order" --from=dev >/dev/null 2>&1
+out=$(cmd_task_answer DIVE-510 --value=A --from=main --human --human-proof="$(printf '0%.0s' {1..32})" 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-510)" == "open" ]] \
+  && ok_t "S17 a WRONG proof is refused (the value is checked, not its presence)" \
+  || bad_t "S17 wrong proof" "rc=$rc state=$(answered DIVE-510) out=$out"
+
+printf '\n%s\n' "-----------------------------------------------"
+printf 'DIVE-2233 item 2 — tier-2 nonce: mint, emit, verify: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/gate_t2_nonce_proof_unit.sh
+++ b/tests/gate_t2_nonce_proof_unit.sh
@@ -121,6 +121,55 @@ setrev()    { db "UPDATE tasks SET routed_reviewer=$(sqlq "$2") WHERE ident='$1'
 export SUDO_UID=1234          # agent-ish uid: NOT the non-agent human-evidence form
 touch "$GATE_PROOF_ENFORCE"   # enforcement ON — the human-only floor is live
 
+# ======================================================================================
+# CALLER-IDENTITY PIN (DIVE-2365). The `export SUDO_UID` above is INERT, and every forge
+# arm in this file depends on it.
+#
+# `_gate_sudo_uid_nonagent` reads SUDO_UID **only** in its root branch (DIVE-1413).
+# Unprivileged — which is how this suite runs — it reads `id -u`: whoever launched the
+# harness. On a 5dive box that is an `agent-*` user, so the arms below were handed their
+# "the caller is an agent" precondition by the HOST, for free, and nobody noticed it was
+# never established here. GitHub's runner is `runner`, a name that does not start with
+# `agent-`, so the real resolver correctly reported non-agent human evidence, the forge
+# CLEARED, and S13/S17 (and E3b next door) failed — with S14 falling over behind S13
+# because its gate had already been closed by the answer S13 was supposed to refuse.
+#
+# The inversion is the dangerous half: the identical harness on a box where the caller is
+# non-agent grades the OPPOSITE behaviour and still prints `ok`. So the precondition is
+# pinned here and ASSERTED at each site, never inherited.
+#
+# `_gate_is_root` is the DIVE-1401 seam (S15 uses the same one). The passwd LOOKUP is
+# stubbed for the pinned uid alone; anything else falls through to the real getent. The
+# resolver itself is NOT stubbed — the root branch, the unknown-uid refusal and the
+# `agent-*` prefix test all still run, against a name this file controls rather than one
+# the host happens to supply.
+# ======================================================================================
+AGENT_UID=1234
+agent_caller_on() {
+  _gate_is_root() { return 0; }
+  getent() {
+    if [[ "${1:-}" == passwd && "${2:-}" == "$AGENT_UID" ]]; then
+      printf 'agent-fixture:x:%s:%s::/home/agent-fixture:/bin/bash\n' "$AGENT_UID" "$AGENT_UID"
+      return 0
+    fi
+    command getent "$@"
+  }
+  export SUDO_UID="$AGENT_UID"
+}
+agent_caller_off() { unset -f getent; _gate_is_root() { [[ $EUID -eq 0 ]]; }; }
+# The anchor. Reads the REAL resolver and refuses to let a forge arm run under a caller
+# it would treat as human — that is the exact state in which the arm inverts silently.
+assert_agent_caller() { # <label>
+  if _gate_sudo_uid_nonagent; then
+    bad_t "$1 precond: caller pinned as an AGENT" \
+      "the real resolver still reports NON-AGENT human evidence — the forge arm below would \
+grade the opposite behaviour and report ok (this is DIVE-2365)"
+  else
+    ok_t "$1 precond: the pinned caller reads as an AGENT to the real resolver"
+  fi
+}
+agent_caller_on
+
 # A routed tier-1 approval owned by dev, routed to $1. Returns the ident.
 mk_routed() { # <ident> <reviewer>
   seed_task "$1" "delegated push for the retry backoff fix"
@@ -249,6 +298,7 @@ fi
 #     DIVE-2131 with need_answered_uid=1004 and human_nonce_hash NULL. It is now REFUSED.
 # --------------------------------------------------------------------------------------
 FAKE_CALLER="agent-main"
+assert_agent_caller S13
 out=$(cmd_task_answer DIVE-506 --value=A --from=main --human 2>&1); rc=$?
 [[ $rc -ne 0 && "$(answered DIVE-506)" == "open" ]] \
   && ok_t "S13 THE FORGE IS DEAD: bare --human on a nonce-bearing tier-2 gate is refused" \
@@ -268,12 +318,14 @@ out=$(cmd_task_answer DIVE-506 --value=A --from=main --human --human-proof="$T2_
 # S15 THE OTHER EVIDENCE FORM. A non-agent SUDO_UID (dashboard exec / human-on-box) also
 #     clears, with no nonce — the two DIVE-916 forms stay EQUIVALENT and are never
 #     double-gated (DIVE-525).
-#     `_gate_is_root` is stubbed here and ONLY here. It is the seam DIVE-1401 put in for
-#     exactly this: `_gate_sudo_uid_nonagent` reads SUDO_UID only in its root branch, and
-#     this harness runs unprivileged, so without the seam it falls to `id -u` = the agent
-#     running the suite and the arm can never reach the branch it is meant to grade. The
-#     resolver itself is NOT stubbed — SUDO_UID=0 still has to survive the real
-#     getent/agent-* check inside it.
+#     This arm flips the caller pin to the OTHER side: SUDO_UID=0 under the DIVE-1401
+#     root seam. It is the only arm that wants non-agent evidence. The resolver itself is
+#     NOT stubbed and neither is this lookup — uid 0 misses the pinned-uid branch of the
+#     `getent` stub, so `root` comes from the real passwd db and still has to survive the
+#     real agent-* check inside the resolver.
+#     (Historic note, DIVE-2365: this comment used to say the harness "falls to `id -u` =
+#     the agent running the suite" — asserting as a property the very thing that was only
+#     ever true by accident of who ran it. That is what the pin above now establishes.)
 # --------------------------------------------------------------------------------------
 seed_task DIVE-508 "pick the rollout order"
 cmd_task_need DIVE-508 --type=decision --tier=2 --options="A|B" \
@@ -284,8 +336,8 @@ _gate_sudo_uid_nonagent \
   && ok_t "S15 precond: the real resolver accepts SUDO_UID=0 as non-agent evidence" \
   || bad_t "S15 precond" "_gate_sudo_uid_nonagent refused SUDO_UID=0 under the root seam"
 out=$(cmd_task_answer DIVE-508 --value=A --from=main --human 2>&1); rc=$?
-_gate_is_root() { [[ $EUID -eq 0 ]]; }     # restore production behaviour immediately
 export SUDO_UID="$SAVED_UID"
+agent_caller_on                            # back to the AGENT pin for S16/S17 below
 [[ $rc -eq 0 && "$(answered DIVE-508)" == "closed" ]] \
   && ok_t "S15 a non-agent SUDO_UID still clears with no nonce (forms stay equivalent)" \
   || bad_t "S15 sudo_uid form" "rc=$rc state=$(answered DIVE-508) out=$out"
@@ -313,6 +365,7 @@ out=$(cmd_task_answer DIVE-509 --value=A --from=main --human 2>&1); rc=$?
 seed_task DIVE-510 "pick the rollout order"
 cmd_task_need DIVE-510 --type=decision --tier=2 --options="A|B" \
   --ask="which rollout order" --from=dev >/dev/null 2>&1
+assert_agent_caller S17
 out=$(cmd_task_answer DIVE-510 --value=A --from=main --human --human-proof="$(printf '0%.0s' {1..32})" 2>&1); rc=$?
 [[ $rc -ne 0 && "$(answered DIVE-510)" == "open" ]] \
   && ok_t "S17 a WRONG proof is refused (the value is checked, not its presence)" \

--- a/tests/gate_t2_nonce_proof_unit.sh
+++ b/tests/gate_t2_nonce_proof_unit.sh
@@ -318,6 +318,63 @@ out=$(cmd_task_answer DIVE-510 --value=A --from=main --human --human-proof="$(pr
   && ok_t "S17 a WRONG proof is refused (the value is checked, not its presence)" \
   || bad_t "S17 wrong proof" "rc=$rc state=$(answered DIVE-510) out=$out"
 
+# --------------------------------------------------------------------------------------
+# M — THE MINT ITSELF (DIVE-2233 item 2, found by Marcus on the pre-merge read).
+#     Everything above assumes a nonce exists. If the mint silently yields nothing, the
+#     tier-2 block is SKIPPED and a bare `--human` is accepted with no proof — the floor
+#     is absent on that box while every gate on it still looks protected. That is
+#     DIVE-2131 restated, so it is graded here rather than assumed away.
+# --------------------------------------------------------------------------------------
+# M1 THE FALLBACK. openssl broken must NOT disarm the floor: /dev/urandom is the same
+#    kernel CSPRNG openssl seeds from, so the nonce is not weaker for coming from it.
+( openssl() { return 1; }
+  n=$(_human_nonce_mint) && [[ "$n" =~ ^[0-9a-f]{32}$ ]] ) \
+  && ok_t "M1 a broken openssl falls back to /dev/urandom and still mints 32 hex chars" \
+  || bad_t "M1 fallback mint" "no well-formed nonce when openssl fails"
+# M1b the mint VALIDATES rather than trusting: a truncated 12-char read is not a nonce.
+( _human_nonce_mint() { printf 'abc123'; }
+  [[ "$(_human_nonce_mint)" =~ ^[0-9a-f]{32}$ ]] ) \
+  && bad_t "M1b short value must not pass as a nonce" "12 chars accepted" \
+  || ok_t "M1b a short/truncated value is not a well-formed nonce"
+
+# M2 THE REFUSAL. Both sources gone => a tier-2 gate must REFUSE TO FILE. Filing it would
+#    create a gate claiming a hard human floor it cannot enforce.
+_af_reset 2>/dev/null || true
+seed_task DIVE-520 "rotate the prod signing key"
+out=$( _human_nonce_mint() { return 1; }
+       cmd_task_need DIVE-520 --type=decision --tier=2 --options="A|B" \
+         --ask="which rollout order" --from=dev 2>&1 ); rc=$?
+[[ $rc -ne 0 ]] \
+  && ok_t "M2 a tier-2 gate whose nonce cannot be minted REFUSES to file (rc=$rc)" \
+  || bad_t "M2 mint-failure refused" "rc=$rc out=$out"
+[[ "$out" == *"cannot mint its own human proof"* ]] \
+  && ok_t "M2 the refusal names the cause (RNG), not a generic internal error" \
+  || bad_t "M2 refusal names cause" "out=$out"
+[[ -z "$(hashof DIVE-520)" && "$(db "SELECT COALESCE(need_type,'') FROM tasks WHERE ident='DIVE-520';")" == "" ]] \
+  && ok_t "M2 no half-filed gate is left behind (need_type unset, no hash)" \
+  || bad_t "M2 no partial gate" "type='$(db "SELECT COALESCE(need_type,'') FROM tasks WHERE ident='DIVE-520';")' hash='$(hashof DIVE-520)'"
+
+# M3 SCOPE. The refusal is tier-2 ONLY. A tier-1 gate with the same broken mint still
+#    files — its NULL hash means what it always meant, and DIVE-916's verify path fails
+#    closed on it unchanged. Widening the refusal would take out gate filing for no gain.
+seed_task DIVE-521 "pick the rollout order"
+out=$( _human_nonce_mint() { return 1; }
+       cmd_task_need DIVE-521 --type=decision --tier=1 --options="A|B" \
+         --ask="which rollout order" --from=dev 2>&1 ); rc=$?
+[[ $rc -eq 0 ]] \
+  && ok_t "M3 a TIER-1 gate with the same broken mint still files (refusal is scoped)" \
+  || bad_t "M3 tier-1 unaffected" "rc=$rc out=$out"
+
+# M4 NON-VACUITY FOR M2. The same gate shape with a WORKING mint files fine — without
+#    this, an M2 that passed because `cmd_task_need` is broken for every tier-2 gate
+#    would be indistinguishable from one that passed for the right reason.
+seed_task DIVE-522 "rotate the prod signing key"
+out=$(cmd_task_need DIVE-522 --type=decision --tier=2 --options="A|B" \
+        --ask="which rollout order" --from=dev 2>&1); rc=$?
+[[ $rc -eq 0 && -n "$(hashof DIVE-522)" ]] \
+  && ok_t "M4 the SAME gate with a working mint files and stores a hash (M2 is not vacuous)" \
+  || bad_t "M4 non-vacuity" "rc=$rc hash='$(hashof DIVE-522)' out=$out"
+
 printf '\n%s\n' "-----------------------------------------------"
 printf 'DIVE-2233 item 2 — tier-2 nonce: mint, emit, verify: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/tests/gate_t2_routed_escalate_unit.sh
+++ b/tests/gate_t2_routed_escalate_unit.sh
@@ -51,9 +51,15 @@ tasks_db_init
 # File-backed observer: cmd_task_answer runs inside a `$(...)` subshell in the cases
 # that capture its output, so a plain var would be lost — record the ping on disk.
 NOTIFIED_FILE="$TMP/notified"; : > "$NOTIFIED_FILE"
-task_need_notify() { echo "$1:$2" > "$NOTIFIED_FILE"; }   # "<ident>:<type>"
+# DIVE-2233 item 2: also capture the RAW nonce the notifier is handed ($8), in a SEPARATE
+# file so the _nf_reset the arms call between cases cannot clobber it. The notifier is the
+# only place the raw value is ever exposed — it is deliberately never printed to stdout,
+# so the filing agent cannot read it back — and E3 needs it to simulate a REAL human tap.
+NONCE_FILE="$TMP/nonce"; : > "$NONCE_FILE"
+task_need_notify() { echo "$1:$2" > "$NOTIFIED_FILE"; printf '%s' "${8:-}" > "$NONCE_FILE"; }
 _nf()   { cat "$NOTIFIED_FILE" 2>/dev/null; }
 _nf_reset() { : > "$NOTIFIED_FILE"; }
+last_nonce() { cat "$NONCE_FILE" 2>/dev/null; }
 audit_log() { :; }
 
 # The immediate caller is the agent LEAD (agent-marcus) attempting to clear a gate that
@@ -123,17 +129,40 @@ out=$(cmd_task_answer DIVE-302 --value=approved 2>&1); rc=$?
 
 # --- E3: a routed tier-2 manual gate cleared by a real HUMAN (--human) clears normally —
 #     escalation only fires for the NON-human refusal path (DIVE-525: taps never break). -
+#
+# DIVE-2233 item 2 CHANGED THIS ARM'S FIXTURE, not its claim. The caller here is a stubbed
+# agent-marcus (line ~62), so the pre-item-2 form — a bare `--human` from an agent process
+# with no proof — IS the DIVE-2131 forge this ships to kill, and it is now refused. What
+# the arm means to grade is that a REAL human clear still works, so it supplies what a real
+# tap actually carries: the minted nonce. E3b withholds ONLY the proof on the same shape.
 seed_task DIVE-303
 cmd_task_need DIVE-303 --type=manual --ask="run the physical box swap" >/dev/null 2>&1
 route_to DIVE-303 marcus
+E3_NONCE="$(last_nonce)"
+[[ -n "$E3_NONCE" ]] \
+  && ok_t "E3 precond: filing a tier-2 manual gate minted a nonce for the tap to carry" \
+  || bad_t "E3 precond nonce minted" "notifier was handed no nonce"
 _nf_reset
-cmd_task_answer DIVE-303 --value=approved --human >/dev/null 2>&1
+out=$(cmd_task_answer DIVE-303 --value=approved --human --human-proof="$E3_NONCE" 2>&1); rc=$?
 [[ "$(answered DIVE-303)" == "closed" ]] \
-  && ok_t "E3 --human answer on a routed tier-2 gate CLEARS (no escalation needed)" \
-  || bad_t "E3 --human clears" "still $(answered DIVE-303)"
+  && ok_t "E3 a REAL human tap (--human + the minted nonce) on a routed tier-2 gate CLEARS" \
+  || bad_t "E3 real tap clears" "rc=$rc still $(answered DIVE-303) out=$out"
 [[ -z "$(_nf)" ]] \
   && ok_t "E3 no re-escalation on a genuine human clear" \
   || bad_t "E3 no re-escalation" "notified='$(_nf)'"
+
+# --- E3b NON-VACUITY FOR E3 (DIVE-2233 item 2): same gate shape, same caller — only the
+#     proof is withheld. This is the exact answer that closed DIVE-2131 with
+#     need_answered_uid=1004 and human_nonce_hash NULL. Without it, an E3 that accepted
+#     anything is indistinguishable from an E3 that verifies. ----------------------------
+seed_task DIVE-305
+cmd_task_need DIVE-305 --type=manual --ask="run the physical box swap" >/dev/null 2>&1
+route_to DIVE-305 marcus
+_nf_reset
+out=$(cmd_task_answer DIVE-305 --value=approved --human 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-305)" == "open" ]] \
+  && ok_t "E3b bare --human from an agent (the DIVE-2131 forge) is REFUSED on the same gate" \
+  || bad_t "E3b forge refused" "rc=$rc state=$(answered DIVE-305) out=$out"
 
 # --- E4: rollout safety — enforcement OFF => the floor (and thus the escalation) is
 #     dormant; a routed tier-2 manual gate is cleared by its lead directly (DIVE-1182). -

--- a/tests/gate_t2_routed_escalate_unit.sh
+++ b/tests/gate_t2_routed_escalate_unit.sh
@@ -78,6 +78,37 @@ tierof()     { db "SELECT COALESCE(tier,'') FROM tasks WHERE ident='$1';"; }
 export SUDO_UID=1234   # an agent-ish uid: not the non-agent (root/claude) evidence form
 touch "$GATE_PROOF_ENFORCE"   # enforcement ON (the floor + escalation are live)
 
+# --- CALLER-IDENTITY PIN (DIVE-2365) ---------------------------------------------------
+# The export above is INERT here. `_gate_sudo_uid_nonagent` reads SUDO_UID only in its
+# root branch (DIVE-1413); unprivileged it reads `id -u` — whoever ran the suite. That is
+# `agent-*` on a 5dive box and `runner` in CI, so E3b's "from an agent" was supplied by
+# the host rather than by this file, and on the runner the forge CLEARED instead. Pin it:
+# seam `_gate_is_root`, stub the passwd lookup for the pinned uid only, leave the
+# resolver's own root-branch / unknown-uid / `agent-*` logic real. Full write-up lives at
+# the top of tests/gate_t2_nonce_proof_unit.sh.
+AGENT_UID=1234
+agent_caller_on() {
+  _gate_is_root() { return 0; }
+  getent() {
+    if [[ "${1:-}" == passwd && "${2:-}" == "$AGENT_UID" ]]; then
+      printf 'agent-fixture:x:%s:%s::/home/agent-fixture:/bin/bash\n' "$AGENT_UID" "$AGENT_UID"
+      return 0
+    fi
+    command getent "$@"
+  }
+  export SUDO_UID="$AGENT_UID"
+}
+assert_agent_caller() { # <label>
+  if _gate_sudo_uid_nonagent; then
+    bad_t "$1 precond: caller pinned as an AGENT" \
+      "the real resolver still reports NON-AGENT human evidence — the arm below would grade \
+the opposite behaviour and report ok (DIVE-2365)"
+  else
+    ok_t "$1 precond: the pinned caller reads as an AGENT to the real resolver"
+  fi
+}
+agent_caller_on
+
 # --- E1: THE FIX — a ROUTED tier-2 manual gate, answered by its lead, ESCALATES to the
 #     human instead of dead-ending: routed_reviewer cleared, ping re-armed, fresh nonce
 #     minted, human ping fired, and the gate stays OPEN (awaiting the human tap). -------
@@ -159,6 +190,7 @@ seed_task DIVE-305
 cmd_task_need DIVE-305 --type=manual --ask="run the physical box swap" >/dev/null 2>&1
 route_to DIVE-305 marcus
 _nf_reset
+assert_agent_caller E3b
 out=$(cmd_task_answer DIVE-305 --value=approved --human 2>&1); rc=$?
 [[ $rc -ne 0 && "$(answered DIVE-305)" == "open" ]] \
   && ok_t "E3b bare --human from an agent (the DIVE-2131 forge) is REFUSED on the same gate" \

--- a/tests/gate_tier2_floor_unit.sh
+++ b/tests/gate_tier2_floor_unit.sh
@@ -63,9 +63,18 @@ provby()  { db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident='$1'
 tierof()  { db "SELECT COALESCE(tier,'') FROM tasks WHERE ident='$1';"; }
 
 # A non-agent SUDO_UID throughout (root) so the DIVE-916 evidence forms are NOT what
-# gates these cases — the tier-2 provenance floor is. (A tier-2 decision mints no
-# nonce anyway; see gate_nonce_unit T2.)
+# gates these cases — the tier-2 provenance floor is.
+#
+# DIVE-2233 item 2: the parenthetical that used to end this comment — "a tier-2 decision
+# mints no nonce anyway" — is no longer true, and it was load-bearing by accident. Tier 2
+# now mints for EVERY type, so T2's --human answer meets the evidence rule, and the
+# SUDO_UID=0 above does not satisfy that on its own: DIVE-1413 only trusts $SUDO_UID at
+# EUID 0, and this harness runs unprivileged. That is the production rule behaving
+# correctly — the caller this harness DESCRIBES (post-sudo root / dashboard-as-claude)
+# really is at EUID 0 — so the root seam is stubbed to put the harness in the world its
+# own header claims, rather than weakening an assertion.
 export SUDO_UID=0
+_gate_is_root() { return 0; }
 
 touch "$GATE_PROOF_ENFORCE"   # enforcement ON for the floor tests
 
@@ -89,7 +98,13 @@ out=$(cmd_task_answer DIVE-101 --value=A 2>&1); rc=$?
 #     (DIVE-525 — a real tap/dashboard answer must never be blocked). --------------
 seed_task DIVE-102
 cmd_task_need DIVE-102 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 >/dev/null 2>&1
-cmd_task_answer DIVE-102 --value=A --human >/dev/null 2>&1
+# SUBSHELLED (DIVE-2233). The one bare `cmd_task_answer` in this file whose expected
+# outcome is SUCCESS: T1/T4 capture into `out=$(…)`, already a subshell, so a refusal
+# there returns a code. Here a refusal calls production's `fail`, which `exit`s — in a
+# SOURCED harness that kills the whole script and T2..T5 never run, while the log ends on
+# three green T1 lines. Measured: mutating away the floor's `(( ! human ))` exemption (the
+# over-fire this arm exists to catch) took the run down at exactly this line.
+( cmd_task_answer DIVE-102 --value=A --human ) >/dev/null 2>&1
 [[ "$(answered DIVE-102)" == "closed" ]] \
   && ok_t "T2 --human answer on tier-2 decision CLEARS (trusted path)" \
   || bad_t "T2 --human tier-2 clears" "still $(answered DIVE-102)"


### PR DESCRIPTION
Cut out of DIVE-2233 phase 3 and shipped alone — it closes a live hole and has no dependency on the constitution seal or its council motion. DIVE-2131 itself closed with `need_answered_uid=1004` (the plugin's own agent uid) and `human_nonce_hash` NULL, i.e. the tier-2 hard human floor was a label on every box.

Mints the per-gate nonce for every tier-2 type (not just approval/secret/manual/access) and requires a `--human` answer on a nonce-bearing tier-2 gate to produce it.

Also closes a silent fail-open found in review: `_human_nonce_mint` was `openssl rand -hex 16 2>/dev/null` with stderr eaten and no rc check, so a box without a usable openssl minted nothing, left `human_nonce_hash` NULL, filed a gate indistinguishable from a protected one — and the new enforcement block then *skipped* on NULL. Now: `/dev/urandom` fallback (same kernel CSPRNG), `^[0-9a-f]{32}$` validation on both paths so a truncated read cannot pass, rc 1 when neither works, and a tier-2 gate that cannot arm itself **refuses to file** — before the row transaction, so no half-filed gate is left behind — with an unfenced audit row.

Refusal is tier-2 scoped: for other human types a NULL hash means what it always meant and DIVE-916's verify path fails closed on it unchanged.

Suite 222/222. Harness count reconciles: 220 at ec9f95d, 221 after phase 1, 222 here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)