### PR TITLE
fix(task): authenticate the maker self-verified-close mark (DIVE-2015)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -3349,17 +3349,19 @@ cmd_task_verify() {
     # DIVE-2015: a maker is deliberately ALLOWED to rescue a stalled delivered
     # loop with `task verify --cmd=...`; refusing it would remove the only
     # zero-human exit when the assigned verifier never runs. Permitted must not
-    # mean invisible, though. When the REAL caller is the recorded maker and the
-    # still-live row is held by its verifier, stamp the durable task result,
-    # emit a separately classifiable audit event, and warn on stderr. The mark
-    # names every fact a later reader needs to weigh the close: maker, verifier
-    # who never recorded a grade, and loop iteration.
+    # mean invisible, though. When the kernel-authenticated caller is the recorded
+    # maker and the still-live row is held by its verifier, stamp the durable task
+    # result, emit a separately classifiable audit event, and warn on stderr. The
+    # mark names every fact a later reader needs to weigh the close: maker,
+    # verifier who never recorded a grade, and loop iteration. An unidentified
+    # caller cannot safely be classified as maker or verifier, so its passing
+    # evidence is retained but it cannot close a live delivered loop.
     #
     # This belongs in audit_log, not policy_refusals: nothing was refused. Route
     # through the task-store fence so fixture DBs cannot write real-looking task
     # telemetry into the fleet audit log (DIVE-2010).
-    local _svc_actor _svc_row _svc_assignee _svc_status
-    _svc_actor=$(task_actor)
+    local _svc_auth_actor _svc_row _svc_assignee _svc_status
+    _svc_auth_actor=$(_gate_authenticated_actor)
     _svc_row=$(db "SELECT COALESCE(maker_agent,'')||x'1f'||
                         COALESCE(verifier,'')||x'1f'||
                         COALESCE(assignee,'')||x'1f'||
@@ -3368,11 +3370,16 @@ cmd_task_verify() {
     IFS=$'\x1f' read -r self_verify_maker self_verify_verifier \
       _svc_assignee self_verify_iteration _svc_status <<<"$_svc_row"
     if [[ -n "$self_verify_maker" && -n "$self_verify_verifier" \
-          && "$_svc_actor" == "$self_verify_maker" \
           && "$_svc_assignee" == "$self_verify_verifier" \
           && "$_svc_status" != "done" && "$_svc_status" != "cancelled" ]]; then
-      self_verified_close=1
-      result_txt="⚠ self-verified-close: maker=${self_verify_maker}; verifier=${self_verify_verifier} never graded; iteration=${self_verify_iteration}"$'\n'"${result_txt}"
+      if [[ -z "$_svc_auth_actor" ]]; then
+        db "UPDATE tasks SET result=$(sqlq "$result_txt") WHERE id=${id};"
+        fail "$E_PERMISSION" "$ident verify passed and the evidence was recorded, but auto-close was refused: the caller identity could not be authenticated for this live delivered loop"
+      fi
+      if [[ "$_svc_auth_actor" == "$self_verify_maker" ]]; then
+        self_verified_close=1
+        result_txt="⚠ self-verified-close: maker=${self_verify_maker}; verifier=${self_verify_verifier} never graded; iteration=${self_verify_iteration}"$'\n'"${result_txt}"
+      fi
     fi
     db "UPDATE tasks SET status='done', done_at=datetime('now'), result=$(sqlq "$result_txt") WHERE id=${id};"
     flipped=1

--- a/tests/task_verify_self_close_visibility_unit.sh
+++ b/tests/task_verify_self_close_visibility_unit.sh
@@ -3,6 +3,12 @@
 # with `task verify --cmd`, but the permitted self-close must be visible in the
 # task record, the audit log, and stderr. No policy refusal is expected.
 #
+# DEPENDENCY: the identity arms assume DIVE-2330's resolver contract:
+# `_gate_authenticated_actor` obtains its uid from `_gate_caller_uid` and maps it
+# only through `_gate_passwd_stream`. Keep this branch atop DIVE-2330 until that
+# resolver lands on main; pinning these function seams is what keeps the arms from
+# silently grading the harness runner when the production implementation changes.
+#
 # Same isolation contract as the other task harnesses: source src/ directly,
 # use a throwaway TASKS_DB, stub the task-store audit sink, and touch neither the
 # live board nor the fleet audit log.
@@ -38,8 +44,27 @@ PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 run()   { local verb="$1"; shift; ( JSON_MODE=1; "cmd_task_$verb" "$@" ) 2>"$TMP/err"; }
+# Drive the real authenticated-actor resolver through the DIVE-2330 uid/passwd
+# seams while varying caller provenance independently. These are function seams,
+# not PATH-resolved commands: production defines them after imported functions are
+# loaded, while this already-sourced harness can pin them without teaching a caller
+# how to override the live resolver.
+run_with_identity() { local authenticated="$1" claimed_user="$2" verb="$3"; shift 3
+  (
+    local pinned_uid=987654
+    _gate_caller_uid() { printf '%s' "$pinned_uid"; }
+    _gate_passwd_stream() {
+      [[ -n "$authenticated" ]] \
+        && printf 'agent-%s:x:%s:%s::/nonexistent:/bin/false\n' \
+             "$authenticated" "$pinned_uid" "$pinned_uid"
+      printf '%s\n' "$(</etc/passwd)"
+    }
+    USER="$claimed_user"; SUDO_UID=""; SUDO_USER=""; JSON_MODE=1
+    "cmd_task_$verb" "$@"
+  ) 2>"$TMP/err"
+}
 run_as() { local who="$1" verb="$2"; shift 2
-  ( USER="agent-${who}"; SUDO_UID=""; SUDO_USER=""; JSON_MODE=1; "cmd_task_$verb" "$@" ) 2>"$TMP/err"
+  run_with_identity "$who" "agent-${who}" "$verb" "$@"
 }
 jf() { jq -r "$1" 2>/dev/null; }
 col() { db "SELECT COALESCE($2,'') FROM tasks WHERE id=$1;"; }
@@ -79,6 +104,39 @@ audit_row=$(tail -n 1 "$AUDIT_CALLS")
 [[ "$audit_row" == "task.verify-self-close self-verified-close 0 -- task=${maker_ident} maker=alice verifier=boss iteration=1" ]] \
   && ok_t "distinct audit verb/result attributes the maker close" \
   || bad_t "audit receipt wrong" "$audit_row"
+
+# Regression arm: provenance is forgeable, authenticated identity is not. The
+# recorded maker still receives all three visibility marks when USER and the old
+# resolver's PATH commands both claim a non-maker identity. On the pre-DIVE-2330
+# resolver this shim suppresses the mark; the uid/passwd resolver must ignore it.
+FORGED_PATH="$TMP/forged-path"
+mkdir -p "$FORGED_PATH"
+printf '#!/bin/bash\n[[ "${1:-}" == "-u" ]] && printf "1000\\n" || printf "agent-nobody\\n"\n' >"$FORGED_PATH/id"
+printf '#!/bin/bash\nprintf "agent-nobody:x:1000:1000::/nonexistent:/bin/false\\n"\n' >"$FORGED_PATH/getent"
+chmod +x "$FORGED_PATH/id" "$FORGED_PATH/getent"
+P=$(make_delivered "maker forged provenance visibility")
+before=$(wc -l <"$AUDIT_CALLS")
+forged_out=$(PATH="$FORGED_PATH:$PATH" run_with_identity alice nobody verify "$P" --cmd=true); forged_rc=$?
+after=$(wc -l <"$AUDIT_CALLS")
+[[ $forged_rc -eq 0 && "$(col "$P" status)" == "done" \
+   && "$(col "$P" result)" == *"self-verified-close: maker=alice; verifier=boss never graded; iteration=1"* \
+   && "$after" -eq $((before+1)) && "$(cat "$TMP/err")" == *"self-verified-close"* ]] \
+  && ok_t "forged USER/PATH cannot suppress an authenticated maker self-close mark" \
+  || bad_t "forged USER/PATH bypass remains" "rc=$forged_rc status=$(col "$P" status) audit=$before/$after out=$forged_out err=$(cat "$TMP/err")"
+
+# Fail closed when the kernel identity resolver cannot attribute a caller. The
+# passing command remains useful evidence, but an unclassifiable caller cannot
+# create the exact silent-close shape this visibility rail exists to prevent.
+U=$(make_delivered "unidentified caller control")
+before=$(wc -l <"$AUDIT_CALLS")
+unknown_out=$(run_with_identity "" nobody verify "$U" --cmd=true); unknown_rc=$?
+after=$(wc -l <"$AUDIT_CALLS")
+[[ $unknown_rc -ne 0 && "$(col "$U" status)" == "todo" \
+   && "$(col "$U" result)" == "✅ verify PASS (exit 0): true"* \
+   && "$(col "$U" result)" != *"self-verified-close"* && "$before" == "$after" \
+   && "$(cat "$TMP/err")" == *"caller identity could not be authenticated"* ]] \
+  && ok_t "unidentified caller records PASS evidence but cannot close a delivered loop" \
+  || bad_t "unidentified caller did not fail closed" "rc=$unknown_rc status=$(col "$U" status) result=$(col "$U" result) audit=$before/$after out=$unknown_out err=$(cat "$TMP/err")"
 
 # Control: the assigned verifier's same PASS is an ordinary independent grade.
 V=$(make_delivered "verifier grade control")


### PR DESCRIPTION
Makes the DIVE-2015 maker self-verified-close mark trigger on **kernel-authenticated identity** instead of caller-supplied provenance.

Built by **codex** (commit is theirs, rebased by main onto current main after DIVE-2330 squash-merged and orphaned the stack).

## What changed

`cmd_task_verify` previously keyed the visibility mark on `task_actor`, which this tree documents as answering *"who does the caller **say** they are"* — provenance, and never authentication. Its no-argument fallback chain ends at `${USER}`, a plain env var, so `USER=nobody 5dive task verify DIVE-X --cmd=true` closed the task with **no stamp, no audit row and no stderr warning**. The party the mark exists to expose could switch it off with one env var, silently.

Now the trigger reads `_gate_authenticated_actor` (`$EUID` resolved in pure bash over `/etc/passwd`, no `id`, no `getent` — hardened in DIVE-2330). And an **unidentified** caller — the resolver fails closed to empty — records the passing evidence and then *refuses the auto-close*, rather than closing unmarked.

## Why the harness pins through the seams

The arms drive `_gate_caller_uid` and `_gate_passwd_stream`, the DIVE-2330 function seams, not an `id()` stub. That matters: DIVE-2330 removed `id -un` from this resolver, so an `id()`-based pin would silently stop reaching it and every arm would start grading the real runner — the stranding that took nine harnesses to repair on that row. Function seams also cannot be injected from the environment, because `src` defines them after imported functions load.

## Verification

Graded by main on the **rebased** tree (`f0c90e7`), which descends from current `main`:

| harness | result |
|---|---|
| `task_verify_self_close_visibility_unit` | **10 / 0** |
| `gate_nonce_unit` | 19 / 0 |
| `gate_actor_path_forgery_unit` | 5 / 0 |
| `gate_sudo_uid_forge_unit` | 8 / 0 |
| `gate_t2_nonce_proof_unit` | 25 / 0 |
| `gate_lead_standing_unit` | 73 / 0 |
| `task_cascade_unblock_unit` | 16 / 0 |
| `names_the_tree_contract_unit` | 2 / 0 |
| `ledger_unit` | **19 / 0** (16/1 without a built bundle — the funnel arms fail rather than skip; build first) |

The adversarial arm is genuinely adversarial and I checked it specifically, because its name grew from "forged USER" to "forged USER/PATH" and a widened name over an unchanged body is a classic overclaim. It is not one: it builds a real shim directory with executable `id` and `getent` fakes printing `agent-nobody`, prepends it to `PATH`, and asserts the mark **still** fires with `maker=alice`. That arm would have caught the defect this iteration fixes.

## History

Rejected twice by main. Iteration 1 keyed on `task_actor`; iteration 2 moved to the right resolver but pinned the harness through `id()`, which DIVE-2330 was about to remove. Both are fixed here, and codex picked up the `grading_tree` contract unasked.
