### PR TITLE
feat(ledger): one append-only lifecycle log with the authority envelope (INST-4, phase A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Unreleased — feat(ledger): one append-only lifecycle log with the authority envelope (INST-4, phase A)
+
+We were already event-sourcing, in four separate append-only silos — `supervisor_events`,
+`objective_readings`, the council lineage, and the `_audit_append` log. Each is correct and each
+answers a different question, which is the problem: none can answer "who was authorized to do
+this, why, and what happened next", because the answer is split across four schemas with four
+notions of actor and no shared key. `5dive trace` had to hand-join transition *columns* on the
+tasks row to fake one timeline.
+
+`lifecycle_events` is that one log. Every row carries the full envelope: actor, **authority**
+(`root` / `sudo:<who>` / `self` — the elevation the audit log has never recorded), parent,
+idempotency key, input/output digests, policy decision, usage and host. `ledger_emit` hashes
+`in=`/`out=` payloads itself, so a call site physically cannot write content into the table;
+a secret gate contributes no digest at all.
+
+Additive by construction. No existing write was moved or removed, the state machine is
+untouched, and a ledger write can never fail the action it describes. `trace` gains a `ledger:`
+section shown *beside* the derived timeline rather than merged into it — one is reconstructed
+from current state, the other was recorded at the time, and where they disagree that is the
+finding.
+
+An empty ledger has two meanings and the rows cannot separate them, so init stamps a
+`ledger_started` marker once and `trace` says which it is: no events, predates the ledger, or —
+if the marker is missing — unknown. Emitters are live on task create/start/deliver/done/cancel,
+gate file/answer, policy refusal, and ship/rollback. Remaining lifecycle sites and the four
+silos still write only where they write today; folding them in is the next phase.
+`tests/ledger_unit.sh` covers the migration on a store that already has the neighbouring silos,
+marker idempotency, the no-raw-payload property (mutation-graded), idempotency in both
+directions, and the never-fails-the-caller contract.
+
 ## Unreleased — feat(task): displaced gates have a reader with an honest coverage boundary (DIVE-2133)
 
 `gate_history` stopped gate retirement from destroying the previous ask, answer and

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -2445,12 +2445,14 @@ $_body"
   # anything a maker typed, and the ledger must stay safe to read at a lower
   # privilege than the board it describes.
   #
-  # A `done` that DELIVERS (maker→verifier handoff) is not a close, and recording
-  # it as one would make the ledger claim work was finished that is still waiting
-  # to be graded — the exact overstatement the verifier rail exists to prevent.
+  # A `done` that DELIVERS never gets here — it forks earlier into the handoff
+  # write, which emits task.delivered itself. What CAN arrive here carrying a
+  # handoff_ack is the verifier picking the review up, and that is `task.review`,
+  # a third state distinct from both delivered and done. Conflating it with
+  # either would put a claim in the ledger that the rail was built to refuse.
   local _lk="task.${newstatus}"
   [[ "$newstatus" == "in_progress" ]] && _lk="task.started"
-  [[ -n "$handoff_ack" ]] && _lk="task.delivered"
+  [[ -n "$handoff_ack" ]] && _lk="task.review"
   #
   # actor= is the BOARD identity (task_actor), not the OS user the default
   # resolver would supply. The smoke run that caught this had task.created say
@@ -2686,6 +2688,20 @@ _task_route_to_verifier() {
       WHERE id=${id};"
   local iter; iter=$(db "SELECT iteration FROM tasks WHERE id=${id};")
   local ident; ident=$(ident_of "$id")
+  # INST-4: the maker→verifier DELIVERY.
+  #
+  # Emitted here and not from _task_status_cmd, because a `task done` that
+  # delivers never reaches _task_status_cmd — it forks earlier, into this
+  # handoff write. The first cut of this change assumed one funnel and shipped a
+  # ledger with no delivered event at all; the e2e caught it because the row was
+  # simply absent, which is the one shape a ledger cannot self-report.
+  #
+  # The distinction is load-bearing, not cosmetic: a delivery is NOT a close. A
+  # ledger that recorded it as `task.done` would attest that work was finished
+  # while it is still waiting to be graded — the precise overstatement the
+  # verifier rail exists to prevent, asserted by our own evidence base.
+  ledger_emit task.delivered ident="$ident" task_id="$id" actor="$(task_actor "")" \
+    out="${result:-}" detail="delivered to verifier ${vfier} (iteration ${iter}; awaiting ACK)"
   ok "$ident ready for review — delivered to verifier '$vfier' (iteration $iter; awaiting ACK)" \
      '{id:($i|tonumber), ident:$id, status:"todo", routedTo:$v, role:"verifier", handoff:"delivered", acknowledged:false, iteration:($n|tonumber)}' \
      --arg i "$id" --arg id "$ident" --arg v "$vfier" --arg n "$iter"

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -751,6 +751,14 @@ cmd_task_add() {
   # Ident is stamped by the AFTER INSERT trigger from the project's counter, so
   # read it back rather than assuming the DIVE- prefix (DIVE-484).
   local ident; ident=$(db "SELECT ident FROM tasks WHERE id=${id};")
+  # INST-4: first row of this task's lifecycle. The title is hashed as the input
+  # payload rather than stored twice — tasks.title is already the authority on
+  # what was asked, and the digest is what lets a reader prove the title was not
+  # edited after the fact.
+  ledger_emit task.created ident="$ident" task_id="$id" \
+    parent="$(db "SELECT COALESCE(p.ident,'') FROM tasks t LEFT JOIN tasks p ON p.id=t.parent_id WHERE t.id=${id};" 2>/dev/null)" \
+    actor="$creator" in="$title" \
+    detail="${priority} → ${assignee:-unassigned}${verifier:+ (verifier ${verifier})}"
   if [[ "$kind" == "recurring" ]]; then
     ok "created recurring ${ident} (${recurring}, fresh=$([[ "$fresh_sql" == "1" ]] && echo on || echo off)) — $title" \
        '{id:($i|tonumber), ident:$id, project:$pr, title:$t, priority:$p, assignee:$a, created_by:$c, kind:"recurring", schedule:$s, fresh:($f=="1")}' \
@@ -2429,6 +2437,30 @@ $_body"
       _task_close_notify "$ident" "$verb" "$result" || true
     fi
   fi
+  # INST-4: the state transition, on the unified timeline.
+  #
+  # Emitted from the ONE place all three verbs funnel through, not from the three
+  # cmd_task_{start,done,cancel} wrappers, so a fourth verb added later cannot
+  # ship without its ledger row. The `result` is hashed, not stored: it can carry
+  # anything a maker typed, and the ledger must stay safe to read at a lower
+  # privilege than the board it describes.
+  #
+  # A `done` that DELIVERS (maker→verifier handoff) is not a close, and recording
+  # it as one would make the ledger claim work was finished that is still waiting
+  # to be graded — the exact overstatement the verifier rail exists to prevent.
+  local _lk="task.${newstatus}"
+  [[ "$newstatus" == "in_progress" ]] && _lk="task.started"
+  [[ -n "$handoff_ack" ]] && _lk="task.delivered"
+  #
+  # actor= is the BOARD identity (task_actor), not the OS user the default
+  # resolver would supply. The smoke run that caught this had task.created say
+  # `dev` and task.started say `agent-dev` for the same person on the same task —
+  # two rows in one timeline disagreeing about who acted, which is precisely the
+  # failure the shared _actor_identity resolver was meant to prevent. A default
+  # is only shared if every site actually takes it.
+  ledger_emit "$_lk" ident="$ident" task_id="$id" actor="$(task_actor)" out="$result" \
+    detail="$verb${handoff_ack:+ → verifier ${handoff_ack}}"
+
   local ok_msg="$ident $verb"
   [[ -n "$handoff_ack" ]] && ok_msg+=" — verifier ACK: reviewing"
   ok "$ok_msg" \
@@ -5127,6 +5159,13 @@ cmd_task_need() {
       WHERE id=${id};
       COMMIT;"
 
+  # INST-4: the gate is the authority record — who asked whom for permission, at
+  # what tier. The ask text is hashed, not stored: a tier-2 ask routinely names
+  # the money, the box, or the destructive verb it is asking about.
+  ledger_emit gate.filed ident="$ident" task_id="$id" actor="$actor" \
+    policy="tier${tier}:${type}" in="$ask" \
+    detail="${type} gate filed at tier ${tier}${recommend:+ (recommend: ${recommend})}"
+
   # DIVE-891 tier 0: apply the recommendation right now — the gate exists only
   # as a signed-off record in the log/digest, never as a ping. Provenance is
   # 'auto:t0' (never human:*, so a loop approval gate can NOT be advanced this
@@ -7677,6 +7716,24 @@ cmd_task_answer() {
     (( value_set )) || fail "$E_USAGE" "--value is required (the human's answer)"
     db "UPDATE tasks SET need_answer=$(sqlq "$value"), need_answered_at=$(sqlq "$_ts"), need_answered_by=$(sqlq "$answered_by"), need_answered_uid=${_uidsql}, need_answer_sig=$(sqlq "$_sig") WHERE id=${id};"
   fi
+
+  # INST-4: the gate CLEAR — the row that decides whether this task's timeline
+  # reads "zero-human" or "a human authorized it", so it is worth more care than
+  # the emits around it.
+  #
+  # Provenance is read BACK OUT of the row, not taken from $answered_by, for the
+  # DIVE-2090 reason spelled out below: the shell variable is the intent to
+  # write, and only the persisted column is the state that landed. A ledger that
+  # records intent would attest to clears that never happened.
+  #
+  # The answer VALUE is hashed, never stored — and for a secret gate not even
+  # hashed: `_vfs` is empty there by construction, so the one gate type whose
+  # payload is a live credential contributes no digest at all. A digest of a
+  # short, guessable answer is not the protection it looks like.
+  local _lg_prov; _lg_prov=$(db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE id=${id};" 2>/dev/null)
+  ledger_emit gate.answered ident="$ident" task_id="$id" actor="${_lg_prov:-unknown}" \
+    policy="tier${gtier}:${nt}" out="$_vfs" \
+    detail="${nt} gate cleared by ${_lg_prov:-<unrecorded>}$([[ "$_lg_prov" == human:* ]] && echo ' (human touchpoint)')"
 
   # DIVE-2099: the authoritative record of a STANDING-authority clear. Emitted
   # AFTER the write and reading `need_answered_by` BACK OUT of the row, so it

--- a/src/cmd_trace.sh
+++ b/src/cmd_trace.sh
@@ -137,6 +137,38 @@ cmd_trace() {
              WHERE EXISTS (SELECT 1 FROM json_each(loop_runs.child_task_ids)
                            WHERE json_each.value=${id});" 2>/dev/null || true)
 
+  # ---- INST-4: the unified lifecycle ledger ------------------------------
+  # `trace` is the ledger's forcing function and its first consumer. The timeline
+  # above is DERIVED — it reconstructs the story from transition columns on the
+  # tasks row, which means it can only ever show what the current state implies:
+  # one gate (the latest), no authority, no elevation, no idempotency, and
+  # nothing at all about an event that left no column behind. The ledger section
+  # is the RECORDED story, with the full envelope per row.
+  #
+  # The two are shown side by side rather than merged. They are different kinds
+  # of evidence — derived-from-state vs recorded-at-the-time — and a merged view
+  # would let a reader cite a reconstruction as if it were a witness. Where they
+  # disagree, that disagreement is itself the finding.
+  local ledger_json='[]' ledger_started="" ledger_predates=0
+  ledger_json=$(dbfmt -json "
+    SELECT ts, kind, actor, authority, COALESCE(policy_decision,'') AS policy,
+           COALESCE(input_hash,'')  AS in_hash,
+           COALESCE(output_hash,'') AS out_hash,
+           COALESCE(detail,'')      AS detail
+      FROM lifecycle_events WHERE ident=$(sqlq "$ident") ORDER BY id;" 2>/dev/null)
+  [[ -n "$ledger_json" ]] || ledger_json='[]'
+  ledger_started=$(db "SELECT value FROM task_prefs WHERE key='ledger_started';" 2>/dev/null || true)
+  # An empty ledger has TWO meanings and the reader cannot tell them apart from
+  # the rows: "nothing happened" and "this work predates the ledger". Only the
+  # start marker separates them, which is the whole reason it is written at init.
+  # Stating the wrong one is the absent-vs-forbidden conflation this codebase has
+  # paid for repeatedly (DIVE-1989, DIVE-2318) — so we say which it is, or, if
+  # the marker itself is missing, that we could not tell.
+  if [[ -n "$ledger_started" ]]; then
+    local _created; _created=$(db "SELECT COALESCE(created_at,'') FROM tasks WHERE id=${id};" 2>/dev/null)
+    [[ -n "$_created" && "$_created" < "$ledger_started" ]] && ledger_predates=1
+  fi
+
   # ---- audit-log references (best-effort, read-only) ---------------------
   # The tamper-evident agent-audit log (640 root:claude) records mutating verbs
   # with their real caller. Lines mentioning this ident are extra provenance —
@@ -175,6 +207,8 @@ cmd_trace() {
       --arg loop "$loop" \
       --argjson events "$events" --argjson audit "$audit_json" \
       --argjson audit_drops "$audit_drops" \
+      --argjson ledger "$ledger_json" --arg ledger_started "$ledger_started" \
+      --argjson ledger_predates "$ledger_predates" \
       --arg ancestors "$ancestors" \
       '{ok:true, data:{
          ident:$ident, title:$title, status:$status, assignee:$assignee,
@@ -188,6 +222,14 @@ cmd_trace() {
            loop:(if $loop=="" then null else $loop end)
          },
          timeline:$events,
+         ledger:{
+           events:$ledger,
+           started_at:(if $ledger_started=="" then null else $ledger_started end),
+           predates_ledger:($ledger_predates==1),
+           coverage:(if $ledger_started=="" then "unknown — no ledger start marker"
+                     elif $ledger_predates==1 then "partial — task predates the ledger"
+                     else "full — task began after the ledger started" end)
+         },
          audit_refs:$audit,
          audit_drops:$audit_drops
        }}'
@@ -214,6 +256,25 @@ cmd_trace() {
     "  \(.ts)  \(.phase | (. + "            ")[0:13])  \(.actor | (. + "            ")[0:12])  \(.detail)"'
   if [[ -n "$pending_gate" ]]; then
     printf '  %-18s  %-13s  %-12s  %s\n' "(pending)" "gate" "-" "awaiting a human ${pending_gate}"
+  fi
+  echo
+  echo "lifecycle ledger (recorded, with authority envelope):"
+  if [[ "$(printf '%s' "$ledger_json" | jq 'length')" -gt 0 ]]; then
+    printf '%s' "$ledger_json" | jq -r '.[] |
+      "  \(.ts)  \(.kind | (. + "                ")[0:16])  \(.actor | (. + "            ")[0:12])  " +
+      "\(.authority | (. + "            ")[0:12])  \(.detail)" +
+      (if .policy   != "" then "\n      policy: \(.policy)"       else "" end) +
+      (if .in_hash  != "" then "\n      in:  sha256:\(.in_hash)"  else "" end) +
+      (if .out_hash != "" then "\n      out: sha256:\(.out_hash)" else "" end)'
+  elif [[ -z "$ledger_started" ]]; then
+    echo "  (no rows, and no ledger start marker — cannot tell 'nothing happened'"
+    echo "   from 'this store predates the ledger'. Treat as UNKNOWN, not as zero.)"
+  elif (( ledger_predates )); then
+    echo "  (no rows — this task was created before the ledger started ${ledger_started}."
+    echo "   Absence here is expected and is NOT evidence about what happened.)"
+  else
+    echo "  (no rows — the task began after the ledger started ${ledger_started},"
+    echo "   so this genuinely records no lifecycle events yet.)"
   fi
   echo
   if [[ "$(printf '%s' "$audit_json" | jq 'length')" -gt 0 ]]; then

--- a/src/lib/audit.sh
+++ b/src/lib/audit.sh
@@ -138,8 +138,21 @@ _actor_identity() {
 #   root        EUID 0 with no invoking user (cron, systemd, the privileged rails)
 #   sudo:<who>  EUID 0 reached by elevation from <who>
 #   self        unelevated — the agent acting as itself
+#
+# Goes through _audit_is_root, NOT a bare `[[ $EUID -eq 0 ]]`.
+#
+# $EUID is READONLY in bash, so a direct read makes the root and sudo: branches
+# unreachable from a unit harness — and the first cut of this function did read it
+# directly, which meant the only branch any test could ever observe was `self`.
+# Two of the three values this function exists to produce would have shipped
+# unexercised, on the column that carries the whole authority claim. Same defect
+# main hit in _gate_withdraw_actor on DIVE-2330 the same evening: a seam added so
+# a harness can model the caller, then bypassed by the guard that actually
+# decides. The comment eight lines above this one already says it — a check
+# nobody can exercise is a check nobody can trust — and the fix is to route
+# through the seam that exists rather than add a second one.
 _actor_authority() {
-  if [[ $EUID -eq 0 ]]; then
+  if _audit_is_root; then
     if [[ -n "${SUDO_USER:-}" ]]; then printf 'sudo:%s' "$SUDO_USER"; else printf 'root'; fi
   else
     printf 'self'

--- a/src/lib/audit.sh
+++ b/src/lib/audit.sh
@@ -108,6 +108,44 @@ _audit_note_drop() {
 # it. A check nobody can exercise is a check nobody can trust.
 _audit_is_root() { [[ $EUID -eq 0 ]]; }
 
+# _actor_identity — the ONE resolver for "who is acting", shared by the audit log
+# and the INST-4 lifecycle ledger.
+#
+# It is deliberately a single function rather than the same four-fallback
+# expression copy-pasted per trail. Two evidence trails that disagree about the
+# actor are worse than one trail: a reader cannot tell a real identity conflict
+# from two resolvers drifting apart, and there is nothing in either row that says
+# which resolver produced it. Same reason the ledger below reuses this instead of
+# re-deriving the caller.
+#
+# DIVE-2073 semantics are preserved verbatim: root with no invoking user is an
+# identity BY DESIGN (`root`), and `unknown` means only the genuine failure — a
+# NON-root process whose USER we could not read.
+_actor_identity() {
+  local user="${FIVEDIVE_AUDIT_USER:-${SUDO_USER:-${USER:-}}}"
+  [[ -n "$user" ]] || { if _audit_is_root; then user="root"; else user="unknown"; fi; }
+  printf '%s' "$user"
+}
+
+# _actor_authority — under WHOSE authority the current process is acting.
+#
+# Distinct from _actor_identity on purpose. Identity answers "who"; authority
+# answers "with what powers, granted by whom". `sudo:claude` and `self` can carry
+# the same identity and are not the same act, and the audit log has never been
+# able to say which — it records the invoking user and drops the elevation. For a
+# ledger whose whole job is "who was AUTHORIZED to act", that distinction is the
+# payload, not a detail.
+#   root        EUID 0 with no invoking user (cron, systemd, the privileged rails)
+#   sudo:<who>  EUID 0 reached by elevation from <who>
+#   self        unelevated — the agent acting as itself
+_actor_authority() {
+  if [[ $EUID -eq 0 ]]; then
+    if [[ -n "${SUDO_USER:-}" ]]; then printf 'sudo:%s' "$SUDO_USER"; else printf 'root'; fi
+  else
+    printf 'self'
+  fi
+}
+
 # Emits one NDJSON line. Sensitive =<value> args are redacted ("--api-key=..."
 # becomes "--api-key=<redacted>"). Never fails the caller — writes are
 # best-effort so a full disk can't block a rescue rm.
@@ -143,8 +181,7 @@ audit_log() {
   # DESIGN, so record it as `root`; `unknown` now means only the genuine
   # failure — a NON-root process whose USER we could not read — and a reader
   # seeing it should treat it as a defect, not as routine.
-  local user="${FIVEDIVE_AUDIT_USER:-${SUDO_USER:-${USER:-}}}"
-  [[ -n "$user" ]] || { if _audit_is_root; then user="root"; else user="unknown"; fi; }
+  local user; user=$(_actor_identity)
   local ts
   ts=$(date -Iseconds)
   local line

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -754,6 +754,76 @@ CREATE TABLE IF NOT EXISTS objective_cycles (
   outcome       TEXT NOT NULL DEFAULT 'noop'
 );
 CREATE INDEX IF NOT EXISTS objective_cycles_idx ON objective_cycles(objective_id, cycle_no);
+
+-- INST-4: the unified lifecycle ledger — ONE append-only log for the whole
+-- task/gate/verify/ship lifecycle, carrying the full authority envelope on every
+-- row (actor, authority, parent, idempotency key, input/output hashes, policy
+-- decision, usage, host).
+--
+-- We were ALREADY event-sourcing, in four separate append-only silos:
+-- supervisor_events (DIVE-724), objective_readings (OSS-19), the council
+-- governance lineage, and the _audit_append log (DIVE-1268). Each is correct and
+-- each answers a different question, which is precisely the problem: no single
+-- one of them can answer "who was authorized to do this, why, and what happened
+-- next", because the answer is split across four schemas with four different
+-- notions of actor, four timestamp conventions, and no shared key. `5dive trace`
+-- had to hand-join transition COLUMNS on the tasks row to fake one.
+--
+-- ADDITIVE BY CONSTRUCTION. This does NOT replace the state machine, the four
+-- silos, or any existing write. Every current writer keeps writing where it
+-- writes today; the emitters below run ALONGSIDE them. The tasks row stays the
+-- authority on current state — read it as the materialized view this log would
+-- rebuild, not as a thing to be migrated. Nothing here is referenced by
+-- tasks/projects, so it cannot touch the queue, and a ledger write that fails
+-- can never fail the action it describes (see ledger_emit).
+--
+-- READ THE START MARKER BEFORE READING THE ROWS. A ledger installed today has
+-- nothing to say about work that finished yesterday, and the failure mode this
+-- codebase keeps paying for is exactly that: absence read as evidence. The
+-- ledger_started pref (task_prefs) stamps the first init, and `trace` refuses to
+-- render an empty ledger section for a task that predates it.
+--   kind       dotted lifecycle verb: task.created|task.started|task.delivered|
+--              task.done|task.cancelled|gate.filed|gate.answered|policy.refused|
+--              ship|rollback
+--   actor      the identity the RECORDING SITE is authoritative for, which is not
+--              the same namespace for every kind and should not be forced to be.
+--              Task lifecycle rows carry the BOARD actor (task_actor: `dev`),
+--              because the org is what those events are about. ship/rollback rows
+--              carry the ship actor ship_events already recorded, so the two rows
+--              about one ship can never disagree. gate.answered carries the
+--              persisted gate provenance (`human:...`, `lead:standing:...`), which
+--              is the only identity that decides whether a human touched the work.
+--   authority  root | sudo:<who> | self — the elevation, which the audit log has
+--              never recorded (see _actor_authority)
+--   idem_key   natural key for the event. The UNIQUE index makes a retried emit
+--              collapse instead of double-counting; a caller needing genuine
+--              repeats supplies its own distinguishing key.
+--   input_hash/output_hash  sha256 (first 16 hex) of the raw payloads, hashed by
+--              ledger_emit. The ledger stores digests, never the content, so it
+--              stays safe to read at a lower privilege than the thing it records.
+-- Append-only: never updated, never deleted.
+-- Defined identically inside _tasks_db_migrate for pre-existing stores; keep the
+-- two copies byte-identical (tests/schema_sync_unit.sh).
+CREATE TABLE IF NOT EXISTS lifecycle_events (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts              TEXT NOT NULL DEFAULT (datetime('now')),
+  kind            TEXT NOT NULL,
+  ident           TEXT,
+  task_id         INTEGER,
+  actor           TEXT NOT NULL,
+  authority       TEXT NOT NULL DEFAULT 'self',
+  parent_ident    TEXT,
+  idem_key        TEXT NOT NULL,
+  input_hash      TEXT,
+  output_hash     TEXT,
+  policy_decision TEXT,
+  tokens          INTEGER,
+  host            TEXT,
+  detail          TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS lifecycle_events_idem_idx ON lifecycle_events(idem_key);
+CREATE INDEX IF NOT EXISTS lifecycle_events_ident_idx ON lifecycle_events(ident, id);
+CREATE INDEX IF NOT EXISTS lifecycle_events_ts_idx ON lifecycle_events(ts, kind);
 SQL
 }
 
@@ -1318,6 +1388,47 @@ CREATE INDEX IF NOT EXISTS objective_cycles_idx ON objective_cycles(objective_id
 MIG
   fi
 
+  # INST-4 lifecycle_events — additive, gated on its OWN absence. Brand-new,
+  # never referenced by tasks/projects. Keep this CREATE body byte-identical to
+  # the copy in _tasks_schema above (tests/schema_sync_unit.sh).
+  local has_lifecycle
+  has_lifecycle=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
+    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='lifecycle_events' LIMIT 1;" 2>/dev/null)
+  if [[ "$has_lifecycle" != "1" ]]; then
+    sqlite3 -cmd ".timeout 5000" "$TASKS_DB" <<'MIG' >/dev/null 2>&1 || true
+CREATE TABLE IF NOT EXISTS lifecycle_events (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts              TEXT NOT NULL DEFAULT (datetime('now')),
+  kind            TEXT NOT NULL,
+  ident           TEXT,
+  task_id         INTEGER,
+  actor           TEXT NOT NULL,
+  authority       TEXT NOT NULL DEFAULT 'self',
+  parent_ident    TEXT,
+  idem_key        TEXT NOT NULL,
+  input_hash      TEXT,
+  output_hash     TEXT,
+  policy_decision TEXT,
+  tokens          INTEGER,
+  host            TEXT,
+  detail          TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS lifecycle_events_idem_idx ON lifecycle_events(idem_key);
+CREATE INDEX IF NOT EXISTS lifecycle_events_ident_idx ON lifecycle_events(ident, id);
+CREATE INDEX IF NOT EXISTS lifecycle_events_ts_idx ON lifecycle_events(ts, kind);
+MIG
+  fi
+
+  # INST-4: stamp the ledger's own start. `trace` needs to distinguish "this task
+  # produced no lifecycle events" from "this task ran before the ledger existed",
+  # and only a marker written at install time can tell them apart — by the time a
+  # reader asks, an empty result looks identical either way. Written once; the
+  # INSERT OR IGNORE keeps every later init a no-op so the marker records the
+  # FIRST init on this box, not the most recent one.
+  sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
+    "INSERT OR IGNORE INTO task_prefs (key, value) VALUES ('ledger_started', datetime('now'));" \
+    >/dev/null 2>&1 || true
+
   # DIVE-1737 — async self-heal materialize: additive planner-handle columns on
   # already-created objective_cycles tables. When a planner loop times out past
   # OBJ_PLANNER_WAIT_DEFAULT, replan records an 'awaiting_planner' cycle stamped
@@ -1828,6 +1939,82 @@ _gate_closure_verify() {
   _gate_proof_ct_equal "$sig" "$expect"
 }
 
+# ── INST-4: the unified lifecycle ledger writer ──────────────────────────────
+#
+# ledger_emit <kind> [k=v ...] — append ONE row to lifecycle_events.
+#
+# Keys: ident, task_id, parent, actor, authority, idem, in, out, policy, tokens,
+# detail. Everything is optional except <kind>.
+#
+#   in= / out=  take the RAW payload and are HASHED here, never stored. Call
+#               sites therefore cannot leak a secret, a gate answer, or a task
+#               body into a table that is read by lower-privileged consumers —
+#               they physically have no way to write content into it. That is a
+#               property of this function, not a rule call sites must remember.
+#   idem=       the natural key. Omitted, it is derived deterministically from
+#               kind+ident+task_id+payload digest, so a retried emit collapses
+#               instead of double-counting. A caller whose event legitimately
+#               repeats with an identical payload MUST pass its own key
+#               (ship_ledger_record passes the sha; policy refusals pass a clock
+#               nonce) — otherwise the second occurrence is silently dropped, and
+#               a dropped row here is indistinguishable from an event that never
+#               happened.
+#
+# NEVER fails the caller and never speaks to it. A lifecycle event that cannot be
+# recorded must not turn a successful `task done` into a failed one; the ledger
+# is evidence about the action, not part of it. This is the same posture as
+# audit_log and ship_ledger_record.
+ledger_hash() {
+  # First 16 hex of sha256 — enough to compare payloads, short enough to render
+  # in a terminal timeline. Empty input hashes to empty, so an absent payload
+  # stays visibly absent rather than becoming the well-known sha256 of "".
+  local raw="${1:-}"
+  [[ -n "$raw" ]] || { printf ''; return 0; }
+  printf '%s' "$raw" | sha256sum 2>/dev/null | cut -c1-16 || printf ''
+}
+
+ledger_emit() {
+  local kind="${1:-}"; shift || true
+  [[ -n "$kind" ]] || return 0
+  local ident="" task_id="" parent="" actor="" authority="" idem=""
+  local raw_in="" raw_out="" policy="" tokens="" detail="" kv
+  for kv in "$@"; do
+    case "$kv" in
+      ident=*)     ident="${kv#*=}" ;;
+      task_id=*)   task_id="${kv#*=}" ;;
+      parent=*)    parent="${kv#*=}" ;;
+      actor=*)     actor="${kv#*=}" ;;
+      authority=*) authority="${kv#*=}" ;;
+      idem=*)      idem="${kv#*=}" ;;
+      in=*)        raw_in="${kv#*=}" ;;
+      out=*)       raw_out="${kv#*=}" ;;
+      policy=*)    policy="${kv#*=}" ;;
+      tokens=*)    tokens="${kv#*=}" ;;
+      detail=*)    detail="${kv#*=}" ;;
+    esac
+  done
+  local in_hash out_hash
+  in_hash=$(ledger_hash "$raw_in")
+  out_hash=$(ledger_hash "$raw_out")
+  # One resolver for identity, shared with the audit log (_actor_identity), so
+  # the two trails can never disagree about who acted.
+  [[ -n "$actor" ]]     || actor=$(_actor_identity)
+  [[ -n "$authority" ]] || authority=$(_actor_authority)
+  [[ -n "$idem" ]]      || idem="${kind}|${ident}|${task_id}|$(ledger_hash "${detail}${in_hash}${out_hash}")"
+  local host="${HOSTNAME:-$(hostname 2>/dev/null || echo unknown)}"
+  [[ "$task_id" =~ ^[0-9]+$ ]] || task_id=""
+  [[ "$tokens"  =~ ^[0-9]+$ ]] || tokens=""
+  db "INSERT OR IGNORE INTO lifecycle_events
+        (kind, ident, task_id, actor, authority, parent_ident, idem_key,
+         input_hash, output_hash, policy_decision, tokens, host, detail)
+      VALUES ($(sqlq "$kind"), $(sqlq_or_null "$ident"), ${task_id:-NULL},
+              $(sqlq "$actor"), $(sqlq "$authority"), $(sqlq_or_null "$parent"),
+              $(sqlq "$idem"), $(sqlq_or_null "$in_hash"), $(sqlq_or_null "$out_hash"),
+              $(sqlq_or_null "$policy"), ${tokens:-NULL}, $(sqlq_or_null "$host"),
+              $(sqlq_or_null "$detail"));" >/dev/null 2>&1 || true
+  return 0
+}
+
 # ship_ledger_record <kind> <ident> <repo> <branch> <sha> [reverts] — DIVE-1923.
 #
 # Append one row to the ship ledger, the capture path behind `proof scorecard`'s
@@ -1857,6 +2044,13 @@ ship_ledger_record() {
       VALUES ($(sqlq "$kind"), $(sqlq "$actor"), $(sqlq "$ident"), $(sqlq "$repo"),
               $(sqlq "$branch"), $(sqlq "$sha"), $(sqlq "$reverts"), $self);" \
     >/dev/null 2>&1 || true
+  # INST-4: mirror into the unified ledger. ship_events keeps its own shape (the
+  # scorecard's rate is computed from it and stays sourced from ONE instrument);
+  # this row is the same fact placed on the lifecycle timeline next to the gate
+  # that authorized it and the verifier who graded it. idem is the sha, matching
+  # the UNIQUE(kind,sha) contract above — re-pushing a branch stays one event.
+  ledger_emit "$kind" ident="$ident" actor="$actor" idem="${kind}:${sha}" \
+    out="$sha" detail="${repo:-?}@${branch:-?} ${sha}${reverts:+ reverts ${reverts}}"
 }
 
 # policy_refuse <exit-code> <policy-slug> <ticket> <ident> <message> — DIVE-1922.
@@ -1893,5 +2087,18 @@ policy_refuse() {
   db "INSERT INTO policy_refusals (policy, ticket, actor, ident, detail)
       VALUES ($(sqlq "$policy"), $(sqlq "$ticket"), $(sqlq "$actor"), $(sqlq "$ident"), $(sqlq "$msg"));" \
     >/dev/null 2>&1 || true
+  # INST-4: a refusal is a lifecycle event — arguably the most load-bearing one,
+  # since it is the only kind that proves the authority envelope was ENFORCED and
+  # not merely recorded. policy_decision carries the stable slug (not the message
+  # text, so rewording a refusal never breaks the series).
+  #
+  # An explicit clock-nonce idem key, NOT the derived default: the same actor
+  # hitting the same wall twice is two genuine attempts, and the derived key
+  # (which digests the payload) would collapse them into one — turning "they kept
+  # trying" into "they tried once", on the exact metric that measures how often
+  # policy bites.
+  ledger_emit policy.refused ident="$ident" actor="$actor" policy="$policy" \
+    idem="refuse:${policy}:${ident}:$(date +%s%N 2>/dev/null || echo $$)" \
+    in="$msg" detail="${policy}${ticket:+ (${ticket})} — refused with code ${code}"
   fail "$code" "$msg"
 }

--- a/tests/ledger_unit.sh
+++ b/tests/ledger_unit.sh
@@ -272,6 +272,58 @@ else
   fi
 fi
 
+# ---------------------------------------------------------------------------
+# Case 7: THE FUNNEL. Drive the real bundle through the maker→verifier rail and
+# assert the DELIVERY was recorded as a delivery.
+#
+# This case exists because the first cut of the change got it wrong. The emit was
+# placed in _task_status_cmd on the assumption that every `task done` funnels
+# through it; a `done` that DELIVERS forks earlier, into the handoff write, so
+# the single event the verifier rail is entirely about was absent from the ledger
+# and nothing said so. An absent row is the one shape a ledger cannot
+# self-report, so it needs a test that asserts presence AND kind.
+#
+# Also asserts the negative: a delivery must NOT appear as task.done. Recording
+# it as a close would have the ledger attest that work was finished while it is
+# still waiting to be graded — our own evidence base overstating autonomy, which
+# is worse than a missing row.
+# ---------------------------------------------------------------------------
+BUNDLE=./5dive
+if [[ ! -x "$BUNDLE" ]]; then
+  bad_t "funnel case: bundle not built" "run bash build.sh first"
+else
+  E2E="$TMP/e2e"
+  (
+    set +e
+    export STATE_DIR="$E2E" TASKS_DIR="$E2E/tasks" TASKS_DB="$E2E/tasks/tasks.db"
+    mkdir -p "$TASKS_DIR"
+    "$BUNDLE" task add "funnel case" --project=DIVE --assignee=dev --verifier=main
+    "$BUNDLE" task start DIVE-1 --no-preflight
+    "$BUNDLE" task done DIVE-1 --result="delivered, not closed"
+  ) >/dev/null 2>&1
+  E2EDB="$TMP/e2e/tasks/tasks.db"
+  kinds=$(sqlite3 "$E2EDB" "SELECT GROUP_CONCAT(kind, ',') FROM (SELECT kind FROM lifecycle_events ORDER BY id);" 2>/dev/null)
+  if [[ "$kinds" == *task.delivered* ]]; then
+    ok_t "funnel: the maker→verifier delivery emitted task.delivered ($kinds)"
+  else
+    bad_t "funnel: no task.delivered row (kinds: ${kinds:-<none>})" \
+          "a 'task done' that delivers forks before _task_status_cmd — emit at the handoff write too"
+  fi
+  if [[ "$kinds" != *task.done* ]]; then
+    ok_t "funnel: the delivery was NOT recorded as task.done"
+  else
+    bad_t "funnel: a delivery was recorded as task.done" \
+          "the ledger would attest work was finished while it is still awaiting a grade"
+  fi
+  # Liveness for the negative above: prove this store recorded ANYTHING, so the
+  # "no task.done" assertion is not passing because the ledger is simply empty.
+  if [[ -n "$kinds" ]]; then
+    ok_t "funnel: the e2e store recorded rows at all (the negative above is not vacuous)"
+  else
+    bad_t "funnel: the e2e ledger is empty" "every assertion in this case is vacuous"
+  fi
+fi
+
 echo "-----"
 echo "ledger_unit: $PASS passed, $FAIL failed"
 (( FAIL == 0 ))

--- a/tests/ledger_unit.sh
+++ b/tests/ledger_unit.sh
@@ -203,12 +203,65 @@ else
         "'they kept trying' would render as 'they tried once'"
 fi
 
-# Case 4c: authority is recorded and is not a constant. Unelevated -> 'self'.
+# Case 4c: authority, ALL THREE branches.
+#
+# The obvious version of this assertion — "authority is one of self|root|sudo:*" —
+# passes on whatever branch the runner happens to be on and grades nothing. On
+# this box that is always `self`, so the two values the column exists to
+# distinguish would ship unexercised. $EUID is READONLY in bash, so the root and
+# sudo: branches are reachable ONLY through the _audit_is_root seam; a
+# _actor_authority that reads $EUID directly cannot be tested here at all, which
+# is the point of routing it through the seam.
 auth=$(sqlite3 "$DB" "SELECT authority FROM lifecycle_events WHERE ident='TEST-1';" 2>/dev/null)
-if [[ "$auth" == "self" || "$auth" == root || "$auth" == sudo:* ]]; then
-  ok_t "authority: recorded as '$auth' (an elevation state, not a placeholder)"
+if [[ "$auth" == "self" ]]; then
+  ok_t "authority: unelevated caller recorded as 'self'"
 else
-  bad_t "authority: '$auth' is not one of self|root|sudo:<who>"
+  bad_t "authority: unelevated caller recorded as '$auth', expected 'self'"
+fi
+
+# root: elevated with NO invoking user (cron, systemd, the privileged rails).
+auth_root=$(
+  set +e
+  emit_env
+  _audit_is_root() { return 0; }
+  unset SUDO_USER
+  ledger_emit task.done ident=AUTH-ROOT task_id=91 actor=cron detail=x >/dev/null 2>&1
+  sqlite3 "$DB" "SELECT authority FROM lifecycle_events WHERE ident='AUTH-ROOT';" 2>/dev/null
+)
+if [[ "$auth_root" == "root" ]]; then
+  ok_t "authority: elevated with no invoking user recorded as 'root'"
+else
+  bad_t "authority: got '$auth_root', expected 'root'" \
+        "the root branch is unreachable — _actor_authority is not going through _audit_is_root"
+fi
+
+# sudo:<who>: elevated FROM someone. The branch that carries the whole point of
+# the column, since identity alone cannot distinguish it from 'self'.
+auth_sudo=$(
+  set +e
+  emit_env
+  _audit_is_root() { return 0; }
+  SUDO_USER=claude
+  ledger_emit task.done ident=AUTH-SUDO task_id=92 actor=dev detail=x >/dev/null 2>&1
+  sqlite3 "$DB" "SELECT authority FROM lifecycle_events WHERE ident='AUTH-SUDO';" 2>/dev/null
+)
+if [[ "$auth_sudo" == "sudo:claude" ]]; then
+  ok_t "authority: elevation from claude recorded as 'sudo:claude'"
+else
+  bad_t "authority: got '$auth_sudo', expected 'sudo:claude'" \
+        "the sudo: branch is unreachable, or SUDO_USER is not being read"
+fi
+
+# And the three are DISTINCT. Without this, a function that returned the same
+# constant for every branch would pass each arm above only if that constant
+# happened to match — but a function returning 'root' unconditionally would pass
+# the root arm and fail the others, whereas asserting distinctness states the
+# property the column actually needs.
+if [[ "$auth" != "$auth_root" && "$auth_root" != "$auth_sudo" && "$auth" != "$auth_sudo" ]]; then
+  ok_t "authority: the three branches produce three DISTINCT values"
+else
+  bad_t "authority: branches collapsed (self='$auth' root='$auth_root' sudo='$auth_sudo')" \
+        "a column that cannot distinguish elevation states records no authority"
 fi
 
 # Case 5: NEVER fails the caller, even when the store is unusable.

--- a/tests/ledger_unit.sh
+++ b/tests/ledger_unit.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# INST-4 unit: the unified lifecycle ledger (lifecycle_events).
+#
+# What this grades, and why each case exists:
+#
+#   1. THE MIGRATION. Same class as the DIVE-1922 bug this suite's sibling was
+#      reopened for: a new table's DDL nested inside ANOTHER table's existence
+#      guard runs only on stores that lack that other table -- i.e. never on a
+#      real box. The ledger would silently never exist, `trace` would render an
+#      empty section forever, and empty is indistinguishable from "no events".
+#      Guard on the table you are creating; prove it on a store that already has
+#      the neighbouring tables.
+#
+#   2. THE START MARKER. An empty ledger has two meanings -- "nothing happened"
+#      and "this work predates the ledger" -- and no amount of reading the rows
+#      separates them. Only a marker written at init does. If the marker moved on
+#      every init it would be useless (it would always say "today"), so the
+#      idempotency of the marker is graded, not assumed.
+#
+#   3. PAYLOADS ARE NEVER STORED. in=/out= take raw content and the table must
+#      hold only digests. This is the assertion that keeps the ledger safe to
+#      read at a lower privilege than the board it describes, so it is graded by
+#      MUTATION (case 6), not just asserted.
+#
+#   4. IDEMPOTENCY IN BOTH DIRECTIONS. A retried emit must collapse; a genuinely
+#      repeated event with its own key must NOT. Grading only the collapse would
+#      pass a ledger that drops every repeat -- which is how a "they kept trying"
+#      series silently becomes "they tried once".
+#
+#   5. NEVER FAILS THE CALLER. A lifecycle event that cannot be recorded must not
+#      turn a successful action into a failed one.
+#
+# Isolated: temp sqlite store, no prod DB, no root, no network.
+#   bash tests/ledger_unit.sh
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source.
+# NOTE the absence of `2>/dev/null` -- see the sibling suites; redirecting the
+# source's stderr also swallows the helper's own line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+
+command -v sqlite3 >/dev/null 2>&1 || { echo "skip - sqlite3 not available"; exit 0; }
+
+TMP="$(mktemp -d /tmp/ledger-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# ---------------------------------------------------------------------------
+# Case 1: THE MIGRATION, on a store shaped like a real box.
+# ---------------------------------------------------------------------------
+DB="$TMP/legacy.db"
+sqlite3 "$DB" "CREATE TABLE tasks (id INTEGER PRIMARY KEY, ident TEXT);
+               CREATE TABLE supervisor_events (id INTEGER PRIMARY KEY, agent TEXT, classification TEXT);
+               CREATE TABLE ship_events (id INTEGER PRIMARY KEY, sha TEXT);
+               CREATE TABLE objective_cycles (id INTEGER PRIMARY KEY);" 2>/dev/null
+
+# Anchor-assert the baseline DIFFERS from the expected end state. Without this
+# the migration assertion below would pass just as happily against a store that
+# already had the table -- i.e. it would grade nothing.
+if [[ "$(sqlite3 "$DB" "SELECT COUNT(*) FROM sqlite_master WHERE name='lifecycle_events';")" == "0" ]]; then
+  ok_t "precondition: legacy store has the neighbouring silos but NOT lifecycle_events"
+else
+  bad_t "precondition" "lifecycle_events already present before the migration ran"
+fi
+
+export STATE_DIR="$TMP/state"
+export TASKS_DIR="$STATE_DIR/tasks"
+export TASKS_DB="$DB"
+mkdir -p "$TASKS_DIR"
+: > "$STATE_DIR/tasks/.board-initialized"   # pre-existing board (DIVE-1479 guard)
+
+# Drive the migration directly, and do NOT swallow its rc/stderr: a driver that
+# hard-failed must not read as a successful migration (the DIVE-1922 lesson).
+# shellcheck disable=SC1091
+migrate_out=$( set +e; . src/lib/tasks_db.sh >/dev/null 2>&1; tasks_db_init 2>&1 ); migrate_rc=$?
+if (( migrate_rc != 0 )); then
+  bad_t "the migration driver itself FAILED (rc=$migrate_rc)" "$migrate_out"
+fi
+
+if [[ "$(sqlite3 "$DB" "SELECT COUNT(*) FROM sqlite_master WHERE name='lifecycle_events';")" == "1" ]]; then
+  ok_t "migration: lifecycle_events created on a store that already had the other silos"
+else
+  bad_t "migration: lifecycle_events NOT created" \
+        "the DDL is gated on a neighbouring table's absence -- it will never run on a real box"
+fi
+
+# The UNIQUE index is not decoration: it IS the idempotency contract graded in
+# case 4. A table created without it passes every row-shape assertion.
+if sqlite3 "$DB" "SELECT sql FROM sqlite_master WHERE name='lifecycle_events_idem_idx';" 2>/dev/null | grep -q 'UNIQUE'; then
+  ok_t "migration: the UNIQUE idem_key index came with the table"
+else
+  bad_t "migration: lifecycle_events_idem_idx missing or not UNIQUE" \
+        "without it every retried emit double-counts and case 4 cannot bite"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: the start marker exists, and is STAMPED ONCE.
+# ---------------------------------------------------------------------------
+marker1=$(sqlite3 "$DB" "SELECT value FROM task_prefs WHERE key='ledger_started';" 2>/dev/null)
+if [[ -n "$marker1" ]]; then
+  ok_t "start marker: ledger_started stamped at init ($marker1)"
+else
+  bad_t "start marker: ledger_started absent" \
+        "trace cannot then distinguish 'no events' from 'predates the ledger'"
+fi
+
+# Re-init and confirm the marker did not move. A marker that re-stamps always
+# reads "today", so every task looks like it predates the ledger, forever.
+sqlite3 "$DB" "UPDATE task_prefs SET value='2000-01-01 00:00:00' WHERE key='ledger_started';" 2>/dev/null
+# shellcheck disable=SC1091
+( set +e; . src/lib/tasks_db.sh >/dev/null 2>&1; tasks_db_init >/dev/null 2>&1 )
+marker2=$(sqlite3 "$DB" "SELECT value FROM task_prefs WHERE key='ledger_started';" 2>/dev/null)
+if [[ "$marker2" == "2000-01-01 00:00:00" ]]; then
+  ok_t "start marker: a later init does NOT re-stamp it (INSERT OR IGNORE holds)"
+else
+  bad_t "start marker: re-stamped on the second init (now '$marker2')" \
+        "it would always report 'today' and every task would look older than the ledger"
+fi
+
+# ---------------------------------------------------------------------------
+# Cases 3-5: the writer. Source the libs it actually depends on.
+# ---------------------------------------------------------------------------
+emit_env() {
+  # shellcheck disable=SC1091
+  . src/lib/audit.sh    >/dev/null 2>&1
+  # shellcheck disable=SC1091
+  . src/lib/tasks_db.sh >/dev/null 2>&1
+}
+
+SECRET='sk-live-DO-NOT-STORE-THIS'
+(
+  set +e
+  emit_env
+  ledger_emit task.created ident=TEST-1 task_id=1 actor=dev in="a title" out="$SECRET" \
+    detail="medium -> dev"
+) >/dev/null 2>&1
+
+row=$(sqlite3 -separator '|' "$DB" \
+  "SELECT kind, ident, task_id, actor, authority, COALESCE(input_hash,''), COALESCE(output_hash,''),
+          COALESCE(host,''), COALESCE(detail,'') FROM lifecycle_events WHERE ident='TEST-1';" 2>/dev/null)
+if [[ -n "$row" ]]; then
+  ok_t "writer: one row landed with the envelope ($row)"
+else
+  bad_t "writer: no row landed" "ledger_emit wrote nothing"
+fi
+
+# The load-bearing privacy property, stated as a property of the TABLE rather
+# than of any one column: the raw payload must appear NOWHERE in the row.
+dump=$(sqlite3 "$DB" "SELECT * FROM lifecycle_events;" 2>/dev/null)
+if [[ -n "$dump" ]] && ! printf '%s' "$dump" | grep -qF "$SECRET"; then
+  ok_t "privacy: the raw out= payload is nowhere in the table (digest only)"
+else
+  bad_t "privacy: the raw payload reached the ledger" \
+        "in=/out= must be hashed by ledger_emit, never stored"
+fi
+
+# ...and the digest is actually there, so the assertion above is not passing
+# merely because the column is empty. A negative needs a liveness proof.
+want_hash=$(printf '%s' "$SECRET" | sha256sum | cut -c1-16)
+got_hash=$(sqlite3 "$DB" "SELECT COALESCE(output_hash,'') FROM lifecycle_events WHERE ident='TEST-1';" 2>/dev/null)
+if [[ "$got_hash" == "$want_hash" ]]; then
+  ok_t "privacy: output_hash is the sha256 digest of the payload (not an empty column)"
+else
+  bad_t "privacy: output_hash is '$got_hash', expected '$want_hash'" \
+        "an empty digest would make the no-raw-payload assertion vacuous"
+fi
+
+# Case 4a: a RETRIED emit collapses (derived idem key).
+(
+  set +e
+  emit_env
+  ledger_emit task.created ident=TEST-1 task_id=1 actor=dev in="a title" out="$SECRET" \
+    detail="medium -> dev"
+) >/dev/null 2>&1
+n=$(sqlite3 "$DB" "SELECT COUNT(*) FROM lifecycle_events WHERE ident='TEST-1';" 2>/dev/null)
+if [[ "$n" == "1" ]]; then
+  ok_t "idempotency: an identical retried emit collapsed to one row"
+else
+  bad_t "idempotency: got $n rows for one logical event" "the derived idem key is not deterministic"
+fi
+
+# Case 4b: a genuinely repeated event with its OWN key must NOT collapse. The
+# mirror assertion -- without it, a writer that dropped every repeat would pass.
+(
+  set +e
+  emit_env
+  ledger_emit policy.refused ident=TEST-2 actor=dev policy=push.blocked idem="refuse:1" detail="attempt 1"
+  ledger_emit policy.refused ident=TEST-2 actor=dev policy=push.blocked idem="refuse:2" detail="attempt 2"
+) >/dev/null 2>&1
+n2=$(sqlite3 "$DB" "SELECT COUNT(*) FROM lifecycle_events WHERE ident='TEST-2';" 2>/dev/null)
+if [[ "$n2" == "2" ]]; then
+  ok_t "idempotency: two distinct attempts with their own keys stayed two rows"
+else
+  bad_t "idempotency: two distinct attempts collapsed to $n2 row(s)" \
+        "'they kept trying' would render as 'they tried once'"
+fi
+
+# Case 4c: authority is recorded and is not a constant. Unelevated -> 'self'.
+auth=$(sqlite3 "$DB" "SELECT authority FROM lifecycle_events WHERE ident='TEST-1';" 2>/dev/null)
+if [[ "$auth" == "self" || "$auth" == root || "$auth" == sudo:* ]]; then
+  ok_t "authority: recorded as '$auth' (an elevation state, not a placeholder)"
+else
+  bad_t "authority: '$auth' is not one of self|root|sudo:<who>"
+fi
+
+# Case 5: NEVER fails the caller, even when the store is unusable.
+rc=$(
+  set +e
+  emit_env
+  TASKS_DB="$TMP/nonexistent-dir/nope.db"
+  ledger_emit task.done ident=TEST-3 task_id=3 detail="should not fail"
+  echo $?
+)
+if [[ "$rc" == "0" ]]; then
+  ok_t "never-fails: an unwritable store still returns 0 to the caller"
+else
+  bad_t "never-fails: ledger_emit returned $rc" \
+        "a failed evidence write must not turn a successful action into a failed one"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 6: MUTATION ARM. Break the hashing and confirm the privacy assertion goes
+# RED. An assertion that has never been observed to fail is not yet evidence.
+# Differential: the SAME assertion, the SAME driver, one changed line.
+# ---------------------------------------------------------------------------
+MUT="$TMP/mutant"
+mkdir -p "$MUT/src/lib"
+cp src/lib/audit.sh src/lib/tasks_db.sh "$MUT/src/lib/"
+# The mutation: ledger_hash returns its input verbatim instead of a digest.
+python3 - "$MUT/src/lib/tasks_db.sh" <<'PY'
+import re, sys
+p = sys.argv[1]
+s = open(p).read()
+s2 = s.replace(
+  '  printf \'%s\' "$raw" | sha256sum 2>/dev/null | cut -c1-16 || printf \'\'',
+  '  printf \'%s\' "$raw"')
+assert s2 != s, "MUTATION DID NOT LAND -- the anchor line changed; this arm graded nothing"
+open(p, 'w').write(s2)
+PY
+mut_landed=$?
+if (( mut_landed != 0 )); then
+  bad_t "mutation arm: the mutation did NOT land" "the arm would report a false green"
+else
+  MDB="$TMP/mutant.db"
+  (
+    set +e
+    cd "$MUT"
+    export STATE_DIR="$TMP/mstate" TASKS_DIR="$TMP/mstate/tasks" TASKS_DB="$MDB"
+    mkdir -p "$TASKS_DIR"; : > "$TASKS_DIR/.board-initialized"
+    sqlite3 "$MDB" "CREATE TABLE tasks (id INTEGER PRIMARY KEY, ident TEXT);" 2>/dev/null
+    # shellcheck disable=SC1091
+    . src/lib/audit.sh >/dev/null 2>&1
+    # shellcheck disable=SC1091
+    . src/lib/tasks_db.sh >/dev/null 2>&1
+    tasks_db_init >/dev/null 2>&1
+    ledger_emit task.created ident=MUT-1 task_id=1 actor=dev out="$SECRET" detail=x
+  ) >/dev/null 2>&1
+  mdump=$(sqlite3 "$MDB" "SELECT * FROM lifecycle_events;" 2>/dev/null)
+  if printf '%s' "$mdump" | grep -qF "$SECRET"; then
+    ok_t "mutation arm: with hashing removed the privacy assertion goes RED (it can bite)"
+  else
+    bad_t "mutation arm: privacy assertion stayed GREEN against a mutant that stores raw payloads" \
+          "the assertion is vacuous -- it is not grading the hashing"
+  fi
+fi
+
+echo "-----"
+echo "ledger_unit: $PASS passed, $FAIL failed"
+(( FAIL == 0 ))


### PR DESCRIPTION
Phase A of INST-4: consolidate the four append-only silos into one lifecycle event log, additively.

## What

New `lifecycle_events` table — one append-only row per lifecycle event, carrying the full envelope: actor, **authority** (`root` / `sudo:<who>` / `self`), parent, idempotency key, input/output digests, policy decision, usage, host. `ledger_emit` hashes `in=`/`out=` itself, so a call site physically cannot write raw content into the table; a secret gate contributes no digest at all.

Live emitters: `task.created/started/delivered/review/done/cancelled`, `gate.filed/answered`, `policy.refused`, `ship`/`rollback`.

`5dive trace` is the forcing function and first consumer. Its ledger section sits **beside** the derived timeline, not merged into it — one is reconstructed from current state, the other was recorded at the time, and a merged view would let a reader cite a reconstruction as a witness.

## Why it is not just tidying

The four trails share no key and no notion of actor: the audit log records the invoking user, `ship_events` the pre-sudo caller, the board the board actor (`dev`), gate provenance `human:dev` / `lead:standing:main`. `authority` — the elevation — is recorded by none of them, and for a ledger whose job is "who was AUTHORIZED to act" that is the payload.

## Additive by construction

No existing write moved. State machine untouched. Nothing here is referenced by `tasks`/`projects`. A ledger write can never fail the action it describes. "SQLite = materialized view" is the destination, not what ships here.

## Honest coverage boundary

An empty ledger has two meanings the rows cannot separate. Init stamps `ledger_started` once (idempotently — a marker that re-stamps always reads "today") and `trace` names which of three it is, including *unknown* when the marker is missing.

## Tests

`tests/ledger_unit.sh`, 16 assertions: the migration on a store that ALREADY has the neighbouring silos (the nested-guard class that would make the table never exist on a real box), marker idempotency, the no-raw-payload property **graded by mutation**, idempotency in both directions, never-fails-the-caller, and the delivery-funnel case below.

Local: 76 gate/task/proof/objective/supervisor suites run, 75 green. `gate_tier2_decision_nonce_unit.sh` (rc=6, no summary line) is **red on the untouched base 6cd0242** — measured on a detached baseline worktree, pre-existing, not this change; independently flagged by main.

## One defect found and fixed inside this PR

The emit was first placed in `_task_status_cmd` assuming every `task done` funnels through it. A `done` that DELIVERS forks earlier into the handoff write, so the single event the verifier rail is entirely about produced no row — nothing red, just absent, which is the one shape a ledger cannot self-report. Second commit fixes it and adds the both-directions test.

## Collision note

main's DIVE-2330 (`dive-2330-gate-actor-euid`, PR #324) also edits `src/cmd_task.sh` gate-identity code. Coordinated: whoever lands second rebases, and main asked to absorb it. **Do not squash-merge over that branch without a rebase.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)