### PR TITLE
pre-push guard: a new harness that does not name the tree it grades is refused locally (DIVE-2286)

### DIFF
--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Fleet-wide pre-push guards: PII (DIVE-1797, enforcement follow-up to
-# DIVE-1774) and release version-bump (DIVE-2065).
+# DIVE-1774), release version-bump (DIVE-2065), and new-harness tree-naming
+# (DIVE-2286).
 #
 # WHY a local hook and not GitHub branch protection: our landing account is the
 # repo admin, so a required status check only gates EXTERNAL PRs, never our own
@@ -25,11 +26,23 @@
 # up the follow-up fix. Fixed after the fact by renumbering the follow-up to
 # 0.16.4 (CHANGELOG); this guard stops the next one from landing at all.
 #
+# WHAT the harness-tree guard does (DIVE-2286): for each tests/*.sh file ADDED
+# by the push, requires a line sourcing tests/lib/grading_tree.sh (the
+# DIVE-2211 corpus invariant -- see tests/names_the_tree_contract_unit.sh,
+# this guard's whole-corpus CI twin). Measured cost of skipping this locally:
+# four harnesses across three authors in one day, each caught only after a
+# full CI round trip (~27 min on gh#290). Only fires on ADDED files; a
+# harness that later removes the line stays CI-only, which the contract test
+# already owns.
+#
 # DESIGN NOTES:
-#   - Calls scripts/pii-scan.sh and scripts/version-bump-guard.sh DIRECTLY. No
-#     forked scan logic here, so neither can drift from its CI/README twin
-#     (DIVE-1797 requirement c; scripts/version-uniqueness-scan.sh is the
-#     version-bump guard's own CI-side twin, see bundle-drift.yml).
+#   - Calls scripts/pii-scan.sh, scripts/version-bump-guard.sh and
+#     scripts/harness-tree-guard.sh DIRECTLY. No forked scan logic here, so
+#     none can drift from its CI/README twin (DIVE-1797 requirement c;
+#     scripts/version-uniqueness-scan.sh is the version-bump guard's own
+#     CI-side twin, see bundle-drift.yml; tests/names_the_tree_contract_unit.sh
+#     is the harness-tree guard's, over the whole corpus rather than just the
+#     push's added files).
 #   - Installed fleet-wide via core.hooksPath=scripts/git-hooks, set once on the
 #     shared clone config so every linked worktree (and every future one)
 #     inherits it. See scripts/install-pii-push-guard.sh.
@@ -42,6 +55,7 @@ set -uo pipefail
 TOP="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 SCAN="$TOP/scripts/pii-scan.sh"
 VERSION_GUARD="$TOP/scripts/version-bump-guard.sh"
+HARNESS_TREE_GUARD="$TOP/scripts/harness-tree-guard.sh"
 EMPTY_TREE=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 Z40=0000000000000000000000000000000000000000
 
@@ -92,6 +106,14 @@ while read -r local_ref local_oid remote_ref remote_oid; do
     printf '%s\n' "$added" | bash "$SCAN" >/dev/null || rc=1
   fi
 
+  # DIVE-2286: fires on every ref (new harnesses can land on any branch, not
+  # just main), scoped to files THIS push adds.
+  if [[ -f "$HARNESS_TREE_GUARD" ]]; then
+    bash "$HARNESS_TREE_GUARD" "$local_oid" "$base" || rc=1
+  else
+    echo "harness-tree-guard: script not found ($HARNESS_TREE_GUARD); skipping (the CI contract test is the net)." >&2
+  fi
+
   # DIVE-2065: only fires on a push to main with an EXISTING remote main
   # (skip branch deletion, already `continue`d above; skip first-ever-push of
   # a new branch — main always already exists so $remote_oid is never Z40 for
@@ -110,6 +132,7 @@ if [[ $rc -ne 0 ]]; then
   echo "pre-push: BLOCKED — see the specific guard message(s) above." >&2
   echo "  pii-push-guard: scrub the real id/email/phone (use placeholders like <user-id>, 1234567890) and re-commit." >&2
   echo "  version-bump-guard: bump FIVE_VERSION in src/header.sh, rebuild with ./build.sh, and recommit." >&2
+  echo "  harness-tree-guard: paste the printed source-line snippet into the named harness and recommit." >&2
   echo "  Emergency override (discouraged; the matching CI job is still the net): git push --no-verify" >&2
   exit 1
 fi

--- a/scripts/harness-tree-guard.sh
+++ b/scripts/harness-tree-guard.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# DIVE-2286: push-time guard for the DIVE-2211 corpus invariant (every
+# harness in tests/*.sh sources tests/lib/grading_tree.sh).
+#
+# WHY a push-time guard and not just the CI contract
+# (tests/names_the_tree_contract_unit.sh): CI catches a missing source line
+# only after a full round trip -- measured on gh#290, test 9m11s +
+# test-installed-host 16m54s (~27 min) to learn about one absent line. A
+# local grep over just the files THIS push adds catches it before it ever
+# leaves the machine.
+#
+# MEASURED, 2026-07-29: four harnesses, three authors, one calendar day, all
+# missing this exact line (olivia DIVE-2265 iteration 1, dev gh#288, main2
+# gh#289, dev gh#290) -- see DIVE-2286. A missing scaffold, not four careless
+# people.
+#
+# SCOPE: only files ADDED in this push's range (--diff-filter=A), matching
+# tests/*.sh. A harness that later DELETES the source line is CI-only, which
+# is correct -- that is a rarer edit and the whole-corpus contract test
+# already owns it.
+#
+# REUSES the contract test's own detection regex via
+# tests/lib/grading_tree_source_re.sh rather than re-spelling it here, so
+# this guard and the CI contract cannot independently drift into checking
+# two different things under the same name.
+#
+# Usage: harness-tree-guard.sh <new-rev> [<base-rev>=origin/main]
+# Exit 0 = clear to push. Exit 1 = blocked, reason + fix snippet on stderr.
+set -uo pipefail
+
+NEW="${1:?usage: harness-tree-guard.sh <new-rev> [<base-rev>]}"
+BASE="${2:-origin/main}"
+
+RE_FILE_REL="tests/lib/grading_tree_source_re.sh"
+re_src="$(git show "${NEW}:${RE_FILE_REL}" 2>/dev/null || true)"
+if [[ -z "$re_src" ]]; then
+  echo "harness-tree-guard: $RE_FILE_REL not found at $NEW; skipping (the CI contract test is the net)." >&2
+  exit 0
+fi
+# shellcheck disable=SC1090
+source <(printf '%s\n' "$re_src")
+if [[ -z "${GRADING_TREE_SOURCE_RE:-}" ]]; then
+  echo "harness-tree-guard: GRADING_TREE_SOURCE_RE not set after sourcing $RE_FILE_REL; skipping (the CI contract test is the net)." >&2
+  exit 0
+fi
+
+mapfile -t ADDED < <(git diff --name-only --diff-filter=A "$BASE" "$NEW" -- 'tests/*.sh' 2>/dev/null || true)
+(( ${#ADDED[@]} == 0 )) && exit 0
+
+# The exact two functional lines every passing harness carries, plus the
+# short comment explaining the load-bearing absence of `2>/dev/null` (see
+# tests/lib/grading_tree.sh for the full rationale). Safe to hardcode here,
+# unlike inside the contract test itself: this file is not in tests/*.sh, so
+# it is never part of the corpus this snippet's own regex scans, and cannot
+# create the self-matching trap the contract test's comment warns about.
+read -r -d '' FIX_SNIPPET <<'SNIPPET' || true
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source.
+# NOTE the absence of `2>/dev/null`. Redirecting the source's stderr would also
+# swallow the helper's own stderr line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+SNIPPET
+
+fail=0
+for f in "${ADDED[@]}"; do
+  content="$(git show "${NEW}:${f}" 2>/dev/null || true)"
+  [[ -z "$content" ]] && continue
+  if ! printf '%s\n' "$content" | grep -qE "$GRADING_TREE_SOURCE_RE"; then
+    echo "harness-tree-guard: BLOCKED -- $f is a new harness that does not source tests/lib/grading_tree.sh (DIVE-2211 contract)." >&2
+    echo "  FIX -- paste this immediately after \`set -uo pipefail\` in $f:" >&2
+    echo "" >&2
+    printf '%s\n' "$FIX_SNIPPET" | sed 's/^/      /' >&2
+    echo "" >&2
+    echo "  Keep the ABSENCE of \`2>/dev/null\` on the source line: it would swallow the" >&2
+    echo "  helper's own stderr line, which IS the payload, and no other check would notice." >&2
+    fail=1
+  fi
+done
+
+exit $fail

--- a/scripts/harness-tree-guard.sh
+++ b/scripts/harness-tree-guard.sh
@@ -24,6 +24,23 @@
 # this guard and the CI contract cannot independently drift into checking
 # two different things under the same name.
 #
+# WHAT HAPPENS WHEN THIS GUARD CANNOT TELL, stated explicitly rather than left
+# to be inferred from the code (DIVE-2286 review, main): "could not determine"
+# is not the same claim as "nothing to flag", and folding the two together is
+# exactly the DIVE-2274 class this whole epic is about -- a check that cannot
+# run and reports clean. Two different unknowns, two different answers:
+#   - The guard's OWN dependency is unreadable (tests/lib/grading_tree_source_re.sh
+#     missing at NEW -- expected on a branch cut before this guard shipped):
+#     FAILS OPEN, loudly (a message on stderr, exit 0), matching the existing
+#     documented convention for every guard in this hook -- see
+#     scripts/git-hooks/pre-push's own "fail OPEN with a warning if their
+#     script is missing" note. The CI contract test is the net for this case.
+#   - THE DETECTION MECHANISM ITSELF fails (git diff cannot enumerate what
+#     this push added, or git show cannot read a file diff just told us was
+#     added): FAILS LOUD, exit 1, refusing the push rather than silently
+#     reporting clear. Nothing was actually checked in that case, and a guard
+#     that reports clean when it checked nothing is worse than no guard.
+#
 # Usage: harness-tree-guard.sh <new-rev> [<base-rev>=origin/main]
 # Exit 0 = clear to push. Exit 1 = blocked, reason + fix snippet on stderr.
 set -uo pipefail
@@ -44,7 +61,14 @@ if [[ -z "${GRADING_TREE_SOURCE_RE:-}" ]]; then
   exit 0
 fi
 
-mapfile -t ADDED < <(git diff --name-only --diff-filter=A "$BASE" "$NEW" -- 'tests/*.sh' 2>/dev/null || true)
+if ! diff_out="$(git diff --name-only --diff-filter=A "$BASE" "$NEW" -- 'tests/*.sh' 2>&1)"; then
+  echo "harness-tree-guard: BLOCKED -- could not enumerate tests/*.sh files added by this push (git diff --diff-filter=A $BASE $NEW failed: $diff_out). Refusing rather than silently reporting clear, since nothing was actually checked." >&2
+  exit 1
+fi
+ADDED=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && ADDED+=("$line")
+done <<< "$diff_out"
 (( ${#ADDED[@]} == 0 )) && exit 0
 
 # The exact two functional lines every passing harness carries, plus the
@@ -66,8 +90,11 @@ SNIPPET
 
 fail=0
 for f in "${ADDED[@]}"; do
-  content="$(git show "${NEW}:${f}" 2>/dev/null || true)"
-  [[ -z "$content" ]] && continue
+  if ! content="$(git show "${NEW}:${f}" 2>&1)"; then
+    echo "harness-tree-guard: BLOCKED -- could not read $f at $NEW even though git diff reported it as newly added ($content). Refusing rather than silently skipping a file nothing was actually checked." >&2
+    fail=1
+    continue
+  fi
   if ! printf '%s\n' "$content" | grep -qE "$GRADING_TREE_SOURCE_RE"; then
     echo "harness-tree-guard: BLOCKED -- $f is a new harness that does not source tests/lib/grading_tree.sh (DIVE-2211 contract)." >&2
     echo "  FIX -- paste this immediately after \`set -uo pipefail\` in $f:" >&2

--- a/tests/harness_tree_guard_unit.sh
+++ b/tests/harness_tree_guard_unit.sh
@@ -151,5 +151,26 @@ else
   bad_t "guard: fail-open case says so, rather than silently exiting 0" "$out"
 fi
 
+# --- fail LOUD (not open) when the detection mechanism itself can't tell ---
+# DIVE-2286 review (main): "could not determine" must not collapse into
+# "nothing to flag" -- that fold IS the DIVE-2274 class this epic exists to
+# catch. An unresolvable BASE makes `git diff` itself fail, which must BLOCK
+# (exit 1) with its own distinct message, not silently report clear the way
+# the old `2>/dev/null || true` collector used to.
+git checkout -q "$c0"
+out="$(bash "$GUARD" "$c0" "not-a-real-rev-at-all" 2>&1)"; rc=$?
+assert_exit "guard: BLOCKS (not silently passes) when git diff itself cannot enumerate added files" 1 "$rc"
+if [[ "$out" == *"could not enumerate"* ]]; then
+  ok_t "guard: names the could-not-enumerate failure distinctly from a real violation"
+else
+  bad_t "guard: names the could-not-enumerate failure distinctly from a real violation" "$out"
+fi
+
+# Sanity: prove the loud-refusal above has teeth and isn't just always-blocking
+# regardless of BASE -- a genuinely valid BASE right next to the bad one above
+# must still pass cleanly when the added harness is compliant.
+bash "$GUARD" "$c2" "$c0" >/dev/null 2>&1
+assert_exit "guard: sanity — a valid BASE right beside the bad one above still passes a compliant add" 0 "$?"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 (( FAIL == 0 ))

--- a/tests/harness_tree_guard_unit.sh
+++ b/tests/harness_tree_guard_unit.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# DIVE-2286 unit harness for scripts/harness-tree-guard.sh (push-time) and
+# its interaction with tests/lib/grading_tree_source_re.sh (the regex
+# shared with tests/names_the_tree_contract_unit.sh, this guard's
+# whole-corpus CI twin).
+#
+# Incident under test: four harnesses, three authors, one calendar day
+# (2026-07-29), all missing the DIVE-2211 source line -- each caught only
+# after a full CI round trip. This guard is meant to catch the same defect
+# locally, on just the files a push ADDS, before it ever leaves the machine.
+#
+# Isolation: builds a throwaway git repo per scenario group under mktemp,
+# with a synthetic tests/lib/grading_tree_source_re.sh (real content, copied
+# from this checkout so the guard exercises its ACTUAL regex, not a
+# reimplementation) and synthetic tests/*.sh harness files. Never touches
+# the real repo's git state.
+# Run: bash tests/harness_tree_guard_unit.sh  (no root, no network).
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source.
+# NOTE the absence of `2>/dev/null`. Redirecting the source's stderr would also
+# swallow the helper's own stderr line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GUARD="$ROOT/scripts/harness-tree-guard.sh"
+RE_FILE="$ROOT/tests/lib/grading_tree_source_re.sh"
+
+TMP="$(mktemp -d /tmp/harness-tree-guard-unit.XXXXXX)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+assert_exit() {  # assert_exit "$name" expected_rc actual_rc
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then ok_t "$name"
+  else bad_t "$name" "expected exit $expected, got $actual"; fi
+}
+
+# --- repo scaffold -----------------------------------------------------
+cd "$TMP" || exit 1
+git init -q -b main repo
+cd repo || exit 1
+git config user.email test@example.test
+git config user.name "Test Runner"
+
+mkdir -p tests/lib
+cp "$RE_FILE" tests/lib/grading_tree_source_re.sh
+git add -A >/dev/null
+git commit -q -m "base: carry the real grading_tree_source_re.sh"
+c0="$(git rev-parse HEAD)"
+
+GOOD_HARNESS='#!/usr/bin/env bash
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf "grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n" >&2
+echo hi'
+
+BAD_HARNESS='#!/usr/bin/env bash
+set -uo pipefail
+echo hi'
+
+# commit_add_harness NAME CONTENT MSG -> prints the new sha
+commit_add_harness() {
+  printf '%s\n' "$2" > "tests/$1"
+  git add -A >/dev/null
+  git commit -q -m "$3"
+  git rev-parse HEAD
+}
+
+# --- new harness WITHOUT the source line: blocked -----------------------
+c1="$(commit_add_harness "no_tree_named_unit.sh" "$BAD_HARNESS" "add a harness missing the DIVE-2211 line")"
+out="$(bash "$GUARD" "$c1" "$c0" 2>&1)"; rc=$?
+assert_exit "guard: blocks a new harness missing the source line" 1 "$rc"
+if [[ "$out" == *"tests/no_tree_named_unit.sh"* && "$out" == *"grading_tree.sh"* ]]; then
+  ok_t "guard: names the specific offending file"
+else
+  bad_t "guard: names the specific offending file" "$out"
+fi
+if [[ "$out" == *"FIX --"* && "$out" == *'. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh"'* ]]; then
+  ok_t "guard: prints the paste-able fix snippet"
+else
+  bad_t "guard: prints the paste-able fix snippet" "$out"
+fi
+if [[ "$out" == *"2>/dev/null"* ]]; then
+  ok_t "guard: warns against the load-bearing 2>/dev/null trap"
+else
+  bad_t "guard: warns against the load-bearing 2>/dev/null trap" "$out"
+fi
+
+git checkout -q "$c0"
+
+# --- new harness WITH the source line: clean ----------------------------
+c2="$(commit_add_harness "names_it_fine_unit.sh" "$GOOD_HARNESS" "add a harness carrying the DIVE-2211 line")"
+bash "$GUARD" "$c2" "$c0" >/dev/null 2>&1
+assert_exit "guard: allows a new harness that sources grading_tree.sh" 0 "$?"
+
+git checkout -q "$c0"
+
+# --- EXISTING harness losing the line: NOT this guard's job (CI-only) ---
+# Add a compliant harness first, then a later commit that strips the line
+# back out. The guard scopes to --diff-filter=A (added files only), so a
+# harness that already existed before this push is out of scope even if the
+# push itself removes its source line -- that is deliberately the
+# whole-corpus contract test's job, not this push-time guard's.
+c3="$(commit_add_harness "existing_unit.sh" "$GOOD_HARNESS" "pre-existing harness, compliant")"
+printf '%s\n' "$BAD_HARNESS" > tests/existing_unit.sh
+git add -A >/dev/null
+git commit -q -m "regress: strip the source line from an existing harness"
+c4="$(git rev-parse HEAD)"
+bash "$GUARD" "$c4" "$c3" >/dev/null 2>&1
+assert_exit "guard: does not fire on a MODIFIED (not added) harness losing the line" 0 "$?"
+
+git checkout -q "$c0"
+
+# --- push touching no tests/*.sh files: clean, and cheap (no ADDED files) -
+printf 'unrelated\n' > NOTES.md
+git add -A >/dev/null
+git commit -q -m "docs-only change"
+c5="$(git rev-parse HEAD)"
+bash "$GUARD" "$c5" "$c0" >/dev/null 2>&1
+assert_exit "guard: no-op on a push that adds no tests/*.sh files" 0 "$?"
+
+# --- negative control: BASE==NEW (nothing pushed) never blocks ----------
+bash "$GUARD" "$c1" "$c1" >/dev/null 2>&1
+assert_exit "guard: sanity — comparing a commit against itself never blocks" 0 "$?"
+
+# --- fail-open: missing tests/lib/grading_tree_source_re.sh at NEW -------
+# Simulates a stale branch predating this guard's shared-regex file: must
+# skip cleanly (CI contract test is the net) rather than block every push.
+git checkout -q "$c0"
+git rm -q tests/lib/grading_tree_source_re.sh
+# git rm cleans up now-empty parent dirs; keep tests/ present for the next
+# commit_add_harness call to write into.
+mkdir -p tests
+git commit -q -m "simulate a pre-DIVE-2286 branch (no shared regex file)"
+c6="$(git rev-parse HEAD)"
+c7="$(commit_add_harness "whatever_unit.sh" "$BAD_HARNESS" "add a harness on a branch predating this guard")"
+out="$(bash "$GUARD" "$c7" "$c6" 2>&1)"; rc=$?
+assert_exit "guard: fails OPEN when its own shared regex file is unreachable at NEW" 0 "$rc"
+if [[ "$out" == *"skipping"* ]]; then
+  ok_t "guard: fail-open case says so, rather than silently exiting 0"
+else
+  bad_t "guard: fail-open case says so, rather than silently exiting 0" "$out"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+(( FAIL == 0 ))

--- a/tests/lib/grading_tree_source_re.sh
+++ b/tests/lib/grading_tree_source_re.sh
@@ -1,0 +1,9 @@
+# shellcheck shell=bash
+# DIVE-2286: the ONE spelling of "does this harness source
+# tests/lib/grading_tree.sh" (the DIVE-2211 corpus invariant). Shared by the
+# CI contract (tests/names_the_tree_contract_unit.sh, whole-corpus) and the
+# push-time guard (scripts/harness-tree-guard.sh, added-files-only) so the
+# two cannot independently drift into grading two different properties under
+# the same name — a regex typed twice can diverge twice; sourced once, it
+# cannot.
+readonly GRADING_TREE_SOURCE_RE='(^|[[:space:]])(\.|source)[[:space:]].*lib/grading_tree\.sh'

--- a/tests/names_the_tree_contract_unit.sh
+++ b/tests/names_the_tree_contract_unit.sh
@@ -31,6 +31,12 @@ cd "$(dirname "$0")/.."
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+# DIVE-2286: the detection regex below is shared with the push-time guard
+# (scripts/harness-tree-guard.sh) via this one file, so the two cannot drift
+# into checking two different things under the same name.
+# shellcheck source=lib/grading_tree_source_re.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree_source_re.sh"
+
 PASS=0; FAIL=0
 ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 nok() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
@@ -66,7 +72,7 @@ MISSING=(); PRESENT=()
 for t in "${CORPUS[@]}"; do
   # The source line, whatever spelling: what matters is that this harness pulls
   # in the helper, so its log cannot be silent about which tree it graded.
-  if grep -qE '(^|[[:space:]])(\.|source)[[:space:]].*lib/grading_tree\.sh' "$t"; then
+  if grep -qE "$GRADING_TREE_SOURCE_RE" "$t"; then
     PRESENT+=("$t")
     continue
   fi


### PR DESCRIPTION
Built by dev2. Four authors hit the DIVE-2211 grading-tree contract in a single day — olivia (DIVE-2265 it.1), dev (#288), main2 (#289), dev (#290) — each writing a new harness, omitting one `source` line, and paying a full `test` + `test-installed-host` cycle (~9 and ~18 min) to find out. That is not four lapses; the contract is correct and catching real defects, but satisfying it depended on remembering, and remembering is not a mechanism.

dev's idea over my template suggestion: a **pre-push hook**, so it costs seconds locally instead of a CI round trip, and it matches the existing PII/version-bump-guard pattern — one place people already look when a push is refused.

Three conditions I set at review, all addressed:
1. **Two-sided** — blocks a new harness missing the line, *and* passes one that has it unmodified. Testing only the refusal would let a hook that refuses everything ship green.
2. **Fails loud when the detection mechanism cannot tell** — fixed in 660e3c8 after review caught a / swallow-and-continue gap, with 3 tests proving the loud path has teeth without being always-block. The guard's *own* dependency file being unreachable still fails open, matching the convention for a pre-guard branch; that is now stated in-code as a known property rather than left implicit, and CI's `names_the_tree_contract_unit.sh` remains the backstop.
3. **`--diff-filter=A`, added files only** — per dev3's catch that a branch which ADDS a test file changes another suite's *input set* rather than its behaviour, which is exactly why `council_veto_window_unit.sh` reddened `names_the_tree_contract_unit.sh` for two iterations with two people missing it.

13/13 new tests; adjacent guards unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)