### PR TITLE
fix(gate): the SIGNED closure subject and audit caller= must be kernel-owned (DIVE-2383)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -8760,7 +8760,7 @@ cmd_task_answer() {
     # DIVE-2412: _cs_ok is the attested cited-message form. Unlike _cp_ok it is
     # NOT tier-fenced, so it satisfies the evidence rule on a tier-2 approval too.
     local _evid=$(( _hp || _su || _lead_clear || _cp_ok || _cs_ok ))
-    local _caller2; _caller2=$(id -un 2>/dev/null || echo '?')
+    local _caller2; _caller2=$(_gate_caller_user)
     # DIVE-2054: the human-proof/nonce evidence being scored here is stored
     # against $ident in TASKS_DB (not an independent channel/delivery fact like
     # the 3 named exemptions) — fenced.
@@ -8817,7 +8817,7 @@ cmd_task_answer() {
   # (the heuristic can over-match) waits for a human — the conservative correct
   # default for a hard floor; re-file at a lower --tier if the floor misfired.
   if [[ "$gtier" == "2" ]] && (( ! human )) && _gate_proof_enforced; then
-    local _caller3; _caller3=$(id -un 2>/dev/null || echo '?')
+    local _caller3; _caller3=$(_gate_caller_user)
     # DIVE-1437: a tier-2 gate that was LEAD-ROUTED (routed_reviewer set) but is an
     # approval/manual builder gate is the DIVE-1429 stall — the DIVE-1145/1182
     # routing sent it to the org lead, but the T2 hard-human floor here refuses the
@@ -8907,7 +8907,7 @@ cmd_task_answer() {
       # this box, while the citation is attested by Telegram, the one party the
       # caller cannot speak for (_gate_channel_session_ok).
       local _t2_cs="${_cs_ok:-0}"
-      local _t2_caller; _t2_caller=$(id -un 2>/dev/null || echo '?')
+      local _t2_caller; _t2_caller=$(_gate_caller_user)
       # DIVE-2054: the nonce being scored is task-store state for $ident — fenced.
       _task_store_audit_log "task answer t2-human-evidence" \
         "$([[ $(( _t2_hp || _t2_su || _t2_cs )) -eq 1 ]] && echo ok || echo error)" 0 -- \
@@ -8988,7 +8988,7 @@ cmd_task_answer() {
   # the non-root trusted path (dashboard exec as claude) we re-exec the root-only
   # `gate-proof sign` over sudo. Best-effort — a box that can't sign just stores
   # an empty sig (verify reports "unsigned"); the answer NEVER fails on this.
-  local _uid="${SUDO_UID:-$(id -u 2>/dev/null || echo "")}"
+  local _uid; _uid=$(_gate_closure_subject_uid)
   local _ts; _ts=$(date -u '+%Y-%m-%d %H:%M:%S')
   local _vfs=""; [[ "$nt" != "secret" ]] && _vfs="$value"
   local _sig=""
@@ -9116,7 +9116,7 @@ cmd_task_answer() {
   # worse, and the caller has no way to retry a half-applied answer). NEVER logs
   # $value: a secret gate stores nothing, and a decision answer is the human's
   # prose, neither of which belongs in the fleet log.
-  local _caller4; _caller4=$(id -un 2>/dev/null || echo '?')
+  local _caller4; _caller4=$(_gate_caller_user)
   _task_store_audit_log "task answer gate" ok 0 -- \
     "task=$ident" "type=$nt" "tier=${gtier:-}" "answered_by=$answered_by" \
     "uid=${_uid:-}" "sig=$([[ -n "$_sig" ]] && echo present || echo absent)" \

--- a/src/lib/actor.sh
+++ b/src/lib/actor.sh
@@ -111,6 +111,42 @@ _gate_authenticated_actor() {
 # after the fact and not only at answer time.
 _gate_agent_for_uid() { _gate_uid_to_agent "${1:-}"; }
 
+# DIVE-2383: the caller's real username, for the audit log's `caller=` field. Was a
+# bare `id -un` at four sites in cmd_task.sh, which resolves through the CALLER'S
+# PATH — so the one field a forensic reader uses to attribute an action was writable
+# by the party being attributed. None of these feeds a predicate (grepped every use),
+# which is why DIVE-2330 correctly left them alone; but the audit log is our
+# NON-REFUSAL sink, and a forgeable `caller=` poisons the only record of the things
+# that did not refuse.
+#
+# Composed over `actor_uid_to_name`, NOT over `_gate_uid_to_agent`: the latter fails
+# closed to EMPTY for a non-agent uid, which is right for an authorization check and
+# wrong here — `claude` and `root` are real callers and the forensic record has to
+# name them. DIVE-2517 moved that passwd walk here and its own comment gives the
+# reason to reuse it rather than add a second one: "one passwd walk in the tree
+# rather than two that can drift."
+# Falls back to `?` — the same unknown marker the old `|| echo '?'` emitted — so a
+# uid missing from passwd still writes a row rather than an empty field.
+_gate_caller_user() {
+  local u; u=$(actor_uid_to_name "$(_gate_caller_uid)")
+  [[ -n "$u" ]] && { printf '%s' "$u"; return; }
+  printf '?'
+}
+
+# DIVE-2383: the uid stamped into — and SIGNED over — the DIVE-756 closure payload.
+# Was `${SUDO_UID:-$(id -u 2>/dev/null || echo "")}`: it trusted SUDO_UID
+# unconditionally and fell back to a PATH-resolved `id -u`. Both are caller-writable
+# below EUID 0, so a forged subject landed inside a tamper-EVIDENT record and the
+# signature then attested the lie. That is strictly worse than an unsigned wrong
+# value, because `gate-proof verify` reports the forgery as INTACT.
+# SUDO_UID is honoured ONLY at EUID 0 — the same fence `_gate_authenticated_actor`
+# above already documents: sudo writes it, and a non-root process that forges it
+# cannot also become root. Below root the answer is $EUID, which the kernel owns.
+_gate_closure_subject_uid() {
+  if _gate_is_root && [[ -n "${SUDO_UID:-}" ]]; then printf '%s' "$SUDO_UID"; return; fi
+  _gate_caller_uid
+}
+
 # ---------------------------------------------------------------------------
 # actor_derive — the same uid-first derivation, but it REPORTS its work.
 #

--- a/tests/gate_actor_path_forgery_unit.sh
+++ b/tests/gate_actor_path_forgery_unit.sh
@@ -7,6 +7,19 @@
 # every agent sets its own PATH. These arms run the REAL substitution and demand
 # the real identity back.
 #
+# DIVE-2383 extends this harness rather than adding a sibling, because the defect is
+# the SAME defect at three more resolvers that DIVE-2330 correctly left out of scope
+# (none of them authorizes anything):
+#   * `_gate_caller_user`        — the audit log's `caller=` field, our non-refusal sink.
+#   * `_gate_closure_subject_uid` — the DIVE-756 SIGNED closure subject. This one is
+#     worse than an unsigned wrong value: the signature attests the forgery, so
+#     `gate-proof verify` reports a forged subject as INTACT.
+#   Both compose over DIVE-2517's `actor_uid_to_name` (src/lib/actor.sh), the
+#   pure-bash passwd resolver — not a second walk of their own.
+# Every arm below carries its own VACUITY ANCHOR proving the pre-fix expression IS
+# forged by the very same shim, because an arm that only checks the new code cannot
+# tell a fix from a coincidence.
+#
 # GROUND TRUTH IS TAKEN WITHOUT THE FUNCTION UNDER TEST: the expected name comes
 # from /proc/self/status's real uid resolved against /etc/passwd by awk, never
 # from `id` and never from the resolver being graded.
@@ -50,20 +63,30 @@ EXPECT=""; [[ "$REAL_NAME" == agent-* ]] && EXPECT="${REAL_NAME#agent-}"
 # strict uid-first derivation was promoted to the single one. Same names, same
 # bodies — only the file changed. `actor_uid_to_name` is NOT optional: it is the
 # passwd walk `_gate_uid_to_agent` now composes over, and without it the resolver
-# returns empty for every uid and arms 1-3 pass vacuously (the same way
-# `_gate_passwd_stream` had to be added in iteration 2).
-eval "$(sed -n '/^_gate_passwd_stream()/,/^}/p'        src/lib/actor.sh)"
-eval "$(sed -n '/^_gate_is_root()/,/^}/p'             src/lib/actor.sh)"
-eval "$(sed -n '/^actor_uid_to_name()/,/^}/p'         src/lib/actor.sh)"
-eval "$(sed -n '/^_gate_uid_to_agent()/,/^}/p'        src/lib/actor.sh)"
-eval "$(sed -n '/^_gate_caller_uid()/,/^}/p'          src/lib/actor.sh)"
-eval "$(sed -n '/^_gate_authenticated_actor()/,/^}/p' src/lib/actor.sh)"
-for _f in _gate_passwd_stream _gate_is_root actor_uid_to_name _gate_uid_to_agent _gate_caller_uid _gate_authenticated_actor; do
+# returns empty for every uid and arms 1-3 pass vacuously.
+#
+# DIVE-2383 adds the last two to that SAME file. Its original form defined a third,
+# `actor_uid_to_name`, in cmd_task.sh — dropped because DIVE-2517's
+# `actor_uid_to_name` IS that function, arrived at independently. actor.sh's own
+# comment gives the reason not to add a second: "one passwd walk in the tree rather
+# than two that can drift."
+eval "$(sed -n '/^_gate_passwd_stream()/,/^}/p'         src/lib/actor.sh)"
+eval "$(sed -n '/^_gate_is_root()/,/^}/p'              src/lib/actor.sh)"
+eval "$(sed -n '/^actor_uid_to_name()/,/^}/p'          src/lib/actor.sh)"
+eval "$(sed -n '/^_gate_uid_to_agent()/,/^}/p'         src/lib/actor.sh)"
+eval "$(sed -n '/^_gate_caller_uid()/,/^}/p'           src/lib/actor.sh)"
+eval "$(sed -n '/^_gate_authenticated_actor()/,/^}/p'  src/lib/actor.sh)"
+eval "$(sed -n '/^_gate_caller_user()/,/^}/p'          src/lib/actor.sh)"
+eval "$(sed -n '/^_gate_closure_subject_uid()/,/^}/p'  src/lib/actor.sh)"
+for _f in _gate_passwd_stream _gate_is_root actor_uid_to_name _gate_uid_to_agent _gate_caller_uid \
+          _gate_authenticated_actor _gate_caller_user _gate_closure_subject_uid; do
   declare -F "$_f" >/dev/null || { printf 'NOT OK - %s did not load; the arms below would be vacuous\n' "$_f"; exit 1; }
 done
 
 SHIM=$(mktemp -d)
-printf '#!/bin/sh\necho agent-lodar\n'  > "$SHIM/id";     chmod +x "$SHIM/id"
+# `id -u` must forge a NUMERIC uid too — DIVE-2383's closure-subject arm abuses
+# `id -u`, not `id -un`. Dispatching on the flag keeps arms 1-4 byte-identical.
+printf '#!/bin/sh\ncase "$1" in\n  -u) echo 4242 ;;\n  *)  echo agent-lodar ;;\nesac\n' > "$SHIM/id"; chmod +x "$SHIM/id"
 printf '#!/bin/sh\necho agent-lodar:x:0:0:::\n' > "$SHIM/getent"; chmod +x "$SHIM/getent"
 trap 'rm -rf "$SHIM"' EXIT
 
@@ -105,6 +128,79 @@ old_shim=$(PATH="$SHIM:$PATH" _old_actor)
 [[ -z "$(_gate_uid_to_agent 'not-a-uid')" ]] \
   && ok "a non-numeric uid resolves to empty (fails closed)" \
   || no "non-numeric uid did not fail closed"
+
+# --- DIVE-2383: the audit `caller=` field ------------------------------------
+# Ground truth is REAL_NAME straight from /proc + /etc/passwd via awk. Note this arm
+# needs no agent-* precondition: unlike the actor resolver, `caller=` must name
+# `claude` and `root` too, which is exactly why actor_uid_to_name exists alongside
+# _gate_uid_to_agent.
+caller_clean=$(_gate_caller_user)
+caller_shim=$(PATH="$SHIM:$PATH" _gate_caller_user)
+
+# 6. A hostile PATH must not change the logged caller, and it must be the real name.
+if [[ "$caller_shim" == "$caller_clean" && "$caller_shim" == "$REAL_NAME" ]]; then
+  ok "the audit caller= survives a hostile PATH and names the kernel identity ($REAL_NAME)"
+else
+  no "caller= forged or wrong: clean='$caller_clean' shimmed='$caller_shim' real='$REAL_NAME'"
+fi
+
+# 7. And never the forged name.
+[[ "$caller_shim" != "agent-lodar" && "$caller_shim" != "lodar" ]] \
+  && ok "the forged caller name is never logged" \
+  || no "caller= returned the FORGED identity '$caller_shim'"
+
+# 8. VACUITY ANCHOR for arms 6-7: the pre-fix expression IS forged by this shim.
+_old_caller() { id -un 2>/dev/null || echo '?'; }
+old_caller_shim=$(PATH="$SHIM:$PATH" _old_caller)
+[[ "$old_caller_shim" == "agent-lodar" ]] \
+  && ok "ANCHOR: the pre-fix bare 'id -un' logs the forged caller (agent-lodar)" \
+  || no "ANCHOR FAILED — shim did not forge the old caller= (got '$old_caller_shim'); arms 6-7 are vacuous"
+
+# --- DIVE-2383: the SIGNED closure subject uid --------------------------------
+# Two independent forges, because the pre-fix expression had two holes:
+#   ${SUDO_UID:-$(id -u)}  ->  an env var below root, AND a PATH-resolved binary.
+_old_subject_uid() { printf '%s' "${SUDO_UID:-$(id -u 2>/dev/null || echo "")}"; }
+
+if _gate_is_root; then
+  # At EUID 0 SUDO_UID is written by sudo and is TRUSTED by design — the fix keeps
+  # that branch. Skipping rather than passing: this runner cannot exercise the hole.
+  skip "closure-subject arms — runner is root (uid $REAL_UID), where SUDO_UID is trusted by design"
+  skip "closure-subject SUDO_UID anchor — same reason"
+else
+  # 9. Forged SUDO_UID + hostile PATH must not move the signed subject.
+  subj=$(SUDO_UID=4242 PATH="$SHIM:$PATH" _gate_closure_subject_uid)
+  [[ "$subj" == "$REAL_UID" ]] \
+    && ok "the SIGNED closure subject stays the kernel uid ($REAL_UID) under a forged SUDO_UID and PATH" \
+    || no "signed closure subject was moved to '$subj' (expected $REAL_UID)"
+
+  # 10. ANCHOR: the pre-fix expression takes the forged env var.
+  old_subj_env=$(SUDO_UID=4242 _old_subject_uid)
+  [[ "$old_subj_env" == "4242" ]] \
+    && ok "ANCHOR: the pre-fix \${SUDO_UID:-...} signs the forged env uid (4242)" \
+    || no "ANCHOR FAILED — forged SUDO_UID did not move the old subject (got '$old_subj_env'); arm 9 is vacuous"
+
+  # 11. ANCHOR: and with SUDO_UID absent it takes the PATH shim instead. Both holes
+  #     are real, so both need their own anchor — closing one would otherwise look
+  #     like closing the class.
+  old_subj_path=$(unset SUDO_UID; PATH="$SHIM:$PATH" _old_subject_uid)
+  [[ "$old_subj_path" == "4242" ]] \
+    && ok "ANCHOR: with SUDO_UID unset the pre-fix falls back to the PATH-forged 'id -u' (4242)" \
+    || no "ANCHOR FAILED — PATH shim did not forge the old subject (got '$old_subj_path'); arm 9 is half-vacuous"
+fi
+
+# 12. Numeric-only contract on the new resolver, matching arm 5.
+[[ -z "$(actor_uid_to_name 'not-a-uid')" ]] \
+  && ok "actor_uid_to_name: a non-numeric uid resolves to empty (fails closed)" \
+  || no "actor_uid_to_name did not fail closed on a non-numeric uid"
+
+# 13. And the `?` fallback is reached rather than an empty field, so a uid missing
+#     from passwd still writes an attributable row.
+_gate_caller_uid_saved=$(declare -f _gate_caller_uid)
+_gate_caller_uid() { printf '%s' '4242'; }
+[[ "$(_gate_caller_user)" == "?" ]] \
+  && ok "an unresolvable uid logs '?' rather than an empty caller= field" \
+  || no "unresolvable uid did not fall back to '?' (got '$(_gate_caller_user)')"
+eval "$_gate_caller_uid_saved"
 
 printf '\ngate_actor_path_forgery_unit: %d passed, %d failed, %d skipped (runner %s, uid %s)\n' \
   "$PASS" "$FAIL" "$SKIP" "${REAL_NAME:-?}" "$REAL_UID"


### PR DESCRIPTION
Maker: **main**. Needs a verifier — I wrote this, so I am not grading it. Suggest **dev**, who filed the row while verifying DIVE-2330.

## Why this is not just more of DIVE-2330

2330 fixed the resolvers that **authorize**. It correctly stopped there. These three **decide nothing and record everything**, and they all read a PATH-resolved `id`:

| site | old expression | what it feeds |
|---|---|---|
| `cmd_task.sh` closure stamp | `${SUDO_UID:-$(id -u 2>/dev/null \|\| echo "")}` | the **DIVE-756 SIGNED** closure subject |
| `_caller2` / `_caller3` / `_t2_caller` / `_caller4` | `id -un 2>/dev/null \|\| echo '?'` | `audit_log caller=` only |

**The signed one is the sharp one.** Everything DIVE-2330 fixed was a predicate — forge it and a check says yes when it should say no, which is bad but leaves no artifact. Forge *this* and the false uid goes **inside a tamper-evident record**, and `_gate_closure_sign` then attests it. `gate-proof verify` reports a forged subject as **INTACT**. A signature over an unauthenticated subject is worse than no signature, because it converts "we don't know" into "we checked".

Two independent holes, both real, both anchored in the tests:
- `SUDO_UID` was trusted **unconditionally**. Below EUID 0 it is a plain env var. It is now honoured only when `_gate_is_root`, the identical fence `_gate_authenticated_actor` already documents: sudo writes it, and a non-root process that forges it cannot also become root.
- the fallback was a **PATH-resolved** `id -u`. It is now `$EUID`, a bash builtin the kernel owns.

**The four `caller=` sites are lower severity and still worth closing.** None reaches a predicate — dev grepped every use before filing and I re-checked. But the audit log is our **non-refusal sink**: the only record of the things that did *not* get stopped. A forgeable `caller=` poisons precisely the surface a forensic reader has left after everything else has failed open.

## What changed

- `_gate_uid_to_user` — `_gate_uid_to_agent`'s sibling over the same `_gate_passwd_stream` seam. It exists because `caller=` must be able to name `claude` and `root`, and the agent resolver fails closed to empty for both.
- `_gate_caller_user` — the caller's real username, `?` when the uid is not in passwd (the same unknown marker the old `|| echo '?'` emitted, so a missing uid still writes an attributable row rather than an empty field).
- `_gate_closure_subject_uid` — the signed subject, per the fence above.
- five call sites re-pointed. No new seam: `_gate_caller_uid` and `_gate_passwd_stream` were already in this file.

## Verification

`tests/gate_actor_path_forgery_unit.sh` extended from 5 arms to **13 passed, 0 failed, 0 skipped** (runner agent-main, uid 1004). Extended rather than forked, because it is the same defect at three more resolvers.

The shim now answers `id -u` numerically as well as `id -un`, so the closure-subject arm abuses the **real** substitution rather than a mock. Arms 1-4 are byte-identical in behaviour.

**Mutations — each new claim has its own anchor, and I ran both:**

| mutation | result |
|---|---|
| `_gate_caller_user` back to `id -un` | **10 passed, 3 failed** — forged caller, forged-name arm, and the `?` fallback arm |
| `_gate_closure_subject_uid` back to `${SUDO_UID:-$(id -u)}` | **12 passed, 1 failed** — `signed closure subject was moved to '4242'` |

Plus three in-harness anchors that fire on every run, proving the pre-fix expressions ARE forged by the very same shim: bare `id -un` returns `agent-lodar`; `${SUDO_UID:-…}` takes the forged env uid `4242`; and with `SUDO_UID` unset it takes the PATH-forged `id -u` `4242`. Both holes get their own anchor deliberately — closing one would otherwise look like closing the class.

Root runners **skip** the closure-subject arms with a stated reason rather than passing them, since at EUID 0 the `SUDO_UID` branch is trusted by design and the hole cannot be exercised. A skip is not a pass.

No collateral, all on this tree: `gate_nonce` 19/0, `gate_sudo_uid_forge` 8/0, `gate_t2_nonce_proof` 25/0, `gate_lead_standing` 73/0, `gate_proof_verify` 10/0, `gate_proof_lazy_resolve` 8/0, `gate_delivery_actor` 13/0, `task_core` 35/0, `names_the_tree_contract` 2/0, `task_merge_gate_ancestry` 32/0.

## Found while in here, deliberately NOT fixed in this PR

`_task_owner_channel` (`cmd_task.sh:~5870`) resolves `${USER:-$(id -un 2>/dev/null)}` to pick **which agent's bot sends a notification**. Both halves are caller-writable — the env var directly, the fallback via PATH. Same *kind* of defect, different surface (notification routing, not the gate path), so it does not belong in this diff. Recorded here and on DIVE-2383 rather than filed as its own row, because tonight's lesson was that our review process files rows faster than anyone drains them. The other two remaining `id -un` uses are benign: `cmd_task.sh:1229` only decides whether to attempt a `sudo -n` that fails closed anyway.