### PR TITLE
fix(install): refuse a backwards move on --upgrade instead of announcing it as an upgrade (DIVE-2243)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -173,6 +173,82 @@ say() { echo "→ $*"; }
 
 [[ $EUID -eq 0 ]] || die "run as root: curl -fsSL ... | sudo bash"
 
+# >>> DIVE-2243 monotonicity guard (extracted verbatim by tests/install_monotonicity_unit.sh)
+# DIVE-2243: the DIVE-2144 cutover moved publishing from mutable `main` HEAD to
+# the newest release TAG. For ~23h the newest tag (v0.16.32) sat BELOW what the
+# fleet was running (0.16.33, .34, .36, then 0.17.0) because release-cut.yml had
+# never once succeeded (DIVE-2238). Every box that self-updated inside that
+# window rolled BACKWARDS — and printed `5dive upgraded: 0.16.33 -> 0.16.32`
+# while doing it.
+#
+# Nothing here noticed, because nothing here could: the only version comparison
+# on the upgrade path was `!=`, and its only job was choosing which of two report
+# strings to print. `sort -V` appears above to pick the newest TAG, and never
+# once to compare that tag's payload against what is already installed. So the
+# old version's sole purpose was a printed string, and that string asserted the
+# one thing the code never checked.
+#
+# A cutover that STALLS is loud — nothing updates, someone notices staleness. A
+# cutover that REVERSES presents as success: an update ran, it exited 0, and it
+# said "upgraded". Every signal a monitor watches says the system worked. It was
+# caught only because a human happened to read the same version number twice.
+#
+# So make DIRECTION a first-class assertion, separate from the action:
+#
+#   - Refuse a strictly-lower candidate by default, naming both versions and the
+#     tag/sha it came from. Same fail-closed posture the tag resolver above takes
+#     for "no tag resolves", and equally a no-op rather than a brick: the box
+#     keeps the CLI it already has, exactly as it does every hour nothing is
+#     published.
+#   - A real rollback is a legitimate operation, so it stays possible — but it
+#     must be ASKED FOR (FIVE_ALLOW_DOWNGRADE=1), never a side effect of tag
+#     resolution.
+#   - Refuse only on versions we can actually ORDER. An unreadable installed or
+#     candidate version is not evidence of a backwards move, and bricking an
+#     upgrade over a grep that came back empty would be a worse failure than the
+#     one this guards. Those cases WARN, name which side was unreadable, and
+#     proceed.
+
+# version_lt A B — true when semver A sorts strictly below B. Equal → false.
+# `sort -V`, never `sort`: lexically "0.16.10" sorts BELOW "0.16.9", so a plain
+# sort here would refuse ordinary forward upgrades roughly one patch in ten.
+version_lt() {
+  [[ "$1" != "$2" ]] && [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" == "$1" ]]
+}
+
+# assert_version_monotonic <installed-bin> <candidate-bundle>
+# 0 = proceed, 1 = refuse (message already on stderr; caller cleans up + exits).
+# Deliberately does NOT call die(): the caller holds a temp bundle in $BIN_DIR
+# that must be removed before we exit, and a guard that leaves debris in the
+# directory it just refused to touch is its own small mess.
+assert_version_monotonic() {
+  local _inst_bin="$1" _cand_file="$2" _inst="" _cand="" _src=""
+  # Fresh install: nothing to move backwards from.
+  [[ -f "$_inst_bin" ]] || return 0
+  _inst="$(grep -m1 'readonly FIVE_VERSION=' "$_inst_bin" 2>/dev/null | sed -E 's/.*="([^"]+)".*/\1/')" || _inst=""
+  _cand="$(grep -m1 'readonly FIVE_VERSION=' "$_cand_file" 2>/dev/null | sed -E 's/.*="([^"]+)".*/\1/')" || _cand=""
+  if [[ -z "$_inst" || -z "$_cand" ]]; then
+    echo "  ! version not comparable (installed='${_inst:-unreadable}', candidate='${_cand:-unreadable}') — direction unchecked, proceeding" >&2
+    return 0
+  fi
+  version_lt "$_cand" "$_inst" || return 0
+  # Name where the lower version came from — the whole point is that a backwards
+  # move is traceable to the thing that resolved it.
+  _src="${GH_PINNED_TAG:-}"
+  [[ -n "$_src" ]] || _src="${GH_PINNED_SHA:-}"
+  [[ -n "$_src" ]] || _src="${REPO:-}"
+  if [[ "${FIVE_ALLOW_DOWNGRADE:-0}" == "1" ]]; then
+    echo "  ! DOWNGRADE ${_inst} -> ${_cand}${_src:+ (from ${_src})} — allowed by FIVE_ALLOW_DOWNGRADE=1" >&2
+    return 0
+  fi
+  printf 'error: refusing to DOWNGRADE 5dive: installed %s, candidate %s%s — this would move the box BACKWARDS.\n' \
+    "$_inst" "$_cand" "${_src:+, resolved from ${_src}}" >&2
+  printf '       Nothing was changed; the box keeps %s. If the rollback is deliberate, re-run with FIVE_ALLOW_DOWNGRADE=1.\n' \
+    "$_inst" >&2
+  return 1
+}
+# <<< DIVE-2243 monotonicity guard
+
 # Refresh CLI binaries, systemd unit, hooks, and skills from $REPO. Shared by
 # the default install path and `--upgrade`. Never touches state, auth profiles,
 # the claude user, apt packages, nvm, or bun — so it's safe to rerun on a
@@ -211,6 +287,13 @@ refresh_managed_files() {
     fi
   else
     echo "  ! no published 5dive.sha256 (or fetch failed) — skipping integrity check" >&2
+  fi
+  # DIVE-2243: direction is a separate assertion from the action. Checked HERE —
+  # after integrity, before the swap — so a refusal leaves the installed binary
+  # untouched and the box keeps running the version it already has.
+  if ! assert_version_monotonic "$BIN_DIR/5dive" "$_bundle_tmp"; then
+    rm -f "$_bundle_tmp"
+    exit 1
   fi
   chmod 755 "$_bundle_tmp"
   mv -f "$_bundle_tmp" "$BIN_DIR/5dive"
@@ -808,11 +891,19 @@ if [[ "${1:-}" == "--upgrade" ]]; then
   echo
   # DIVE-1260: report the version actually swapped in, read from the new bundle.
   _new_ver="$(grep -m1 'readonly FIVE_VERSION=' "$BIN_DIR/5dive" 2>/dev/null | sed -E 's/.*="([^"]+)".*/\1/')"
-  if [[ -n "${_old_ver:-}" && "${_old_ver}" != "${_new_ver:-}" ]]; then
+  # >>> DIVE-2243 upgrade report (extracted verbatim by tests/install_monotonicity_unit.sh)
+  # DIVE-2243: never call a backwards move an upgrade. Reachable only via
+  # FIVE_ALLOW_DOWNGRADE=1 now that the guard above refuses otherwise — but this
+  # line is what made the fleet-wide downgrade invisible, so it states the
+  # direction it actually measured rather than the one it assumed.
+  if [[ -n "${_old_ver:-}" && -n "${_new_ver:-}" ]] && version_lt "$_new_ver" "$_old_ver"; then
+    echo "5dive DOWNGRADED: ${_old_ver} -> ${_new_ver}"
+  elif [[ -n "${_old_ver:-}" && "${_old_ver}" != "${_new_ver:-}" ]]; then
     echo "5dive upgraded: ${_old_ver} -> ${_new_ver:-unknown}"
   else
     echo "5dive upgraded (now ${_new_ver:-unknown})"
   fi
+  # <<< DIVE-2243 upgrade report
   exit 0
 fi
 

--- a/tests/install_monotonicity_unit.sh
+++ b/tests/install_monotonicity_unit.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# DIVE-2243: install.sh's upgrade path had NO monotonicity guard. The DIVE-2144
+# publish-source cutover pointed the fleet at the newest release TAG while that
+# tag sat below what boxes were running, so ~23h of self-updates rolled boxes
+# BACKWARDS — and each one printed "5dive upgraded: 0.16.33 -> 0.16.32".
+#
+# This asserts the guard DISCRIMINATES rather than that it blocks: a lower
+# candidate must be refused, a higher one must proceed, and the refusal must
+# name both versions. Hermetic by construction — the guard and the report block
+# are extracted VERBATIM from install.sh by their fence markers and run under
+# install.sh's real `set -euo pipefail`, so this asserts the shipped bytes
+# rather than a paraphrase of them (same shape as install_pin_sha_unit.sh).
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
+PASS=0; FAIL=0
+ok_t(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t(){ FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+guard="$(sed -n '/^# >>> DIVE-2243 monotonicity guard/,/^# <<< DIVE-2243 monotonicity guard/p' install.sh)"
+report="$(sed -n '/^  # >>> DIVE-2243 upgrade report/,/^  # <<< DIVE-2243 upgrade report/p' install.sh)"
+
+if [[ -n "$guard" ]] && grep -q 'assert_version_monotonic()' <<<"$guard" && grep -q 'version_lt()' <<<"$guard"; then
+  ok_t "monotonicity guard is extractable from install.sh"
+else
+  bad_t "monotonicity guard missing" "markers '# >>> / # <<< DIVE-2243 monotonicity guard' not found in install.sh"
+  echo; echo "$PASS passed, $FAIL failed"; exit 1
+fi
+if [[ -n "$report" ]] && grep -q 'DOWNGRADED' <<<"$report"; then
+  ok_t "upgrade-report block is extractable from install.sh"
+else
+  bad_t "upgrade-report block missing" "markers '# >>> / # <<< DIVE-2243 upgrade report' not found in install.sh"
+  echo; echo "$PASS passed, $FAIL failed"; exit 1
+fi
+
+TD="$(mktemp -d)"; trap 'rm -rf "$TD"' EXIT
+# A "5dive binary" here is only ever grepped for its FIVE_VERSION line, so a
+# one-line stand-in exercises the real read path. `--none--` writes a file that
+# carries no version at all (the unreadable case).
+mkbin() { # $1=path $2=version|--none--
+  if [[ "$2" == "--none--" ]]; then printf '#!/usr/bin/env bash\necho hi\n' > "$1"
+  else printf '#!/usr/bin/env bash\nreadonly FIVE_VERSION="%s"\n' "$2" > "$1"; fi
+}
+
+# Run the extracted guard against an installed version and a candidate version.
+# Prints stderr; returns the guard's rc. `--absent--` as the installed version
+# means no binary on disk at all (fresh install).
+run_guard() { # $1=installed $2=candidate [$3=FIVE_ALLOW_DOWNGRADE] [$4=GH_PINNED_TAG]
+  local inst="$TD/installed" cand="$TD/candidate"
+  rm -f "$inst" "$cand"
+  [[ "$1" == "--absent--" ]] || mkbin "$inst" "$1"
+  mkbin "$cand" "$2"
+  env -i PATH="/usr/bin:/bin" \
+    FIVE_ALLOW_DOWNGRADE="${3:-0}" GH_PINNED_TAG="${4:-}" GH_PINNED_SHA="" REPO="" \
+    bash -c "set -euo pipefail
+$guard
+assert_version_monotonic '$inst' '$cand'" 2>&1
+}
+
+# 1. THE DEFECT: a strictly lower candidate is refused, and the refusal names
+#    both versions and where the lower one came from.
+out="$(run_guard 0.16.33 0.16.32 0 v0.16.32)"; rc=$?
+if (( rc != 0 )) && [[ "$out" == *"refusing to DOWNGRADE"* && "$out" == *"0.16.33"* && "$out" == *"0.16.32"* && "$out" == *"v0.16.32"* ]]; then
+  ok_t "0.16.33 -> 0.16.32 REFUSED, naming both versions and the resolved tag"
+else
+  bad_t "downgrade was not refused" "rc=$rc out: ${out//$'\n'/ | }"
+fi
+
+# 2. CONTROL — the guard must DISCRIMINATE, not block. A higher candidate
+#    proceeds silently. Liveness for this negative is case 1 above: the same
+#    harness proves the string DOES appear when the direction is backwards.
+out="$(run_guard 0.16.32 0.17.0 0 v0.17.0)"; rc=$?
+if (( rc == 0 )) && [[ "$out" != *"refusing to DOWNGRADE"* ]]; then
+  ok_t "0.16.32 -> 0.17.0 PROCEEDS (guard discriminates on direction)"
+else
+  bad_t "forward upgrade was blocked" "rc=$rc out: ${out//$'\n'/ | }"
+fi
+
+# 3. VERSION SORT, not lexical. "0.16.10" sorts BELOW "0.16.9" as a string, so a
+#    plain `sort` here would refuse an ordinary forward patch upgrade. This is
+#    the same trap resolve_gh_tag documents, on the other side of the compare.
+out="$(run_guard 0.16.9 0.16.10)"; rc=$?
+if (( rc == 0 )) && [[ "$out" != *"refusing to DOWNGRADE"* ]]; then
+  ok_t "0.16.9 -> 0.16.10 PROCEEDS (sort -V, not lexical sort)"
+else
+  bad_t "lexical sort refused a forward upgrade" "rc=$rc out: ${out//$'\n'/ | }"
+fi
+
+# 4. Equal versions are not a downgrade (the daily no-op self-update).
+out="$(run_guard 0.17.0 0.17.0)"; rc=$?
+if (( rc == 0 )) && [[ "$out" != *"refusing to DOWNGRADE"* ]]; then
+  ok_t "0.17.0 -> 0.17.0 PROCEEDS (equal is not backwards)"
+else
+  bad_t "equal versions were refused" "rc=$rc out: ${out//$'\n'/ | }"
+fi
+
+# 5. The deliberate escape exists, and it is LOUD. A real rollback is legitimate;
+#    the point is that it must be asked for, never a side effect of resolution.
+out="$(run_guard 0.16.33 0.16.32 1 v0.16.32)"; rc=$?
+if (( rc == 0 )) && [[ "$out" == *"DOWNGRADE 0.16.33 -> 0.16.32"* && "$out" == *"FIVE_ALLOW_DOWNGRADE=1"* ]]; then
+  ok_t "FIVE_ALLOW_DOWNGRADE=1 permits the rollback and announces it"
+else
+  bad_t "escape hatch did not permit/announce the rollback" "rc=$rc out: ${out//$'\n'/ | }"
+fi
+
+# 6. Fresh install: nothing installed to move backwards from.
+out="$(run_guard --absent-- 0.16.1)"; rc=$?
+if (( rc == 0 )); then ok_t "no installed binary PROCEEDS (fresh install)"
+else bad_t "fresh install was refused" "rc=$rc out: ${out//$'\n'/ | }"; fi
+
+# 7. Unreadable version fails OPEN, and says so. An empty grep is not evidence of
+#    a backwards move, and bricking an upgrade over one would be worse than the
+#    defect this guards.
+out="$(run_guard --none-- 0.16.1)"; rc=$?
+if (( rc == 0 )) && [[ "$out" == *"not comparable"* ]]; then
+  ok_t "unreadable installed version PROCEEDS with a stated warning"
+else
+  bad_t "unreadable version did not fail open with a warning" "rc=$rc out: ${out//$'\n'/ | }"
+fi
+
+# --- the printed line -------------------------------------------------------
+# The report is what made this invisible: it asserted a direction nothing had
+# measured. Run the shipped branch verbatim with old/new pinned.
+run_report() { # $1=_old_ver $2=_new_ver
+  env -i PATH="/usr/bin:/bin" bash -c "set -euo pipefail
+$(sed -n '/^# >>> DIVE-2243 monotonicity guard/,/^# <<< DIVE-2243 monotonicity guard/p' install.sh)
+_old_ver='$1'; _new_ver='$2'; BIN_DIR='$TD'
+$report" 2>&1
+}
+
+out="$(run_report 0.16.33 0.16.32)"
+if [[ "$out" == *"5dive DOWNGRADED: 0.16.33 -> 0.16.32"* && "$out" != *"upgraded: 0.16.33"* ]]; then
+  ok_t "report says DOWNGRADED (never 'upgraded') when the new version is lower"
+else
+  bad_t "report announced a downgrade as an upgrade" "out: ${out//$'\n'/ | }"
+fi
+
+out="$(run_report 0.16.32 0.17.0)"
+if [[ "$out" == *"5dive upgraded: 0.16.32 -> 0.17.0"* && "$out" != *"DOWNGRADED"* ]]; then
+  ok_t "report still says upgraded on a real forward move"
+else
+  bad_t "forward move mis-reported" "out: ${out//$'\n'/ | }"
+fi
+
+out="$(run_report 0.16.9 0.16.10)"
+if [[ "$out" == *"5dive upgraded: 0.16.9 -> 0.16.10"* && "$out" != *"DOWNGRADED"* ]]; then
+  ok_t "report uses version sort (0.16.9 -> 0.16.10 is forward)"
+else
+  bad_t "report lexically mis-sorted a forward patch move" "out: ${out//$'\n'/ | }"
+fi
+
+# --- wiring -----------------------------------------------------------------
+# The guard is worthless where it cannot stop the swap. Assert it is called in
+# refresh_managed_files AFTER the integrity check and BEFORE the atomic mv, and
+# that a refusal removes the temp bundle instead of leaving debris in BIN_DIR.
+call_ln="$(grep -n 'assert_version_monotonic "\$BIN_DIR/5dive" "\$_bundle_tmp"' install.sh | head -1 | cut -d: -f1)"
+mv_ln="$(grep -n 'mv -f "\$_bundle_tmp" "\$BIN_DIR/5dive"' install.sh | head -1 | cut -d: -f1)"
+sum_ln="$(grep -n 'sha256sum "\$_bundle_tmp"' install.sh | head -1 | cut -d: -f1)"
+if [[ -n "$call_ln" && -n "$mv_ln" && -n "$sum_ln" ]] && (( sum_ln < call_ln && call_ln < mv_ln )); then
+  ok_t "guard runs after the checksum and before the swap (lines $sum_ln < $call_ln < $mv_ln)"
+else
+  bad_t "guard is not wired between the checksum and the swap" "checksum=$sum_ln guard=${call_ln:-none} mv=${mv_ln:-none}"
+fi
+if sed -n "${call_ln:-1},$((${call_ln:-1} + 4))p" install.sh | grep -q 'rm -f "\$_bundle_tmp"'; then
+  ok_t "a refusal removes the temp bundle from BIN_DIR"
+else
+  bad_t "refusal leaves the temp bundle behind" "no 'rm -f \$_bundle_tmp' within 4 lines of the guard call"
+fi
+
+echo; echo "$PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/tests/install_monotonicity_unit.sh
+++ b/tests/install_monotonicity_unit.sh
@@ -11,6 +11,15 @@
 # install.sh's real `set -euo pipefail`, so this asserts the shipped bytes
 # rather than a paraphrase of them (same shape as install_pin_sha_unit.sh).
 set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source. NOTE the absence of
+# `2>/dev/null` — redirecting the source's stderr also swallows the helper's own
+# stderr line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 PASS=0; FAIL=0
 ok_t(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }


### PR DESCRIPTION
## The defect

The DIVE-2144 cutover moved publishing from mutable `main` HEAD to the newest release **tag**. For ~23h the newest tag (`v0.16.32`) sat **below** what the fleet was running (0.16.33, .34, .36, then 0.17.0), because `release-cut.yml` had never once succeeded (DIVE-2238). Every box that self-updated inside that window rolled **backwards** — and printed `5dive upgraded: 0.16.33 -> 0.16.32` while doing it.

The installer could not notice. Its only version comparison was `!=`, and its only job was choosing which of two report strings to print. `sort -V` appears in `resolve_gh_tag()` to pick the newest tag and **never once** to compare that tag's payload against what is installed. So the old version's sole purpose was a printed string, and that string asserted the one thing the code never checked.

A cutover that **stalls** is loud. A cutover that **reverses** presents as success: an update ran, exited 0, and said *upgraded*. It was caught only because a human happened to read the same version number twice, six hours apart.

## What this changes

- **`assert_version_monotonic()`** runs inside `refresh_managed_files()` **after** the checksum guard and **before** the atomic swap, so a refusal leaves the installed binary untouched — the box keeps the CLI it has, the same no-op it performs every hour nothing is published. The bundle swap is the first write in that function, so a refusal aborts before any other managed file (cron, journald, `5dive-agent-start`, hooks, skills) is touched.
- **`FIVE_ALLOW_DOWNGRADE=1`** is the deliberate escape. A real rollback stays possible but must be *asked for*, never a side effect of tag resolution.
- **The report states the direction it measured**: `5dive DOWNGRADED: X -> Y`. Reachable only via the escape hatch now, but this line is what made the fleet-wide downgrade invisible.
- **Unreadable versions fail OPEN** with a stated warning naming which side was unreadable. An empty grep is not evidence of a backwards move, and bricking an upgrade over one would be worse than the defect this guards.

## How it was checked

`tests/install_monotonicity_unit.sh` extracts both blocks **verbatim** by fence marker and runs them under `install.sh`'s real `set -euo pipefail` — no network, asserts the shipped bytes (same shape as `install_pin_sha_unit.sh`). 14 assertions, and they grade **direction differentially** rather than just proving the guard blocks:

| case | expected |
|---|---|
| 0.16.33 -> 0.16.32 | REFUSED, naming both versions + the resolved tag |
| 0.16.32 -> 0.17.0 | proceeds |
| 0.16.9 -> **0.16.10** | proceeds — lexically this sorts backwards; `sort -V` is load-bearing |
| 0.17.0 -> 0.17.0 | proceeds (equal is not backwards) |
| `FIVE_ALLOW_DOWNGRADE=1` | permits **and announces** the rollback |
| no installed binary | proceeds (fresh install) |
| unreadable version | proceeds with a stated warning |

Plus the report branch (DOWNGRADED / upgraded / lexical control) and two wiring assertions: the guard sits between the checksum and the `mv`, and a refusal removes the temp bundle from `BIN_DIR`.

**Mutation-graded, all differential** (each reds a specific subset; the controls stay green, which is what proves the guard discriminates rather than blocks):

| mutation | result |
|---|---|
| guard neutered (`return 0`) | 2 red — refusal + escape hatch; **all controls green** |
| `sort -V` -> `sort` | 2 red — both lexical controls; **the refusal stays green** |
| guard call removed from `refresh_managed_files` | 2 red — wiring + temp-bundle cleanup |
| guard moved AFTER the swap | 1 red — ordering |
| report reverted to `!=`-only | red |

Existing `install_pin_sha_unit.sh` (15), `install_checksum_unit.sh` (8), `install_update_hint_unit.sh` (6) all still green. `unit-tests.yml` globs `tests/*.sh`, so the new file is picked up with no workflow change.

## What this does NOT close

- **DIVE-2238 is untouched.** With `release-cut.yml` still unable to tag, this converts a silent fleet-wide downgrade into a loud refusal *and a fleet frozen at its current version*. That is the intended trade, but it is a different failure mode, and nothing here alarms on "the fleet has stopped updating."
- **Blast radius from the original 23h window stays unmeasured.** Boxes that landed on 0.16.32 roll forward on the next tick now that v0.17.0 exists, so they self-heal — but nothing retro-detects which ones were affected.
- The guard compares the **bundle** version only; it protects the other managed files by aborting before they are written, not by checking each of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
