### PR TITLE
fix(tests): drop the live demo-box IP from the grok capture fixture (DIVE-2284)

### DIFF
--- a/tests/ask_capture_grok_inline_unit.sh
+++ b/tests/ask_capture_grok_inline_unit.sh
@@ -5,7 +5,7 @@
 #
 # The two fixtures here are NOT reconstructions. They are `tmux capture-pane -p`
 # taken verbatim off the live grok seat 'creative' on the council-demo box
-# (49.13.152.195, released 5dive 0.16.32, 2026-07-28), immediately after an
+# (a throwaway Hetzner cx23, released 5dive 0.16.32, 2026-07-28), immediately after an
 # `agent ask` that exited 11 with "the reply fence was OPENED but never
 # completed". The seat had answered. Both captures show the same shape:
 #


### PR DESCRIPTION
The public repo carried the live IP of the council-demo box in a test fixture's provenance comment (`tests/ask_capture_grok_inline_unit.sh:8`, introduced in ec3056e / DIVE-2216). The box is still running with seven agent seats, several holding root-all sudo.

The identifier carried nothing the comment needed. Removed rather than replaced with a `192.0.2.x` placeholder — this is a prose provenance note, not test data, and a fake IP would assert the capture came from a box that never existed.

Class sweep over the tracked tree after the change: no public IPv4, no 9-digit provider ids, no Telegram ids, no non-placeholder emails.

Does NOT address the value in git history (`ec3056e`) — rewrite-vs-leave is a human call and is filed as a gate on DIVE-2284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)