### PR TITLE
cli: assign 0.17.8 — nine merges landed unassigned (DIVE-2339)

### DIFF
--- a/src/header.sh
+++ b/src/header.sh
@@ -26,7 +26,7 @@ esac
 
 # Bumped on every public release. `build.sh` checks this line exists; CI fails
 # the bundle-drift check if it's missing or empty.
-readonly FIVE_VERSION="0.17.7"
+readonly FIVE_VERSION="0.17.8"
 
 # GitHub org our repos live under. The org is being renamed
 # 5dive-com -> 5dive-ai (2026-06); fetches must work on either side of the


### PR DESCRIPTION
`version-assign` has failed on **all six merges today**, so main's `FIVE_VERSION` sat at 0.17.7 — set by #313 itself — while **nine merges landed**. The shared-checkout updater is version-triggered (DIVE-2065), so none of it reached anything: the DIVE-2338 `rm -rf` traversal fix, DIVE-2356's nonce minting, the template-skills CI rail, and DIVE-2009's doctor check all sat undelivered behind a version that never moved. The only symptom was red CI that reads like a flake.

Computed by the shipped script rather than by hand: `scripts/version-assign.sh HEAD` reports ASSIGNMENT OWED against anchor `84d94293`, next = **0.17.8**. Applied with `--apply`, which changed exactly one line. The bundle rebuilt but is gitignored post-#313, so it correctly does not appear in the diff.

This unblocks delivery and **fixes nothing structural** — the next merge fails identically. The structural fix is DIVE-2339's answered gate (version-assign opens an auto-merging PR instead of pushing main), which is not in this commit.

This PR also serves as the empirical test for that fix: it is opened under a real credential rather than the workflow's `GITHUB_TOKEN`. If it collects checks and auto-merges, that confirms the mechanism works *given a credential* — and confirms the open question, which is that a PR opened by the automatic `GITHUB_TOKEN` does not trigger its own checks and would sit unmergeable forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)