### PR TITLE
fix(gates): mint the human nonce for every tier>=2 gate, not just the hard-human types (DIVE-2356)

### DIFF
--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -1641,31 +1641,37 @@ _hb_gate_renag_batch() { # <recipient_agent> <comma-separated task ids> <route_l
   local text="🔁 Gate reminder — unanswered gates (${route_label}):"
   [[ -n "$_escalated_from" ]] \
     && text+=$'\n'"↑ filed by ${_escalated_from} (no channel of its own) — escalated to you"
-  local rows='[]' row id ident ntype options recommend ask nonce="" markup=""
+  local rows='[]' row id ident ntype options recommend gtier ask nonce="" markup="" _mint_n=0
   local -a nonce_ids=() nonce_hashes=()
   while IFS= read -r row; do
     [[ -n "$row" ]] || continue
-    IFS=$'\x1f' read -r id ident ntype options recommend ask <<<"$row"
+    IFS=$'\x1f' read -r id ident ntype options recommend gtier ask <<<"$row"
     [[ -n "$id" && -n "$ident" ]] || continue
     text+=$'\n\n'"• [${ident}] ${ntype} — ${ask} /task_${id}"
     [[ -n "$recommend" ]] && text+=$'\n'"  ✅ Recommended: ${recommend}"
     [[ -n "$options" ]] && text+=$'\n'"  Options: ${options}"
 
-    nonce=""
-    case "$ntype" in
-      approval|secret|manual)
-        nonce=$(_human_nonce_mint)
-        if [[ -n "$nonce" ]]; then
-          nonce_ids+=("$id")
-          nonce_hashes+=("$(_human_nonce_sha "$nonce")")
-        fi
-        ;;
-    esac
+    # DIVE-2356: hard-human TYPE **or** tier>=2 (matches the cmd_task_need mint).
+    # This sweep is the rescue path for gates filed BEFORE the widened mint — a
+    # tier-2 decision that has been sitting nonce-less picks one up on its first
+    # re-nag rather than waiting to be re-filed. `tier` is now selected below.
+    nonce=""; _mint_n=0
+    case "$ntype" in approval|secret|manual) _mint_n=1 ;; esac
+    [[ "${gtier:-}" =~ ^[0-9]+$ ]] && (( gtier >= 2 )) && _mint_n=1
+    if (( _mint_n )); then
+      nonce=$(_human_nonce_mint)
+      if [[ -n "$nonce" ]]; then
+        nonce_ids+=("$id")
+        nonce_hashes+=("$(_human_nonce_sha "$nonce")")
+      fi
+    fi
     markup=$(_task_gate_reply_markup "$id" "$ntype" "$options" "$recommend" "$nonce" "$TASK_CH_TYPE" "$ident")
     if [[ -n "$markup" ]]; then
       rows=$(jq -cn --argjson a "$rows" --argjson b "$markup" '$a + ($b.inline_keyboard // [])' 2>/dev/null) || rows='[]'
     fi
-  done < <(db "SELECT id||x'1f'||ident||x'1f'||need_type||x'1f'||COALESCE(need_options,'')||x'1f'||COALESCE(recommend,'')||x'1f'||substr(replace(COALESCE(ask,''),x'0a',' '),1,240)
+    # `ask` stays LAST so it remains the greedy tail of the `read`; tier is
+    # spliced in ahead of it rather than appended after it.
+  done < <(db "SELECT id||x'1f'||ident||x'1f'||need_type||x'1f'||COALESCE(need_options,'')||x'1f'||COALESCE(recommend,'')||x'1f'||COALESCE(tier,'')||x'1f'||substr(replace(COALESCE(ask,''),x'0a',' '),1,240)
                FROM tasks WHERE id IN (${idlist}) ORDER BY COALESCE(need_asked_at,updated_at,created_at),id;")
 
   local reply_markup=""

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -5334,14 +5334,61 @@ cmd_task_need() {
   # human-territory) or the org named no distinct lead (the filer IS the lead, who
   # is re-escalating). Both are legitimate human clears, so it needs the same
   # tap-safe nonce as approval/secret/manual for the Telegram tap.
-  local human_nonce=""
-  case "$type" in
-    approval|secret|manual|access)
-      human_nonce=$(_human_nonce_mint)
-      [[ -n "$human_nonce" ]] \
-        && db "UPDATE tasks SET human_nonce_hash=$(sqlq "$(_human_nonce_sha "$human_nonce")") WHERE id=${id};"
-      ;;
-  esac
+  #
+  # DIVE-2356 (from the DIVE-2355 measurement): the mint was gated on gate TYPE
+  # ALONE, and the "decision gates are agent-clearable → no nonce" line above is
+  # true only at tier 0/1. A `decision` FLOORED to tier 2 is by definition NOT
+  # agent-clearable — the DIVE-1117 floor refuses a non-human answer on it — yet
+  # it minted nothing, so it carried no per-gate human evidence at all. Measured
+  # across every answered gate on the live board: approval/manual/secret tier-2
+  # were 40/40 nonce-SET, decision tier-2 was 4/47 (and those 4 came from the
+  # escalate-to-human path below, the one unconditional mint). So the mint
+  # condition is now "hard-human TYPE **or** tier>=2", which is what the DIVE-916
+  # comment always meant by "the types `task answer` enforces as human-only".
+  #
+  # ORDERING, DELIBERATE — this ships ALONE. The companion rule (refuse a tier-2
+  # answer whose human_nonce_hash IS NULL) must NOT land until tier-2 decision
+  # gates have accumulated nonces in the wild: shipped together, it would refuse
+  # the overwhelming majority of tier-2 decision answers, i.e. the dominant
+  # working path. Safe to land alone on the ANSWER side, which is the side that
+  # could break: the tier-2 floor in cmd_task_answer is provenance-only
+  # (`(( ! human ))`), and the DIVE-916 evidence block never fires for `decision`.
+  #
+  # BUT THE HASH IS NOT INERT, AND AN EARLIER DRAFT OF THIS COMMENT SAID IT WAS.
+  # `_proof_ledger` (cmd_proof.sh) counts a done row as an ASK when
+  # `human_nonce_hash IS NOT NULL`, as an OR-arm beside the human-answered test,
+  # and the published zero-human badge is `1 - asks/shipped`. Measured on the live
+  # board when this landed: 704 shipped, 101 asks, of which 20 came from the nonce
+  # arm ALONE — rows with no human answer at all, counted only because a nonce
+  # existed. So widening the mint moves a PUBLISHED METRIC DOWNWARD, and every
+  # future tier-2 decision joins that arm.
+  #
+  # That is intended, not incidental. A tier-2 decision IS a human ask; counting
+  # it is more truthful than not, and the ledger's own header says the arm is
+  # deliberately conservative so the badge understates autonomy rather than
+  # flattering it. Named here because the comment above that query warns against
+  # moving this metric as a SIDE EFFECT — which is a rule about surprise, not
+  # about direction, and so applies to lowering it too.
+  #
+  # If you are here to add a nonce mint somewhere new: check what it does to the
+  # ledger before you assume it is a no-op. This one was assumed to be.
+  #
+  # NOT DONE HERE, on purpose: the minted nonce is not yet reachable by a decision
+  # TAP. `_task_gate_reply_markup` appends `:${nonce}` to callback_data for
+  # approval/secret/manual but not for the decision option buttons, and
+  # telegram-pi's parser is `^tna:(\d+):(.+)$` (greedy) — appending there would
+  # swallow the nonce into the option token and break decision taps on pi
+  # runtimes. That is a plugin-side fix (all four TNA_RE variants) and its own
+  # ticket; until it lands the hash is at-rest evidence only, which is exactly
+  # and only what the refuse-on-NULL rule needs.
+  local human_nonce="" _mint_nonce=0
+  case "$type" in approval|secret|manual|access) _mint_nonce=1 ;; esac
+  [[ "${tier:-}" =~ ^[0-9]+$ ]] && (( tier >= 2 )) && _mint_nonce=1
+  if (( _mint_nonce )); then
+    human_nonce=$(_human_nonce_mint)
+    [[ -n "$human_nonce" ]] \
+      && db "UPDATE tasks SET human_nonce_hash=$(sqlq "$(_human_nonce_sha "$human_nonce")") WHERE id=${id};"
+  fi
   # DIVE-1927: rc 3 = filed and answerable, but NOBODY was pinged. The gate always
   # stands — the dashboard "Needs you" card, `task inbox` and `task answer` need no
   # channel, and a headless/solo/CI box answers gates exactly that way. What must
@@ -6690,31 +6737,36 @@ _task_inbox_send() {
   local shown=$(( total < cap ? total : cap ))
 
   local text="🗂 Gate inbox — waiting on you now:"
-  local kbrows='[]' row id ident prio ntype options recommend ask nonce="" markup="" idlist=""
+  local kbrows='[]' row id ident prio ntype options recommend gtier ask nonce="" markup="" idlist="" _mint_n=0
   local -a nonce_ids=() nonce_hashes=()
   while IFS= read -r row; do
     [[ -n "$row" ]] || continue
-    IFS=$'\x1f' read -r id ident prio ntype options recommend ask <<<"$row"
+    IFS=$'\x1f' read -r id ident prio ntype options recommend gtier ask <<<"$row"
     [[ -n "$id" && -n "$ident" ]] || continue
     idlist+="${idlist:+,}${id}"
     text+=$'\n\n'"• [${ident}] ${ntype}, ${prio} — ${ask} /task_${id}"
     [[ -n "$recommend" ]] && text+=$'\n'"  ✅ Recommended: ${recommend}"
     [[ -n "$options" ]] && text+=$'\n'"  Options: ${options}"
-    nonce=""
-    case "$ntype" in
-      approval|secret|manual)
-        nonce=$(_human_nonce_mint)
-        if [[ -n "$nonce" ]]; then
-          nonce_ids+=("$id")
-          nonce_hashes+=("$(_human_nonce_sha "$nonce")")
-        fi
-        ;;
-    esac
+    # DIVE-2356: same widened condition as the cmd_task_need mint — hard-human
+    # TYPE **or** tier>=2. Without the tier arm a tier-2 `decision` filed before
+    # that change stays nonce-less forever, since this rotation is the only other
+    # write to human_nonce_hash on the non-escalation path. `tier` is now selected
+    # below, spliced in AHEAD of `ask` so `ask` stays the greedy tail of the read.
+    nonce=""; _mint_n=0
+    case "$ntype" in approval|secret|manual) _mint_n=1 ;; esac
+    [[ "${gtier:-}" =~ ^[0-9]+$ ]] && (( gtier >= 2 )) && _mint_n=1
+    if (( _mint_n )); then
+      nonce=$(_human_nonce_mint)
+      if [[ -n "$nonce" ]]; then
+        nonce_ids+=("$id")
+        nonce_hashes+=("$(_human_nonce_sha "$nonce")")
+      fi
+    fi
     markup=$(_task_gate_reply_markup "$id" "$ntype" "$options" "$recommend" "$nonce" "$TASK_CH_TYPE" "$ident")
     if [[ -n "$markup" ]]; then
       kbrows=$(jq -cn --argjson a "$kbrows" --argjson b "$markup" '$a + ($b.inline_keyboard // [])' 2>/dev/null) || kbrows='[]'
     fi
-  done < <(db "SELECT id||x'1f'||ident||x'1f'||priority||x'1f'||need_type||x'1f'||COALESCE(need_options,'')||x'1f'||COALESCE(recommend,'')||x'1f'||substr(replace(COALESCE(ask,''),x'0a',' '),1,240)
+  done < <(db "SELECT id||x'1f'||ident||x'1f'||priority||x'1f'||need_type||x'1f'||COALESCE(need_options,'')||x'1f'||COALESCE(recommend,'')||x'1f'||COALESCE(tier,'')||x'1f'||substr(replace(COALESCE(ask,''),x'0a',' '),1,240)
                FROM tasks WHERE ${where} ${order} LIMIT ${cap};")
   if (( total > cap )); then
     text+=$'\n\n'"…and $(( total - cap )) more — 5dive task inbox on the box or the dashboard."
@@ -7254,12 +7306,26 @@ cmd_task_answer() {
   # genuine human answer is NEVER rejected here (DIVE-525). We gate this on
   # `gate-proof enforce` for the SAME rollout envelope as the evidence block
   # above; enforce is ON fleet-wide (DIVE-950). We deliberately do NOT require the
-  # evidence forms here: a tier-2 `decision` gate mints no per-gate nonce and its
-  # tap runs as SUDO_UID=agent, so demanding evidence would reject a real human
-  # decision tap — provenance is the correct, tap-safe floor. Residual (an agent
-  # sudo->--human-forging human:* on a tier-2 *decision*, which has no nonce
-  # evidence layer) is the forged-human threat DIVE-916/DIVE-1115 own; tracked as
-  # follow-up. NO downgrade path from the answer side by design: an over-fired T2
+  # evidence forms here: a tier-2 `decision` gate's tap runs as SUDO_UID=agent and
+  # its option buttons carry NO nonce in their callback_data, so demanding evidence
+  # would reject a real human decision tap — provenance is the correct, tap-safe
+  # floor. Residual (an agent sudo->--human-forging human:* on a tier-2 *decision*)
+  # is the forged-human threat DIVE-916/DIVE-1115 own; tracked as follow-up.
+  #
+  # DIVE-2356 UPDATED THE FIRST HALF OF THAT REASONING, AND READ THIS BEFORE
+  # TIGHTENING THIS BLOCK. A tier-2 decision now DOES mint a per-gate nonce at
+  # filing — so "it has no nonce" is no longer why evidence is not required here.
+  # The reason is now narrower and entirely about the TAP: the decision option
+  # buttons still do not carry the nonce (telegram-pi's TNA_RE is greedy and would
+  # swallow it), so a real human tap arrives with no proof to offer and an evidence
+  # requirement would reject it — the DIVE-525 trap.
+  #
+  # The sanctioned next step is NOT an evidence requirement. It is the far weaker
+  # "refuse a tier>=2 answer whose human_nonce_hash IS NULL", and it must not land
+  # until tier-2 decision gates filed BEFORE DIVE-2356 have aged out or been
+  # rescued by the digest/re-nag mints: at the time of writing that rule would
+  # refuse 43 of the last 47 tier-2 decision answers. Check the live NULL count
+  # first; do not infer that it has drained. NO downgrade path from the answer side by design: an over-fired T2
   # (the heuristic can over-match) waits for a human — the conservative correct
   # default for a hard floor; re-file at a lower --tier if the floor misfired.
   if [[ "$gtier" == "2" ]] && (( ! human )) && _gate_proof_enforced; then

--- a/tests/gate_nonce_unit.sh
+++ b/tests/gate_nonce_unit.sh
@@ -2,7 +2,10 @@
 # DIVE-916 isolated unit harness for the per-gate HUMAN nonce that closes the
 # sudo->--human gate-forge, folded into the DIVE-931 secret-drop chain:
 #   * `task need --type=approval|secret|manual` mints human_nonce_hash (hash-only
-#     at rest); decision does NOT (agent-clearable).
+#     at rest); a TIER 0/1 decision does NOT (genuinely agent-clearable). Since
+#     DIVE-2356 the condition is "hard-human TYPE **or** tier>=2", so a tier-2
+#     decision mints too — T2 below pins the tier-1 side of that boundary, and
+#     gate_tier2_decision_nonce_unit.sh owns the tier-2 side.
 #   * the RAW nonce reaches task_need_notify (embedded in the tap callback_data)
 #     and hashes back to the stored value.
 #   * `task answer` clears an approval/secret/manual gate under enforcement iff
@@ -102,13 +105,20 @@ for ty in approval secret manual; do
   else bad_t "T1 $ty raw nonce -> notify hashes to stored" "nonce='$NOTIFY_NONCE' h='$h'"; fi
 done
 
-# --- T2: decision gate mints NO nonce (agent-clearable) -----------------------
+# --- T2: a TIER-1 decision gate mints NO nonce (genuinely agent-clearable) ----
+#     DIVE-2356: the tier is now load-bearing for this assertion, so assert it
+#     rather than relying on "decision defaults to tier 1 and 'pick' trips no
+#     floor". If either ever moves, this gate would land at tier 2 and T2 would
+#     quietly invert from "the boundary holds" to "the mint is broken".
 seed_task DIVE-200
 NOTIFY_NONCE="sentinel"
 cmd_task_need DIVE-200 --type=decision --ask="pick" --options="A|B" --recommend="A" >/dev/null 2>&1
+t=$(db "SELECT COALESCE(tier,'') FROM tasks WHERE ident='DIVE-200';")
+[[ "$t" == "1" ]] && ok_t "T2 precondition: gate landed at tier 1" \
+  || bad_t "T2 precondition: gate landed at tier 1" "got tier '$t' — the no-nonce assertion below is no longer about tier 1"
 h=$(db "SELECT COALESCE(human_nonce_hash,'null') FROM tasks WHERE ident='DIVE-200';")
-[[ "$h" == "null" || -z "$h" ]] && ok_t "T2 decision gate mints no nonce" \
-  || bad_t "T2 decision gate mints no nonce" "got: '$h'"
+[[ "$h" == "null" || -z "$h" ]] && ok_t "T2 tier-1 decision gate mints no nonce" \
+  || bad_t "T2 tier-1 decision gate mints no nonce" "got: '$h'"
 [[ -z "$NOTIFY_NONCE" ]] && ok_t "T2 decision passes empty nonce to notify" \
   || bad_t "T2 decision passes empty nonce to notify" "got: '$NOTIFY_NONCE'"
 

--- a/tests/gate_tier2_decision_nonce_unit.sh
+++ b/tests/gate_tier2_decision_nonce_unit.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# DIVE-2356 — the per-gate human nonce must be minted for EVERY tier>=2 gate, not
+# only for the hard-human TYPES (approval/secret/manual/access).
+#
+# THE BUG THIS GRADES (measured in DIVE-2355, not inferred): the mint cased on gate
+# TYPE alone, so a `decision` floored to tier 2 minted nothing — even though the
+# DIVE-1117 floor refuses a non-human answer on exactly that gate. Across every
+# answered gate on the live board: approval/manual/secret tier-2 were 40/40 nonce
+# SET; decision tier-2 was 4/47, and those 4 came from the escalate-to-human path
+# (the one unconditional mint). So a tier-2 decision was the one hard-human gate
+# carrying no per-gate evidence at rest.
+#
+# WHAT THIS CHANGE IS NOT. It ships the MINT alone. The companion rule — refuse a
+# tier-2 answer whose human_nonce_hash IS NULL — must not land until tier-2
+# decision gates have accumulated nonces in the wild, or it would refuse 43 of the
+# last 47 tier-2 decision answers. T5/T6 below are the guard for that: they assert
+# the answer path is UNCHANGED, so a future edit that sneaks the refusal in early
+# turns this harness red instead of turning the fleet red.
+#
+# RED-ON-UNFIXED (the test bar): revert the mint condition at src/cmd_task.sh to
+# `case "$type" in approval|secret|manual|access)` and T1/T2/T3 fail. Verified by
+# mutation, not by reading. T4 is the anchor — it passes on BOTH trees, so a
+# harness that silently stopped exercising the code path cannot read as a pass.
+#
+# Isolation matches the sibling harnesses (gate_tier2_floor_unit.sh): source src/
+# libs, throwaway STATE_DIR — the live shared tasks.db is NEVER touched.
+# Run: bash tests/gate_tier2_decision_nonce_unit.sh (no root, no network).
+set -uo pipefail
+
+# See gate_tier2_floor_unit.sh: the absence of `2>/dev/null` here is deliberate —
+# redirecting the source's stderr also swallows the helper's own stderr line,
+# which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/gate-t2-decision-nonce.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh cmd_task.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+GATE_PROOF_KEY="$STATE_DIR/gate-proof.key"
+GATE_PROOF_ENFORCE="$STATE_DIR/gate-proof.enforce"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"; set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+tasks_db_init
+
+# Don't DM on gate filing; no root-owned audit log in this harness. Capture the
+# nonce handed to the notifier so we can assert the RAW nonce travels to the tap
+# builder and is never left only at rest.
+NOTIFY_NONCE=""
+task_need_notify() { NOTIFY_NONCE="${8:-}"; }
+audit_log() { :; }
+
+# Non-agent immediate caller, as in gate_tier2_floor_unit.sh, so nothing here is
+# decided by the DIVE-394 agent-uid guard.
+FAKE_CALLER="root"
+id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+export SUDO_UID=0
+
+seed_task() { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
+hashof()  { db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE ident='$1';"; }
+tierof()  { db "SELECT COALESCE(tier,'')             FROM tasks WHERE ident='$1';"; }
+typeof_() { db "SELECT COALESCE(need_type,'')        FROM tasks WHERE ident='$1';"; }
+answered(){ db "SELECT CASE WHEN need_answered_at IS NULL THEN 'open' ELSE 'closed' END FROM tasks WHERE ident='$1';"; }
+
+# openssl is the mint's entropy source. If it is unavailable this harness cannot
+# distinguish "not minted" from "could not mint", so it SKIPS rather than passing
+# vacuously or failing for the wrong reason.
+if ! _n=$(_human_nonce_mint) || [[ -z "$_n" ]]; then
+  printf 'SKIP - gate_tier2_decision_nonce_unit: _human_nonce_mint produced nothing (no entropy source); cannot grade the mint\n'
+  exit 0
+fi
+unset _n
+
+touch "$GATE_PROOF_ENFORCE"   # match the live envelope: enforce is ON fleet-wide
+
+# --- T1: a decision gate EXPLICITLY pinned --tier=2 MINTS a nonce. -------------
+#     This is the headline regression. RED on the unfixed tree.
+seed_task DIVE-201
+NOTIFY_NONCE=""
+cmd_task_need DIVE-201 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 >/dev/null 2>&1
+[[ "$(tierof DIVE-201)" == "2" && "$(typeof_ DIVE-201)" == "decision" ]] \
+  && ok_t "T1 precondition: gate stored as a tier-2 decision" \
+  || bad_t "T1 precondition tier-2 decision" "tier='$(tierof DIVE-201)' type='$(typeof_ DIVE-201)'"
+[[ "$(hashof DIVE-201)" =~ ^[0-9a-f]{64}$ ]] \
+  && ok_t "T1 tier-2 decision MINTS a 64-hex human_nonce_hash" \
+  || bad_t "T1 tier-2 decision mints a nonce" "got '$(hashof DIVE-201)' (this is the DIVE-2355 hole)"
+[[ -n "$NOTIFY_NONCE" ]] \
+  && ok_t "T1 the RAW nonce reaches task_need_notify (tap builder), not just the DB" \
+  || bad_t "T1 raw nonce passed to notify" "got empty"
+
+# --- T2: same, via the CATEGORY FLOOR rather than an explicit pin. -------------
+#     "secrets" in the ask trips _gate_tier2_floor_hit — the OSS-16 mechanism, and
+#     the way most tier-2 decisions actually get there.
+seed_task DIVE-202
+cmd_task_need DIVE-202 --type=decision --ask="rotate the prod secrets now?" --options="yes|no" --recommend="no" >/dev/null 2>&1
+if [[ "$(tierof DIVE-202)" == "2" ]]; then
+  ok_t "T2 precondition: category heuristic floored the decision to tier 2"
+  [[ "$(hashof DIVE-202)" =~ ^[0-9a-f]{64}$ ]] \
+    && ok_t "T2 category-FLOORED tier-2 decision mints a nonce" \
+    || bad_t "T2 category-floored tier-2 decision mints a nonce" "got '$(hashof DIVE-202)'"
+else
+  # Never pass silently if the keyword floor moves — that would make T2 vacuous.
+  bad_t "T2 precondition: category floor" "got tier '$(tierof DIVE-202)' (keyword floor may have moved)"
+fi
+
+# --- T3: the RESCUE path — a gate filed BEFORE this change (nonce-less at rest)
+#     picks one up on the next `task inbox --send` digest. DIVE-2355 called this
+#     remedy a no-op precisely because the digest mint was type-gated the same
+#     way; this asserts it no longer is. RED on the unfixed tree.
+seed_task DIVE-203
+cmd_task_need DIVE-203 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 >/dev/null 2>&1
+db "UPDATE tasks SET human_nonce_hash=NULL WHERE ident='DIVE-203';"   # simulate a pre-fix row
+[[ -z "$(hashof DIVE-203)" ]] \
+  && ok_t "T3 precondition: legacy row starts with human_nonce_hash NULL" \
+  || bad_t "T3 precondition NULL hash" "got '$(hashof DIVE-203)'"
+TASK_CH_TYPE=claude
+_task_send_owner() { TASK_SEND_DELIVERED=1; TASK_SEND_MESSAGE_IDS="1"; }
+# `task inbox --send` is root-only (it reads other agents' channel state) and this
+# harness runs unprivileged by design. Neutralise ONLY that guard, and say so: the
+# root guard is a separate property with its own coverage, and what is under test
+# here is the mint condition inside the digest loop. Without this the T3 assertion
+# would be graded against a permission error, i.e. it would fail for a reason that
+# has nothing to do with the fix.
+require_root() { :; }
+# DIVE-1506 fail-closed fixture guard: the digest refuses to run when the active
+# task DB is not the prod DB, and names FIVEDIVE_PROD_TASKS_DB as the opt-in. Point
+# it at THIS harness's throwaway DB — deliberately NOT exported, so it can never
+# reach a real `5dive` subprocess and re-designate a fixture as prod. The guard is
+# doing its job; this is the sanctioned way to grade the code behind it, and the
+# assertion below is a DB write, so opting in cannot make it vacuous.
+FIVEDIVE_PROD_TASKS_DB="$TASKS_DB"
+# Third and last precondition: the digest refuses without a paired owner channel
+# (it lives in cmd_agent_pairing.sh, which this harness deliberately does not
+# source). TASK_CH_TYPE above supplies the only thing the mint path reads from it.
+#
+# THREE STUBS, NAMED DELIBERATELY. Each neutralises a PRECONDITION of reaching the
+# digest loop — root, prod-DB fence, paired channel — and none of them is the
+# property under test. The property under test is a WRITE to human_nonce_hash, so
+# no stub can satisfy the assertion on its behalf: with the mint condition
+# reverted, all three stubs still apply and T3 still goes red. That is what makes
+# this a test of the fix rather than a test of the scaffolding.
+_task_owner_channel() { :; }
+# SUBSHELL on purpose: _task_inbox_send finishes through `ok`, which exits the
+# process. The rotation we are grading is a write to the sqlite FILE, so it
+# survives the subshell — but the rest of this harness would not.
+( _task_inbox_send "" \
+    "need_type IS NOT NULL AND need_answered_at IS NULL AND status NOT IN ('done','cancelled')" \
+    "ORDER BY created_at" ) >/dev/null 2>&1
+[[ "$(hashof DIVE-203)" =~ ^[0-9a-f]{64}$ ]] \
+  && ok_t "T3 inbox digest RESCUES a nonce-less tier-2 decision (rotates a hash in)" \
+  || bad_t "T3 inbox digest rescues nonce-less tier-2 decision" "got '$(hashof DIVE-203)'"
+
+# --- T4: ANCHOR — an approval gate still mints, on both trees. A pass here with
+#     T1/T2/T3 red means the harness is exercising the code path and the mint
+#     condition is what changed; a FAIL here means the harness itself broke.
+seed_task DIVE-204
+cmd_task_need DIVE-204 --type=approval --ask="ship it?" --recommend="approve" >/dev/null 2>&1
+[[ "$(hashof DIVE-204)" =~ ^[0-9a-f]{64}$ ]] \
+  && ok_t "T4 anchor: approval gate still mints (unchanged by this fix)" \
+  || bad_t "T4 anchor approval mints" "got '$(hashof DIVE-204)' — harness broken, not the fix"
+
+# --- T5: BOUNDARY — a tier-1 decision still mints NOTHING. The widened condition
+#     is tier>=2, not "all decisions": a tier-1 decision is genuinely
+#     agent-clearable and must not acquire human-gate machinery. This must be
+#     green on BOTH trees; if it ever goes red the condition over-widened.
+seed_task DIVE-205
+cmd_task_need DIVE-205 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=1 >/dev/null 2>&1
+[[ "$(tierof DIVE-205)" == "1" ]] \
+  && ok_t "T5 precondition: gate stored as a tier-1 decision" \
+  || bad_t "T5 precondition tier-1" "got '$(tierof DIVE-205)'"
+[[ -z "$(hashof DIVE-205)" ]] \
+  && ok_t "T5 boundary: tier-1 decision mints NO nonce (still agent-clearable)" \
+  || bad_t "T5 tier-1 decision mints no nonce" "got '$(hashof DIVE-205)' — condition over-widened"
+
+# --- T6: THE ORDERING GUARD. Minting must not, by itself, change who can answer.
+#     A --human answer on a nonce-bearing tier-2 decision still CLEARS (DIVE-525:
+#     a real tap is never rejected — and the decision tap carries NO nonce in its
+#     callback_data today, so an evidence requirement here would reject it).
+seed_task DIVE-206
+cmd_task_need DIVE-206 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 >/dev/null 2>&1
+[[ "$(hashof DIVE-206)" =~ ^[0-9a-f]{64}$ ]] || bad_t "T6 precondition: gate minted a nonce" "got '$(hashof DIVE-206)'"
+cmd_task_answer DIVE-206 --value=A --human >/dev/null 2>&1
+[[ "$(answered DIVE-206)" == "closed" ]] \
+  && ok_t "T6 ordering guard: --human answer on a NONCE-BEARING tier-2 decision still clears" \
+  || bad_t "T6 --human tier-2 decision still clears" "still $(answered DIVE-206) — refuse-on-NULL may have landed early"
+
+# --- T7: the pre-existing DIVE-1117 floor is untouched — a BARE-AGENT answer on
+#     the same shape is still refused. Pairs with T6: together they pin the answer
+#     path to exactly where it was before this change, in both directions.
+seed_task DIVE-207
+cmd_task_need DIVE-207 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 >/dev/null 2>&1
+out=$(cmd_task_answer DIVE-207 --value=A 2>&1); rc=$?
+[[ "$(answered DIVE-207)" == "open" && $rc -ne 0 ]] \
+  && ok_t "T7 bare-agent answer on tier-2 decision still REFUSED (DIVE-1117 floor intact)" \
+  || bad_t "T7 bare-agent tier-2 still refused" "rc=$rc state=$(answered DIVE-207) out=$out"
+
+echo "-----"
+printf 'gate_tier2_decision_nonce_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/gate_tier2_floor_unit.sh
+++ b/tests/gate_tier2_floor_unit.sh
@@ -69,8 +69,10 @@ export SUDO_UID=0
 
 touch "$GATE_PROOF_ENFORCE"   # enforcement ON for the floor tests
 
-# --- T1: a decision gate EXPLICITLY filed at tier 2 mints no nonce yet is a hard
-#     floor: a bare-agent answer (no --human) is REFUSED under enforcement. --------
+# --- T1: a decision gate EXPLICITLY filed at tier 2 is a hard floor: a bare-agent
+#     answer (no --human) is REFUSED under enforcement. (Since DIVE-2356 such a
+#     gate also MINTS a nonce, but this floor is provenance-based and does not read
+#     it — that independence is what gate_tier2_decision_nonce_unit T6/T7 pin.) ---
 seed_task DIVE-101
 cmd_task_need DIVE-101 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 >/dev/null 2>&1
 [[ "$(tierof DIVE-101)" == "2" ]] && ok_t "T1 decision --tier=2 stored as tier 2" \

--- a/tests/heartbeat_gate_renag_unit.sh
+++ b/tests/heartbeat_gate_renag_unit.sh
@@ -87,6 +87,21 @@ stored=$(db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE id=${g2};")
 [[ "$(pinged "$g1")" == "SET" && "$(pinged "$g2")" == "SET" ]] \
   && ok_t "confirmed batch stamps both delivery receipts" || bad_t "batch receipt missing"
 
+# DIVE-2356: the re-nag mint is "hard-human TYPE **or** tier>=2", so g1 — a tier-2
+# DECISION, which minted nothing before — now gets a hash rotated in on a confirmed
+# send. This sweep is the rescue path for the 43 tier-2 decision gates measured
+# nonce-less in DIVE-2355: they acquire evidence on their next reminder instead of
+# waiting to be re-filed. Deliberately asserts the STORED HASH only, not a button:
+# the decision keyboard still carries no nonce in its callback_data (telegram-pi's
+# TNA_RE is greedy and would swallow it), which is why the assertion above for the
+# APPROVAL gate can pair callback_data to the hash and this one cannot.
+[[ "$(db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE id=${g1};")" =~ ^[0-9a-f]{64}$ ]] \
+  && ok_t "tier-2 DECISION gate gets a nonce rotated in by the re-nag (DIVE-2356)" \
+  || bad_t "tier-2 decision re-nag mint" "hash='$(db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE id=${g1};")'"
+# (The tier-1 ANCHOR for this lives at the END of the file: it needs its own
+# `reset`, and resetting here would pull the gates out from under the +24h
+# throttle assertions that follow.)
+
 # Immediate second tick is idempotent; then a 24h-old reminder stamp re-arms.
 : >"$SEND_LOG"
 _hb_gate_renag_sweep
@@ -112,6 +127,17 @@ newhash=$(db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE id=${bad};")
 [[ "$(pinged "$bad")" == "NULL" && "$newhash" == "$oldhash" ]] \
   && ok_t "failed re-nag leaves receipt and nonce unchanged for retry" \
   || bad_t "failed re-nag mutated delivery state" "pinged=$(pinged "$bad") old=$oldhash new=$newhash"
+
+# DIVE-2356 ANCHOR (last, because it needs its own `reset`): a tier-1 decision must
+# NOT acquire a nonce — the widened condition is tier>=2, not "every decision".
+# Green on BOTH the fixed and unfixed tree; red here means the mint over-widened
+# and tier-1 gates started dragging human-gate machinery around.
+reset
+t1d=$(mk_gate DIVE-14 1 decision '-2 hours' '-119 minutes' 'A|B' A '')
+_hb_gate_renag_sweep
+[[ -z "$(db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE id=${t1d};")" ]] \
+  && ok_t "anchor: tier-1 decision gets NO nonce from the re-nag (DIVE-2356)" \
+  || bad_t "anchor: tier-1 decision re-nag mint (DIVE-2356)" "over-widened — got a hash"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Step 1 of DIVE-2356, and **only** step 1. Closes the mint gap DIVE-2355 measured; deliberately does **not** land the refuse-on-NULL rule.

## The bug

The per-gate human nonce was minted on gate **TYPE** alone (`approval|secret|manual|access`). A `decision` **floored to tier 2** minted nothing — even though the DIVE-1117 floor refuses a non-human answer on exactly that gate. So the one hard-human gate class with no per-gate evidence at rest was the one the floor was written for.

Every other hard-human type at tier 2 mints 100% — approval 29/29, manual 12/12, secret 3/3. Tier-2 `decision` was a handful out of ~46, and those came from the escalate-to-human path: the one unconditional mint. The floor works exactly where it is implemented and is absent where it is not.

## The change

Widens the condition to *hard-human TYPE **or** tier>=2* at all three type-cased mint sites:

- `cmd_task_need` — new gates
- `_task_inbox_send` — the `/inbox` digest rotation
- `_hb_gate_renag_sweep` — the re-nag batch

The last two are the **rescue path**: gates filed before this change pick up a nonce on their next reminder rather than waiting to be re-filed. DIVE-2355 called that remedy a no-op — correctly, because both were type-gated the same way. They aren't any more.

## This moves a published metric, downward, on purpose

`_proof_ledger` (`cmd_proof.sh`) counts a done row as an **ask** when `human_nonce_hash IS NOT NULL` — an OR-arm beside the human-answered test — and the published zero-human badge is `1 - asks/shipped`.

Live board at merge time: **704 shipped, 101 asks, of which 20 come from the nonce arm alone** — rows with no human answer at all, counted as asks only because a nonce was minted. Widening the mint adds every future tier-2 decision to that arm, so **the badge drifts down**.

That is the honest direction and it is intended, not incidental. A tier-2 decision *is* a human ask; counting it is more truthful than not, and the ledger's own header says the arm is deliberately conservative so the number understates autonomy rather than flattering it. It is named here because the comment above that query warns against moving this metric **as a side effect** — a rule about surprise, not about direction, so it applies to lowering it too.

Caught in review by Marcus. An earlier draft of this PR claimed *"nothing reads the hash's presence"* — true of the answer path, false of the proof path. The source comment now carries the correction, so the next person to add a mint checks the ledger instead of assuming a no-op.

## Why this ships alone

The companion rule — *refuse a tier>=2 answer whose `human_nonce_hash` IS NULL* — **must not land until these have soaked**. Today it would refuse the overwhelming majority of tier-2 decision answers: the dominant working path. Filed as **DIVE-2368** with the gating query to run first.

Minting alone is safe on the **answer** side, which is the side that could break: the tier-2 floor is provenance-only (`(( ! human ))`), and the DIVE-916 evidence block never fires for `decision`. T6/T7 pin that in **both** directions — a `--human` answer on a nonce-bearing tier-2 decision still clears, a bare-agent one is still refused — so a future edit that sneaks the refusal in early turns this harness red instead of turning the fleet red.

## Known residue, named on purpose

The decision option buttons still carry **no nonce** in their `callback_data`. `telegram-pi`'s parser is `^tna:(\d+):(.+)$` — greedy — so appending one would swallow it into the option token and break decision taps on pi runtimes. (The other three variants use `([^:]+)(?::([0-9a-f]{32}))?$` and would be fine; pi is the odd one out.) Plugin-side fix across all four `TNA_RE` variants, filed as **DIVE-2369**. Until it lands the hash is **at-rest evidence only** — which is exactly and only what refuse-on-NULL needs.

The stale comment in `cmd_task_answer` that justified skipping evidence with *"a tier-2 decision mints no per-gate nonce"* is updated in place, because that sentence is what a future editor would otherwise rely on when landing step 2.

PR #285 (openssl mint hardening) is orthogonal and still open — openssl works on this box, so it did not produce these NULLs.

## Test bar: mutation-graded, per-site, differential

New `tests/gate_tier2_decision_nonce_unit.sh` (12 assertions) + 2 added to `heartbeat_gate_renag_unit.sh`. Reverting the tier arm at each site reddens a **different** set:

| mutation | red |
|---|---|
| `cmd_task_need` | T1, T2 |
| `_task_inbox_send` | T3 |
| re-nag sweep | the new heartbeat assertion |

Anchors — approval still mints, tier-1 decision still does not — stay green on **both** trees, so a harness that silently stopped exercising the path cannot read as a pass.

The three stubs in T3 (root guard, DIVE-1506 prod-DB fence, owner channel) each neutralise a *precondition* of reaching the digest loop. None can satisfy the assertion on its behalf: the assertion is a DB write, and with the mint reverted all three stubs still apply and T3 still goes red.

**42 suites** touching the changed code: all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
