### PR TITLE
feat(task): expose displaced gate history (DIVE-2133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased — feat(task): displaced gates have a reader with an honest coverage boundary (DIVE-2133)
+
+`gate_history` stopped gate retirement from destroying the previous ask, answer and
+provenance, but nothing could read the table. `task show` now carries a compact previous-gate
+count and `task gate-history <id>` lists the archived ask/answer plus `retired_by` and
+`retired_at`; both human and JSON paths redact secret answers.
+
+An empty archive on an upgraded store is not evidence that no gate was displaced before the
+archive existed. Every store now stamps a conservative `gate_history_coverage` boundary once:
+before the first task on a fresh store, the earliest already-archived row on an upgraded store
+that has evidence, or migration time when it has none. The same value records whether the basis
+is fresh or inferred, so a second-granular timestamp equality is trusted only on a fresh store.
+Readers therefore say a bare `0` only when coverage reaches the task's creation; older tasks
+say `0 recorded` and name the unknown earlier era. `tests/gate_history_unit.sh` covers the detailed
+reader, both `task show` surfaces, secret redaction, complete-vs-partial zero, and the one-time
+migration stamp.
+
 ## Unreleased — fix(up): a skill that FAILED to install is no longer summarised as `errors=0` (DIVE-2347)
 
 `agent create` does not fail when a preseeded skill won't install, and that is the right

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -24,6 +24,8 @@ _task_usage() {
                                                      # the scheduler is actually still driving (schedule set, status=todo);
                                                      # --recurring --all: every template regardless, incl. stopped ones
   5dive task show <id|DIVE-N>                        # full detail + subtasks + blockers
+  5dive task gate-history <id|DIVE-N>                # displaced gates + retirement reason/time;
+                                                     # distinguishes a true zero from pre-archive blindness
   5dive task assign <id|DIVE-N> <agent>
   5dive task verifier <id|DIVE-N> <agent> [--accept=<criteria>] [--max-iters=<n>]
                                                      # DIVE-1880: attach the maker→verifier rail to an ALREADY-FILED open
@@ -251,6 +253,7 @@ cmd_task() {
     add|new)         cmd_task_add "$@" ;;
     ls|list)         cmd_task_ls "$@" ;;
     show|view)       cmd_task_show "$@" ;;
+    gate-history)    cmd_task_gate_history "$@" ;;
     assign)          cmd_task_assign "$@" ;;
     set-branch)      cmd_task_set_branch "$@" ;;
     set-body)        cmd_task_set_body "$@" ;;
@@ -865,14 +868,16 @@ cmd_task_show() {
   [[ $# -gt 0 ]] || fail "$E_USAGE" "usage: 5dive task show <id|DIVE-N>"
   resolve_task_id "$1"; local id="$RESOLVED_TASK_ID"
   if (( JSON_MODE )); then
-    local task subs deps
+    local task subs deps previous_gates
     task=$(dbfmt -json "SELECT * FROM tasks WHERE id=${id};")
     subs=$(dbfmt -json "SELECT id,ident,title,status FROM tasks WHERE parent_id=${id} ORDER BY id;")
     deps=$(dbfmt -json "SELECT t.id,t.ident,t.title,t.status FROM task_deps d JOIN tasks t ON t.id=d.blocked_by WHERE d.task_id=${id} ORDER BY t.id;")
+    previous_gates=$(_gate_history_summary_json "$id")
     [[ -n "$subs" ]] || subs="[]"
     [[ -n "$deps" ]] || deps="[]"
     jq -cn --argjson t "$task" --argjson s "$subs" --argjson b "$deps" \
-      '{ok:true, data:{task:($t[0]), subtasks:$s, blocked_by:$b}}'
+      --argjson g "$previous_gates" \
+      '{ok:true, data:{task:($t[0]), subtasks:$s, blocked_by:$b, previous_gates:$g}}'
   else
     dbfmt -line "SELECT ident, title, status, priority, assignee, created_by, parent_id, created_at, started_at, done_at, body, result FROM tasks WHERE id=${id};"
     # DIVE-1064: surface the creator's isolation tier (read-time from the
@@ -904,6 +909,7 @@ cmd_task_show() {
       *)                    printf 'created_by_tier = %s
 ' "$_ctier" ;;
     esac
+    _gate_history_show_summary "$id"
     # Human gate (only when set) — mirrors the conditional subtasks/blockers
     # blocks below so an ordinary task's `show` stays clean.
     local gate
@@ -950,6 +956,104 @@ cmd_task_show() {
     deps=$(db "SELECT t.ident||'  ['||t.status||']  '||t.title FROM task_deps d JOIN tasks t ON t.id=d.blocked_by WHERE d.task_id=${id} ORDER BY t.id;")
     [[ -n "$deps" ]] && { echo; echo "blocked by:"; printf '%s\n' "$deps" | indent2; }
   fi
+}
+
+# DIVE-2133 — gate_history was an append-only WRITE path with no reader. Keep
+# the summary logic shared by `task show` and the detailed verb so the compact
+# count can never claim stronger archive coverage than the listing beneath it.
+#
+# gate_history_coverage is a conservative evidence boundary, not a release/
+# version guess. Its single value is prefixed fresh: or inferred: so the boundary
+# and its proof basis commit atomically. Fresh stores stamp before their first
+# task. Existing stores stamp the earliest row they can prove was archived, or
+# migration time when the archive is empty. A task older than that boundary may
+# have displaced gates from the blind era, so zero means "zero recorded", never
+# "none existed". Equality is complete only for a fresh store: SQLite timestamps
+# are second-granular, so an upgraded task stamped in the boundary second may
+# still predate the migration.
+_gate_history_facts() {
+  local id="$1" count raw coverage="" basis="unknown" created state="unknown"
+  count=$(db "SELECT COUNT(*) FROM gate_history WHERE task_id=${id};")
+  raw=$(_task_pref_get gate_history_coverage)
+  case "$raw" in
+    fresh:*)    basis="fresh"; coverage="${raw#*:}" ;;
+    inferred:*) basis="inferred"; coverage="${raw#*:}" ;;
+  esac
+  created=$(db "SELECT created_at FROM tasks WHERE id=${id};")
+  if [[ -n "$coverage" ]]; then
+    state="partial"
+    if [[ "$created" > "$coverage" || ( "$basis" == "fresh" && "$created" == "$coverage" ) ]]; then
+      state="complete"
+    fi
+  fi
+  printf '%s|%s|%s|%s\n' "$count" "$coverage" "$state" "$basis"
+}
+
+_gate_history_summary_json() {
+  local id="$1" count coverage state basis complete="null"
+  IFS='|' read -r count coverage state basis < <(_gate_history_facts "$id")
+  case "$state" in
+    complete) complete="true" ;;
+    partial)  complete="false" ;;
+  esac
+  jq -cn --argjson n "${count:-0}" --arg started "$coverage" --arg state "$state" --arg basis "$basis" \
+    --argjson complete "$complete" \
+    '{recorded:$n, coverage_state:$state, coverage_basis:$basis, coverage_complete_for_task:$complete,
+      coverage_started_at:(if $started=="" then null else $started end),
+      history_before_coverage:(if $state=="complete" then "none" else "unknown" end)}'
+}
+
+_gate_history_show_summary() {
+  local id="$1" count coverage state basis
+  IFS='|' read -r count coverage state basis < <(_gate_history_facts "$id")
+  case "$state" in
+    complete) printf 'previous gates = %s\n' "$count" ;;
+    partial)  printf 'previous gates = %s recorded (earlier history unknown; coverage begins %s)\n' "$count" "$coverage" ;;
+    *)        printf 'previous gates = %s recorded (archive coverage NOT measured)\n' "$count" ;;
+  esac
+}
+
+cmd_task_gate_history() {
+  tasks_db_init
+  [[ $# -eq 1 ]] || fail "$E_USAGE" "usage: 5dive task gate-history <id|DIVE-N>"
+  resolve_task_id "$1"
+  local id="$RESOLVED_TASK_ID" ident="$RESOLVED_TASK_IDENT"
+  local summary rows count coverage state basis
+  summary=$(_gate_history_summary_json "$id")
+  if (( JSON_MODE )); then
+    # Deliberately omit need_answer_sig and human_nonce_hash: they prove the
+    # archive internally but are not reader payload. Secret answers are always
+    # redacted on both output paths, matching the live gate in `task show`.
+    rows=$(dbfmt -json "SELECT id, ident, need_type, ask, need_options, recommend, tier,
+          need_asked_at,
+          CASE WHEN need_type='secret' AND need_answer IS NOT NULL
+               THEN '(provided - redacted)' ELSE need_answer END AS need_answer,
+          need_answered_at, need_answered_by, need_answered_uid,
+          CASE WHEN need_answer_sig IS NOT NULL THEN 1 ELSE 0 END AS answer_attested,
+          retired_by, retired_at
+        FROM gate_history WHERE task_id=${id} ORDER BY id;")
+    [[ -n "$rows" ]] || rows="[]"
+    jq -cn --arg id "$ident" --argjson s "$summary" --argjson rows "$rows" \
+      '{ok:true, data:{ident:$id, summary:$s, gates:$rows}}'
+    return
+  fi
+
+  IFS='|' read -r count coverage state basis < <(_gate_history_facts "$id")
+  case "$state" in
+    complete) printf '%s previous gates: %s\n' "$ident" "$count" ;;
+    partial)  printf '%s previous gates: %s recorded — history before %s is unknown\n' "$ident" "$count" "$coverage" ;;
+    *)        printf '%s previous gates: %s recorded — archive coverage is NOT measured\n' "$ident" "$count" ;;
+  esac
+  (( count > 0 )) || return 0
+  dbfmt -box "SELECT id AS seq, need_type AS type, COALESCE(tier,'-') AS tier,
+      COALESCE(need_asked_at,'-') AS asked_at, COALESCE(ask,'-') AS ask,
+      COALESCE(need_options,'-') AS options, COALESCE(recommend,'-') AS recommend,
+      CASE WHEN need_type='secret' AND need_answer IS NOT NULL
+           THEN '(provided - redacted)' ELSE COALESCE(need_answer,'-') END AS answer,
+      COALESCE(need_answered_at,'-') AS answered_at,
+      COALESCE(need_answered_by,'-') AS answered_by,
+      retired_by, retired_at
+    FROM gate_history WHERE task_id=${id} ORDER BY id;"
 }
 
 cmd_task_assign() {

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -670,6 +670,13 @@ CREATE TABLE IF NOT EXISTS task_prefs (
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- DIVE-2133: evidence boundary for the gate_history reader. A fresh store
+-- stamps this before its first task, so zero archived rows can truthfully mean
+-- zero displaced gates. Existing stores stamp conservatively in migration: the
+-- earliest row already present, or migration time when the archive is empty.
+INSERT OR IGNORE INTO task_prefs(key,value)
+  SELECT 'gate_history_coverage', 'fresh:'||datetime('now');
+
 -- OSS-19 (OSS-26, phase A1): outcome-loop objectives. An objective is a standing
 -- goal bound to a READ-ONLY metric command (metric_cmd: stdout -> one number).
 -- The metric is run ONLY by `objective tick` and the digest — NEVER by a planner
@@ -1218,6 +1225,22 @@ CREATE TABLE IF NOT EXISTS task_prefs (
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 MIG
+  fi
+
+  # DIVE-2133: do not let an empty archive assert that the pre-DIVE-2119 era
+  # was quiet. Stamp the earliest PROVEN coverage boundary once. If this store
+  # already archived rows, the first retirement proves the writer was live by
+  # then; otherwise only this migration time is knowable. The read guard avoids
+  # taking a write lock on every command after the one-time stamp.
+  local gate_history_coverage
+  gate_history_coverage=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
+    "SELECT value FROM task_prefs WHERE key='gate_history_coverage';" 2>/dev/null)
+  if [[ -z "$gate_history_coverage" ]]; then
+    sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
+      "INSERT OR IGNORE INTO task_prefs(key,value)
+         SELECT 'gate_history_coverage',
+                'inferred:'||COALESCE((SELECT MIN(retired_at) FROM gate_history), datetime('now'));" \
+      >/dev/null 2>&1 || true
   fi
 
   # OSS-19 (OSS-26) objectives + objective_readings — additive, gated on the

--- a/src/main.sh
+++ b/src/main.sh
@@ -183,7 +183,7 @@ Auth (lower-level; the dashboard uses these — prefer 'account' for human-drive
 Tasks (shared queue, sqlite — any agent, no sudo):
   5dive task add <title...> [--priority=low|medium|high|urgent] [--assignee=<agent>] [--parent=<id>] [--project=<key>]
   5dive task ls [--mine] [--status=<s>] [--all] [--project=<key>]   # open work, priority-ordered
-  5dive task show|start|done|cancel|rm <id|PREFIX-N>
+  5dive task show|gate-history|start|done|cancel|rm <id|PREFIX-N>
   5dive task assign <id|PREFIX-N> <agent>
   5dive task block <id|PREFIX-N> --by=<id|PREFIX-N>
   # full surface: 5dive task --help

--- a/tests/gate_history_unit.sh
+++ b/tests/gate_history_unit.sh
@@ -32,6 +32,8 @@
 #   6. _proof_ledger's need_answered_by arm no longer counts re-file residue,
 #      while its human_nonce_hash arm still counts a delivered-but-unanswered
 #      gate (the deliberate asymmetry — see cmd_proof.sh).
+#   7. the archive is READABLE through task show + task gate-history, with
+#      secret answers redacted and pre-archive blindness stated explicitly.
 # Run: bash tests/gate_history_unit.sh   (no root, no network)
 set -uo pipefail
 
@@ -295,6 +297,115 @@ if [[ "$(led_asks)" == "1" ]]; then
   ok_t "the nonce arm still counts a delivered-but-unanswered gate (conservative)"
 else
   bad_t "the nonce arm must keep its delivered semantics" "asks=$(led_asks)"
+fi
+
+# --- 8. reader: detailed rows + compact task-show summary --------------------
+JSON_MODE=1
+HJSON=$(cmd_task_gate_history "$t1" 2>"$TMP/history-json.err")
+if jq -e '.ok == true and .data.summary.recorded == 1 and
+          .data.summary.coverage_state == "complete" and
+          .data.gates[0].need_answer == "B" and
+          .data.gates[0].retired_by == "file" and
+          (.data.gates[0].retired_at | length > 0)' <<<"$HJSON" >/dev/null; then
+  ok_t "gate-history JSON reads the displaced answer plus retirement reason/time"
+else
+  bad_t "gate-history JSON must expose the archived gate" "$HJSON"
+fi
+
+SHOWJSON=$(cmd_task_show "$t1" 2>"$TMP/show-json.err")
+if jq -e '.data.previous_gates.recorded == 1 and
+          .data.previous_gates.coverage_complete_for_task == true' <<<"$SHOWJSON" >/dev/null; then
+  ok_t "task show JSON carries the compact previous-gate count and coverage state"
+else
+  bad_t "task show JSON must surface the archive summary" "$SHOWJSON"
+fi
+
+JSON_MODE=0
+HSHOW=$(cmd_task_show "$t1" 2>"$TMP/show-human.err")
+if grep -Fq 'previous gates = 1' <<<"$HSHOW"; then
+  ok_t "task show human output surfaces the compact previous-gate count"
+else
+  bad_t "task show human output must surface previous gates" "$HSHOW"
+fi
+
+# --- 9. secret answers never cross the new reader ----------------------------
+JSON_MODE=1
+t8=$(addt --assignee=dev -- "fixture: archived secret is redacted")
+db "INSERT INTO gate_history(task_id,ident,need_type,ask,need_answer,retired_by)
+      SELECT id,ident,'secret','provide fixture secret','DO-NOT-PRINT','withdraw'
+      FROM tasks WHERE id=${t8};"
+SECRET_JSON=$(cmd_task_gate_history "$t8" 2>"$TMP/secret-json.err")
+JSON_MODE=0
+SECRET_HUMAN=$(cmd_task_gate_history "$t8" 2>"$TMP/secret-human.err")
+if [[ "$SECRET_JSON" != *"DO-NOT-PRINT"* && "$SECRET_HUMAN" != *"DO-NOT-PRINT"* ]] \
+   && grep -Fq '(provided - redacted)' <<<"$SECRET_JSON" \
+   && grep -Fq '(provided - redacted)' <<<"$SECRET_HUMAN"; then
+  ok_t "gate-history redacts secret answers in JSON and human output"
+else
+  bad_t "a secret answer crossed the reader" "json=$SECRET_JSON human=$SECRET_HUMAN"
+fi
+
+# --- 10. zero rows: complete evidence vs pre-archive blindness ---------------
+# t5 was created after the fresh-store coverage stamp, so zero is a truthful
+# complete zero. A task moved before the boundary must instead say only zero
+# RECORDED and mark its earlier era unknown.
+JSON_MODE=1
+FRESH_STAMP=$(_task_pref_get gate_history_coverage)
+FRESH_TIME="${FRESH_STAMP#fresh:}"
+db "UPDATE tasks SET created_at=$(sqlq "$FRESH_TIME") WHERE id=${t5};"
+COMPLETE_ZERO=$(cmd_task_gate_history "$t5" 2>"$TMP/complete-zero.err")
+t9=$(addt --assignee=dev -- "fixture: task predates archive coverage")
+db "UPDATE tasks SET created_at='2000-01-01 00:00:00' WHERE id=${t9};"
+PARTIAL_ZERO=$(cmd_task_gate_history "$t9" 2>"$TMP/partial-zero.err")
+if jq -e '.data.summary.recorded == 0 and
+          .data.summary.coverage_complete_for_task == true and
+          .data.summary.coverage_basis == "fresh" and
+          .data.summary.history_before_coverage == "none"' <<<"$COMPLETE_ZERO" >/dev/null; then
+  ok_t "a fresh-store task exactly on the second-granular boundary reports a complete zero"
+else
+  bad_t "fresh-boundary equality must be distinguishable" "$COMPLETE_ZERO"
+fi
+if jq -e '.data.summary.recorded == 0 and
+          .data.summary.coverage_complete_for_task == false and
+          .data.summary.history_before_coverage == "unknown"' <<<"$PARTIAL_ZERO" >/dev/null; then
+  ok_t "a pre-boundary task reports zero recorded with earlier history unknown"
+else
+  bad_t "pre-archive blindness must not render as no displaced gates" "$PARTIAL_ZERO"
+fi
+
+JSON_MODE=0
+PARTIAL_SHOW=$(cmd_task_show "$t9" 2>"$TMP/partial-show.err")
+if grep -Fq 'previous gates = 0 recorded (earlier history unknown; coverage begins ' <<<"$PARTIAL_SHOW"; then
+  ok_t "task show states the blind era on a pre-boundary zero"
+else
+  bad_t "task show must not assert the pre-archive era was quiet" "$PARTIAL_SHOW"
+fi
+
+# --- 11. upgraded store marker: earliest provable row, stamped once ----------
+EARLIEST=$(db "SELECT MIN(retired_at) FROM gate_history;")
+db "DELETE FROM task_prefs WHERE key='gate_history_coverage';"
+tasks_db_init
+STAMPED=$(_task_pref_get gate_history_coverage)
+if [[ -n "$EARLIEST" && "$STAMPED" == "inferred:$EARLIEST" ]]; then
+  ok_t "migration stamps the earliest provable archived row as the coverage boundary"
+else
+  bad_t "migration must use evidence, not a release-date guess" "earliest=$EARLIEST stamped=$STAMPED"
+fi
+tasks_db_init
+if [[ "$(_task_pref_get gate_history_coverage)" == "$STAMPED" ]]; then
+  ok_t "the coverage boundary is immutable after its one-time stamp"
+else
+  bad_t "coverage boundary drifted on a second init"
+fi
+db "UPDATE tasks SET created_at=$(sqlq "$EARLIEST") WHERE id=${t9};"
+JSON_MODE=1
+INFERRED_EQUAL=$(cmd_task_gate_history "$t9" 2>"$TMP/inferred-equal.err")
+if jq -e '.data.summary.coverage_basis == "inferred" and
+          .data.summary.coverage_complete_for_task == false and
+          .data.summary.history_before_coverage == "unknown"' <<<"$INFERRED_EQUAL" >/dev/null; then
+  ok_t "inferred-boundary equality stays partial (timestamps are only second-granular)"
+else
+  bad_t "an inferred same-second task must not be overstated as covered" "$INFERRED_EQUAL"
 fi
 
 printf -- '-----\n'


### PR DESCRIPTION
## What

`gate_history` (DIVE-2119, landed a4d450c / 0.16.27) was a **write-only sink**: all four gate-retirement paths archived the outgoing gate, and no verb could read it back. An audit trail nobody can query is indistinguishable from no audit trail at the moment someone needs it.

This adds the reader:
- `task show <id>` gains a compact `previous gates: N` line
- `task gate-history <id>` lists the archived gates with `retired_by` / `retired_at` / the archived answer text

## The constraint that shaped it

`gate_history` starts **empty on every existing store** and no backfill was possible — the answer text was already overwritten on all 21 pre-fix residue rows. So the reader must distinguish *"no gate was ever displaced here"* from *"this store predates the archive"*. Conflating them would assert the pre-fix era was quiet when it is only **blind**.

It does this with a one-time coverage boundary stamped on first run (`inferred:<earliest retired_at>`, or `inferred:<migration time>` on a true pre-2119 store), and renders `0 recorded - history before <t> is unknown` below the boundary.

## Verification

Maker: codex. Verifier: olivia (`--verifier` loop, iteration 1 rejected for delivery, not substance).

**Verified by olivia directly on the rebased tip `1973b9a`:**
- `tests/gate_history_unit.sh` → **32 passed, 0 failed**
- Runtime on a built bundle against an isolated `TASKS_DIR`: filed a gate, answered `B`, filed a second gate to displace it → `task show` renders `previous gates = 1`, `task gate-history` returns the archived row with `answer=B`, `retired_by=file`
- Rebase integrity: `origin/main` is an ancestor of the tip, and the introduced hunks are **byte-identical** to the earlier `4ada0f1` reviewed at iteration 1 (only a blob index line moved)

**Re-verified because the base moved:** iteration-1 runtime evidence was collected on an older base. `main` has since landed 129 net lines in `src/cmd_task.sh` via 62d98ab (DIVE-2356, nonce minting for tier>=2 gates) and c26e478 (DIVE-2015, maker self-verified closes) — both in the gate machinery this reader reads. Applies-cleanly is not behaves-the-same, so the suite and runtime checks above were re-run on the rebased tip rather than carried over.

**Reported by codex, not independently re-run by olivia:** "affected suites 35/0" (olivia confirmed the 32/0 `gate_history_unit` subset and the runtime behaviour above).

Closes DIVE-2133.


## Rebase verification (appended by dev at codex's request)

**CI is still pending on this head — this section is evidence, not a green claim.**

- Rebased head `27f14202bbc9a624f303fcfc6f0e6367e0dd99fd` on base `6af1ff70e449c06b77702516f675e757cc01148b`.
- `git range-diff`: the `1973b9a` and `27f1420` patches are identical.
- `bash tests/gate_history_unit.sh` on that exact tip: **32 passed, 0 failed** (independently re-run by dev).
- Codex built a bundle, sha256 `8c5873a749bd5da1882879b1366ca32456cc569777d5e8989bbe8eed8ffd75de`, and ran an isolated `TASKS_DIR` smoke on the exact tip: `task show` reported `previous_gates recorded=1` and `coverage_complete_for_task=true`; `task gate-history` returned the archived answer `B` with `retired_by=file`.
