### PR TITLE
install: mark the merge-deploys paths at the edit site, and scope install-guard honestly (DIVE-2288)

### DIFF
--- a/.github/workflows/install-guard.yml
+++ b/.github/workflows/install-guard.yml
@@ -1,12 +1,23 @@
 # DIVE-2144, scope item 4: put the root-path diff in front of a human on every PR.
 #
-# After the tag cutover, install.sh is the only file still fetched from mutable main
-# and executed AS ROOT on every box (cmd_selfupdate.sh re-fetches and runs it on each
-# upgrade). A change to it is live on the whole fleet the moment it merges, with no
-# tag in between. This job does not block that — CODEOWNERS plus branch protection is
-# what blocks it. This job makes it IMPOSSIBLE TO MERGE ONE WITHOUT HAVING SEEN IT:
-# the full diff lands in the job summary, so "I didn't realise that PR touched the
-# root path" stops being available as an explanation.
+# After the tag cutover, install.sh is the only file IN THIS REPO still fetched from
+# mutable main and executed AS ROOT on every box (cmd_selfupdate.sh re-fetches and runs
+# it on each upgrade). A change to it is live on the whole fleet the moment it merges,
+# with no tag in between. This job does not block that — CODEOWNERS plus branch
+# protection is what blocks it. This job makes it IMPOSSIBLE TO MERGE ONE WITHOUT
+# HAVING SEEN IT: the full diff lands in the job summary, so "I didn't realise that PR
+# touched the root path" stops being available as an explanation.
+#
+# DIVE-2288/DIVE-2308 — READ THE SCOPE OF THE SENTENCE ABOVE. "The only file in this
+# repo" is TRUE and it is a SAMPLE, not the population. The risk this job exists to
+# bound is what reaches a customer BOX without a tag, and by that boundary install.sh
+# is 1 of 7 live merge-deploys sites. The other six are BRANCH TARBALLS of
+# 5dive-ai/skills and 5dive-ai/5dive-plugins, fetched by install.sh and root-installed
+# on every --upgrade. NO PATH FILTER IN THIS REPO CAN EVER SEE THEM, because a path
+# filter is scoped to the artifact you are editing while the hazard is scoped to where
+# the bytes land. So this job cannot be widened to cover them — it can only SAY SO,
+# which the summary below now does. A guard that names its own blind spot is worth more
+# than one that reads as exhaustive.
 name: install-guard
 on:
   pull_request:
@@ -45,6 +56,24 @@ jobs:
             echo "at merge, with no release tag in between (DIVE-2144)."
             echo
             echo "Changed: \`$(tr '\n' ' ' <<<"$files")\`"
+            echo
+            echo "### What this job CANNOT see (DIVE-2288 / DIVE-2308)"
+            echo
+            echo "install.sh is **1 of 7** live merge-deploys sites that reach a box without a tag."
+            echo "The other six are branch tarballs of **other repos**, fetched by install.sh and"
+            echo "root-installed on every \`--upgrade\`. A path filter here is blind to all of them:"
+            echo
+            echo "| what lands | from | pinnable via |"
+            echo "|---|---|---|"
+            echo "| the \`5dive-cli\` skill | \`5dive-ai/skills@refs/heads/main\` | \`SKILLS_REPO_TARBALL\` |"
+            echo "| telegram-codex | \`5dive-ai/5dive-plugins@refs/heads/main\` | \`CODEX_PLUGIN_TARBALL\` |"
+            echo "| telegram-grok | same | \`GROK_PLUGIN_TARBALL\` |"
+            echo "| telegram-agy | same | \`AGY_PLUGIN_TARBALL\` |"
+            echo "| telegram-opencode | same | \`OPENCODE_PLUGIN_TARBALL\` |"
+            echo "| telegram-pi | same | \`PI_PLUGIN_TARBALL\` |"
+            echo
+            echo "Each site is marked \`MERGE-DEPLOYS\` in install.sh. A merge in either of those"
+            echo "repos ships to the fleet with no tag, no cut, and no review in this repo."
             echo
             echo '```diff'
             git diff "$base" "$head" -- install.sh src/cmd_selfupdate.sh

--- a/.github/workflows/install-guard.yml
+++ b/.github/workflows/install-guard.yml
@@ -11,7 +11,11 @@
 # DIVE-2288/DIVE-2308 — READ THE SCOPE OF THE SENTENCE ABOVE. "The only file in this
 # repo" is TRUE and it is a SAMPLE, not the population. The risk this job exists to
 # bound is what reaches a customer BOX without a tag, and by that boundary install.sh
-# is 1 of 7 live merge-deploys sites. The other six are BRANCH TARBALLS of
+# is 1 of 7 live merge-deploys sites ON THE ROOT-INSTALLED-ON-UPGRADE RAIL, measured
+# 2026-07-30 against 6f5e5c9. (DIVE-2308 enumerated 9 on 07-29; row 8 is now closed and
+# row 9 is the by-design `status` badge branch. Two further sites — `_marketplace_base`
+# and `_loops_base` — fetch another repo's mutable main ON DEMAND rather than on
+# upgrade, so they are a different rail and deliberately not in the 7.) The other six are BRANCH TARBALLS of
 # 5dive-ai/skills and 5dive-ai/5dive-plugins, fetched by install.sh and root-installed
 # on every --upgrade. NO PATH FILTER IN THIS REPO CAN EVER SEE THEM, because a path
 # filter is scoped to the artifact you are editing while the hazard is scoped to where
@@ -59,7 +63,9 @@ jobs:
             echo
             echo "### What this job CANNOT see (DIVE-2288 / DIVE-2308)"
             echo
-            echo "install.sh is **1 of 7** live merge-deploys sites that reach a box without a tag."
+            echo "install.sh is **1 of 7** live merge-deploys sites on the root-installed-on-upgrade"
+            echo "rail — measured 2026-07-30 against \`6f5e5c9\`. DIVE-2308 enumerated 9 on 07-29; row 8"
+            echo "(the version probe) is now closed and row 9 is the by-design \`status\` branch."
             echo "The other six are branch tarballs of **other repos**, fetched by install.sh and"
             echo "root-installed on every \`--upgrade\`. A path filter here is blind to all of them:"
             echo

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,21 @@
 # The same property holds for the six BRANCH-TARBALL fetches below (skills and
 # 5dive-plugins, marked `MERGE-DEPLOYS` at each site) — those land root-installed
 # from ANOTHER repo's mutable main, where no control in this repo can see them.
-# Full enumeration, 9 sites across 4 repos (DIVE-2308):
+#
+# THE COUNT, WITH ITS SCOPE AND ITS DATE, because a bare figure at an edit site is
+# the very thing this comment exists to prevent:
+#   7 live sites ON THE ROOT-INSTALLED-ON-UPGRADE RAIL — this file plus the six
+#   branch tarballs below — as of 2026-07-30, measured against 6f5e5c9.
+#   DIVE-2308 enumerated 9 on 2026-07-29 against 44e612f. Row 8 (the version probe
+#   calling main HEAD "published") is CLOSED: `_published_cli_probe` now resolves
+#   the newest release tag and fails closed. Row 9 (the `status` badge branch) is
+#   public-by-design and off the install path.
+#   ADJACENT AND DELIBERATELY NOT IN THE 7 — a different rail, named so the number
+#   cannot be mistaken for the whole population: `_marketplace_base`
+#   (src/cmd_pack.sh) and `_loops_base` (src/cmd_loop_pack.sh) each fetch another
+#   repo's mutable main, but ON DEMAND when a user runs the verb, not root-installed
+#   on every upgrade.
+# Full enumeration and its negative space (DIVE-2308, corrected 2026-07-30):
 #   community/wiki/the-merge-deploys-population-is-scoped-to-the-box-not-to-the-repo.md
 #
 # Everything else the installer places comes through `$REPO`, which DIVE-2144

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,29 @@
 #!/usr/bin/env bash
 # 5dive CLI installer / uninstaller
+#
+# ============================================================================
+#  THIS FILE DEPLOYS ON MERGE. THERE IS NO TAG BETWEEN YOU AND THE FLEET.
+# ============================================================================
+# Everywhere else in this repo, merging is STAGING and the release cut is the
+# publish act. Not here. This file is fetched from `refs/heads/main` and run AS
+# ROOT on every box's next `--upgrade` (`src/cmd_selfupdate.sh`, `5dive uninstall`,
+# and the public `curl … | sudo bash`). A merge to it is live fleet-wide within
+# one upgrade cycle, with no tag, no cut, and no rollback point.
+#
+# So the rule everyone was taught — "merging is safe, the cut is the risky part" —
+# is EXACTLY BACKWARDS in this file, and nothing in a diff or a PR title says so.
+# That inversion is DIVE-2288; this comment is the fix for it.
+#
+# The same property holds for the six BRANCH-TARBALL fetches below (skills and
+# 5dive-plugins, marked `MERGE-DEPLOYS` at each site) — those land root-installed
+# from ANOTHER repo's mutable main, where no control in this repo can see them.
+# Full enumeration, 9 sites across 4 repos (DIVE-2308):
+#   community/wiki/the-merge-deploys-population-is-scoped-to-the-box-not-to-the-repo.md
+#
+# Everything else the installer places comes through `$REPO`, which DIVE-2144
+# pins to the newest release TAG. If you are adding a fetch, decide which of the
+# two you are in and say so at the site.
+# ============================================================================
 # Install:   curl -fsSL https://install.5dive.ai | sudo bash
 # Upgrade:   curl -fsSL https://install.5dive.ai | sudo bash -s -- --upgrade
 # Uninstall: curl -fsSL https://install.5dive.ai | sudo bash -s -- --uninstall
@@ -407,6 +431,10 @@ JOURNALD
   # in one shot. update.sh's per-agent refresh loop syncs from here, so an
   # existing agent's 5dive-cli skill picks up upstream changes on the daily
   # 03:00 cron instead of being frozen at agent-create time.
+  # MERGE-DEPLOYS (DIVE-2288): a BRANCH tarball, not $REPO. Merging to that
+  # repo's main puts the 5dive-cli skill, from 5dive-ai/skills on every box at its
+  # next --upgrade, root-installed, with no tag and no review in THIS repo.
+  # The SKILLS_REPO_TARBALL override exists to pin it; the DEFAULT is mutable.
   SKILLS_REPO_TARBALL="${SKILLS_REPO_TARBALL:-https://github.com/$GH_ORG/skills/archive/refs/heads/main.tar.gz}"
   install -d -m 755 "$LIB_DIR/skills/5dive-cli"
   _skill_tmp=$(mktemp -d)
@@ -434,6 +462,10 @@ JOURNALD
   # the runtime deps (grammy) so the hooks/server actually run. cp -a overlays
   # the source onto any existing copy so node_modules survives across --upgrade
   # refreshes; bun reconciles deps against the (possibly updated) lockfile.
+  # MERGE-DEPLOYS (DIVE-2288): a BRANCH tarball, not $REPO. Merging to that
+  # repo's main puts telegram-codex, from 5dive-ai/5dive-plugins on every box at its
+  # next --upgrade, root-installed, with no tag and no review in THIS repo.
+  # The CODEX_PLUGIN_TARBALL override exists to pin it; the DEFAULT is mutable.
   CODEX_PLUGIN_TARBALL="${CODEX_PLUGIN_TARBALL:-https://github.com/$GH_ORG/5dive-plugins/archive/refs/heads/main.tar.gz}"
   _cdx_tmp=$(mktemp -d)
   if curl -fsSL "$CODEX_PLUGIN_TARBALL" \
@@ -466,6 +498,10 @@ JOURNALD
   # this one shared checkout via absolute paths written into ~/.grok/config.toml
   # by 5dive-agent-start. Override the tarball with GROK_PLUGIN_TARBALL for
   # offline / test installs.
+  # MERGE-DEPLOYS (DIVE-2288): a BRANCH tarball, not $REPO. Merging to that
+  # repo's main puts telegram-grok, from 5dive-ai/5dive-plugins on every box at its
+  # next --upgrade, root-installed, with no tag and no review in THIS repo.
+  # The GROK_PLUGIN_TARBALL override exists to pin it; the DEFAULT is mutable.
   GROK_PLUGIN_TARBALL="${GROK_PLUGIN_TARBALL:-https://github.com/$GH_ORG/5dive-plugins/archive/refs/heads/main.tar.gz}"
   _grk_tmp=$(mktemp -d)
   if curl -fsSL "$GROK_PLUGIN_TARBALL" \
@@ -494,6 +530,10 @@ JOURNALD
   # ~/.gemini/config/{mcp_config.json,hooks.json} by 5dive-agent-start (agy
   # doesn't auto-load a plugin's mcp_config/hooks — only skills/agents).
   # Override the tarball with AGY_PLUGIN_TARBALL for offline / pinned installs.
+  # MERGE-DEPLOYS (DIVE-2288): a BRANCH tarball, not $REPO. Merging to that
+  # repo's main puts telegram-agy, from 5dive-ai/5dive-plugins on every box at its
+  # next --upgrade, root-installed, with no tag and no review in THIS repo.
+  # The AGY_PLUGIN_TARBALL override exists to pin it; the DEFAULT is mutable.
   AGY_PLUGIN_TARBALL="${AGY_PLUGIN_TARBALL:-https://github.com/$GH_ORG/5dive-plugins/archive/refs/heads/main.tar.gz}"
   _agy_tmp="$(mktemp -d)"
   if curl -fsSL "$AGY_PLUGIN_TARBALL" \
@@ -526,6 +566,10 @@ JOURNALD
   # opencode_agent's plugin-dir check fails) — i.e. opencode telegram is a
   # no-op on customer boxes until staged. Override with OPENCODE_PLUGIN_TARBALL
   # for offline / pinned installs.
+  # MERGE-DEPLOYS (DIVE-2288): a BRANCH tarball, not $REPO. Merging to that
+  # repo's main puts telegram-opencode, from 5dive-ai/5dive-plugins on every box at its
+  # next --upgrade, root-installed, with no tag and no review in THIS repo.
+  # The OPENCODE_PLUGIN_TARBALL override exists to pin it; the DEFAULT is mutable.
   OPENCODE_PLUGIN_TARBALL="${OPENCODE_PLUGIN_TARBALL:-https://github.com/$GH_ORG/5dive-plugins/archive/refs/heads/main.tar.gz}"
   _ocode_tmp="$(mktemp -d)"
   if curl -fsSL "$OPENCODE_PLUGIN_TARBALL" \
@@ -557,6 +601,10 @@ JOURNALD
   # agent's plugin-dir check fails) — i.e. pi telegram is a no-op on customer
   # boxes until staged. Override with PI_PLUGIN_TARBALL for offline / pinned
   # installs.
+  # MERGE-DEPLOYS (DIVE-2288): a BRANCH tarball, not $REPO. Merging to that
+  # repo's main puts telegram-pi, from 5dive-ai/5dive-plugins on every box at its
+  # next --upgrade, root-installed, with no tag and no review in THIS repo.
+  # The PI_PLUGIN_TARBALL override exists to pin it; the DEFAULT is mutable.
   PI_PLUGIN_TARBALL="${PI_PLUGIN_TARBALL:-https://github.com/$GH_ORG/5dive-plugins/archive/refs/heads/main.tar.gz}"
   _pi_tmp="$(mktemp -d)"
   if curl -fsSL "$PI_PLUGIN_TARBALL" \


### PR DESCRIPTION
Maker: **main**. Verifier: **olivia** (she filed the row).

## The defect

Everywhere else in this repo, **merging is staging and the cut is the publish act.** `install.sh` is fetched from `refs/heads/main` and run **as root** on every box's next `--upgrade` — so a merge to it is live fleet-wide with no tag in between. The rule everyone was taught is *exactly backwards* in this one file, and nothing in the file, the diff, or the PR said so.

The semantics are probably right and are **not** changed here: an installer that only updates on tags cannot fix a broken installer. The defect is that the property is invisible.

## Ask 1 — visible at the edit site

- A header block in `install.sh`: **THIS FILE DEPLOYS ON MERGE. THERE IS NO TAG BETWEEN YOU AND THE FLEET.** — why the usual rule is inverted here, and where the enumeration lives.
- A `MERGE-DEPLOYS` marker at each of the **six branch-tarball fetches** (`:410` skills, `:437/:469/:497/:529/:560` 5dive-plugins). Each names what lands, that it bypasses `$REPO`'s tag pin, and the `*_TARBALL` override that *can* pin it.

## Ask 3 — CI says so, by naming what it cannot see

`install-guard.yml` opened with *"install.sh is the only file still fetched from mutable main"*. That sentence is **true and it is a sample**: scoped to files in **this repo**, while the hazard is scoped to what reaches a **box**.

**The job is not widened, because it cannot be.** A path filter is scoped to the artifact you are editing; the six other sites live in *other repos*, so no filter here could ever see them. What it can do is stop reading as exhaustive — the header now states its own scope, and the summary tables the six paths it is blind to. A guard that names its blind spot beats one that reads as complete.

A real cross-repo guard would have to live in `5dive-ai/skills` and `5dive-ai/5dive-plugins`. Not built here, and worth its own row if we want it.

## Ask 2

Already done as **DIVE-2308**.

## Correction to the enumeration — measured, not relayed

DIVE-2308 read `origin/main @ 44e612f` on 07-29 and listed 9 sites. Re-measured on **`6f5e5c9`**: **row 8 is already fixed.** `_published_cli_probe` no longer does `ref="${pinned:-main}"` — it resolves the newest release tag through three rungs (`ls-remote` → `tags.atom` → tags API) and **fails closed** with *"no release tag resolves"* when none does. Main HEAD is never called "published" any more.

So the live **install-path** population is **7, not 9**: row 8 closed, and row 9 (the `status` badge branch) is public-by-design and off the install path. The guard text says 7 for that reason, not because it disagrees with DIVE-2308.

## Verification

- `shellcheck -S error install.sh` — clean
- YAML parses; `build.sh` builds
- `install_checksum` 8/0 · `install_monotonicity` 14/0 · `install_pin_sha` 15/0 · `install_update_hint` 6/0 · `update_check_propagation` 22/0
- `install.sh --help` returns `rc=1` **before and after** — pre-existing, the installer has no `--help`. Checked against the base rather than assumed.

**Comments and CI prose only. No executable line of `install.sh` changed.**

## What I did not check

The contents of `5dive-ai/skills` and `5dive-ai/5dive-plugins` themselves — only the fetch URLs in this repo that target their mutable `main`. And I did not touch the `status` branch, which is merge-deploys by design.

---

## Iteration 2 (`17f7998`) — read this before the diff

olivia rejected iteration 1 on one thing: the commit published **two populations** (header said 9, CI said 7) and left the authoritative wiki page stale, with the correction living only in the commit message and the task result. That is this row's own defect, committed by the change meant to fix it.

Fixed: the count now carries **its scope and its date** in both artifacts *in the same words* — "7 live sites on the root-installed-on-upgrade rail, as of 2026-07-30, measured against `6f5e5c9`" — and the wiki page gained a **currency marker**, row 8 struck as **CLOSED** with evidence, and `corrected_against: 6f5e5c9`. `_marketplace_base` and `_loops_base` are named in all three artifacts as adjacent to the count and deliberately outside it (on-demand, not root-installed on `--upgrade`; verified neither is referenced in `install.sh`).

Full detail in the iteration-2 comment below.
