### PR TITLE
council: surface a zero-substantive-vote round instead of absorbing it into the merged tally (DIVE-2103, re-land)

### DIFF
--- a/src/cmd_council.sh
+++ b/src/cmd_council.sh
@@ -1222,6 +1222,12 @@ export function canonicalTranscript(rec) {
     const r1 = rec.round1Votes.slice().sort((a, b) => (norm(a.seat) < norm(b.seat) ? -1 : 1))
     for (const v of r1) L.push(`round1 ${norm(v.seat)}: ${norm(v.vote != null ? v.vote : v.choice)} :: ${norm(v.rationale)}`)
   }
+  // DIVE-2103: CONDITIONAL on the CNCL-19 precedent — emitted ONLY when some round returned
+  // zero substantive votes, so a healthy convene seals BYTE-IDENTICALLY.
+  if (Array.isArray(rec.roundStats) && rec.roundStats.some(r => r && r.substantive === 0)) {
+    for (const r of rec.roundStats) L.push(`round${norm(r.round)} participation: dispatched=${norm(r.dispatched)} substantive=${norm(r.substantive)} abstains=${norm(r.abstains)} unreached=${norm(r.unreached)}`)
+    if (rec.degradedToSingleRound) L.push('degraded: adversarial round 1 returned zero substantive votes — the rebuttal had nothing to rebut')
+  }
   // DIVE-1869: SEAL which seats we never REACHED. The abstain/capture-failure distinction has to
   // survive on the DURABLE record, not just in the run — a later reader of a receipt is otherwise
   // back to guessing whether "0 of 6 voted" was a council that said nothing or a rail that was
@@ -1797,6 +1803,18 @@ function log(on, msg) { if (on) process.stderr.write(`[council] ${msg}\n`) }
 // round1Votes + rebuttalVotes stay recorded raw alongside the merged `votes`, so the full two-round
 // record is auditable. Deterministic + pure (unit-tested). A seat that never cast a substantive vote
 // in either round stays an abstain; a convene where every seat re-casts is byte-identical to before.
+// DIVE-2103: per-round participation, so an EMPTY round is VISIBLE instead of being absorbed
+// by the merged tally. Both existing guards read only the MERGED votes — quorum in
+// countConveneVotes, and the DIVE-1869 outage refusal — so a round returning nothing escapes
+// both. Measured n=2 on OPPOSITE rounds (2026-07-20 round 2; 2026-07-21 seq 1 round 1).
+// Surfaced, NEVER fatal: a degenerate round does not invalidate a verdict that met quorum.
+export function roundParticipation(round, votes) {
+  const v = Array.isArray(votes) ? votes : []
+  const substantive = v.filter(x => x && x.vote !== 'abstain').length
+  const unreached = v.filter(x => x && x.capture === false).length
+  return { round, dispatched: v.length, substantive, abstains: v.length - substantive, unreached }
+}
+
 export function carryForwardVotes(round1Votes, rebuttalVotes) {
   const SUBSTANTIVE = new Set(['approve', 'reject', 'escalate'])
   const r1By = new Map((round1Votes || []).map(v => [String(v.seat), v]))
@@ -1911,6 +1929,7 @@ async function runConvene(input, deps, h) {
   // retrieval is deterministic + key-free; the pool is passed in by the CLI (which reads the log).
   const precedents = selectPrecedents(question, input.precedentPool || [], input.precedentK != null ? input.precedentK : 3)
   let round1Votes, finalVotes, rebuttalVotes = null, verdict
+  let _roundStats = null, _degraded = false   // DIVE-2103
   if (seatVote) {
     log(verbose, `dispatching ${seats.length} real seats (blind round 1, ${mode})${precedents.length ? `, ${precedents.length} precedent(s)` : ''}`)
     round1Votes = await dispatchRound(seats, { question, role, mode, round: 1, precedents }, seatVote)
@@ -1920,6 +1939,11 @@ async function runConvene(input, deps, h) {
       rebuttalVotes = await dispatchRound(seats, { question, role, mode, round: 2, priorVotes: round1Votes, precedents }, seatVote)
       finalVotes = carryForwardVotes(round1Votes, rebuttalVotes)
     }
+    _roundStats = [roundParticipation(1, round1Votes)]   // DIVE-2103
+    if (rebuttalVotes) _roundStats.push(roundParticipation(2, rebuttalVotes))
+    _degraded = mode === 'adversarial' && _roundStats[0].substantive === 0
+    for (const _r of _roundStats) if (_r.substantive === 0) process.stderr.write(`council: WARNING round ${_r.round} returned ZERO substantive votes (${_r.dispatched} dispatched, ${_r.abstains} abstained, ${_r.unreached} unreached) — the verdict stands; the deliberation for that round does not\n`)
+    if (_degraded) process.stderr.write('council: WARNING adversarial run DEGRADED TO SINGLE ROUND — round 1 was empty\n')
     const counted = tallyVotes(finalVotes, tallyOpts)
     verdict = buildConveneVerdict(counted, synthesizeNarrative(finalVotes, counted), finalVotes)
   } else {
@@ -1933,6 +1957,11 @@ async function runConvene(input, deps, h) {
       rebuttalVotes = await Promise.all(seats.map(s => askSeam(s, { question, round: 2, priorVotes: round1Votes, precedents })))
       finalVotes = carryForwardVotes(round1Votes, rebuttalVotes)
     }
+    _roundStats = [roundParticipation(1, round1Votes)]   // DIVE-2103
+    if (rebuttalVotes) _roundStats.push(roundParticipation(2, rebuttalVotes))
+    _degraded = mode === 'adversarial' && _roundStats[0].substantive === 0
+    for (const _r of _roundStats) if (_r.substantive === 0) process.stderr.write(`council: WARNING round ${_r.round} returned ZERO substantive votes (${_r.dispatched} dispatched, ${_r.abstains} abstained, ${_r.unreached} unreached) — the verdict stands; the deliberation for that round does not\n`)
+    if (_degraded) process.stderr.write('council: WARNING adversarial run DEGRADED TO SINGLE ROUND — round 1 was empty\n')
     const counted = tallyVotes(finalVotes, tallyOpts)
     const narr = await chairNarrative(modelCall, question, finalVotes)
     verdict = buildConveneVerdict(counted, narr, finalVotes)
@@ -1950,7 +1979,7 @@ async function runConvene(input, deps, h) {
   verdict = attachVetoOffer(verdict, input.vetoOffer)
   return finish(role, input, {
     question, mode, seats, guardrail: null, convened: true,
-    takes: [], votes: finalVotes, round1Votes, rebuttalVotes, verdict,
+    takes: [], votes: finalVotes, round1Votes, rebuttalVotes, verdict, roundStats: _roundStats, degradedToSingleRound: _degraded,
   })
 }
 
@@ -2014,6 +2043,7 @@ function finish(role, input, base) {
       // Seal round-1 history ONLY when a rebuttal round ran (adversarial); a single-round receipt
       // omits it and stays byte-identical to CNCL-6. Makes the between-round record tamper-evident.
       ...(base.rebuttalVotes ? { round1Votes: base.round1Votes } : {}),
+      ...(base.roundStats ? { roundStats: base.roundStats, degradedToSingleRound: !!base.degradedToSingleRound } : {}),
     }
     out.receipt = { canonical: canonicalTranscript(rec), ...sealCommands() }
   }

--- a/src/council/engine.mjs
+++ b/src/council/engine.mjs
@@ -975,6 +975,12 @@ export function canonicalTranscript(rec) {
     const r1 = rec.round1Votes.slice().sort((a, b) => (norm(a.seat) < norm(b.seat) ? -1 : 1))
     for (const v of r1) L.push(`round1 ${norm(v.seat)}: ${norm(v.vote != null ? v.vote : v.choice)} :: ${norm(v.rationale)}`)
   }
+  // DIVE-2103: CONDITIONAL on the CNCL-19 precedent — emitted ONLY when some round returned
+  // zero substantive votes, so a healthy convene seals BYTE-IDENTICALLY.
+  if (Array.isArray(rec.roundStats) && rec.roundStats.some(r => r && r.substantive === 0)) {
+    for (const r of rec.roundStats) L.push(`round${norm(r.round)} participation: dispatched=${norm(r.dispatched)} substantive=${norm(r.substantive)} abstains=${norm(r.abstains)} unreached=${norm(r.unreached)}`)
+    if (rec.degradedToSingleRound) L.push('degraded: adversarial round 1 returned zero substantive votes — the rebuttal had nothing to rebut')
+  }
   // DIVE-1869: SEAL which seats we never REACHED. The abstain/capture-failure distinction has to
   // survive on the DURABLE record, not just in the run — a later reader of a receipt is otherwise
   // back to guessing whether "0 of 6 voted" was a council that said nothing or a rail that was
@@ -1550,6 +1556,18 @@ function log(on, msg) { if (on) process.stderr.write(`[council] ${msg}\n`) }
 // round1Votes + rebuttalVotes stay recorded raw alongside the merged `votes`, so the full two-round
 // record is auditable. Deterministic + pure (unit-tested). A seat that never cast a substantive vote
 // in either round stays an abstain; a convene where every seat re-casts is byte-identical to before.
+// DIVE-2103: per-round participation, so an EMPTY round is VISIBLE instead of being absorbed
+// by the merged tally. Both existing guards read only the MERGED votes — quorum in
+// countConveneVotes, and the DIVE-1869 outage refusal — so a round returning nothing escapes
+// both. Measured n=2 on OPPOSITE rounds (2026-07-20 round 2; 2026-07-21 seq 1 round 1).
+// Surfaced, NEVER fatal: a degenerate round does not invalidate a verdict that met quorum.
+export function roundParticipation(round, votes) {
+  const v = Array.isArray(votes) ? votes : []
+  const substantive = v.filter(x => x && x.vote !== 'abstain').length
+  const unreached = v.filter(x => x && x.capture === false).length
+  return { round, dispatched: v.length, substantive, abstains: v.length - substantive, unreached }
+}
+
 export function carryForwardVotes(round1Votes, rebuttalVotes) {
   const SUBSTANTIVE = new Set(['approve', 'reject', 'escalate'])
   const r1By = new Map((round1Votes || []).map(v => [String(v.seat), v]))
@@ -1664,6 +1682,7 @@ async function runConvene(input, deps, h) {
   // retrieval is deterministic + key-free; the pool is passed in by the CLI (which reads the log).
   const precedents = selectPrecedents(question, input.precedentPool || [], input.precedentK != null ? input.precedentK : 3)
   let round1Votes, finalVotes, rebuttalVotes = null, verdict
+  let _roundStats = null, _degraded = false   // DIVE-2103
   if (seatVote) {
     log(verbose, `dispatching ${seats.length} real seats (blind round 1, ${mode})${precedents.length ? `, ${precedents.length} precedent(s)` : ''}`)
     round1Votes = await dispatchRound(seats, { question, role, mode, round: 1, precedents }, seatVote)
@@ -1673,6 +1692,11 @@ async function runConvene(input, deps, h) {
       rebuttalVotes = await dispatchRound(seats, { question, role, mode, round: 2, priorVotes: round1Votes, precedents }, seatVote)
       finalVotes = carryForwardVotes(round1Votes, rebuttalVotes)
     }
+    _roundStats = [roundParticipation(1, round1Votes)]   // DIVE-2103
+    if (rebuttalVotes) _roundStats.push(roundParticipation(2, rebuttalVotes))
+    _degraded = mode === 'adversarial' && _roundStats[0].substantive === 0
+    for (const _r of _roundStats) if (_r.substantive === 0) process.stderr.write(`council: WARNING round ${_r.round} returned ZERO substantive votes (${_r.dispatched} dispatched, ${_r.abstains} abstained, ${_r.unreached} unreached) — the verdict stands; the deliberation for that round does not\n`)
+    if (_degraded) process.stderr.write('council: WARNING adversarial run DEGRADED TO SINGLE ROUND — round 1 was empty\n')
     const counted = tallyVotes(finalVotes, tallyOpts)
     verdict = buildConveneVerdict(counted, synthesizeNarrative(finalVotes, counted), finalVotes)
   } else {
@@ -1686,6 +1710,11 @@ async function runConvene(input, deps, h) {
       rebuttalVotes = await Promise.all(seats.map(s => askSeam(s, { question, round: 2, priorVotes: round1Votes, precedents })))
       finalVotes = carryForwardVotes(round1Votes, rebuttalVotes)
     }
+    _roundStats = [roundParticipation(1, round1Votes)]   // DIVE-2103
+    if (rebuttalVotes) _roundStats.push(roundParticipation(2, rebuttalVotes))
+    _degraded = mode === 'adversarial' && _roundStats[0].substantive === 0
+    for (const _r of _roundStats) if (_r.substantive === 0) process.stderr.write(`council: WARNING round ${_r.round} returned ZERO substantive votes (${_r.dispatched} dispatched, ${_r.abstains} abstained, ${_r.unreached} unreached) — the verdict stands; the deliberation for that round does not\n`)
+    if (_degraded) process.stderr.write('council: WARNING adversarial run DEGRADED TO SINGLE ROUND — round 1 was empty\n')
     const counted = tallyVotes(finalVotes, tallyOpts)
     const narr = await chairNarrative(modelCall, question, finalVotes)
     verdict = buildConveneVerdict(counted, narr, finalVotes)
@@ -1703,7 +1732,7 @@ async function runConvene(input, deps, h) {
   verdict = attachVetoOffer(verdict, input.vetoOffer)
   return finish(role, input, {
     question, mode, seats, guardrail: null, convened: true,
-    takes: [], votes: finalVotes, round1Votes, rebuttalVotes, verdict,
+    takes: [], votes: finalVotes, round1Votes, rebuttalVotes, verdict, roundStats: _roundStats, degradedToSingleRound: _degraded,
   })
 }
 
@@ -1767,6 +1796,7 @@ function finish(role, input, base) {
       // Seal round-1 history ONLY when a rebuttal round ran (adversarial); a single-round receipt
       // omits it and stays byte-identical to CNCL-6. Makes the between-round record tamper-evident.
       ...(base.rebuttalVotes ? { round1Votes: base.round1Votes } : {}),
+      ...(base.roundStats ? { roundStats: base.roundStats, degradedToSingleRound: !!base.degradedToSingleRound } : {}),
     }
     out.receipt = { canonical: canonicalTranscript(rec), ...sealCommands() }
   }

--- a/tests/council_empty_round_unit.mjs
+++ b/tests/council_empty_round_unit.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// DIVE-2103: an EMPTY convene round must be VISIBLE, never silently absorbed.
+//
+// The defect this guards: both existing guards read only the MERGED tally — quorum in
+// countConveneVotes, and the DIVE-1869 outage-is-not-a-decision refusal — so a round that
+// returned zero substantive votes escapes both. Measured n=2 on OPPOSITE rounds: 2026-07-20
+// round 2 empty (a live approve/reject split ERASED, run went inquorate), and 2026-07-21 seq 1
+// round 1 empty while the receipt still read `approve a3/r0/e0 conf=1 dissent=none`.
+//
+// MUTATION-GRADED (the VERIFY BY bar): arm D neutralises the detector and REQUIRES red. A test
+// that only asserts the happy path cannot tell a working detector from a deleted one — which is
+// the exact class (vacuous assertion) that made T9 pass on a timeout for its entire life.
+import { roundParticipation, canonicalTranscript } from '../src/council/engine.mjs'
+
+let pass = 0, fail = 0
+const ok = (m) => { pass++; console.log(`ok   - ${m}`) }
+const bad = (m, d) => { fail++; console.log(`FAIL - ${m}${d ? `\n   ${d}` : ''}`) }
+const t = (m, c, d) => (c ? ok(m) : bad(m, d))
+
+const abstained = (seats) => seats.map(s => ({ seat: s, vote: 'abstain', abstainKind: 'deadline' }))
+const voted     = (seats) => seats.map(s => ({ seat: s, vote: 'approve', rationale: 'r' }))
+const SEATS = ['a', 'b', 'c']
+
+// --- A. the detector itself -------------------------------------------------
+{
+  const r = roundParticipation(1, abstained(SEATS))
+  t('A1 all-abstain round reports ZERO substantive', r.substantive === 0, `got ${r.substantive}`)
+  t('A2 dispatched still counts every seat', r.dispatched === 3, `got ${r.dispatched}`)
+  t('A3 abstains account for the whole round', r.abstains === 3, `got ${r.abstains}`)
+
+  const g = roundParticipation(2, voted(SEATS))
+  t('A4 a healthy round reports substantive === dispatched', g.substantive === 3 && g.dispatched === 3)
+
+  // capture===false is DIVE-1869 "never reached", which is NOT the same as abstained-by-deadline
+  const u = roundParticipation(1, [{ seat: 'a', vote: 'abstain', capture: false }])
+  t('A5 unreached seats are counted separately from abstains', u.unreached === 1)
+}
+
+// --- B. the canonical seals it ONLY when a round was empty -------------------
+// olivia's hard constraint: a healthy receipt must stay byte-identical, or every prior seal breaks.
+{
+  const base = {
+    council: 'c', mode: 'adversarial', stampedAt: '2026-01-01T00:00:00Z', question: 'q',
+    seats: SEATS, votes: voted(SEATS), verdict: { recommendation: 'approve' },
+  }
+  const healthy = canonicalTranscript({ ...base, roundStats: [roundParticipation(1, voted(SEATS))] })
+  t('B1 a HEALTHY round emits NO participation line (byte-identical constraint)',
+    !healthy.includes('participation:'), healthy.split('\n').find(l => l.includes('participation')))
+
+  const degenerate = canonicalTranscript({
+    ...base,
+    roundStats: [roundParticipation(1, abstained(SEATS)), roundParticipation(2, voted(SEATS))],
+    degradedToSingleRound: true,
+  })
+  t('B2 an EMPTY round emits its participation line', degenerate.includes('round1 participation:'))
+  t('B3 the sibling round is emitted too, so the record is symmetric', degenerate.includes('round2 participation:'))
+  t('B4 the empty line reports substantive=0', /round1 participation:.*substantive=0/.test(degenerate))
+  t('B5 an adversarial run with an empty round 1 is marked DEGRADED', degenerate.includes('degraded:'))
+
+  // the omission must be driven by emptiness, not by the flag being absent
+  const noFlag = canonicalTranscript({ ...base, roundStats: [roundParticipation(1, abstained(SEATS))] })
+  t('B6 participation seals even when degradedToSingleRound is unset', noFlag.includes('round1 participation:'))
+  t('B7 ...but the degraded line does NOT', !noFlag.includes('degraded:'))
+}
+
+// --- C. no roundStats at all => pre-2103 receipts are unchanged --------------
+{
+  const legacy = canonicalTranscript({
+    council: 'c', mode: 'deliberate', stampedAt: '2026-01-01T00:00:00Z', question: 'q',
+    seats: SEATS, votes: voted(SEATS), verdict: { recommendation: 'approve' },
+  })
+  t('C1 a record with no roundStats seals with no participation lines',
+    !legacy.includes('participation:') && !legacy.includes('degraded:'))
+}
+
+// --- D. MUTATION ARM: neutralise the detector, REQUIRE red -------------------
+// If roundParticipation stopped distinguishing abstains, A1/B4 would still pass on a *healthy*
+// round — so this arm proves the assertions above are load-bearing rather than decorative.
+{
+  const neutralised = (round, votes) => ({
+    round, dispatched: (votes || []).length,
+    substantive: (votes || []).length,          // <- the bug: counts abstains as substantive
+    abstains: 0, unreached: 0,
+  })
+  const r = neutralised(1, abstained(SEATS))
+  t('D1 MUTANT: a detector that counts abstains as substantive reports 3, not 0', r.substantive === 3)
+
+  const canon = canonicalTranscript({
+    council: 'c', mode: 'adversarial', stampedAt: '2026-01-01T00:00:00Z', question: 'q',
+    seats: SEATS, votes: voted(SEATS), verdict: { recommendation: 'approve' },
+    roundStats: [r], degradedToSingleRound: false,
+  })
+  t('D2 MUTANT: the empty round would seal NOTHING, i.e. the defect returns silently',
+    !canon.includes('participation:'),
+    'if this fails the mutation did not neutralise anything and arm B proves less than it claims')
+}
+
+console.log(`\nDIVE-2103 empty-round visibility: ${pass} passed, ${fail} failed`)
+process.exit(fail === 0 ? 0 : 1)


### PR DESCRIPTION
**This is a re-land of work that was graded PASS on 2026-07-26 and never reached main.** Maker was **codex** (`d949a14`), verifier **olivia**. Content unchanged in substance; I rebased, resolved, and re-verified.

## Why it was lost

The task was closed `done` on 2026-07-26 16:48:50. Its verifier wrote the reason it should not have been, verbatim in the close result:

> "…and the branch is unmerged, so the ship itself is still Marcus's gate."

Nobody came back for it. This predates the DIVE-1830 merge-gate, so nothing refused the close — the board said done, the code said nothing, and the only copy was a branch on the stale pile. Found while auditing that pile; **DIVE-2389** inventories three more of these, including two test harnesses (224 lines) that exist nowhere but a `salvage/*` branch.

Measured before writing this: `grep DIVE-2103` over `origin/main`'s `src/cmd_council.sh` and `src/council/engine.mjs` returns **0**, and `tests/council_empty_round_unit.mjs` is absent from main entirely.

## Two mechanical differences from `d949a14`, both forced by main moving four days

1. The branch carried the generated bundle (`5dive`, `5dive.sha256`). DIVE-2091 stopped tracking those on main, so they are **dropped**, not resurrected.
2. `src/cmd_council.sh` is **generated** from `engine.mjs` + `cli.mjs` by `src/council/gen_cmd.mjs`. Hand-resolving its conflict would have written a file the next regen silently reverts, so main's copy was taken and the file regenerated from the merged engine. I checked the original diff for any non-JS hunk first — there is none, and the template needed no change.

## Verification on THIS tree, not read off the original grade

- `tests/council_empty_round_unit.mjs` — **15 passed, 0 failed**
- `tests/council_cli_contract.mjs` — **64 passed, 0 failed**
- `tests/council_engine_unit.mjs` — **195 passed, 0 failed** (bound to `src/council/engine.mjs`)
- **Mutation, reproducing the verifier's own control exactly**: neutralise the detector (`substantive = v.length`) → **8 passed, 7 failed**; restore → back to 15/0. The suite is mutation-graded, not vacuous.

The seal stays **conditional**, so a healthy convene and every pre-2103 receipt seal byte-identically.

## What is still not verified, and was not in the original grade either

No live end-to-end convene receipt was diffed — there are no real seats to dispatch. The byte-identical property rests on the conditional-seal code path plus the executable arms, exactly as olivia recorded on the original close.