### PR TITLE
task: gate-withdraw refusal must name every identity the authorizing block walked (DIVE-2382)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -4692,8 +4692,14 @@ cmd_task_need() {
     # SUDO_* or the real id -un — see its comment), NEVER on --from. The gate's filer
     # is its assignee of record; the filer's routed lead / org coordinator may also
     # withdraw, as may a genuine human. An agent that is none of these is refused.
-    local w_filer w_id w_kind w_name="" w_lead w_coord w_ok=0
+    local w_filer w_id w_kind w_name="" w_lead w_coord w_ok=0 w_by w_who
     w_filer=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=${id};")
+    # DIVE-2382: the ORIGINAL filer-of-record, for the refusal text ONLY. Authorization
+    # stays on the assignee by DIVE-1945's decision (withdraw rights follow the HOLDER,
+    # so a handoff moves the ask away from whoever first filed it) — but the old refusal
+    # called the assignee "the gate's filer", which on a handed-off or auto-created row
+    # names as filer someone who never filed it. Name both, and say which one authorizes.
+    w_by=$(db "SELECT COALESCE(NULLIF(gate_filed_by,''),NULLIF(created_by,''),'') FROM tasks WHERE id=${id};")
     w_id=$(_gate_withdraw_actor)                          # "agent <name>" | "human" | "none"
     w_kind="${w_id%% *}"
     [[ "$w_kind" == "agent" ]] && w_name="${w_id#agent }"
@@ -4703,7 +4709,17 @@ cmd_task_need() {
     [[ -n "$w_name" && "$w_name" == "$w_filer" ]] && w_ok=1                # the filer
     [[ -n "$w_name" && -n "$w_lead"  && "$w_name" == "$w_lead"  ]] && w_ok=1  # filer's lead
     [[ -n "$w_name" && -n "$w_coord" && "$w_name" == "$w_coord" ]] && w_ok=1  # org coordinator
-    (( w_ok )) || policy_refuse "$E_AUTH_REQUIRED" gate-withdraw-not-authorized DIVE-1401 "$ident" "only the gate's filer (${w_filer:-?}), their lead, or a human can withdraw $ident's gate"
+    # DIVE-2382: name EVERY identity the block above actually walked, with its resolved
+    # value. The old text named only "the gate's filer, their lead, or a human" and
+    # silently dropped the org coordinator — a FILER-INDEPENDENT condition — so a caller
+    # who WAS the coordinator, and was authorized, read a message saying they were not.
+    # Two agents independently concluded from that text that DIVE-2106 could never be
+    # retired; both were wrong, and that is the mechanism behind the stale-gate class.
+    # Unresolvable conditions render as "none" rather than vanishing, so a reader can
+    # tell "this route does not exist here" from "this route was never offered".
+    w_who="the gate's holder (assignee ${w_filer:-?})"
+    [[ -n "$w_by" && "$w_by" != "$w_filer" ]] && w_who+=" — filed by ${w_by}, who cannot withdraw it since the handoff"
+    (( w_ok )) || policy_refuse "$E_AUTH_REQUIRED" gate-withdraw-not-authorized DIVE-1401 "$ident" "only ${w_who}, their lead (${w_lead:-none}), the org coordinator (${w_coord:-none}), or a human can withdraw $ident's gate"
     # Clear every gate field and unblock back to todo when no dependency edge
     # still holds it. The withdrawn gate is archived to gate_history first, in
     # the same transaction (DIVE-2119).

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -4694,11 +4694,22 @@ cmd_task_need() {
     # withdraw, as may a genuine human. An agent that is none of these is refused.
     local w_filer w_id w_kind w_name="" w_lead w_coord w_ok=0 w_by w_who
     w_filer=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=${id};")
-    # DIVE-2382: the ORIGINAL filer-of-record, for the refusal text ONLY. Authorization
-    # stays on the assignee by DIVE-1945's decision (withdraw rights follow the HOLDER,
-    # so a handoff moves the ask away from whoever first filed it) — but the old refusal
-    # called the assignee "the gate's filer", which on a handed-off or auto-created row
-    # names as filer someone who never filed it. Name both, and say which one authorizes.
+    # DIVE-2382: the ORIGINAL filer-of-record, for the refusal text ONLY — this change
+    # does NOT move authorization. The old refusal called the assignee "the gate's filer",
+    # which on a handed-off or auto-created row names as filer someone who never filed it.
+    # Name both, and say which one authorizes.
+    #
+    # WHOSE ASK IT IS AND WHO MAY WITHDRAW IT ARE STILL DIFFERENT ANSWERS HERE, and that
+    # is an OPEN question, not a settled one — do not read the text below as ratifying it.
+    # gate_filed_by exists (DIVE-1945) precisely because assignee is not a reliable record
+    # of whose ask a gate is: per its own schema comment, "assignee is rewritten to the
+    # filer only on the human lane, so a gate one agent files on another's task had no
+    # record of whose ask it is". Every other reader honours that (:2857, :6127, the
+    # heartbeat's T1 routing); this site does not, so an agent who filed a gate on someone
+    # else's task cannot withdraw their own ask while the holder can. Latent today (the
+    # live rows where they differ are all answered, and --withdraw refuses an answered
+    # gate). Widening authorization is a policy call and is deliberately NOT bundled into
+    # this text fix — see community/wiki/a-refusal-that-names-a-smaller-set-than-the-code-checked.md.
     w_by=$(db "SELECT COALESCE(NULLIF(gate_filed_by,''),NULLIF(created_by,''),'') FROM tasks WHERE id=${id};")
     w_id=$(_gate_withdraw_actor)                          # "agent <name>" | "human" | "none"
     w_kind="${w_id%% *}"
@@ -4718,7 +4729,7 @@ cmd_task_need() {
     # Unresolvable conditions render as "none" rather than vanishing, so a reader can
     # tell "this route does not exist here" from "this route was never offered".
     w_who="the gate's holder (assignee ${w_filer:-?})"
-    [[ -n "$w_by" && "$w_by" != "$w_filer" ]] && w_who+=" — filed by ${w_by}, who cannot withdraw it since the handoff"
+    [[ -n "$w_by" && "$w_by" != "$w_filer" ]] && w_who+=" — filed by ${w_by}, but withdraw authorizes on the HOLDER, not the filer"
     (( w_ok )) || policy_refuse "$E_AUTH_REQUIRED" gate-withdraw-not-authorized DIVE-1401 "$ident" "only ${w_who}, their lead (${w_lead:-none}), the org coordinator (${w_coord:-none}), or a human can withdraw $ident's gate"
     # Clear every gate field and unblock back to todo when no dependency edge
     # still holds it. The withdrawn gate is archived to gate_history first, in

--- a/tests/gate_withdraw_unit.sh
+++ b/tests/gate_withdraw_unit.sh
@@ -135,7 +135,7 @@ out=$(wd DIVE-201 ROOT SU=agent-creative); rc=$?
 # T2: an unrelated agent (SUDO_USER=agent-grok) is REFUSED.
 file_secret_gate DIVE-202
 out=$(wd DIVE-202 ROOT SU=agent-grok); rc=$?
-[[ $rc -ne 0 && "$(gate_open DIVE-202)" == "open" && "$out" == *"only the gate's filer"* ]] \
+[[ $rc -ne 0 && "$(gate_open DIVE-202)" == "open" && "$out" == *"only the gate's holder"* ]] \
   && ok_t "T2 unrelated agent REFUSED (gate untouched, actionable msg)" \
   || bad_t "T2 unrelated refused" "rc=$rc open=$(gate_open DIVE-202) out=$out"
 
@@ -215,6 +215,83 @@ out=$(wd DIVE-207 ROOT SU=agent-creative); rc=$?
 [[ $rc -ne 0 && "$out" == *"no gate to withdraw"* ]] \
   && ok_t "T7 no-gate task refuses --withdraw" \
   || bad_t "T7 no-gate" "rc=$rc out=$out"
+
+# ── DIVE-2382: the refusal must name EVERY identity the authorizing block walked ──
+# The shipped text named "the gate's filer, their lead, or a human" and dropped the ORG
+# COORDINATOR — condition 4, which does not consult the filer at all. So a coordinator
+# who WAS authorized read a message saying they were not, and two agents independently
+# concluded from that text that a gate could never be retired. Both were wrong.
+#
+# Grading note, and it is the whole point: an assertion that merely greps the word
+# "coordinator" in the message PASSES on a build where condition 4 was deleted and the
+# text left behind — the exact shape that shipped. So the message arms are paired with a
+# LIVENESS arm that actually withdraws AS the coordinator, which goes RED on that
+# mutation, and with a DISTINCTNESS arm proving the coordinator is not reachable through
+# the lead condition (in the org above, main is BOTH creative's lead and the coordinator,
+# so T3 cannot tell the two conditions apart and grades neither of them alone).
+db "INSERT INTO agents_org (name, role, reports_to) VALUES ('pi',NULL,'grok');"
+file_pi_gate() { seed_task "$1"; IS_ROOT=1 IDUN=root cmd_task_need "$1" --type=secret --ask="drop the fixture key" --from=pi >/dev/null 2>&1; }
+z_lead=$(_gate_route_reviewer pi); z_coord=$(_task_resolve_coordinator)
+[[ "$z_lead" == "grok" && "$z_coord" == "main" && "$z_lead" != "$z_coord" ]] \
+  && ok_t "T-2382-DISTINCT pi's lead (grok) is NOT the coordinator (main) — the coordinator arm cannot pass through the lead condition" \
+  || bad_t "T-2382-DISTINCT" "lead='$z_lead' coord='$z_coord'"
+
+# T-2382a LIVENESS / mutation-decisive: the coordinator withdraws a gate held by an agent
+# who does NOT report to them. Only condition 4 can authorize this. Delete condition 4
+# from src/cmd_task.sh and this arm goes RED.
+file_pi_gate DIVE-240
+[[ "$(gate_open DIVE-240)" == "open" ]] || bad_t "T-2382a precond" "open=$(gate_open DIVE-240)"
+out=$(wd DIVE-240 ROOT SU=agent-main); rc=$?
+[[ $rc -eq 0 && "$(gate_open DIVE-240)" == "cleared" ]] \
+  && ok_t "T-2382a org coordinator withdraws a gate held OUTSIDE their reporting line (condition 4 is live)" \
+  || bad_t "T-2382a coordinator withdraw" "rc=$rc open=$(gate_open DIVE-240) out=$out"
+
+# T-2382b/c/d: the refusal on the SAME row, from a caller who is none of the four
+# (creative is neither pi's lead nor the coordinator), names each route by its RESOLVED
+# value — so a reader can act on it instead of deriving "nobody can retire this".
+file_pi_gate DIVE-241
+out=$(wd DIVE-241 ROOT SU=agent-creative); rc=$?
+[[ $rc -ne 0 && "$(gate_open DIVE-241)" == "open" ]] \
+  && ok_t "T-2382b unauthorized caller still refused (the fix is the message, not the policy)" \
+  || bad_t "T-2382b still refused" "rc=$rc open=$(gate_open DIVE-241) out=$out"
+[[ "$out" == *"the org coordinator (main)"* ]] \
+  && ok_t "T-2382c refusal names the ORG COORDINATOR by resolved value (was omitted entirely)" \
+  || bad_t "T-2382c names coordinator" "out=$out"
+[[ "$out" == *"their lead (grok)"* ]] \
+  && ok_t "T-2382d refusal names the LEAD by resolved value, not the bare word 'lead'" \
+  || bad_t "T-2382d names lead" "out=$out"
+
+# T-2382e: on a row where nothing was handed off, holder IS the filer-of-record — the
+# "filed by" clause must NOT appear. Grading the clause's presence is worthless without
+# this arm: a build that appends it unconditionally would pass every arm below.
+[[ "$(db "SELECT COALESCE(gate_filed_by,'') FROM tasks WHERE ident='DIVE-241';")" == "pi" ]] \
+  && ok_t "T-2382e precond: DIVE-241 was filed BY its holder (gate_filed_by=assignee=pi)" \
+  || bad_t "T-2382e precond" "gate_filed_by=$(db "SELECT COALESCE(gate_filed_by,'') FROM tasks WHERE ident='DIVE-241';")"
+[[ "$out" == *"holder (assignee pi)"* && "$out" != *"filed by"* ]] \
+  && ok_t "T-2382e no handoff -> refusal names the holder and omits the filer clause (clause is conditional, not decorative)" \
+  || bad_t "T-2382e no-handoff clause" "out=$out"
+
+# T-2382f HANDOFF (DIVE-1945's case): pi files, the row is then reassigned to creative, so
+# withdraw rights MOVE to creative and pi — who actually filed it — no longer holds them.
+# The old text called creative "the gate's filer", naming as filer someone who never filed
+# it, and gave pi no hint their own ask had left them.
+file_pi_gate DIVE-242
+db "UPDATE tasks SET assignee='creative' WHERE ident='DIVE-242';"   # what a reassign does
+out=$(wd DIVE-242 ROOT SU=agent-grok); rc=$?
+[[ $rc -ne 0 && "$out" == *"holder (assignee creative)"* && "$out" == *"filed by pi"* ]] \
+  && ok_t "T-2382f handoff -> refusal names the HOLDER (creative) and the FILER-OF-RECORD (pi) separately" \
+  || bad_t "T-2382f handoff naming" "rc=$rc out=$out"
+
+# T-2382g the DIVE-2106 shape: a carrier row with NO gate_filed_by, created by someone who
+# is not the holder. This is the row two agents read the old refusal on and concluded
+# nobody could ever retire it. The message must now fall back to created_by AND name the
+# coordinator, which is who could in fact have retired it all along.
+file_pi_gate DIVE-243
+db "UPDATE tasks SET gate_filed_by=NULL WHERE ident='DIVE-243';"    # legacy / auto-created row
+out=$(wd DIVE-243 ROOT SU=agent-creative); rc=$?
+[[ $rc -ne 0 && "$out" == *"filed by main"* && "$out" == *"the org coordinator (main)"* ]] \
+  && ok_t "T-2382g no gate_filed_by -> falls back to created_by AND still names the coordinator (the DIVE-2106 dead-end)" \
+  || bad_t "T-2382g legacy row naming" "rc=$rc out=$out"
 
 echo "----"
 echo "PASS=$PASS FAIL=$FAIL"


### PR DESCRIPTION
## The bug

`task need --withdraw` (DIVE-1401) authorizes on **four** conditions:

1. a genuine human caller
2. the gate's holder — `assignee` of record
3. the holder's routed lead — `_gate_route_reviewer`
4. the **org coordinator** — `_task_resolve_coordinator`, which does **not consult the filer at all**

The refusal named only *"only the gate's filer (X), their lead, or a human can withdraw"* and dropped condition 4. So a caller who **was** the coordinator, and **was** authorized, read a message telling them they were not.

This is the mechanism behind the stale-gate class, not a cosmetic bug. Two agents independently concluded from this text that DIVE-2106 could never be retired — its filer `cli` is absent from `agents_org`, so it has no lead — when the coordinator could have withdrawn it at any point. Same defect class as DIVE-2266 (a refusal naming one member of the set it actually walked), now twice observed in this file.

## Second, smaller, same lines

The message called the `assignee` "the gate's filer". Authorizing on the assignee is **deliberate** (DIVE-1945: withdraw rights follow the **holder**, so a handoff moves the ask away from whoever filed it) — so authorization is unchanged here. But on a handed-off or auto-created carrier row that text names as *filer* someone who never filed it. The refusal now names the holder and, when it differs, the filer-of-record (`gate_filed_by`, falling back to `created_by`), plus which of the two actually authorizes. Unresolvable routes render as `none` rather than vanishing, so a reader can tell "no such route here" from "route never offered".

**No policy change.** Every accept/refuse decision is byte-identical; only the text a refused caller reads changes.

## Grading — why the message arms alone are worthless

`tests/gate_withdraw_unit.sh`: **22 arms, was 15.** The row that filed this warned that an assertion merely grepping for the word "coordinator" *passes on a build where condition 4 was deleted and the text left behind* — the exact shape that shipped. Measured on the committed tree:

| mutation | result |
|---|---|
| delete condition 4, leave the text | **21 pass / 1 FAIL** — only `T-2382a` (liveness: coordinator actually withdraws) goes red. `T-2382c` (names the coordinator) **stays green**, confirming the warned-about vacuity. |
| restore the shipped refusal text, conditions intact | **16 pass / 6 FAIL** (`T2`, `T-2382c/d/e/f/g`) |
| emit the filer clause unconditionally | **21 pass / 1 FAIL** (`T-2382e`) — the clause is conditional, not decorative |

New arms:

- `T-2382-DISTINCT` — the pre-existing fixture had `main` as **both** creative's lead **and** the coordinator, so the old `T3` could not tell conditions 3 and 4 apart and graded neither alone. New `pi → grok` line makes lead ≠ coordinator.
- `T-2382a` — **liveness**, the mutation-decisive arm: the coordinator withdraws a gate held **outside** their reporting line. Only condition 4 can authorize it.
- `T-2382b/c/d` — refusal still refuses, and names the coordinator and lead by **resolved value**.
- `T-2382e` — no handoff → the filer clause must be **absent**.
- `T-2382f` — handoff → names holder and filer-of-record separately.
- `T-2382g` — the DIVE-2106 shape (no `gate_filed_by`, created by a non-holder) → falls back to `created_by` **and** names the coordinator, i.e. exactly the exit the two agents read as nonexistent.

## Verification

- `tests/gate_withdraw_unit.sh` — 22 passed, 0 failed
- adjacent harnesses unaffected: `gate_filer_of_record_unit` 10/0, `gate_history_unit` 32/0, `gate_sudo_uid_forge_unit` 8/0, `verifier_gate_ack_unit` 27/0, `tasks_store_fence_unit` 12/0
- corpus swept for the old refusal string: no other harness asserts on it
- `shellcheck -S error`: clean apart from the file's pre-existing SC2148 (sourced fragment, no shebang)

## Scope

This is fix **#5** of the six on DIVE-2382, and the cheapest. The remaining five (auto-retire on resolution, dedup/link gates sharing a blocker, render the actual tier requirement instead of `human gate:`, let channel proof satisfy a tier-2 gate, make poller *arming* visible) are subsystem work and one of them needs a human policy call. DIVE-2382 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-on — the REPLACE, and how NOT to grade it

Ruled by main on this row: the principal defect is fixed by **replacing** the column at `:4696` so it reads what `:6127` already reads (`gate_filed_by` → `created_by` → `assignee`), then aligning `:2857`. **One notion of "the gate's filer", three sites** — today the file carries three different ones.

**Do not accept the additive version.** Adding `gate_filed_by` as a *fifth* authorizer treats the defect as a missing grant. It fixes only the under-permissive half — the real filer regains the right to retire their own ask — and leaves the over-permissive half standing: **a reassigned holder can still retire a question they never asked**, which is the DIVE-2133 shape this row was filed about.

So the pair of arms that carries the grade is:

| arm | today | after the replace |
|---|---|---|
| the **filer-of-record** can withdraw their own gate | **RED** | green |
| a **reassigned holder** can **no longer** withdraw a gate they never filed | **GREEN** | **must FLIP to red-then-green under the new policy** |

A suite that adds only the first arm **passes on a widening** — the exact change we agreed not to build. Both arms must PERFORM a withdraw, as five **distinct** agents (filer / holder / lead / coordinator / human); see the fixture-collapse note above for why sharing one name across two routes grades neither.

Zero live impact either way: the six rows where the columns differ are all answered, and `--withdraw` refuses an answered gate. That is the argument for changing the policy now rather than later. It needs olivia's sign-off (org coordinator, and the principal condition 4 names) before it lands, and it is **not** in this PR.
