### PR TITLE
fix(up): a skill that FAILED to install is no longer summarised as errors=0 (DIVE-2347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Unreleased — fix(up): a skill that FAILED to install is no longer summarised as `errors=0` (DIVE-2347)
+
+`agent create` does not fail when a preseeded skill won't install, and that is the right
+call — the agent itself is up and a rerun fixes the skill. The consequence was not: the
+failure never reached `5dive up`'s `errors` counter, so the last line the user read
+contradicted the red lines they had just watched scroll past.
+
+Measured on the shipped content-studio template, whose writer and seo roles both request
+a skill that is not in the repo the template names:
+
+```
+error: skill install failed for 'deep-research' on agent 'writer'
+warn:  skill install failed for 'deep-research' from '5dive-ai/skills' (exit 1) — agent is up; rerun: ...
+OK — applied ...: created=5 started=0 skipped=0 errors=0
+```
+
+A first run that reports success while two things failed is worse than one that fails
+loudly: the customer concludes he broke it.
+
+The summary now carries `skills_failed=<n>`, and a consolidated block after it names each
+agent and the exact rerun command. This is the same defect and the same remedy as the
+asleep row (DIVE-2341) — a true statement made once mid-scroll, then overwritten by a
+cheerful one — so it is derived the same way: read back the INSTALLED SET via
+`_skill_list_json` (the reader `skill list` already uses) rather than trusting the create's
+exit code or scraping its render. Display only; it cannot fail a create.
+
+Not fixed here, and deliberately: the templates that request the missing skill. That is a
+separate call about what the templates should ask for — see DIVE-2347.
 ## Unreleased — fix(doctor): a FAILED env-override report no longer reads as "no overrides set" (DIVE-2336)
 
 Both consumers of `_env_overrides_json` wrapped it twice — `|| printf '{}'` and

--- a/src/cmd_compose.sh
+++ b/src/cmd_compose.sh
@@ -456,12 +456,41 @@ HELP
     done
   fi
 
+  # DIVE-2347 — A FAILED SKILL INSTALL IS INVISIBLE TO THE `errors` COUNTER.
+  #
+  # `agent create` deliberately does NOT fail when a preseeded skill won't install
+  # (the agent itself is up), so the failure never reaches `errors` and the summary
+  # says `errors=0` over a red line the user just watched scroll past. Measured on
+  # the content-studio template, whose writer and seo roles both request a skill
+  # that is not in the repo the template names: two `error:` lines, then `errors=0`.
+  #
+  # Same shape and same remedy as the asleep row above: re-derive from the INSTALLED
+  # SET (`_skill_list_json`, the same reader `skill list` uses) rather than trusting
+  # the create's exit code, and restate it after the summary. A spec entry may be
+  # `owner/repo:id`, but only the bare id is ever the installed directory name.
+  # Display only — it cannot regress the create path it describes.
+  # >>> DIVE-2347 degraded-skill derivation (extracted verbatim by tests/compose_skill_degraded_unit.sh)
+  local -a _degraded=()
+  local _want _have _miss
+  for _n in "${_brought_up_names[@]+"${_brought_up_names[@]}"}"; do
+    _want=$(jq -r --arg n "$_n" '(.agents[$n].skills // [])[] | sub("^.*:";"")' <<<"$spec" 2>/dev/null || true)
+    [[ -n "$_want" ]] || continue
+    _have=$(_skill_list_json "$_n" 2>/dev/null | jq -r '.[].name' 2>/dev/null || true)
+    while IFS= read -r _miss; do
+      [[ -n "$_miss" ]] || continue
+      grep -qxF -- "$_miss" <<<"$_have" || _degraded+=("$_n $_miss")
+    done <<<"$_want"
+  done
+  # <<< DIVE-2347 degraded-skill derivation
+
   if (( JSON_MODE )); then
-    ok "" '{file:$f, created:($c|tonumber), started:($s|tonumber), skipped:($k|tonumber), errors:($e|tonumber), asleep:$a}' \
+    ok "" '{file:$f, created:($c|tonumber), started:($s|tonumber), skipped:($k|tonumber), errors:($e|tonumber), asleep:$a, skills_failed:($sf|tonumber), degraded:$d}' \
       --arg f "$file" --arg c "$created" --arg s "$started" --arg k "$skipped" --arg e "$errors" \
-      --argjson a "$(printf '%s\n' "${_asleep[@]+"${_asleep[@]}"}" | jq -R . | jq -sc 'map(select(length>0))')"
+      --argjson a "$(printf '%s\n' "${_asleep[@]+"${_asleep[@]}"}" | jq -R . | jq -sc 'map(select(length>0))')" \
+      --arg sf "${#_degraded[@]}" \
+      --argjson d "$(printf '%s\n' "${_degraded[@]+"${_degraded[@]}"}" | jq -R 'select(length>0) | split(" ") | {agent:.[0], skill:.[1]}' | jq -sc .)"
   else
-    echo "OK — applied $file: created=$created started=$started skipped=$skipped errors=$errors asleep=${#_asleep[@]}"
+    echo "OK — applied $file: created=$created started=$started skipped=$skipped errors=$errors asleep=${#_asleep[@]} skills_failed=${#_degraded[@]}"
     if (( ${#_asleep[@]} > 0 )); then
       echo ""
       echo "── ${#_asleep[@]} agent(s) are ASLEEP — created, but they will not self-act on board work:"
@@ -469,6 +498,14 @@ HELP
         echo "     sudo 5dive heartbeat on $_n"
       done
       echo "   (each line above is the exact command; nothing else is needed)"
+    fi
+    if (( ${#_degraded[@]} > 0 )); then
+      echo ""
+      echo "── ${#_degraded[@]} skill(s) FAILED to install — those agents are up but DEGRADED:"
+      for _n in "${_degraded[@]}"; do
+        echo "     sudo 5dive agent skill ${_n%% *} add --skill=${_n##* }"
+      done
+      echo "   (if a skill is missing from its source repo, the spec is wrong — not your box)"
     fi
   fi
   (( errors == 0 )) || return "$E_GENERIC"

--- a/tests/compose_skill_degraded_unit.sh
+++ b/tests/compose_skill_degraded_unit.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# DIVE-2347 — a skill that FAILED to install must not be summarised as `errors=0`.
+#
+# THE DEFECT: `agent create` deliberately does not fail when a preseeded skill won't
+# install — the agent itself is up, and that choice is correct. The consequence is that
+# the failure never reaches cmd_compose_up's `errors` counter, so the last line the user
+# reads contradicts the red lines they just watched scroll past. Measured on the real
+# content-studio template, whose writer and seo roles both request `deep-research`, a
+# skill that is not in the 5dive-ai/skills repo the template names:
+#
+#   error: skill install failed for 'deep-research' on agent 'writer'
+#   warn:  skill install failed for 'deep-research' from '5dive-ai/skills' (exit 1) ...
+#   OK — applied ...: created=5 started=0 skipped=0 errors=0
+#
+# A first run that reports success while two things failed is worse than one that fails
+# loudly: the customer concludes he broke it.
+#
+# COVERAGE, stated plainly rather than implied: cmd_compose_up CREATES AGENTS, so no
+# harness can run it end-to-end without provisioning real users on this host. T1-T4 below
+# therefore EXTRACT THE DERIVATION VERBATIM from the source between its DIVE-2347 markers
+# and run it against a stubbed installed-set — they are real behavioural arms over the
+# real code, not greps. T5-T8 are source-level arms over the parts (render order, JSON,
+# display-only) that only exist inside the un-runnable function.
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+set +e
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+SRC="$ROOT/src/cmd_compose.sh"
+
+pass=0; fail=0
+ok_t()  { printf 'ok   - %s\n' "$1"; pass=$((pass+1)); }
+bad_t() { printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; fail=$((fail+1)); }
+
+[[ -s "$SRC" ]] \
+  && ok_t 'T0 cmd_compose.sh is present — the arms below are not reading an empty file' \
+  || bad_t 'T0 cmd_compose.sh missing — every arm is vacuous' "src=$SRC"
+
+# ---------------------------------------------------------------------------
+# Extract the derivation verbatim. If the markers ever move or the block is
+# emptied, BLOCK is empty and T1 fails loudly rather than passing vacuously.
+# ---------------------------------------------------------------------------
+BLOCK=$(sed -n '/>>> DIVE-2347 degraded-skill derivation/,/<<< DIVE-2347 degraded-skill derivation/p' "$SRC" \
+        | sed '1d;$d')
+if [[ -n "$BLOCK" ]] && grep -q '_degraded+=' <<<"$BLOCK"; then
+  ok_t "T1 the derivation was extracted from source ($(wc -l <<<"$BLOCK") lines) — T2-T4 run the real code"
+else
+  bad_t 'T1 could not extract the derivation — T2-T4 below would be vacuous' \
+        "markers present? $(grep -c 'DIVE-2347 degraded-skill derivation' "$SRC")"
+fi
+
+# Harness: run the extracted block with a stubbed installed-set. `spec`,
+# `_brought_up_names` and `_skill_list_json` are exactly what cmd_compose_up
+# has in scope at that point.
+#   $1 = spec JSON   $2 = agent names (space sep)   $3.. = "agent:skill,skill" installed
+run_block() {
+  local _spec="$1" _names="$2"; shift 2
+  local _installed=("$@")
+  bash -uo pipefail -c '
+    set +e
+    spec="$1"; read -r -a _brought_up_names <<<"$2"; shift 2
+    _installed=("$@")
+    _skill_list_json() {
+      local want="$1" e
+      for e in "${_installed[@]+"${_installed[@]}"}"; do
+        if [[ "${e%%:*}" == "$want" ]]; then
+          tr "," "\n" <<<"${e#*:}" | jq -R "select(length>0) | {name:.}" | jq -sc .
+          return
+        fi
+      done
+      echo "[]"
+    }
+    _n=""
+    block() {
+      '"$BLOCK"'
+      printf "%s\n" "${_degraded[@]+"${_degraded[@]}"}"
+    }
+    block
+  ' _ "$_spec" "$_names" "${_installed[@]+"${_installed[@]}"}"
+}
+
+SPEC_TWO='{"agents":{"writer":{"skills":["5dive-cli","deep-research"]},"editor":{"skills":["5dive-cli"]}}}'
+
+# --- T2 a missing skill is DETECTED -----------------------------------------
+# The measured case: writer asked for deep-research, only 5dive-cli landed.
+out=$(run_block "$SPEC_TWO" "writer editor" "writer:5dive-cli" "editor:5dive-cli")
+if [[ "$(grep -c . <<<"$out")" == 1 ]] && grep -qx 'writer deep-research' <<<"$out"; then
+  ok_t 'T2 a skill that failed to install is detected (writer/deep-research), and only that one'
+else
+  bad_t 'T2 the missing skill was not detected — the summary would still read errors=0' \
+        "got: $(tr '\n' '|' <<<"$out")"
+fi
+
+# --- T3 ANCHOR: the all-present case must be EMPTY ---------------------------
+# Without this, T2 would pass just as well if the block flagged EVERY skill. This is the
+# arm that makes T2 mean something.
+out=$(run_block "$SPEC_TWO" "writer editor" "writer:5dive-cli,deep-research" "editor:5dive-cli")
+if [[ "$(grep -c . <<<"$out")" == 0 ]]; then
+  ok_t 'T3 ANCHOR a fully-installed roster reports NOTHING degraded (T2 is differential, not blanket)'
+else
+  bad_t 'T3 ANCHOR a healthy roster was reported degraded — the check flags everything' \
+        "got: $(tr '\n' '|' <<<"$out")"
+fi
+
+# --- T4 an owner/repo:id spec entry is matched on the BARE id ----------------
+# Specs may say `5dive-ai/skills:verify`, but the installed directory is `verify`. Without
+# the colon strip every qualified entry would be reported missing forever.
+out=$(run_block '{"agents":{"qa":{"skills":["5dive-ai/skills:verify"]}}}' "qa" "qa:verify")
+if [[ "$(grep -c . <<<"$out")" == 0 ]]; then
+  ok_t 'T4 a fully-qualified `owner/repo:id` entry matches the installed bare id'
+else
+  bad_t 'T4 qualified spec entries are always reported missing — false degraded on every import' \
+        "got: $(tr '\n' '|' <<<"$out")"
+fi
+
+# --- T5 the summary line carries the count ----------------------------------
+# The summary is the line users actually read; a count that is not in it loses to the
+# skill-install render above it.
+grep -q 'skills_failed=\${#_degraded\[@\]}' "$SRC" \
+  && ok_t 'T5 the text summary reports skills_failed=<n> alongside errors' \
+  || bad_t 'T5 the skills_failed count is not in the summary line' "$(grep -n 'applied \$file' "$SRC" | head -2)"
+
+# --- T6 the block is printed AFTER the summary ------------------------------
+# Order is the whole fix — the bug is a true statement made before a cheerful one.
+_sum_ln=$(grep -n 'OK — applied \$file' "$SRC" | head -1 | cut -d: -f1)
+_blk_ln=$(grep -n 'FAILED to install — those agents are up but DEGRADED' "$SRC" | head -1 | cut -d: -f1)
+if [[ -n "$_sum_ln" && -n "$_blk_ln" ]] && (( _blk_ln > _sum_ln )); then
+  ok_t "T6 the degraded block is emitted AFTER the summary (summary $_sum_ln, block $_blk_ln)"
+else
+  bad_t 'T6 the degraded block does not follow the summary — it would be scrolled past too' \
+        "summary=$_sum_ln block=$_blk_ln"
+fi
+
+# --- T7 JSON mode carries it, and survives an EMPTY list ---------------------
+# The empty case is the one that breaks: `set -u` plus `jq --argjson` over an unset array.
+grep -q 'skills_failed:(\$sf|tonumber)' "$SRC" \
+  && ok_t 'T7 JSON mode emits skills_failed' \
+  || bad_t 'T7 JSON mode does not report skills_failed — machine consumers stay blind' ''
+grep -q '_degraded\[@\]+' "$SRC" \
+  && ok_t 'T7b the empty-array expansion is guarded (set -u safe)' \
+  || bad_t 'T7b unguarded array expansion — an empty degraded list aborts under set -u' ''
+
+# --- T8 ANCHOR: display-only. This must not be able to fail a create ---------
+# The fix describes a create; it must never be able to break one.
+if grep -qE '_degraded.*\|\| (fail|return|exit)' "$SRC"; then
+  bad_t 'T8 the degraded derivation can fail the run — display code must not gate a create' ''
+else
+  ok_t 'T8 ANCHOR the degraded derivation cannot fail the run (display-only, as intended)'
+fi
+
+echo "-----"
+echo "compose_skill_degraded_unit: $pass passed, $fail failed"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## The defect

`agent create` does not fail when a preseeded skill won't install — the agent itself is up and a rerun fixes the skill. That is the right call. The consequence was not: the failure never reached `5dive up`'s `errors` counter, so **the last line the user reads contradicts the red lines they just watched scroll past.**

Measured on the shipped `content-studio` template, whose `writer` and `seo` roles both request a skill absent from the repo the template names:

```
error: skill install failed for 'deep-research' on agent 'writer'
warn:  skill install failed for 'deep-research' from '5dive-ai/skills' (exit 1) — agent is up; rerun: ...
OK — applied ...: created=5 started=0 skipped=0 errors=0
```

A first run that reports success while two things failed is worse than one that fails loudly: the customer concludes he broke it.

## The fix

Summary now carries `skills_failed=<n>`, and a consolidated block after it names each agent plus the exact rerun command.

Same defect and same remedy as the asleep row (**DIVE-2341**) — a true statement made once mid-scroll, then overwritten by a cheerful one — so it is derived the same way: read back the **installed set** via `_skill_list_json` (the reader `skill list` already uses) rather than trusting the create's exit code or scraping its render. Display only; it cannot fail a create.

## Testing

`tests/compose_skill_degraded_unit.sh` extracts the derivation **verbatim** from source between its `DIVE-2347` markers and runs it against a stubbed installed-set, so T2–T4 are behavioural arms over the real code rather than greps.

Graded by mutation — each lands exactly one arm red:

| mutation | red arm |
|---|---|
| neuter the match (`grep -qxF` → `true`) | T2 only |
| drop the `owner/repo:id` colon-strip | T4 only |
| remove the count from the summary line | T5 only |

T3 anchors that a fully-installed roster reports **nothing** degraded, so T2 is differential rather than blanket. Empty-array JSON path verified directly (`[]`, set -u safe). `compose_asleep_report_unit` (DIVE-2341) still green — 8/8.

## Not fixed here, deliberately

The templates that request the missing skill. All three shipped templates reference skills absent from `5dive-ai/skills` — `deep-research` (content-studio ×2, startup ×1) and `frontend-design` (all three) — but *what the templates should ask for* is a separate call, gated on DIVE-2347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)