### PR TITLE
fix(task): the bound refusal names every repo it walked, not the last one (DIVE-2266)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -2105,7 +2105,7 @@ _task_status_cmd() {
         # a squash rewrites the sha, so the branch tip is NOT an ancestor of main even
         # though the content is in. Attribution finds it anyway, because the squash
         # commit subject carries the ident.
-        local _slug _bmerged="" _searched="" _attr_slug="" _anc="" _attr="" _anc_novac="" _attr_bound="" _attr_walked="" _attr_unreach=""
+        local _slug _bmerged="" _searched="" _attr_slug="" _anc="" _attr="" _anc_novac="" _attr_bound="" _attr_unreach=""
         while IFS= read -r _slug; do
           [[ -n "$_slug" ]] || continue
           _searched="${_searched:+$_searched, }$_slug"
@@ -2117,10 +2117,11 @@ _task_status_cmd() {
           # guarded — an empty branch contributes no such commit.
           _attr=$(_gate_branch_ident_on_main "$_slug" "$_branch" "$_ghtok" "$ident")
           if [[ "$_attr" == "1" ]]; then _attr_slug="$_slug"; break; fi
-          # bound:<walked> — carry the MEASURED count into the refusal. The number in
-          # that message is the one thing a reader acts on, so it must be what the scan
-          # actually walked and not what it was configured to want.
-          [[ "$_attr" == bound:* ]] && { _attr_bound="$_slug"; _attr_walked="${_attr#bound:}"; }
+          # bound:<walked> — carry every bound-hit repo and ITS OWN measured count into
+          # the refusal. DIVE-2266: overwriting this on each pass named only the last
+          # member of a set search, and a detached count cannot describe multiple repos.
+          [[ "$_attr" == bound:* ]] \
+            && _attr_bound="${_attr_bound:+$_attr_bound, }$_slug:${_attr#bound:} COMMITS WALKED"
           # Ancestry is kept ONLY to name the vacuous shape in the refusal; it can no longer
           # accept anything by itself (that was the DIVE-2101 bug).
           _anc=$(_gate_branch_ancestry "$_slug" "$_branch" "$_ghtok")
@@ -2155,8 +2156,10 @@ _task_status_cmd() {
           # DIVE-2120: the scan stopped AT THE BOUND without finding the ident. That is NOT
           # a miss and must not read as one — a bounded search whose negative looks like an
           # exhaustive one asserts something it never measured. Own slug, so the durable
-          # record says which of the two actually happened.
-          policy_refuse "$E_CONFLICT" done-ident-not-found-within-scan-bound DIVE-2120 "$ident" "$ident cannot close: NOT FOUND IN THE $_attr_walked COMMITS WALKED on ${FIVE_GATE_MAIN_BRANCH:-main} in $_attr_bound — the scan stopped at its bound with main's history NOT exhausted, so this is INCONCLUSIVE, not a finding that the work is absent. TWO explanations survive and this scan cannot separate them: (a) the delivery landed more than $_attr_walked commits ago, or (b) nothing on main ever named $ident in a commit SUBJECT — which is what an EMPTY branch looks like, and a delivery whose subject omits the ident looks the same. For (a) raise the bound and retry (FIVE_GATE_ANCESTRY_SCAN=<n>, paginated since DIVE-2120, so n>100 really does walk n). For (b) land a commit whose SUBJECT names $ident (`5dive push $ident`) or bind the branch that carries it. A merged PR for '$_branch' also satisfies the gate."
+          # record names the whole set that hit a bound, with each repo's own count.
+          # DIVE-2266: a repo outside the searched set is a third live explanation; a
+          # larger bound cannot find it, so give the binding remedies that can terminate.
+          policy_refuse "$E_CONFLICT" done-ident-not-found-within-scan-bound DIVE-2120 "$ident" "$ident cannot close: NOT FOUND WITHIN THE COMMIT SCAN BOUNDS on ${FIVE_GATE_MAIN_BRANCH:-main} in $_attr_bound (repo:commits-walked) — every named repo stopped at its own bound with main's history NOT exhausted, so this is INCONCLUSIVE, not a finding that the work is absent. THREE explanations survive and this scan cannot separate them: (a) the delivery landed before the scanned window in one of those repos, (b) nothing on main ever named $ident in a commit SUBJECT — which is what an EMPTY branch looks like, and a delivery whose subject omits the ident looks the same, or (c) the branch lives in a repo that was NEVER SCANNED. For (a) raise the bound and retry (FIVE_GATE_ANCESTRY_SCAN=<n>, paginated since DIVE-2120, so n>100 really does walk n). For (b) land a commit whose SUBJECT names $ident (\`5dive push $ident\`) or bind the branch that carries it. For (c) add a \`Repo: <owner/repo>\` line to the task body or bind the full delivery_ref (\`task deliver $ident --pr=https://github.com/<owner>/<repo>/pull/N\`). A merged PR for '$_branch' also satisfies the gate."
         elif [[ -n "$_anc_novac" && -z "$_bmerged" ]]; then
           # The vacuous shape, named as itself: an ancestor tip carrying nothing
           # attributable is exactly what an EMPTY branch looks like, and a generic

--- a/tests/task_merge_gate_ancestry_unit.sh
+++ b/tests/task_merge_gate_ancestry_unit.sh
@@ -42,6 +42,9 @@
 #     -> case 3b FAILS (an empty branch closes).
 #   * neuter the refusal — delete/short-circuit the `policy_refuse` in the branch
 #     path -> case 3 FAILS (closes genuinely unmerged work).
+#   * DIVE-2266: change the bound-hit accumulator back to last-write-wins
+#     (`_attr_bound="$_slug:${_attr#bound:}"`) -> ANC-2266 FAILS because the first two
+#     bound-hit repos and their own walked counts disappear from the refusal.
 # Isolation matches the sibling gate harnesses: source src/ into a throwaway
 # STATE_DIR (the live tasks.db is NEVER touched); gh is STUBBED on PATH.
 # Run: bash tests/task_merge_gate_ancestry_unit.sh  (no root, no network).
@@ -360,6 +363,38 @@ slug=$(db "SELECT COALESCE(policy,'') FROM policy_refusals WHERE ident='ANC-8' O
 [[ "$OUT" == *INCONCLUSIVE* ]] \
   && ok_t 'the bound refusal says INCONCLUSIVE, not that the work is absent' \
   || bad_t 'bound message must not read as a miss' "out=$OUT"
+
+# --- DIVE-2266: A SET-BOUND REFUSAL NAMES THE WHOLE SET -----------------------
+# The branch has no Repo: line and no delivery_ref, so every configured repo is
+# searched. Stub the attribution seam directly to give each repo a distinct measured
+# count: that makes both membership and count attachment observable. The old overwrite
+# leaves only the frontend entry and MUST score red here.
+attr_impl=$(declare -f _gate_branch_ident_on_main)
+_gate_branch_ident_on_main() {
+  case "$1" in
+    5dive-ai/5dive)       printf 'bound:2' ;;
+    lodar/5dive-api)      printf 'bound:7' ;;
+    lodar/5dive-frontend) printf 'bound:11' ;;
+  esac
+}
+clear_fx
+seed ANC-2266 'Branch: lives-somewhere-in-the-set'
+FIVE_GATE_REPOS='5dive-ai/5dive,lodar/5dive-api,lodar/5dive-frontend' \
+  run_done ANC-2266 --result='landed somewhere'
+eval "$attr_impl"
+if [[ $RC -ne 0 && "$OUT" == *"5dive-ai/5dive:2"* \
+      && "$OUT" == *"lodar/5dive-api:7"* \
+      && "$OUT" == *"lodar/5dive-frontend:11"* ]]; then
+  ok_t 'a bound-hit refusal names EVERY repo in the searched set with its OWN walked count'
+else
+  bad_t 'bound-hit set must not collapse to its last repo' "rc=$RC out=$OUT"
+fi
+if [[ "$OUT" == *"NEVER SCANNED"* && "$OUT" == *'Repo: <owner/repo>'* \
+      && "$OUT" == *'task deliver ANC-2266 --pr=https://github.com/<owner>/<repo>/pull/N'* ]]; then
+  ok_t 'the bound refusal names the unscanned-repo case and both terminating bindings'
+else
+  bad_t 'bound remediation must cover work outside the searched set' "out=$OUT"
+fi
 
 # --- DIVE-2120: AN INCIDENTAL MENTION IS NOT A DELIVERY -------------------------
 # Searching main widened the attribution set: every commit reachable from a branch tip


### PR DESCRIPTION
Implements DIVE-2266 (diagnosis row DIVE-2263). Maker: codex. Verifier: main.

## What changed

`src/cmd_task.sh` — the multi-repo merge-gate scan loop:

1. The bound-hit accumulator no longer overwrites. Each repo that stops at its bound is appended with **its own** measured walked count (`<slug>:<n> COMMITS WALKED, …`). A single detached `_attr_walked` cannot be correct once N repos are reported, so it is gone.
2. The refusal at the bound interpolates the accumulated set, matching what the sibling refusal already did with `$_searched`.
3. The remediation gained the case it omitted: the branch may live in a repo that was **NEVER SCANNED**. Its remedy is a `Repo:` line or a bound `delivery_ref`, not a bigger `FIVE_GATE_ANCESTRY_SCAN` — raising the bound cannot terminate when the ident is in none of the scanned repos.

Not a behaviour change: searching every configured repo for a task naming none is correct and unchanged. This is a reporting fix.

## Verification (verifier, on the rebased tree f486601)

- `tests/task_merge_gate_ancestry_unit.sh` — **34 passed, 0 failed**
- `tests/task_merge_gate_multirepo_unit.sh` — **36 passed, 0 failed**
- **Required mutation** — restore last-write-wins (`_attr_bound="$_slug:${_attr#bound:} COMMITS WALKED"`) → **33 passed, 1 failed** at `bound-hit set must not collapse to its last repo`. The assertion checks all three `slug:count` pairs, so it cannot pass on the defect the way a "mentions a repo" assertion would.
- `_attr_walked` has no remaining reader in `src/` or `tests/`; `_attr_bound`'s only other use is a presence test, so the format change breaks no consumer.
- The new test stubs the attribution seam per repo with distinct counts and sets `FIVE_GATE_REPOS` explicitly, so it asserts nothing about which repo happens to be last.

Rebased from codex's `d70d9c3` onto `9fc0beb` (authorship preserved) because the branch was cut before DIVE-2330 landed.