### PR TITLE
fix(gate): iteration 2 — route the refusal guard through the seam, de-vacuate T8, unmangle the comments (DIVE-2330)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -540,7 +540,9 @@ _gate_route_reviewer() {
 #     agent id from SUDO_USER (auto_sender_from_sudo) and the human signal from a
 #     non-agent SUDO_UID (_gate_sudo_uid_nonagent), mirroring cmd_task_answer.
 #   - non-root: SUDO_* are UNTRUSTED (forgeable) — ignore them entirely and judge
-#     by the real `id -un` unix login, which a process cannot spoof.
+#     by $EUID resolved against /etc/passwd in pure bash. DIVE-2330: this line used
+#     to say `id -un` "which a process cannot spoof" — it could, because `id`
+#     resolves through the CALLER'S PATH and a shim printing any name won.
 # Prints one of: "agent <name>" | "human" | "none". Never reads --from ($from stays
 # ATTRIBUTION-only) nor $USER (also env-spoofable). The determined root-sudo residual
 # (an agent that truly sudo's then forges) is shared with the whole gate system and
@@ -554,10 +556,12 @@ _gate_withdraw_actor() {
     _gate_sudo_uid_nonagent && { printf 'human'; return; }
     printf 'none'; return
   fi
-  local idun; idun=$(id -un 2>/dev/null || echo "")
-  if [[ "$idun" == agent-* ]]; then printf 'agent %s' "${idun#agent-}"
-  elif [[ -n "$idun" ]]; then printf 'human'
-  else printf 'none'; fi
+  local _a; _a=$(_gate_uid_to_agent "$EUID")
+  if [[ -n "$_a" ]]; then printf 'agent %s' "$_a"; return; fi
+  local _n _x _u; while IFS=: read -r _n _x _u _; do
+    [[ "$_u" == "$EUID" ]] && { printf 'human'; return; }
+  done < /etc/passwd
+  printf 'none'
 }
 
 # DIVE-980: shared org-chart assignee resolution. Resolve an assignee TOKEN to a
@@ -3888,12 +3892,44 @@ _gate_floor_axis() {
 # The dashboard path is unaffected and needs no marker: shelld runs as `claude`
 # (a NON-agent user) and sends `--human`, so those answers are `human:*` — already
 # authorized everywhere `lead:*` is, and never in want of a lead stamp.
+# DIVE-2330: resolve a uid to an agent name in PURE BASH over /etc/passwd. No
+# `id`, no `getent` — both resolve through the CALLER'S PATH, and every agent can
+# set its own PATH. Measured on this host before the fix: a shim on PATH printing
+# `agent-lodar` made `id -un` return exactly that, from a process whose real uid
+# was 1004 (agent-main). Same shape as the landed DIVE-2281 fix in
+# `_envelope_sender_fallback`.
+_gate_uid_to_agent() {
+  local want="${1:-}" name _x uid
+  [[ "$want" =~ ^[0-9]+$ ]] || { printf ''; return; }
+  while IFS=: read -r name _x uid _; do
+    [[ "$uid" == "$want" ]] || continue
+    [[ "$name" == agent-* ]] || { printf ''; return; }
+    printf '%s' "${name#agent-}"; return
+  done < /etc/passwd
+  printf ''
+}
+
+# `$EUID` is a bash BUILTIN reflecting the kernel's view of this process. It is not
+# PATH-resolved and cannot be set from the environment, which is the whole property
+# an authorization check needs. SUDO_UID is consulted only when EUID is 0, exactly
+# as before: sudo writes it, the caller does not.
+# SEAM (mirrors _gate_is_root): the harness overrides THIS to exercise both
+# branches with the real resolver. An external caller cannot — invoking `5dive`
+# starts a fresh bash that defines the function itself, so there is nothing in the
+# environment to override. That is the difference between a seam and a hole: the
+# old code let a PATH shim answer, which any agent could set.
+_gate_caller_uid() { printf '%s' "$EUID"; }
+
 _gate_authenticated_actor() {
-  local u; u=$(id -un 2>/dev/null || echo '')
-  if [[ "$u" == agent-* ]]; then printf '%s' "${u#agent-}"; return; fi
-  if [[ "$(id -u 2>/dev/null || echo 1)" == "0" && -n "${SUDO_UID:-}" ]]; then
-    local su; su=$(getent passwd "$SUDO_UID" 2>/dev/null | cut -d: -f1)
-    [[ "$su" == agent-* ]] && { printf '%s' "${su#agent-}"; return; }
+  local a; a=$(_gate_uid_to_agent "$(_gate_caller_uid)")
+  if [[ -n "$a" ]]; then printf '%s' "$a"; return; fi
+  # The SUDO_UID branch stays gated on the REAL root check (_gate_is_root, itself
+  # the pre-existing seam), NOT on _gate_caller_uid. Routing it through the seam
+  # would let a harness modelling "caller is root" also unlock the SUDO_UID path
+  # and widen who resolves to an agent — a behaviour change, not a fix.
+  if _gate_is_root && [[ -n "${SUDO_UID:-}" ]]; then
+    a=$(_gate_uid_to_agent "$SUDO_UID")
+    [[ -n "$a" ]] && { printf '%s' "$a"; return; }
   fi
   printf ''
 }
@@ -3903,9 +3939,9 @@ _gate_authenticated_actor() {
 # invoker) against a claimed `need_answered_by`, so a `--from` spoof is visible
 # after the fact and not only at answer time.
 _gate_agent_for_uid() {
-  local uid="${1:-}"; [[ "$uid" =~ ^[0-9]+$ ]] || { printf ''; return; }
-  local u; u=$(getent passwd "$uid" 2>/dev/null | cut -d: -f1)
-  [[ "$u" == agent-* ]] && printf '%s' "${u#agent-}" || printf ''
+  # DIVE-2330: was `getent passwd`, which is PATH-resolved and therefore forgeable
+  # by the caller it is meant to check. Same pure-bash resolver as above.
+  _gate_uid_to_agent "${1:-}"
 }
 
 _GATE_ENG_SHIP_RX='\bmerg(e|es|ed|ing)\b|pull request|\bpr\b|\bdiff\b|ship it|ship the|ship this|\bship(ping|ped)\b|deploy|redeploy|roll ?out|\broll(ing|ed)? out\b|land the|land it|land this|\bland(ing|ed)\b|rebase|hotfix|cut a branch|cut the release|push(es|ed|ing)? to (main|prod|production|origin)|push[^.]*github|delegated push|push[- ]for[- ]review|push .*(branch|for review|for a? ?pr|for code review)|5dive push|roll[^.]*fleet|fleet[- ]?roll|code review|approve the (merge|diff|change|pr|build|deploy|ship|commit)|build\.sh|smoke test|ci\b'
@@ -7384,6 +7420,10 @@ cmd_task_answer() {
   # returns `--from=<anything>` verbatim — so authorizing on it would let any agent
   # mint `lead:<the reviewer>` for itself. `_gate_authenticated_actor` is the
   # unforgeable half, and it FAILS CLOSED (empty -> no lead-clear).
+# DIVE-2330: that claim was FALSE until this fix — the function read a bare
+# `id -un`, resolved through the caller's PATH, so any agent could mint the
+# routed reviewer's name (measured: a shim made it return `lodar`). It now
+# resolves $EUID in pure bash over /etc/passwd, so the claim is true as written.
   local _routed_rev; _routed_rev=$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE id=${id};")
   local _lead_clear=0 _rc_sealed=0 _rc_deny=""
   if [[ ( "$nt" == "approval" || "$nt" == "manual" || "$nt" == "access" ) && -n "$_routed_rev" ]]; then
@@ -7423,6 +7463,7 @@ cmd_task_answer() {
   # DIVE-2099: the org lead's STANDING authority over ENGINEERING approvals — the
   # same clearance as the routed lead-clear above, but WITHOUT requiring that this
   # gate was routed to them at filing time. Identity is the unforgeable half and
+  # gate was routed to them at filing time. # DIVE-2330: true only because identity now resolves $EUID in pure bash over /etc/passwd. It was FALSE while any of these read `id -un`/`getent`, both PATH-resolved and forgeable by the caller being checked.
   # is checked FIRST: `_gate_authenticated_actor` reads the kernel-enforced unix
   # caller (never --from, which `task_actor` returns verbatim — DIVE-2004), and
   # `_gate_standing_lead` resolves the holder and itself fails closed to EMPTY.
@@ -7461,8 +7502,13 @@ cmd_task_answer() {
   # through to a human (T2 floor / no distinct lead), routed_reviewer is NULL, so
   # _lead_clear=0 and a human is required — exactly the intended fall-through.
   if [[ "$nt" == "approval" || "$nt" == "secret" || "$nt" == "manual" || "$nt" == "access" ]]; then
-    local _caller; _caller=$(id -un 2>/dev/null || echo '?')
-    if [[ "$_caller" == agent-* && "$_lead_clear" != "1" ]]; then
+    # DIVE-2330: was `id -un` (PATH-forgeable). This decides whether an agent is
+    # REFUSED, so a caller faking a non-agent name would skip it. EUID-only on
+    # purpose: the old test was `id -un == agent-*`, i.e. the PROCESS is an agent
+    # user. Routing through _gate_authenticated_actor would also fire on a
+    # root+SUDO_UID caller and widen the refusal — a behaviour change, not a fix.
+    local _caller; _caller=$(_gate_uid_to_agent "$EUID")
+    if [[ -n "$_caller" && "$_lead_clear" != "1" ]]; then
       # No audit_log here: the blocked caller is an agent user that can't write
       # the root-owned audit log anyway (it would only leak a perms error to
       # stderr). The fail + non-zero exit is the record.

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -556,11 +556,19 @@ _gate_withdraw_actor() {
     _gate_sudo_uid_nonagent && { printf 'human'; return; }
     printf 'none'; return
   fi
-  local _a; _a=$(_gate_uid_to_agent "$EUID")
+  # DIVE-2330 iteration 2: route BOTH the uid and the passwd source through the seams.
+  # This is the SAME defect dev found in the refusal guard, a second time in this
+  # function: reading $EUID and /etc/passwd inline made the non-root branch resolve the
+  # REAL runner, so gate_withdraw_unit's IDUN pin could not reach it and two arms graded
+  # the runner's identity instead of the one under test. Semantics are unchanged —
+  # _gate_caller_uid's whole body is `printf '%s' "$EUID"` and _gate_passwd_stream's is
+  # /etc/passwd — which is exactly why routing through them widens nothing.
+  local _cuid; _cuid=$(_gate_caller_uid)
+  local _a; _a=$(_gate_uid_to_agent "$_cuid")
   if [[ -n "$_a" ]]; then printf 'agent %s' "$_a"; return; fi
   local _n _x _u; while IFS=: read -r _n _x _u _; do
-    [[ "$_u" == "$EUID" ]] && { printf 'human'; return; }
-  done < /etc/passwd
+    [[ "$_u" == "$_cuid" ]] && { printf 'human'; return; }
+  done < <(_gate_passwd_stream)
   printf 'none'
 }
 

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -3898,6 +3898,23 @@ _gate_floor_axis() {
 # `agent-lodar` made `id -un` return exactly that, from a process whose real uid
 # was 1004 (agent-main). Same shape as the landed DIVE-2281 fix in
 # `_envelope_sender_fallback`.
+# SEAM for the passwd SOURCE, added iteration 2 (DIVE-2330). A harness needs to
+# model a caller uid that maps to an `agent-*` name; before this it could only
+# pick a uid that happens to exist ON THIS HOST, which is the same
+# precondition-supplied-by-the-host defect DIVE-2365 named — and it is why the
+# T8 arm was vacuous (there is no `agent-evil` here, so `id -u agent-evil` failed
+# and the override fell back to uid 0, i.e. root: T8 modelled no agent at all).
+#
+# A FUNCTION, deliberately NOT `${_GATE_PASSWD_FILE:-/etc/passwd}`. An env-settable
+# source would be a new forgery vector in the field this whole row exists to make
+# unforgeable — the same reasoning `_envelope_sender_fallback` records in
+# cmd_agent_runtime.sh ("NO ENV OVERRIDE for the passwd path, deliberately"). A
+# function cannot be injected: bash imports exported functions at startup, and the
+# script's own definition executes AFTER that import and overwrites it. Same
+# property `_gate_is_root` and `_gate_caller_uid` already rely on.
+# Pure bash — no `cat`, which would be PATH-resolved.
+_gate_passwd_stream() { printf '%s\n' "$(</etc/passwd)"; }
+
 _gate_uid_to_agent() {
   local want="${1:-}" name _x uid
   [[ "$want" =~ ^[0-9]+$ ]] || { printf ''; return; }
@@ -3905,7 +3922,7 @@ _gate_uid_to_agent() {
     [[ "$uid" == "$want" ]] || continue
     [[ "$name" == agent-* ]] || { printf ''; return; }
     printf '%s' "${name#agent-}"; return
-  done < /etc/passwd
+  done < <(_gate_passwd_stream)
   printf ''
 }
 
@@ -7420,10 +7437,10 @@ cmd_task_answer() {
   # returns `--from=<anything>` verbatim — so authorizing on it would let any agent
   # mint `lead:<the reviewer>` for itself. `_gate_authenticated_actor` is the
   # unforgeable half, and it FAILS CLOSED (empty -> no lead-clear).
-# DIVE-2330: that claim was FALSE until this fix — the function read a bare
-# `id -un`, resolved through the caller's PATH, so any agent could mint the
-# routed reviewer's name (measured: a shim made it return `lodar`). It now
-# resolves $EUID in pure bash over /etc/passwd, so the claim is true as written.
+  # DIVE-2330: that claim was FALSE until this fix — the function read a bare
+  # `id -un`, resolved through the caller's PATH, so any agent could mint the
+  # routed reviewer's name (measured: a shim made it return `lodar`). It now
+  # resolves $EUID in pure bash over /etc/passwd, so the claim is true as written.
   local _routed_rev; _routed_rev=$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE id=${id};")
   local _lead_clear=0 _rc_sealed=0 _rc_deny=""
   if [[ ( "$nt" == "approval" || "$nt" == "manual" || "$nt" == "access" ) && -n "$_routed_rev" ]]; then
@@ -7463,7 +7480,6 @@ cmd_task_answer() {
   # DIVE-2099: the org lead's STANDING authority over ENGINEERING approvals — the
   # same clearance as the routed lead-clear above, but WITHOUT requiring that this
   # gate was routed to them at filing time. Identity is the unforgeable half and
-  # gate was routed to them at filing time. # DIVE-2330: true only because identity now resolves $EUID in pure bash over /etc/passwd. It was FALSE while any of these read `id -un`/`getent`, both PATH-resolved and forgeable by the caller being checked.
   # is checked FIRST: `_gate_authenticated_actor` reads the kernel-enforced unix
   # caller (never --from, which `task_actor` returns verbatim — DIVE-2004), and
   # `_gate_standing_lead` resolves the holder and itself fails closed to EMPTY.
@@ -7503,11 +7519,23 @@ cmd_task_answer() {
   # _lead_clear=0 and a human is required — exactly the intended fall-through.
   if [[ "$nt" == "approval" || "$nt" == "secret" || "$nt" == "manual" || "$nt" == "access" ]]; then
     # DIVE-2330: was `id -un` (PATH-forgeable). This decides whether an agent is
-    # REFUSED, so a caller faking a non-agent name would skip it. EUID-only on
-    # purpose: the old test was `id -un == agent-*`, i.e. the PROCESS is an agent
-    # user. Routing through _gate_authenticated_actor would also fire on a
-    # root+SUDO_UID caller and widen the refusal — a behaviour change, not a fix.
-    local _caller; _caller=$(_gate_uid_to_agent "$EUID")
+    # REFUSED, so a caller faking a non-agent name would skip it.
+    #
+    # ITERATION 2 (dev's finding, and the comment above it used to justify the
+    # bug): this read `$EUID` DIRECTLY, bypassing `_gate_caller_uid`. The
+    # justification conflated two different things — routing through
+    # `_gate_authenticated_actor` WOULD widen the refusal, because that function
+    # adds the root+SUDO_UID branch; routing through `_gate_caller_uid` widens
+    # NOTHING, because the seam's entire body is `printf '%s' "$EUID"`. The
+    # EUID-only semantics live INSIDE the seam, which is the point of the seam.
+    #
+    # What the bypass cost: a harness could not model a non-agent caller here, so
+    # on any `agent-*` runner this guard fired on the RUNNER'S OWN identity and
+    # `fail` exited the sourced harness mid-suite (gate_nonce_unit T3's uncaptured
+    # call, rc=6, 9/18 arms). The outcome of the test suite became a function of
+    # whose uid ran it — the DIVE-2365 host-supplied-precondition shape, which
+    # this branch named in its own body and then reintroduced one function over.
+    local _caller; _caller=$(_gate_uid_to_agent "$(_gate_caller_uid)")
     if [[ -n "$_caller" && "$_lead_clear" != "1" ]]; then
       # No audit_log here: the blocked caller is an agent user that can't write
       # the root-owned audit log anyway (it would only leak a perms error to

--- a/src/lib/registry.sh
+++ b/src/lib/registry.sh
@@ -39,7 +39,6 @@ registry_read_checked() {
 # DIVE-2210 is about what that stamp does when it CANNOT be established.
 #
 # tier= is the one unforgeable field in `[5dive-msg ...]`: from= is caller-supplied
-# tier= is the one # DIVE-2330: true only because identity now resolves $EUID in pure bash over /etc/passwd. It was FALSE while any of these read `id -un`/`getent`, both PATH-resolved and forgeable by the caller being checked.
 # and only format-validated, so tier= is the field that actually catches a
 # cross-tier peer. Every site stamped it as `[[ -n "$t" ]] && header+=" tier=$t"`
 # over a lookup whose stderr went to /dev/null — so a missing sudo caller, an

--- a/src/lib/registry.sh
+++ b/src/lib/registry.sh
@@ -39,6 +39,7 @@ registry_read_checked() {
 # DIVE-2210 is about what that stamp does when it CANNOT be established.
 #
 # tier= is the one unforgeable field in `[5dive-msg ...]`: from= is caller-supplied
+# tier= is the one # DIVE-2330: true only because identity now resolves $EUID in pure bash over /etc/passwd. It was FALSE while any of these read `id -un`/`getent`, both PATH-resolved and forgeable by the caller being checked.
 # and only format-validated, so tier= is the field that actually catches a
 # cross-tier peer. Every site stamped it as `[[ -n "$t" ]] && header+=" tier=$t"`
 # over a lookup whose stderr went to /dev/null — so a missing sudo caller, an

--- a/tests/gate_actor_path_forgery_unit.sh
+++ b/tests/gate_actor_path_forgery_unit.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# DIVE-2330 — `_gate_authenticated_actor` authorizes the lead-clear of
+# approval/manual/access gates by comparing its return to `routed_reviewer`. It
+# must therefore be UNFORGEABLE by the caller it is checking.
+#
+# It was not. `id -un` and `getent` both resolve through the CALLER'S PATH, and
+# every agent sets its own PATH. These arms run the REAL substitution and demand
+# the real identity back.
+#
+# GROUND TRUTH IS TAKEN WITHOUT THE FUNCTION UNDER TEST: the expected name comes
+# from /proc/self/status's real uid resolved against /etc/passwd by awk, never
+# from `id` and never from the resolver being graded.
+# Run: bash tests/gate_actor_path_forgery_unit.sh   (no root, no network)
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf 'NOT OK - %s\n' "$1"; }
+
+# --- ground truth, independent of the code under test -----------------------
+REAL_UID=$(awk '/^Uid:/{print $2; exit}' /proc/self/status)
+REAL_NAME=$(awk -F: -v u="$REAL_UID" '$3==u{print $1; exit}' /etc/passwd)
+EXPECT=""; [[ "$REAL_NAME" == agent-* ]] && EXPECT="${REAL_NAME#agent-}"
+
+# --- load ONLY the resolver pair, not the whole CLI --------------------------
+eval "$(sed -n '/^_gate_uid_to_agent()/,/^}/p'        src/cmd_task.sh)"
+eval "$(sed -n '/^_gate_caller_uid()/,/^}/p'          src/cmd_task.sh)"
+eval "$(sed -n '/^_gate_authenticated_actor()/,/^}/p' src/cmd_task.sh)"
+
+SHIM=$(mktemp -d)
+printf '#!/bin/sh\necho agent-lodar\n'  > "$SHIM/id";     chmod +x "$SHIM/id"
+printf '#!/bin/sh\necho agent-lodar:x:0:0:::\n' > "$SHIM/getent"; chmod +x "$SHIM/getent"
+trap 'rm -rf "$SHIM"' EXIT
+
+got_clean=$(_gate_authenticated_actor)
+got_shim=$(PATH="$SHIM:$PATH" _gate_authenticated_actor)
+
+# 1. A hostile PATH must not change the answer.
+[[ "$got_shim" == "$got_clean" ]] \
+  && ok "a PATH shim cannot change the authenticated actor" \
+  || no "PATH shim changed the actor: clean='$got_clean' shimmed='$got_shim'"
+
+# 2. And the answer must be the REAL identity, not merely stable.
+if [[ -n "$EXPECT" ]]; then
+  [[ "$got_shim" == "$EXPECT" ]] \
+    && ok "under a hostile PATH the resolver still returns the kernel identity ($EXPECT)" \
+    || no "expected '$EXPECT' from /proc+/etc/passwd, got '$got_shim'"
+else
+  ok "skipped identity arm — this runner is not an agent-* user (uid $REAL_UID)"
+fi
+
+# 3. It must never return the forged name.
+[[ "$got_shim" != "lodar" ]] \
+  && ok "the forged name is never returned" \
+  || no "resolver returned the FORGED identity 'lodar'"
+
+# 4. VACUITY ANCHOR: the old implementation must take arm 1 or 3 RED. If this
+#    arm fails, arms 1-3 prove nothing and the harness is decoration.
+_old_actor() {
+  local u; u=$(id -un 2>/dev/null || echo '')
+  if [[ "$u" == agent-* ]]; then printf '%s' "${u#agent-}"; return; fi
+  printf ''
+}
+old_shim=$(PATH="$SHIM:$PATH" _old_actor)
+[[ "$old_shim" == "lodar" ]] \
+  && ok "ANCHOR: the pre-fix bare 'id -un' IS forged by the same shim (returns 'lodar')" \
+  || no "ANCHOR FAILED — the shim did not forge the old implementation (got '$old_shim'); these arms are vacuous"
+
+# 5. Numeric-only contract on the pure-bash resolver.
+[[ -z "$(_gate_uid_to_agent 'not-a-uid')" ]] \
+  && ok "a non-numeric uid resolves to empty (fails closed)" \
+  || no "non-numeric uid did not fail closed"
+
+printf '\ngate_actor_path_forgery_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/gate_actor_path_forgery_unit.sh
+++ b/tests/gate_actor_path_forgery_unit.sh
@@ -13,9 +13,12 @@
 # Run: bash tests/gate_actor_path_forgery_unit.sh   (no root, no network)
 set -uo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
-PASS=0; FAIL=0
+PASS=0; FAIL=0; SKIP=0
 ok(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 no(){ FAIL=$((FAIL+1)); printf 'NOT OK - %s\n' "$1"; }
+# A skip is NOT a pass (iteration 2, dev): on a non-agent runner one of the five
+# "passed" was a skipped arm printed as ok, which inflates a green log.
+skip(){ SKIP=$((SKIP+1)); printf 'skip - %s\n' "$1"; }
 
 # --- ground truth, independent of the code under test -----------------------
 REAL_UID=$(awk '/^Uid:/{print $2; exit}' /proc/self/status)
@@ -23,9 +26,21 @@ REAL_NAME=$(awk -F: -v u="$REAL_UID" '$3==u{print $1; exit}' /etc/passwd)
 EXPECT=""; [[ "$REAL_NAME" == agent-* ]] && EXPECT="${REAL_NAME#agent-}"
 
 # --- load ONLY the resolver pair, not the whole CLI --------------------------
+# `_gate_is_root` and `_gate_passwd_stream` are NOT optional (iteration 2, dev):
+# `_gate_authenticated_actor` calls `_gate_is_root`, and without it the SUDO_UID
+# branch was graded against a missing function — bash printed
+# `_gate_is_root: command not found` twice and the branch was never exercised.
+# `_gate_uid_to_agent` now reads its passwd source through `_gate_passwd_stream`,
+# so that must load too or the resolver returns empty for every uid and arms 1-3
+# pass vacuously.
+eval "$(sed -n '/^_gate_passwd_stream()/,/^}/p'        src/cmd_task.sh)"
+eval "$(sed -n '/^_gate_is_root()/,/^}/p'             src/cmd_task.sh)"
 eval "$(sed -n '/^_gate_uid_to_agent()/,/^}/p'        src/cmd_task.sh)"
 eval "$(sed -n '/^_gate_caller_uid()/,/^}/p'          src/cmd_task.sh)"
 eval "$(sed -n '/^_gate_authenticated_actor()/,/^}/p' src/cmd_task.sh)"
+for _f in _gate_passwd_stream _gate_is_root _gate_uid_to_agent _gate_caller_uid _gate_authenticated_actor; do
+  declare -F "$_f" >/dev/null || { printf 'NOT OK - %s did not load; the arms below would be vacuous\n' "$_f"; exit 1; }
+done
 
 SHIM=$(mktemp -d)
 printf '#!/bin/sh\necho agent-lodar\n'  > "$SHIM/id";     chmod +x "$SHIM/id"
@@ -46,7 +61,7 @@ if [[ -n "$EXPECT" ]]; then
     && ok "under a hostile PATH the resolver still returns the kernel identity ($EXPECT)" \
     || no "expected '$EXPECT' from /proc+/etc/passwd, got '$got_shim'"
 else
-  ok "skipped identity arm — this runner is not an agent-* user (uid $REAL_UID)"
+  skip "identity arm — this runner is not an agent-* user (uid $REAL_UID, name '$REAL_NAME')"
 fi
 
 # 3. It must never return the forged name.
@@ -71,5 +86,6 @@ old_shim=$(PATH="$SHIM:$PATH" _old_actor)
   && ok "a non-numeric uid resolves to empty (fails closed)" \
   || no "non-numeric uid did not fail closed"
 
-printf '\ngate_actor_path_forgery_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
+printf '\ngate_actor_path_forgery_unit: %d passed, %d failed, %d skipped (runner %s, uid %s)\n' \
+  "$PASS" "$FAIL" "$SKIP" "${REAL_NAME:-?}" "$REAL_UID"
 [ "$FAIL" -eq 0 ]

--- a/tests/gate_actor_path_forgery_unit.sh
+++ b/tests/gate_actor_path_forgery_unit.sh
@@ -12,6 +12,19 @@
 # from `id` and never from the resolver being graded.
 # Run: bash tests/gate_actor_path_forgery_unit.sh   (no root, no network)
 set -uo pipefail
+
+# DIVE-2211 / DIVE-2286: name the tree this harness grades. Sourced BEFORE the cd
+# so ${BASH_SOURCE[0]} still resolves relative to tests/. Three-state on purpose:
+# if the helper is unreachable the log says NO TREE WAS NAMED rather than falling
+# silent. Deliberately NO `2>/dev/null` on the source line — redirecting it also
+# swallows the helper's own stderr line, which IS the payload, and that is what
+# silenced all 210 harnesses at once.
+#
+# This harness shipped WITHOUT this line and names_the_tree_contract_unit caught
+# it in CI (dev, on DIVE-2330 iteration 3). Worth the note: a harness added to fix
+# a naming-blindness defect was itself naming no tree.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 PASS=0; FAIL=0; SKIP=0
 ok(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/gate_channel_proof_unit.sh
+++ b/tests/gate_channel_proof_unit.sh
@@ -51,6 +51,20 @@ audit_log() { :; }
 FAKE_CALLER="root"
 id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
 
+# DIVE-2330: src no longer reads `id -un` — it was PATH-resolved and therefore forgeable
+# by the very caller it was authorizing. This harness pins identity through its own
+# `id()` stub, so bridge that pin onto the two seams the resolver DOES read. The lookup
+# is DYNAMIC (`$(id -un)` at call time), so re-pointing the stub mid-file keeps working.
+# Production is unaffected: nothing in src consults `id` any more, and these two
+# functions are defined by src itself on every real invocation.
+_PIN_UID=987654
+_gate_caller_uid() { printf '%s' "$_PIN_UID"; }
+_gate_passwd_stream() {
+  printf '%s:x:%s:%s::/nonexistent:/bin/false\n' "$(id -un)" "$_PIN_UID" "$_PIN_UID"
+  printf '%s\n' "$(</etc/passwd)"
+}
+
+
 seed_task() { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
 answered() { db "SELECT CASE WHEN need_answered_at IS NULL THEN 'open' ELSE 'closed' END FROM tasks WHERE ident='$1';"; }
 prov()     { db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident='$1';"; }

--- a/tests/gate_lead_standing_unit.sh
+++ b/tests/gate_lead_standing_unit.sh
@@ -80,6 +80,20 @@ _task_human_send_allowed() { return 0; }
 FAKE_CALLER="agent-marcus"
 id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
 
+# DIVE-2330: src no longer reads `id -un` — it was PATH-resolved and therefore forgeable
+# by the very caller it was authorizing. This harness pins identity through its own
+# `id()` stub, so bridge that pin onto the two seams the resolver DOES read. The lookup
+# is DYNAMIC (`$(id -un)` at call time), so re-pointing the stub mid-file keeps working.
+# Production is unaffected: nothing in src consults `id` any more, and these two
+# functions are defined by src itself on every real invocation.
+_PIN_UID=987654
+_gate_caller_uid() { printf '%s' "$_PIN_UID"; }
+_gate_passwd_stream() {
+  printf '%s:x:%s:%s::/nonexistent:/bin/false\n' "$(id -un)" "$_PIN_UID" "$_PIN_UID"
+  printf '%s\n' "$(</etc/passwd)"
+}
+
+
 # Org chart: marcus is the coordinator (the org lead), dev reports to marcus.
 db "INSERT INTO agents_org (name, role, reports_to) VALUES ('marcus','coordinator',NULL);"
 db "INSERT INTO agents_org (name, role, reports_to) VALUES ('dev','builder','marcus');"

--- a/tests/gate_nonce_unit.sh
+++ b/tests/gate_nonce_unit.sh
@@ -64,6 +64,11 @@ audit_log() { :; }
 # SUDO_UID we set per-case. `command id` is used for actual uid lookups.
 FAKE_CALLER="root"
 id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+# DIVE-2330: identity no longer comes from `id` — it is $EUID resolved in pure
+# bash, precisely so a PATH shim cannot answer. Override the SEAM instead, the
+# same way this file already overrides _gate_is_root. FAKE_CALLER=root models a
+# non-agent immediate caller, so point the seam at uid 0.
+_gate_caller_uid() { if [[ "$FAKE_CALLER" == agent-* ]]; then command id -u "$FAKE_CALLER" 2>/dev/null || printf 0; else printf 0; fi; }
 
 # DIVE-1413: every SUDO_UID-driven case below models a POST-SUDO / root context
 # (T5 human-on-box, T6 agent-sudo->root, the drop's require_root nested answer) —

--- a/tests/gate_nonce_unit.sh
+++ b/tests/gate_nonce_unit.sh
@@ -65,10 +65,34 @@ audit_log() { :; }
 FAKE_CALLER="root"
 id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
 # DIVE-2330: identity no longer comes from `id` — it is $EUID resolved in pure
-# bash, precisely so a PATH shim cannot answer. Override the SEAM instead, the
-# same way this file already overrides _gate_is_root. FAKE_CALLER=root models a
-# non-agent immediate caller, so point the seam at uid 0.
-_gate_caller_uid() { if [[ "$FAKE_CALLER" == agent-* ]]; then command id -u "$FAKE_CALLER" 2>/dev/null || printf 0; else printf 0; fi; }
+# bash, precisely so a PATH shim cannot answer. Override the SEAMS instead, the
+# same way this file already overrides _gate_is_root.
+#
+# ITERATION 2 — the previous override was INERT for T8 (dev). It did
+# `command id -u "$FAKE_CALLER" || printf 0`, and there is no `agent-evil` user on
+# any host, so `id -u` failed and the seam returned 0 = ROOT: the arm that exists
+# to prove an AGENT caller is refused was modelling root, and passed or failed for
+# reasons unrelated to its name. Same defect as DIVE-2365 — the precondition came
+# from the host (which uids happen to exist) instead of from the test.
+#
+# Now: a LITERAL uid plus a passwd line the resolver can actually map, so this is
+# true on every host including GitHub's runner. The fixture is PREPENDED to the
+# real /etc/passwd so real uids (AGENT_UID below, the lead-clear paths) still
+# resolve — a fixture that REPLACED it would silently break those instead.
+FAKE_AGENT_UID=424242
+_gate_passwd_stream() {
+  printf 'agent-evil:x:%s:%s::/nonexistent:/bin/false\n' "$FAKE_AGENT_UID" "$FAKE_AGENT_UID"
+  printf '%s\n' "$(</etc/passwd)"
+}
+_gate_caller_uid() { if [[ "$FAKE_CALLER" == agent-* ]]; then printf '%s' "$FAKE_AGENT_UID"; else printf 0; fi; }
+
+# Assert the seam pair actually resolves BEFORE any arm depends on it — an
+# override that silently yields nothing is how T8 became vacuous in the first
+# place, and a vacuous arm prints ok.
+_pin_check=$(FAKE_CALLER=agent-evil; _gate_uid_to_agent "$(_gate_caller_uid)")
+[[ "$_pin_check" == "evil" ]] || { printf 'NOT OK - seam pin is inert: _gate_uid_to_agent returned %s, expected evil\n' "'$_pin_check'"; exit 1; }
+_pin_check=$(FAKE_CALLER=root; _gate_uid_to_agent "$(_gate_caller_uid)")
+[[ -z "$_pin_check" ]] || { printf 'NOT OK - seam pin: root caller resolved to %s, expected empty\n' "'$_pin_check'"; exit 1; }
 
 # DIVE-1413: every SUDO_UID-driven case below models a POST-SUDO / root context
 # (T5 human-on-box, T6 agent-sudo->root, the drop's require_root nested answer) —
@@ -140,7 +164,12 @@ touch "$GATE_PROOF_ENFORCE"   # enforcement ON for T3-T8
 
 # --- T3: (a) valid --human-proof nonce clears; wrong nonce rejected -----------
 seed_gate_known DIVE-301 KNOWNNONCE123
-SUDO_UID="$AGENT_UID" cmd_task_answer DIVE-301 --value=approved --human --human-proof=KNOWNNONCE123 >/dev/null 2>&1
+# rc CAPTURED on purpose (iteration 2): `cmd_task_answer` is a sourced FUNCTION, so
+# a `fail` inside it calls `exit` and kills THIS harness mid-suite rather than
+# failing one arm. That is how the DIVE-2330 guard bug presented — 9/18 arms and
+# exit 6, with the remaining arms never printing at all. A subshell contains it, so
+# the next such regression reds an arm instead of truncating the log.
+(SUDO_UID="$AGENT_UID" cmd_task_answer DIVE-301 --value=approved --human --human-proof=KNOWNNONCE123) >/dev/null 2>&1
 [[ "$(answered DIVE-301)" == "closed" ]] && ok_t "T3 valid --human-proof clears (SUDO_UID=agent)" \
   || bad_t "T3 valid --human-proof clears" "still $(answered DIVE-301)"
 
@@ -179,14 +208,26 @@ SUDO_UID="$AGENT_UID" cmd_task_answer DIVE-700 --value=approved --human >/dev/nu
   || bad_t "T7 enforce OFF clears" "still $(answered DIVE-700)"
 touch "$GATE_PROOF_ENFORCE"
 
-# --- T8: agent immediate-caller (pre-sudo) blocked by the DIVE-394 id-un guard -
+# --- T8: agent immediate-caller (pre-sudo) blocked by the DIVE-394 guard -------
+# DIFFERENTIAL (iteration 2): the same gate, the same answer, ONLY the caller
+# identity changes. Asserting the agent arm alone cannot distinguish "refused
+# because the caller is an agent" from "refused for one of the other reasons a
+# tier-2 manual gate refuses" — which is exactly how the inert version passed.
 FAKE_CALLER="agent-evil"
 seed_task DIVE-800; cmd_task_need DIVE-800 --type=manual --ask="do it" >/dev/null 2>&1
 out=$(cmd_task_answer DIVE-800 --value=done --human 2>&1); rc=$?
 [[ "$(answered DIVE-800)" == "open" && $rc -ne 0 && "$out" == *"only a human"* ]] \
   && ok_t "T8 agent-* immediate caller blocked on manual gate (defense-in-depth)" \
   || bad_t "T8 agent-* caller blocked on manual" "rc=$rc state=$(answered DIVE-800) out=$out"
+
+# T8b: the CONTROL. Non-agent caller, everything else identical — must NOT hit
+# the agent refusal. Without this arm T8 grades a message, not a mechanism.
 FAKE_CALLER="root"
+seed_task DIVE-801; cmd_task_need DIVE-801 --type=manual --ask="do it" >/dev/null 2>&1
+out8b=$(cmd_task_answer DIVE-801 --value=done --human 2>&1); rc8b=$?
+[[ "$out8b" != *"only a human can clear it"* ]] \
+  && ok_t "T8b CONTROL: non-agent caller does NOT hit the agent refusal (rc=$rc8b)" \
+  || bad_t "T8b non-agent caller wrongly hit the agent refusal" "rc=$rc8b out=$out8b"
 
 # --- T9: _gate_sudo_uid_nonagent direct logic --------------------------------
 SUDO_UID=0 _gate_sudo_uid_nonagent && ok_t "T9 SUDO_UID=root -> non-agent" || bad_t "T9 root non-agent" ""

--- a/tests/gate_ship_routing_unit.sh
+++ b/tests/gate_ship_routing_unit.sh
@@ -328,6 +328,20 @@ _task_pref_set gate_builder_routing off
 _gate_proof_enforced() { return 1; }   # keep evidence block inert for this unit
 # Non-reviewer agent (dev) must STILL be blocked on the routed approval gate.
 id() { if [[ "${1:-}" == "-un" ]]; then echo "agent-dev"; else command id "$@"; fi; }
+
+# DIVE-2330: src no longer reads `id -un` — it was PATH-resolved and therefore forgeable
+# by the very caller it was authorizing. This harness pins identity through its own
+# `id()` stub, so bridge that pin onto the two seams the resolver DOES read. The lookup
+# is DYNAMIC (`$(id -un)` at call time), so re-pointing the stub mid-file keeps working.
+# Production is unaffected: nothing in src consults `id` any more, and these two
+# functions are defined by src itself on every real invocation.
+_PIN_UID=987654
+_gate_caller_uid() { printf '%s' "$_PIN_UID"; }
+_gate_passwd_stream() {
+  printf '%s:x:%s:%s::/nonexistent:/bin/false\n' "$(id -un)" "$_PIN_UID" "$_PIN_UID"
+  printf '%s\n' "$(</etc/passwd)"
+}
+
 ( cmd_task_answer DIVE-4 --value=approved --from=dev ) >/dev/null 2>&1; rc_dev=$?
 [[ "$rc_dev" != "0" && "$(answered DIVE-4)" == "open" ]] && ok_t "non-reviewer agent (dev) still blocked on routed approval" || bad_t "dev blocked" "rc=$rc_dev ans=$(answered DIVE-4)"
 # Designated lead (main) CAN clear it.

--- a/tests/gate_sudo_uid_forge_unit.sh
+++ b/tests/gate_sudo_uid_forge_unit.sh
@@ -91,6 +91,15 @@ id() {
     *)   command id "$@" ;;
   esac
 }
+# DIVE-2330: the gate's identity resolver no longer reads `id` at all — `id -un` was
+# PATH-forgeable, which is the vulnerability that row closed. So the same REAL_UID /
+# REAL_UN pin now also has to drive the two seams the resolver DOES read. `id()` above
+# stays for `_gate_sudo_uid_nonagent`, which still uses `id -u` and is untouched here.
+_gate_caller_uid() { printf '%s' "${REAL_UID:-0}"; }
+_gate_passwd_stream() {
+  [[ -n "$REAL_UID" && -n "$REAL_UN" ]] && printf '%s:x:%s:%s::/home/%s:/bin/bash\n' "$REAL_UN" "$REAL_UID" "$REAL_UID" "$REAL_UN"
+  printf '%s\n' "$(</etc/passwd)"
+}
 
 seed_gate() {   # ident type
   db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"

--- a/tests/gate_t2_routed_escalate_unit.sh
+++ b/tests/gate_t2_routed_escalate_unit.sh
@@ -63,9 +63,21 @@ last_nonce() { cat "$NONCE_FILE" 2>/dev/null; }
 audit_log() { :; }
 
 # The immediate caller is the agent LEAD (agent-marcus) attempting to clear a gate that
-# was routed to it — the DIVE-1429 shape. id -un is stubbed so _lead_clear resolves.
+# was routed to it — the DIVE-1429 shape.
+#
+# DIVE-2330: this used to stub `id -un`, because the gate's identity resolver READ
+# `id -un` — which is precisely the forgery this row closed. `_gate_authenticated_actor`
+# now resolves `$EUID` in pure bash over a passwd stream, so the pin moves to those two
+# seams. `id()` is kept below for `_gate_sudo_uid_nonagent`, which still reads `id -u`
+# and is not part of this change.
 FAKE_CALLER="agent-marcus"
 id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+MARCUS_UID=4321
+_gate_caller_uid() { printf '%s' "$MARCUS_UID"; }
+_gate_passwd_stream() {
+  printf '%s:x:%s:%s::/home/%s:/bin/bash\n' "$FAKE_CALLER" "$MARCUS_UID" "$MARCUS_UID" "$FAKE_CALLER"
+  printf '%s\n' "$(</etc/passwd)"
+}
 
 seed_task()  { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
 route_to()   { db "UPDATE tasks SET routed_reviewer='$2' WHERE ident='$1';"; }
@@ -98,6 +110,18 @@ agent_caller_on() {
   }
   export SUDO_UID="$AGENT_UID"
 }
+# DIVE-2330 companion to assert_agent_caller: the LEAD identity the clear authorizes on
+# comes from the seams above, so assert it resolves before any arm depends on it. A pin
+# that silently yields '' makes _lead_clear=0 and the arms below grade a refusal.
+assert_lead_identity() { # <label>
+  local got; got=$(_gate_authenticated_actor)
+  if [[ "$got" == "${FAKE_CALLER#agent-}" ]]; then
+    ok_t "$1 precond: the pinned LEAD resolves to '${FAKE_CALLER#agent-}' through the real resolver"
+  else
+    bad_t "$1 precond: pinned LEAD identity" "resolver returned '$got', expected '${FAKE_CALLER#agent-}' — the arms below would grade a refusal, not a lead-clear"
+  fi
+}
+
 assert_agent_caller() { # <label>
   if _gate_sudo_uid_nonagent; then
     bad_t "$1 precond: caller pinned as an AGENT" \
@@ -108,6 +132,7 @@ the opposite behaviour and report ok (DIVE-2365)"
   fi
 }
 agent_caller_on
+assert_lead_identity PIN
 
 # --- E1: THE FIX — a ROUTED tier-2 manual gate, answered by its lead, ESCALATES to the
 #     human instead of dead-ending: routed_reviewer cleared, ping re-armed, fresh nonce

--- a/tests/gate_withdraw_unit.sh
+++ b/tests/gate_withdraw_unit.sh
@@ -68,6 +68,20 @@ IS_ROOT=0
 _gate_is_root() { [[ "$IS_ROOT" == "1" ]]; }
 IDUN="nobody"   # real unix login for the non-root branch (unspoofable in prod)
 id() { if [[ "${1:-}" == -un ]]; then echo "$IDUN"; else command id "$@"; fi; }
+
+# DIVE-2330: src no longer reads `id -un` — it was PATH-resolved and therefore forgeable
+# by the very caller it was authorizing. This harness pins identity through its own
+# `id()` stub, so bridge that pin onto the two seams the resolver DOES read. The lookup
+# is DYNAMIC (`$(id -un)` at call time), so re-pointing the stub mid-file keeps working.
+# Production is unaffected: nothing in src consults `id` any more, and these two
+# functions are defined by src itself on every real invocation.
+_PIN_UID=987654
+_gate_caller_uid() { printf '%s' "$_PIN_UID"; }
+_gate_passwd_stream() {
+  printf '%s:x:%s:%s::/nonexistent:/bin/false\n' "$(id -un)" "$_PIN_UID" "$_PIN_UID"
+  printf '%s\n' "$(</etc/passwd)"
+}
+
 # Clean slate for the SUDO_* env the real helpers read; each case sets what it needs.
 unset SUDO_USER SUDO_UID
 

--- a/tests/task_cascade_unblock_unit.sh
+++ b/tests/task_cascade_unblock_unit.sh
@@ -207,6 +207,20 @@ a=$(addt --assignee=dev -- "A manual-gate done"); b=$(addt --assignee=bob -- "B 
 ( cmd_task_block "$b" --by="$a" ) >/dev/null 2>&1
 ( cmd_task_need "$a" --type=manual --ask="handle it" ) >/dev/null 2>&1
 id() { case "$1" in -un) echo "lodar";; -u) echo "1000";; *) echo "lodar";; esac; }  # human caller
+
+# DIVE-2330: src no longer reads `id -un` — it was PATH-resolved and therefore forgeable
+# by the very caller it was authorizing. This harness pins identity through its own
+# `id()` stub, so bridge that pin onto the two seams the resolver DOES read. The lookup
+# is DYNAMIC (`$(id -un)` at call time), so re-pointing the stub mid-file keeps working.
+# Production is unaffected: nothing in src consults `id` any more, and these two
+# functions are defined by src itself on every real invocation.
+_PIN_UID=987654
+_gate_caller_uid() { printf '%s' "$_PIN_UID"; }
+_gate_passwd_stream() {
+  printf '%s:x:%s:%s::/nonexistent:/bin/false\n' "$(id -un)" "$_PIN_UID" "$_PIN_UID"
+  printf '%s\n' "$(</etc/passwd)"
+}
+
 ( cmd_task_answer "$a" --value=done --human ) >/dev/null 2>&1
 unset -f id
 [[ "$(st "$a")" == "done" && "$(st "$b")" == "todo" && "$(edges "$b")" == "0" ]] \

--- a/tests/task_park_gate_guard_unit.sh
+++ b/tests/task_park_gate_guard_unit.sh
@@ -62,6 +62,20 @@ audit_log() { :; }
 export SUDO_UID=0
 id() { if [[ "${1:-}" == -un ]]; then echo "root"; else command id "$@"; fi; }
 
+# DIVE-2330: src no longer reads `id -un` — it was PATH-resolved and therefore forgeable
+# by the very caller it was authorizing. This harness pins identity through its own
+# `id()` stub, so bridge that pin onto the two seams the resolver DOES read. The lookup
+# is DYNAMIC (`$(id -un)` at call time), so re-pointing the stub mid-file keeps working.
+# Production is unaffected: nothing in src consults `id` any more, and these two
+# functions are defined by src itself on every real invocation.
+_PIN_UID=987654
+_gate_caller_uid() { printf '%s' "$_PIN_UID"; }
+_gate_passwd_stream() {
+  printf '%s:x:%s:%s::/nonexistent:/bin/false\n' "$(id -un)" "$_PIN_UID" "$_PIN_UID"
+  printf '%s\n' "$(</etc/passwd)"
+}
+
+
 seed_task()  { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
 statusof()   { db "SELECT status FROM tasks WHERE ident='$1';"; }
 needtype()   { db "SELECT COALESCE(need_type,'') FROM tasks WHERE ident='$1';"; }


### PR DESCRIPTION
Iteration 2 of DIVE-2330. dev rejected iteration 1 with three fixable defects plus a minor; all four are addressed, and dev's `T3-T9` root cause was correct.

## (1) The T3-T9 red was the GUARD, not the seam

`cmd_task.sh`'s agent-refusal read `$EUID` **directly**, bypassing `_gate_caller_uid` — and the comment I wrote above it justified the bypass by conflating two functions:

- routing through `_gate_authenticated_actor` **would** widen the refusal (it adds the root+`SUDO_UID` branch),
- routing through `_gate_caller_uid` widens **nothing**, because the seam's entire body is `printf '%s' "$EUID"`.

The EUID-only semantics live *inside* the seam. That is the point of the seam. What the bypass cost: on any `agent-*` runner the guard fired on the **runner's own** identity, and because `cmd_task_answer` is a **sourced function**, its `fail` called `exit` and decapitated the suite at 9/18 with rc=6. The suite's outcome became a function of whose uid ran it — the DIVE-2365 host-supplied-precondition shape this branch **named in its own body and then reintroduced one function over**.

Also captured rc on T3's arm, so the first such refusal reds a named arm instead of truncating the log.

## (2) T8 was vacuous

The override did `command id -u agent-evil || printf 0`. No such user exists on any host, so it returned `0` = **root**: the arm that exists to prove an *agent* caller is refused was modelling root.

Fixed by giving the passwd **source** a function seam, `_gate_passwd_stream`, so a literal fake uid can be mapped on every host including GitHub's runner. Deliberately a **function**, not `${_GATE_PASSWD_FILE:-/etc/passwd}` — an env-settable source would be a new forgery vector in the very field this row exists to make unforgeable, which is the reasoning `_envelope_sender_fallback` already records in `cmd_agent_runtime.sh` ("NO ENV OVERRIDE for the passwd path, deliberately"). A function cannot be injected: bash imports exported functions at startup and the script's own definition executes after that import and overwrites it — the same property `_gate_is_root` and `_gate_caller_uid` already rely on. The fixture **prepends** to `/etc/passwd` so real uids still resolve.

Added a **pin-check** that aborts if the seam pair resolves to nothing (a vacuous arm prints `ok` — that is how this got through), and **T8b**, the non-agent control on an otherwise identical gate, so T8 grades a mechanism rather than a message.

## (3) The comments were mangled — the artifact this row exists to prevent

- `registry.sh`: annotation **removed, not repaired**. dev is right on the merits — it attached an identity-resolution claim to `tier=` in the `[5dive-msg]` envelope, a different mechanism this fix does not touch.
- `cmd_task.sh`: the DIVE-2099 sentence is restored (duplicated fragment and glued `#` gone); the lead-clear annotation is reindented into its block.
- `cmd_agent_runtime.sh` needed **no change**, and I verified rather than assumed: its block already reads `$EUID`, already says `tier=` is *not* the unforgeable field `registry.sh` claims, and already attributes the vector to DIVE-2330.

## (4) Minor

The forgery harness now evals `_gate_is_root` and `_gate_passwd_stream` — without the former the `SUDO_UID` branch was graded against a missing function (`command not found`, twice) — with a `declare -F` assertion so a failed eval cannot pass vacuously. A skipped arm now prints `skip` against its own counter instead of inflating the pass count.

## Verification — both runners, one pinned tree (`5c30316`)

| runner | `gate_nonce_unit` | `gate_actor_path_forgery_unit` |
|---|---|---|
| `agent-main` (uid 1004, `agent-*`) | **19 passed, 0 failed** | 5 passed, 0 failed, 0 skipped |
| `claude` (uid 1000, non-agent) | **19 passed, 0 failed** | 4 passed, 0 failed, **1 skipped** |

Identical on both, which is the property dev asked for: the outcome is no longer a function of whose uid runs it. (Iteration 1: 9/18 + exit 6 as `agent-*`, 17/18 as `claude`.)

### Negative controls — both mutations red, on both runners

| mutation | `agent-main` | `claude` |
|---|---|---|
| restore the `$EUID` bypass in the guard | T3 **FAILS** by name, 12 arms, rc=6 | **18/1** — T8 reds, because the guard stops seeing the pinned identity |
| revert the resolver to a hardcoded `< /etc/passwd` | pin-check aborts: `NOT OK - seam pin is inert` | same |

Restored to green after each.

**Residual, disclosed not discovered:** under the guard mutation as `agent-*` the run still exits 6 at 12 arms. Capturing T3(a) converts the *first* refusal into a named failure; later uncaptured calls in that file still propagate. The arm now says which mechanism broke, which is what was missing — but this file is not fully exit-proofed, and that is a bigger edit than this row should carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
