### PR TITLE
fix(tests): stop harnesses inheriting the caller's FIVE_* product knobs (DIVE-2325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## Unreleased — fix(tests): harnesses no longer inherit the caller's product knobs (DIVE-2325)
+
+`task_core_unit` (28/7) and `task_verifier_rail_unit` (17/6) were red on the control-plane
+host and GREEN in CI at the same commit. It presented as host state — the DIVE-1919 class
+`test-installed-host` exists to catch — and it was not. No amount of seeding a runner would
+have reproduced it.
+
+`FIVE_VERIFY_DEFAULT=0` is in the caller's environment. The DIVE-969 verifier-by-default
+rail reads `${FIVE_VERIFY_DEFAULT:-1}`, so the whole mechanism goes inert: not a wrong
+value, no mechanism at all. Reproduced exactly — with that one export, the two harnesses
+give 28/7 and 17/6, same arm names.
+
+**That knob is deliberate fleet policy. Do not delete it to make a test pass.** lodar set it
+for sixteen agents on 2026-07-29 00:49 via the unit's
+`EnvironmentFile=-/var/lib/5dive/agents.d/%i.env`, and each file carries the decision and
+its own revert instruction. Tasks filed without a rail since then are **policy-conformant,
+not damage** — there is no backlog of broken rows to audit.
+
+That is precisely why the harnesses are the only thing that can move. The configuration is
+not an accident awaiting cleanup; it is correct, intentional and permanent. **A harness
+asserting what DIVE-969 does BY DEFAULT while reading that default from the environment is
+grading fleet policy instead of the code.** It has to supply its own.
+
+This is DIVE-2211 one axis over. That change pinned WHICH TREE a harness grades, because
+"21 passed" was a claim about whatever was on disk. The same sentence was still true of the
+ENVIRONMENT: src reads **14 caller-overridable `FIVE_*` knobs**, every harness inherits the
+caller's, and a green log from a clean shell and a red log from a configured one are
+byte-identical apart from the number.
+
+- New `tests/lib/env_isolation.sh` unsets the whole `FIVE_*` namespace and **says on stderr
+  what it cleared** — the reader needs to know a knob was in effect, not be silently fixed
+  up. Silent on a clean environment, so the line means something when it appears.
+- Applied at `tests/lib/grading_tree.sh`, which all 235 harnesses already source near the
+  top before any fixture setup. One seam, no 235-file diff. Verified no harness assigns a
+  `FIVE_*` variable before that point, so nothing a harness meant to set can be clobbered.
+- Blanket rather than one knob on purpose: `FIVE_GATE_REPOS`, `FIVE_GATE_MAIN_BRANCH` and
+  `FIVE_GATE_ANCESTRY_SCAN` would each silently rewrite what the merge-gate harnesses
+  measure, and knob #15 will be added by someone who has never read this file.
+
+`tests/env_isolation_unit.sh` — 13 arms, mutation-graded five ways. T6 anchors T5 (a
+variable that was never going to be set proves nothing when found unset), T7 reproduces the
+incident end-to-end, and T9 exists because mutation found the helper announcing the same
+readonly knob as *both* stuck and cleared — a report of work that did not happen, which is
+not allowed to live in the reporter for that defect class.
+
+Diagnostic caveat recorded in the helper, because the instrument misled first: a
+`/proc/<pid>/environ` sweep found the knob in one session only and that read as a stray
+export. A live environ reflects the env file as of that session's **last exec**, so the
+sweep measured RESTART ORDER, not configuration. Read the config source, not the running
+processes.
+
 ## Unreleased — fix(gate): the merge gate stops reporting COULD-NOT-CHECK as NOT-MERGED (DIVE-2318)
 
 `task done`'s merge gate makes four GitHub queries. Every one of them can come back

--- a/tests/env_isolation_unit.sh
+++ b/tests/env_isolation_unit.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# DIVE-2325 — a harness must not inherit the caller's product knobs.
+#
+# THE INCIDENT. task_core_unit (28/7) and task_verifier_rail_unit (17/6) were red on
+# the control-plane host and green in CI at the same commit. It presented as host
+# state — the DIVE-1919 class where a harness leaks out of its isolation, which the
+# unit-tests workflow comments warn about and which test-installed-host exists to
+# catch. It was not host state, and no amount of seeding a runner would have
+# reproduced it: `FIVE_VERIFY_DEFAULT=0` is in the caller's ENVIRONMENT. The DIVE-969
+# rail reads `${FIVE_VERIFY_DEFAULT:-1}`, so the whole mechanism goes inert — not a
+# wrong value, no mechanism at all (verifyDefaulted:false, verifySkipped:false,
+# verifier:"").
+#
+# THE KNOB IS DELIBERATE FLEET POLICY — DO NOT DELETE IT TO GO GREEN. lodar set it
+# for sixteen agents on 2026-07-29 00:49 via `EnvironmentFile=-/var/lib/5dive/agents.d/%i.env`,
+# with the decision and a revert instruction written into each file. That is exactly
+# why the fix lives HERE: the configuration is correct and permanent, so the harness
+# is the only thing that can move. A harness asserting DIVE-969's DEFAULT behaviour
+# while reading that default from the environment is grading fleet policy, not code.
+#
+# WHY IT MATTERS MORE THAN 13 ASSERTIONS: a suite that is red on the box everyone
+# works on and green in CI trains the whole team to ignore red, and then a real
+# failure reads as the usual noise. It had already cost one near-miss — a false
+# regression nearly reported against a clean merge.
+#
+# WHAT IS GRADED HERE. The helper (T1-T4), THE SEAM that applies it to all 235
+# harnesses (T5, with T6 as its differential anchor), and the incident itself
+# end-to-end (T7). T8 pins the three-state behaviour of an unreachable helper.
+#
+# MUTATION GRADE — RUN, not predicted (2026-07-29; 12/0 clean):
+#   * delete the `. .../env_isolation.sh` line from grading_tree.sh -> 7/3: T5, T7
+#     and T8's UNRESOLVED arm. T7's captured output shows the rail harness back at
+#     "17 passed, 6 failed" — the original incident, reproducing.
+#   * unset without printing            -> 8/2: both T2 arms.
+#   * print unconditionally             -> 9/1: T3.
+#   * filter matches PATHY as well      -> 9/1: T4.
+#   * VOID MUTATION, recorded so nobody wastes a run on it: widening the filter to
+#     `grep ''` does NOT grade T4. It tries to unset BASHOPTS and dies on `!v:
+#     unbound variable`, so the harness never reaches its summary — an absent
+#     summary is not a red arm, it is a broken run. Mutate the filter to match one
+#     EXTRA named variable instead. That run is also what surfaced the readonly
+#     hazard the helper is now hardened against, so the void mutation was not
+#     worthless — it just was not evidence about T4.
+# Run: bash tests/env_isolation_unit.sh  (no root, no network.)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+LIB="tests/lib/env_isolation.sh"
+SEAM="tests/lib/grading_tree.sh"
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# --- T1: the helper UNSETS an inherited knob (not "sets it to a default"). -----
+# Unset is the load-bearing choice: it restores the `:-` default that ships in
+# src/, which is by construction what CI runs with. A hardcoded default here would
+# be a second copy of a constant that lives in src/ and would drift out of it.
+got=$(FIVE_VERIFY_DEFAULT=0 bash -c '. '"$LIB"' 2>/dev/null; printf "[%s]" "${FIVE_VERIFY_DEFAULT-UNSET}"')
+[[ "$got" == "[UNSET]" ]] \
+  && ok_t 'T1 an inherited FIVE_ knob is UNSET, so the src default applies' \
+  || bad_t 'T1 knob not unset' "got=$got"
+
+# --- T2: it ANNOUNCES what it cleared, on stderr. ------------------------------
+# The line is the payload, not decoration: the operator whose shell carries the
+# knob needs to know, because it is affecting their REAL `5dive` invocations too,
+# which is the more expensive half and which no test can fix for them.
+err=$(FIVE_VERIFY_DEFAULT=0 bash -c '. '"$LIB" 2>&1 >/dev/null)
+[[ "$err" == *"CLEARED"* && "$err" == *"FIVE_VERIFY_DEFAULT=0"* ]] \
+  && ok_t 'T2 it names the knob AND its value on stderr' \
+  || bad_t 'T2 no announcement' "err=$err"
+[[ "$err" == *"your real"* || "$err" == *"real \`5dive\`"* ]] \
+  && ok_t 'T2 the line says the knob also affects real invocations, not just tests' \
+  || bad_t 'T2 line must point past the test run' "err=$err"
+
+# --- T3: SILENT on a clean environment, so the line means something when it appears.
+err=$(env -u FIVE_VERIFY_DEFAULT bash -c '. '"$LIB" 2>&1 >/dev/null)
+[[ -z "$err" ]] \
+  && ok_t 'T3 silent when nothing was inherited (CI logs stay quiet)' \
+  || bad_t 'T3 should be silent' "err=$err"
+
+# --- T4: it touches ONLY the FIVE_ namespace. ---------------------------------
+got=$(FIVE_X=1 PATHY=keepme bash -c '. '"$LIB"' 2>/dev/null; printf "[%s][%s]" "${PATHY-GONE}" "${FIVE_X-UNSET}"')
+[[ "$got" == "[keepme][UNSET]" ]] \
+  && ok_t 'T4 non-FIVE_ variables survive; the whole FIVE_ namespace does not' \
+  || bad_t 'T4 wrong blast radius' "got=$got"
+
+# --- T5: THE SEAM. This is what makes the fix cover all 235 harnesses rather
+#     than the two that happened to be red. Every harness sources grading_tree.sh
+#     near the top, before any fixture setup, so applying isolation there reaches
+#     all of them without touching 235 files.
+got=$(FIVE_VERIFY_DEFAULT=0 bash -c '. '"$SEAM"' 2>/dev/null; printf "[%s]" "${FIVE_VERIFY_DEFAULT-UNSET}"')
+[[ "$got" == "[UNSET]" ]] \
+  && ok_t 'T5 SEAM: sourcing grading_tree.sh alone clears the knob (covers every harness)' \
+  || bad_t 'T5 seam not wired' "got=$got"
+
+# --- T6: DIFFERENTIAL ANCHOR for T5. Without the source, the knob survives. A
+#     harness asserting "the variable is unset" proves nothing if the variable was
+#     never going to be set in the first place.
+got=$(FIVE_VERIFY_DEFAULT=0 bash -c 'printf "[%s]" "${FIVE_VERIFY_DEFAULT-UNSET}"')
+[[ "$got" == "[0]" ]] \
+  && ok_t 'T6 ANCHOR: without the seam the knob IS inherited — T5 is not vacuous' \
+  || bad_t 'T6 anchor broken' "got=$got"
+
+# --- T7: THE INCIDENT, end to end. The knob that caused it, against the harness
+#     it caused to fail. Pre-fix this is 17 passed / 6 failed. This arm is the one
+#     that reds if someone removes the seam, and it is deliberately an integration
+#     arm rather than another assertion about the helper: the helper being correct
+#     and the harnesses being protected are different claims.
+out=$(FIVE_VERIFY_DEFAULT=0 bash tests/task_verifier_rail_unit.sh 2>/dev/null | tail -3)
+[[ "$out" == *"0 failed"* ]] \
+  && ok_t 'T7 INCIDENT: the rail harness is GREEN with the knob leaked (was 17/6)' \
+  || bad_t 'T7 incident reproduces' "out=$out"
+
+# --- T8: an unreachable helper is its own third state — it must SAY so and must
+#     not kill a `set -e` harness. Same discipline grading_tree.sh applies to
+#     itself; a fix that turns a knob leak into a dead suite is not a fix.
+tmp=$(mktemp -d /tmp/env-iso-unit.XXXXXX); trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/lib"; cp "$SEAM" "$tmp/lib/"          # copy the seam WITHOUT the helper
+out=$(set -e; bash -c 'set -e; . '"$tmp"'/lib/grading_tree.sh || printf "fallback\n" >&2; printf STILLALIVE' 2>"$tmp/err"); rc=$?
+[[ $rc -eq 0 && "$out" == "STILLALIVE" ]] \
+  && ok_t 'T8 a missing helper does not kill a set -e harness' \
+  || bad_t 'T8 set -e survival' "rc=$rc out=$out err=$(cat "$tmp/err")"
+grep -q 'env isolation: UNRESOLVED' "$tmp/err" \
+  && ok_t 'T8 and it says UNRESOLVED — knobs NOT cleared, rather than falling silent' \
+  || bad_t 'T8 must announce the third state' "err=$(cat "$tmp/err")"
+
+# --- T9: a knob that CANNOT be cleared is reported as stuck and NOT as cleared,
+#     and does not kill a `set -e` harness. Both halves found by mutation rather
+#     than review: `unset` on a readonly variable fails, and the first cut of the
+#     rollback (`${cleared% *}`) silently does nothing when there is exactly one
+#     entry — so the helper announced the SAME knob as stuck and cleared at once.
+#     A reporter for "work that did not happen was reported as done" does not get
+#     to contain that bug.
+err=$(bash -c 'declare -r FIVE_VERIFY_DEFAULT=0; set -e; . '"$LIB"'; printf ALIVE' 2>&1)
+[[ "$err" == *"ALIVE"* ]] \
+  && ok_t 'T9 a readonly knob does not kill a set -e harness' \
+  || bad_t 'T9 set -e survival on readonly' "err=$err"
+[[ "$err" == *"COULD NOT clear"* && "$err" == *"STILL IN EFFECT"* ]] \
+  && ok_t 'T9 it is reported as stuck, and says the knob is still in effect' \
+  || bad_t 'T9 stuck knob must be announced' "err=$err"
+[[ "$err" != *"CLEARED inherited"* ]] \
+  && ok_t 'T9 and it is NOT also announced as cleared — no report of work that did not happen' \
+  || bad_t 'T9 stuck knob double-reported as cleared' "err=$err"
+
+echo "-----"
+printf 'env_isolation_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/lib/env_isolation.sh
+++ b/tests/lib/env_isolation.sh
@@ -1,0 +1,103 @@
+# shellcheck shell=bash
+# NEUTRALISE THE CALLER'S ENVIRONMENT.  (DIVE-2325.)
+#
+# THE DEFECT THIS CLOSES, and it is DIVE-2211 one axis over. grading_tree.sh
+# pinned WHICH TREE a harness grades, because "21 passed" was a claim about
+# whatever was on disk. The same sentence was still true of the ENVIRONMENT: the
+# product reads 14 caller-overridable `FIVE_*` knobs, every harness inherits the
+# caller's environment, and a knob set in that environment silently changes what
+# the harness measures. A green log from a clean shell and a red log from a shell
+# with one export are byte-identical in every respect except the number.
+#
+# MEASURED, and this is the incident that produced this file. `task_core_unit`
+# (28/7) and `task_verifier_rail_unit` (17/6) were red on the control-plane host and
+# GREEN in CI at the same commit. It read as host state — the DIVE-1919 class the
+# unit-tests workflow warns about, where a harness leaks out of its isolation. It
+# was not host state. `FIVE_VERIFY_DEFAULT=0` is in the caller's environment, the
+# DIVE-969 verifier-by-default rail reads `${FIVE_VERIFY_DEFAULT:-1}`, and the whole
+# rail goes inert — not a wrong value, no mechanism at all. Reproduced exactly:
+# `FIVE_VERIFY_DEFAULT=0 bash tests/task_core_unit.sh` gives 28/7 and the rail
+# harness gives 17/6, same arm names.
+#
+# THAT KNOB IS DELIBERATE FLEET POLICY. DO NOT DELETE IT TO MAKE A TEST PASS.
+# It is set for SIXTEEN agents by lodar's backlog policy of 2026-07-29 00:49,
+# delivered through the unit's `EnvironmentFile=-/var/lib/5dive/agents.d/%i.env`,
+# and every one of those files carries the decision and its own revert instruction:
+#
+#     # DIVE backlog policy 2026-07-29 (lodar): verifier-graded is OPT-IN, not default.
+#     # Explicit --verifier=<agent> still forces the rail ON. Revert: set to 1 or delete.
+#     FIVE_VERIFY_DEFAULT=0
+#
+# THIS IS WHY THE HARNESSES ARE THE ONLY THING THAT CAN MOVE — a stronger reason
+# than the one this file was first written with. The configuration is not an
+# accident awaiting cleanup; it is correct, intentional and permanent. So a harness
+# asserting what DIVE-969 does BY DEFAULT must not read that default from the
+# environment, or it grades fleet policy instead of the code. It has to supply its
+# own. Tasks filed without a rail since 00:49 are POLICY-CONFORMANT, not damage;
+# there is no backlog of broken rows to go hunting for.
+#
+# AND BEWARE THE INSTRUMENT THAT DIAGNOSED IT. A scan of `/proc/<pid>/environ` across
+# the fleet found the knob in exactly ONE agent's session, which looked like a stray
+# export by one operator. That inference was wrong. A live process environ reflects
+# the env file as of THAT SESSION'S LAST EXEC, so the scan measured RESTART ORDER and
+# it was read as CONFIGURATION: agents that had not restarted since 00:49 still showed
+# a pre-policy environ, and each picks the knob up on its next restart. **Read the
+# config source, not the running processes.** grading_tree.sh pins WHICH TREE, this
+# file pins WHICH ENVIRONMENT, and that scan needed WHICH MOMENT — a snapshot cannot
+# see a config that has not been exec'd yet.
+#
+# WHY THE WHOLE NAMESPACE AND NOT THE ONE KNOB. The knob that bit us is not
+# special; `FIVE_GATE_REPOS`, `FIVE_GATE_MAIN_BRANCH` and `FIVE_GATE_ANCESTRY_SCAN`
+# would each silently rewrite what the merge-gate harnesses measure, and knob #15
+# will be added by someone who has never read this file. A blanket unset is the
+# only version that covers the knob nobody has invented yet. Verified safe: no
+# harness assigns a `FIVE_*` variable before it sources grading_tree.sh, so this
+# can never clobber a value a harness meant to set — anything set afterwards wins,
+# which is how the harnesses that DO drive these knobs (e.g. the ancestry-scan
+# bound) keep working.
+#
+# UNSET rather than set-to-a-default, deliberately: unsetting restores the `:-`
+# default that ships in src/, which is by construction the value CI runs with. A
+# hardcoded default here would be a second copy of a constant that lives in src/,
+# and it would drift.
+#
+# THE STDERR LINE IS THE PAYLOAD, not decoration. The operator whose shell carries
+# a knob needs to be told, because it is affecting their REAL `5dive` invocations
+# too, not only their test run — that is the more expensive half and no test can
+# fix it for them. Silent on a clean environment so CI logs stay quiet, which also
+# makes the line mean something when it does appear.
+#   NOTE the absence of `2>/dev/null` at the call site in grading_tree.sh. The
+# obvious hardening — redirect this file's stderr so it does not litter the log —
+# swallows exactly the sentence that is the point. That mistake silenced all 210
+# harnesses at once when it was made to grading_tree.sh's own output.
+#
+# HARDENED AGAINST ITS OWN FAILURE, which a mutation run surfaced rather than
+# review: `unset` on a READONLY variable fails, and this file is SOURCED into
+# harnesses, some of which run under `set -e` — so a caller who had marked a knob
+# readonly would not get a knob leak, they would get a suite that dies before its
+# first assertion. A fix that converts a wrong number into no number is worse than
+# the defect. Every step is therefore individually non-fatal, and a knob that
+# cannot be cleared is REPORTED rather than passed over in silence: it is still
+# in effect, so the log must say so.
+_five_env_isolate() {
+  # Record a knob as CLEARED only AFTER the unset actually succeeds. The first cut
+  # appended to `cleared` first and tried to roll the entry back in the failure
+  # branch with `${cleared% *}`, which silently does nothing when there is exactly
+  # one entry (no space to strip) — so a readonly knob was announced as BOTH stuck
+  # and cleared, in the same breath. A report of work that did not happen is the
+  # entire defect class this file exists inside; it is not allowed to live in the
+  # reporter for it. T9 pins this.
+  local v val cleared="" stuck=""
+  for v in $(compgen -v 2>/dev/null | grep '^FIVE_' || true); do
+    val="${!v-}"
+    if unset "$v" 2>/dev/null; then
+      cleared="${cleared:+$cleared }${v}=${val}"
+    else
+      stuck="${stuck:+$stuck }$v"
+    fi
+  done
+  [[ -n "$stuck" ]] && printf 'env isolation: COULD NOT clear %s (readonly) — it is STILL IN EFFECT for this run (DIVE-2325).\n' "$stuck" >&2
+  [[ -n "$cleared" ]] && printf 'env isolation: CLEARED inherited knob(s) — %s. These are set in YOUR shell and also affect your real `5dive` invocations (DIVE-2325).\n' "$cleared" >&2
+  return 0
+}
+_five_env_isolate

--- a/tests/lib/grading_tree.sh
+++ b/tests/lib/grading_tree.sh
@@ -96,4 +96,17 @@ if [[ -z "${_5D_GRADING_TREE_PRINTED:-}" ]]; then
   _5D_GRADING_TREE_PRINTED=1
   _5d_grading_tree_line >&2
 fi
+
+# DIVE-2325: name the tree, then neutralise the ENVIRONMENT. Same class as this
+# file, one axis over — a harness inherits the caller's `FIVE_*` knobs, and a knob
+# set in a shell silently rewrites what the harness measures with no marker in the
+# log. Sourced from HERE rather than added to 235 harnesses because every one of
+# them already sources this file, near the top, before any fixture setup: it is
+# the seam that already exists. See tests/lib/env_isolation.sh for the incident.
+#
+# Same three-state discipline as above — an unreachable helper says so and does
+# NOT kill a `set -e` harness. And no `2>/dev/null`: the helper's stderr line is
+# its payload, exactly as this file's is.
+. "$(dirname -- "${BASH_SOURCE[0]}")/env_isolation.sh" \
+  || printf 'env isolation: UNRESOLVED (tests/lib/env_isolation.sh not reachable; caller FIVE_* knobs NOT cleared)\n' >&2
 :


### PR DESCRIPTION
## What

`task_core_unit` (28/7) and `task_verifier_rail_unit` (17/6) were red on the control-plane host and **GREEN in CI at the same commit**. It presented as host state — the DIVE-1919 class `test-installed-host` exists to catch — and it was not. Seeding a runner would never have reproduced it.

`FIVE_VERIFY_DEFAULT=0` is in the caller's **environment**. The DIVE-969 verifier-by-default rail reads `${FIVE_VERIFY_DEFAULT:-1}`, so the whole mechanism goes inert — not a wrong value, no mechanism at all (`verifyDefaulted:false, verifySkipped:false, verifier:""`). Reproduced exactly: with that one export the two harnesses give **28/7 and 17/6, same arm names**.

## The knob is deliberate fleet policy — do not delete it

lodar set it for **sixteen agents** on 2026-07-29 00:49 via the unit's `EnvironmentFile=-/var/lib/5dive/agents.d/%i.env`, and every file carries the decision and its own revert instruction. Tasks filed without a rail since then are **policy-conformant, not damage** — there is no backlog of broken rows to audit.

That is exactly why **the harnesses are the only thing that can move**. The configuration is not an accident awaiting cleanup; it is correct, intentional and permanent. A harness asserting what DIVE-969 does *by default* while reading that default from the environment is **grading fleet policy instead of the code**.

## The fix

DIVE-2211 one axis over. That change pinned WHICH TREE a harness grades, because "21 passed" was a claim about whatever was on disk. The same sentence was still true of the ENVIRONMENT: src reads **14 caller-overridable `FIVE_*` knobs**.

- `tests/lib/env_isolation.sh` unsets the whole `FIVE_*` namespace and **announces on stderr what it cleared** rather than silently fixing the reader up. Silent on a clean environment, so the line means something when it appears.
- Applied at `tests/lib/grading_tree.sh` — all 235 harnesses already source it near the top before any fixture setup. One seam, no 235-file diff. Verified no harness assigns a `FIVE_*` variable before that point.
- Blanket namespace on purpose: `FIVE_GATE_REPOS`, `FIVE_GATE_MAIN_BRANCH`, `FIVE_GATE_ANCESTRY_SCAN` would each silently rewrite what the merge-gate harnesses measure, and knob #15 gets added by someone who never read the file.
- Unset, not set-to-a-default: unsetting restores the `:-` default that ships in `src/`, which is by construction what CI runs with. A hardcoded default here would be a second copy of a constant that lives in src and would drift.

## Testing

`tests/env_isolation_unit.sh` — 13 arms, **mutation-graded five ways with the measured results in its header**:

| mutation | result |
|---|---|
| delete the source line from the seam | 7/3 — T5, T7, T8; T7's output shows the rail harness back at 17/6 |
| unset without printing | 8/2 — both T2 arms |
| print unconditionally | 9/1 — T3 |
| filter also matches a non-`FIVE_` var | 9/1 — T4 |
| widen filter to `grep ''` | **VOID**, recorded so nobody repeats it |

T6 anchors T5 (a variable that was never going to be set proves nothing when found unset). T7 reproduces the incident end-to-end. **T9 exists because the void mutation caught the helper announcing the same readonly knob as *both* stuck and cleared** — a report of work that did not happen, which is not allowed to live in the reporter for that defect class; it also revealed that `unset` on a readonly var would abort a `set -e` harness, so every step is now individually non-fatal.

Full 236-harness suite green on a committed clean tree, tree unchanged after the run.

## Diagnostic caveat, recorded in the helper

The instrument misled first. A `/proc/<pid>/environ` sweep found the knob in **one** session and that read as a stray export by one operator. A live environ reflects the env file as of that session's **last exec**, so the sweep measured **restart order**, not configuration — agents that hadn't restarted since 00:49 still showed a pre-policy environ. **Read the config source, not the running processes.**
