### PR TITLE
fix(cli): an unknown-flag error must not replay your payload back at you (DIVE-2121)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -359,6 +359,7 @@ cmd_task_set_body() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --append)      append=1 ;;
+      --append=*)    fail "$E_USAGE" '--append is a boolean flag; pass the text as a positional argument: task set-body <id> --append "<text>"' ;;
       --)            shift; words+=("$@"); break ;;
       -*)            fail "$E_USAGE" "unknown flag: $1" ;;
       *)             if [[ -z "$task" ]]; then task="$1"; else words+=("$1"); fi ;;
@@ -374,7 +375,11 @@ cmd_task_set_body() {
   [[ "$st" != "done" && "$st" != "cancelled" ]] \
     || fail "$E_VALIDATION" "$ident is already $st — its body is frozen (closed tasks don't get retro-edited; bounce it back first with: 5dive task reject $ident --feedback=\"…\")"
   local body; body=$(db "SELECT COALESCE(body,'') FROM tasks WHERE id=${id};")
-  local prior_len=${#body}
+  local prior_len=${#body} prior_lines=0
+  if [[ -n "$body" ]]; then
+    local prior_without_newlines="${body//$'\n'/}"
+    prior_lines=$(( ${#body} - ${#prior_without_newlines} + 1 ))
+  fi
   local newbody
   if (( append )); then
     if [[ -n "$body" ]]; then
@@ -386,10 +391,30 @@ cmd_task_set_body() {
     newbody="$text"
   fi
   db "UPDATE tasks SET body=$(sqlq "$newbody") WHERE id=${id};"
+  local new_len=${#newbody} new_lines=0
+  if [[ -n "$newbody" ]]; then
+    local new_without_newlines="${newbody//$'\n'/}"
+    new_lines=$(( ${#newbody} - ${#new_without_newlines} + 1 ))
+  fi
   local mode="replaced"; (( append )) && mode="appended"
   _task_store_audit_log "task set-body" "ok" 0 -- \
     "task=$ident" "actor=$(task_actor)" "mode=$mode" "prior_len=$prior_len" || true
-  ok "$ident body $mode" '{ident:$id, mode:$m}' --arg id "$ident" --arg m "$mode"
+  local prose="$ident body $mode"
+  if (( ! append )); then
+    local line_delta=$(( new_lines - prior_lines )) char_delta=$(( new_len - prior_len ))
+    local line_delta_display="$line_delta" char_delta_display="$char_delta"
+    (( line_delta > 0 )) && line_delta_display="+$line_delta"
+    (( char_delta > 0 )) && char_delta_display="+$char_delta"
+    local prior_line_word="lines" new_line_word="lines"
+    (( prior_lines == 1 )) && prior_line_word="line"
+    (( new_lines == 1 )) && new_line_word="line"
+    prose+=" ($prior_lines $prior_line_word -> $new_lines $new_line_word, $line_delta_display; $prior_len chars -> $new_len chars, $char_delta_display)"
+  fi
+  ok "$prose" \
+    '{ident:$id, mode:$m, prior_len:$pl, new_len:$nl, prior_lines:$pls, new_lines:$nls}' \
+    --arg id "$ident" --arg m "$mode" \
+    --argjson pl "$prior_len" --argjson nl "$new_len" \
+    --argjson pls "$prior_lines" --argjson nls "$new_lines"
 }
 
 cmd_task_init() {

--- a/src/lib/output.sh
+++ b/src/lib/output.sh
@@ -29,6 +29,28 @@ JSON_MODE=0
 fail() {
   local code="$1"; shift
   local msg="$*"
+  # DIVE-2121: an invalid flag is often one shell token containing a pasted
+  # paragraph (for example --json="<text>"). Echoing that token verbatim can
+  # make the paragraph's closing sentence look like an acknowledgement. Keep
+  # enough of the token to identify the typo, but never replay the whole input.
+  local unknown_flag_marker='unknown flag: '
+  if [[ "$msg" == *"$unknown_flag_marker"* ]]; then
+    local unknown_flag_lead="${msg%%"$unknown_flag_marker"*}"
+    local unknown_flag_token="${msg#*"$unknown_flag_marker"}"
+    if (( ${#unknown_flag_token} > 40 )); then
+      msg="${unknown_flag_lead}${unknown_flag_marker}${unknown_flag_token:0:40}..."
+    fi
+  elif [[ "$msg" == *"unknown flag"* ]]; then
+    # A few older parsers say "unknown flag '<token>'" or "unknown flag for
+    # <verb>: <token>". They share the same payload risk even though they do
+    # not use the prevailing colon form above.
+    local unknown_flag_phrase='unknown flag'
+    local unknown_flag_lead="${msg%%"$unknown_flag_phrase"*}"
+    local unknown_flag_tail="${msg#*"$unknown_flag_phrase"}"
+    if (( ${#unknown_flag_tail} > 40 )); then
+      msg="${unknown_flag_lead}${unknown_flag_phrase}${unknown_flag_tail:0:40}..."
+    fi
+  fi
   if (( JSON_MODE )); then
     local class
     class=$(err_class_for "$code")
@@ -69,4 +91,3 @@ ok() {
   fi
   return 0
 }
-

--- a/tests/task_set_body_unit.sh
+++ b/tests/task_set_body_unit.sh
@@ -52,14 +52,27 @@ out=$(run set_body "$id1" "here is the missing context")
   && ok_t "set-body writes the body" || bad_t "set-body writes the body" "got: $(bodyof "$id1")"
 
 # --- T2: default overwrites, not appends
-run set_body "$id1" "replacement text" >/dev/null
+out2=$(run set_body "$id1" "replacement text")
 [[ "$(bodyof "$id1")" == "replacement text" ]] \
   && ok_t "set-body (no --append) overwrites the prior body" || bad_t "set-body overwrites" "got: $(bodyof "$id1")"
+[[ "$(printf '%s' "$out2" | jf '.data.prior_lines')" == "1" \
+   && "$(printf '%s' "$out2" | jf '.data.new_lines')" == "1" \
+   && "$(printf '%s' "$out2" | jf '.data.prior_len')" == "27" \
+   && "$(printf '%s' "$out2" | jf '.data.new_len')" == "16" ]] \
+  && ok_t "set-body overwrite reports its before/after magnitude" \
+  || bad_t "set-body overwrite magnitude" "$out2"
+JSON_MODE=0
+out2_prose=$(run set_body "$id1" $'replacement line one\nreplacement line two')
+JSON_MODE=1
+[[ "$out2_prose" == *"1 line -> 2 lines, +1"* ]] \
+  && ok_t "set-body prose announces overwrite line delta" \
+  || bad_t "set-body prose overwrite magnitude" "$out2_prose"
 
 # --- T3: --append tacks onto the existing body without clobbering it
+before3=$(bodyof "$id1")
 run set_body "$id1" "an addendum" --append >/dev/null
 b3=$(bodyof "$id1")
-{ printf '%s' "$b3" | grep -q "replacement text" && printf '%s' "$b3" | grep -q "an addendum"; } \
+[[ "$b3" == "${before3}"$'\n\n'"an addendum" ]] \
   && ok_t "set-body --append preserves the prior body and adds the new text" \
   || bad_t "set-body --append preserves + adds" "$b3"
 
@@ -88,6 +101,21 @@ e6=$(run set_body "$id4" "too late"); rc=$?
 e7=$(run set_body "$id1"); rc=$?
 [[ $rc -ne 0 ]] && printf '%s' "$e7" | grep -q "usage: 5dive task set-body" \
   && ok_t "set-body with no text errors" || bad_t "set-body with no text errors" "rc=$rc $e7"
+
+# --- T8: boolean --append=<payload> fails safely without echoing the payload
+payload="ZZPAYLOADZZ this must not look acknowledged"
+before8=$(bodyof "$id1")
+e8=$(run set_body "$id1" "--append=$payload"); rc=$?
+err8=$(<"$TMP/err")
+[[ $rc -eq "$E_USAGE" \
+   && "$e8" == *"--append is a boolean flag"* \
+   && "$e8" != *"$payload"* \
+   && "$err8" != *"$payload"* ]] \
+  && ok_t "set-body rejects --append=<payload> without echoing the payload" \
+  || bad_t "set-body payload-safe boolean error" "rc=$rc stdout=$e8 stderr=$err8"
+[[ "$(bodyof "$id1")" == "$before8" ]] \
+  && ok_t "rejected --append=<payload> leaves the body untouched" \
+  || bad_t "rejected --append=<payload> changed the body" "got: $(bodyof "$id1")"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/tests/task_set_body_unit.sh
+++ b/tests/task_set_body_unit.sh
@@ -117,5 +117,34 @@ err8=$(<"$TMP/err")
   && ok_t "rejected --append=<payload> leaves the body untouched" \
   || bad_t "rejected --append=<payload> changed the body" "got: $(bodyof "$id1")"
 
+# --- T9: another boolean flag cannot replay a pasted paragraph through the
+# shared unknown-flag path. This is deliberately `task ls --json=...`, not the
+# set-body special case above, so the generic error emitter carries the proof.
+other_payload="ZZOTHERBOOLZZ context that ends by claiming FAKE CONFIRMATION"
+e9=$(run ls "--json=$other_payload"); rc=$?
+err9=$(<"$TMP/err")
+[[ $rc -eq "$E_USAGE" \
+   && "$e9" == *"unknown flag: --json=ZZOTHERBOOLZZ"* \
+   && "$e9" == *"..."* \
+   && "$e9" != *"$other_payload"* \
+   && "$e9" != *"FAKE CONFIRMATION"* \
+   && "$err9" != *"$other_payload"* \
+   && "$err9" != *"FAKE CONFIRMATION"* ]] \
+  && ok_t "shared unknown-flag errors truncate another boolean payload" \
+  || bad_t "shared unknown-flag payload truncation" "rc=$rc stdout=$e9 stderr=$err9"
+
+# --- T10: legacy unknown-flag phrasings use the same safety ceiling.
+e10=$( ( fail "$E_USAGE" "unknown flag '$other_payload' (see: 5dive help)" ) 2>"$TMP/err" ); rc=$?
+err10=$(<"$TMP/err")
+[[ $rc -eq "$E_USAGE" \
+   && "$e10" == *"unknown flag 'ZZOTHERBOOLZZ"* \
+   && "$e10" == *"..."* \
+   && "$e10" != *"$other_payload"* \
+   && "$e10" != *"FAKE CONFIRMATION"* \
+   && "$err10" != *"$other_payload"* \
+   && "$err10" != *"FAKE CONFIRMATION"* ]] \
+  && ok_t "legacy unknown-flag errors truncate pasted payloads" \
+  || bad_t "legacy unknown-flag payload truncation" "rc=$rc stdout=$e10 stderr=$err10"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Maker: **codex** (iteration 2). Verifier: **olivia** — this PR exists because codex has no GitHub credential; main pushed and opened it, and has NOT graded it. Do not merge on my say-so.

## The defect

`task set-body <id> --append="<text>"` takes `--append` as a boolean with the text positional, so the natural `=` form falls into the unknown-flag branch — and that branch **prints the flag token**, which now contains the caller's entire paragraph:

    $ 5dive task set-body DIVE-2120 --append="ZZPROBE2ZZ ignore"
    error: unknown flag: --append=ZZPROBE2ZZ ignore

The exit code was already correct (rc=2, nothing written). The hazard is the message: an agent that tails the output reads the closing sentence of its own paragraph as a confirmation. That happened, and the missing text was an acceptance criterion on a high-priority ticket.

## What changed

- `src/cmd_task.sh` — an explicit `--append=*` arm, ordered before the `-*` catch-all, that names the shape and the remedy without echoing the payload.
- `src/lib/output.sh` — `fail()` truncates a long unknown-flag token to 40 chars across **every** command and both legacy phrasings, so the class is closed rather than the instance. `task ls --json=<payload>` is the cross-command regression.
- `src/cmd_task.sh` — the overwrite path now reports its **magnitude** (`37 lines -> 35 lines, -2; N chars -> M chars, -K`) instead of a bare "body replaced". Non-breaking, headless-safe, no new flag and no prompt: a destructive default that will not say what it did is indistinguishable from one that did nothing.

## State

Rebased from `ebd9d36` onto `71d5ed7` (main), authorship preserved. Clean rebase, no conflicts.

Suites on the **rebased** tree `96fe5dc`, run by main before pushing:
- `tests/task_set_body_unit.sh` — 15 passed, 0 failed
- `tests/task_core_unit.sh` — 35 passed, 0 failed

Maker's mutation evidence, **not** re-run by main and left for the verifier: removing only the shared redaction reds exactly T9/T10 (13/15).