### PR TITLE
task: gate-withdraw authorizes the FILER OF RECORD, not the holder (DIVE-2382)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -4689,31 +4689,41 @@ cmd_task_need() {
     [[ -n "$w_type" ]] || fail "$E_CONFLICT" "$ident has no gate to withdraw"
     [[ -z "$w_ans" ]]  || fail "$E_CONFLICT" "$ident's gate is already answered — --withdraw only applies to a still-pending gate (need_answered_at IS NULL)"
     # Authorize on the TRUSTED caller identity from _gate_withdraw_actor (EUID-gated
-    # SUDO_* or the real id -un — see its comment), NEVER on --from. The gate's filer
-    # is its assignee of record; the filer's routed lead / org coordinator may also
-    # withdraw, as may a genuine human. An agent that is none of these is refused.
-    local w_filer w_id w_kind w_name="" w_lead w_coord w_ok=0 w_by w_who
-    w_filer=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=${id};")
-    # DIVE-2382: the ORIGINAL filer-of-record, for the refusal text ONLY — this change
-    # does NOT move authorization. The old refusal called the assignee "the gate's filer",
-    # which on a handed-off or auto-created row names as filer someone who never filed it.
-    # Name both, and say which one authorizes.
+    # SUDO_* or the real id -un — see its comment), NEVER on --from. The gate's FILER OF
+    # RECORD, their routed lead, or the org coordinator may withdraw, as may a genuine
+    # human. An agent that is none of these is refused.
     #
-    # WHOSE ASK IT IS AND WHO MAY WITHDRAW IT ARE STILL DIFFERENT ANSWERS HERE, and that
-    # is an OPEN question, not a settled one — do not read the text below as ratifying it.
-    # gate_filed_by exists (DIVE-1945) precisely because assignee is not a reliable record
-    # of whose ask a gate is: per its own schema comment, "assignee is rewritten to the
-    # filer only on the human lane, so a gate one agent files on another's task had no
-    # record of whose ask it is". Every other reader honours that (:2857, :6127, the
-    # heartbeat's T1 routing); this site does not, so an agent who filed a gate on someone
-    # else's task cannot withdraw their own ask while the holder can. Latent today (the
-    # live rows where they differ are all answered, and --withdraw refuses an answered
-    # gate). Widening authorization is a policy call and is deliberately NOT bundled into
-    # this text fix — see community/wiki/a-refusal-that-names-a-smaller-set-than-the-code-checked.md.
-    w_by=$(db "SELECT COALESCE(NULLIF(gate_filed_by,''),NULLIF(created_by,''),'') FROM tasks WHERE id=${id};")
+    # DIVE-2382 (approved by olivia as org coordinator; main ruled the shape): this site
+    # used to authorize on COALESCE(assignee,'') — the HOLDER. That was the bigger half of
+    # the defect this ticket was filed about, and it was wrong in BOTH directions at once:
+    #   under-permissive — an agent who files a gate on someone else's task could not
+    #                      withdraw their OWN ask (DIVE-2015: gate_filed_by=codex,
+    #                      assignee=main, so main could and codex could not);
+    #   over-permissive  — a reassigned holder could retire a question they never asked,
+    #                      which is precisely the DIVE-2133 shape.
+    # A fifth authorizer would have fixed only the first, so this REPLACES the principal.
+    #
+    # THE SHAPE IS DELIBERATELY STRICTER THAN :6154's, which is the one amendment olivia
+    # made to the proposal. :6154 (display/routing) ends its COALESCE on `assignee`;
+    # authorizing on that would silently RE-ADMIT the reassigned-holder route in exactly
+    # the state where both other columns are empty — the route we are removing. So the
+    # authorization site stops at created_by. Two shapes for two jobs, deliberately: the
+    # display readers keep their assignee rung, and what this ticket retires is THREE
+    # shapes for ONE job. Authorizer-existence does not rest on that rung anyway —
+    # conditions 1 (human) and 4 (coordinator) never consult the filer at all, probed
+    # against an all-columns-empty row.
+    local w_filer w_id w_kind w_name="" w_lead w_coord w_ok=0 w_holder w_who
+    w_filer=$(db "SELECT COALESCE(NULLIF(gate_filed_by,''),NULLIF(created_by,''),'') FROM tasks WHERE id=${id};")
+    # The HOLDER, for the refusal text only — it no longer authorizes anything. Named
+    # when it differs so a refused holder learns why, rather than reading a list that
+    # simply omits them.
+    w_holder=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=${id};")
     w_id=$(_gate_withdraw_actor)                          # "agent <name>" | "human" | "none"
     w_kind="${w_id%% *}"
     [[ "$w_kind" == "agent" ]] && w_name="${w_id#agent }"
+    # The lead route follows the PRINCIPAL, so it moves with it: condition 3 is "the
+    # filer's lead", and resolving it from the holder would leave a second copy of the
+    # same defect one rung up.
     w_lead=$(_gate_route_reviewer "$w_filer")
     w_coord=$(_task_resolve_coordinator)
     [[ "$w_kind" == "human" ]] && w_ok=1                                    # a genuine human caller
@@ -4728,8 +4738,13 @@ cmd_task_need() {
     # retired; both were wrong, and that is the mechanism behind the stale-gate class.
     # Unresolvable conditions render as "none" rather than vanishing, so a reader can
     # tell "this route does not exist here" from "this route was never offered".
-    w_who="the gate's holder (assignee ${w_filer:-?})"
-    [[ -n "$w_by" && "$w_by" != "$w_filer" ]] && w_who+=" — filed by ${w_by}, but withdraw authorizes on the HOLDER, not the filer"
+    # DIVE-2382: "unrecorded" rather than "?" — the placeholder shipped in the first pass
+    # and reads as a rendering bug rather than as a fact about the row (olivia approved
+    # the swap in the same pass). An empty principal is reachable by CONFIGURATION, not by
+    # data: created_by is nullable, so a row with neither column set resolves to nothing,
+    # and the reader needs to see that as a stated absence.
+    w_who="the gate's filer (${w_filer:-unrecorded})"
+    [[ -n "$w_holder" && "$w_holder" != "$w_filer" ]] && w_who+=" — held by ${w_holder}, who does NOT authorize a withdraw since they did not file it"
     (( w_ok )) || policy_refuse "$E_AUTH_REQUIRED" gate-withdraw-not-authorized DIVE-1401 "$ident" "only ${w_who}, their lead (${w_lead:-none}), the org coordinator (${w_coord:-none}), or a human can withdraw $ident's gate"
     # Clear every gate field and unblock back to todo when no dependency edge
     # still holds it. The withdrawn gate is archived to gate_history first, in

--- a/tests/gate_withdraw_unit.sh
+++ b/tests/gate_withdraw_unit.sh
@@ -342,15 +342,25 @@ out=$(wd DIVE-255 ROOT SU=agent-creative); rc=$?
 [[ $rc -ne 0 && "$(gate_open DIVE-255)" == "open" ]] \
   && ok_t "T-2382-P7 filer AND created_by empty -> the HOLDER is still refused (authorization does not fall back to assignee)" \
   || bad_t "T-2382-P7 no assignee fallback" "rc=$rc open=$(gate_open DIVE-255) out=$out"
-[[ "$out" == *"the gate's filer (unrecorded)"* ]] \
+# P8/P9 get their OWN rows on purpose. Reading them off P7's row made them CASCADE:
+# under a mutation where the holder is authorized, P7's withdraw SUCCEEDS, so $out holds a
+# success payload and the row has no gate left — P8 and P9 then red as consequences of P7
+# rather than as independent signals, and three reds read as three findings when they are
+# one. Each arm now constructs its own row.
+handoff_gate DIVE-256
+db "UPDATE tasks SET gate_filed_by=NULL, created_by=NULL WHERE ident='DIVE-256';"
+out=$(wd DIVE-256 ROOT SU=agent-grok); rc=$?   # grok: not the holder, so refused either way
+[[ $rc -ne 0 && "$out" == *"the gate's filer (unrecorded)"* ]] \
   && ok_t "T-2382-P8 an unresolvable principal renders as 'unrecorded', a stated absence rather than a '?' placeholder" \
-  || bad_t "T-2382-P8 unrecorded" "out=$out"
-# P9 — and the gate is still retirable, which is why removing the rung costs nothing:
+  || bad_t "T-2382-P8 unrecorded" "rc=$rc out=$out"
+# P9 — the gate is still retirable, which is why removing the assignee rung costs nothing:
 # conditions 1 and 4 never consult the filer. Reachable by CONFIGURATION, not by data.
-out=$(wd DIVE-255 ROOT SU=agent-main); rc=$?
-[[ $rc -eq 0 && "$(gate_open DIVE-255)" == "cleared" ]] \
-  && ok_t "T-2382-P9 the same all-empty row is STILL retirable by the coordinator (no gate is left with no authorizer)" \
-  || bad_t "T-2382-P9 still retirable" "rc=$rc open=$(gate_open DIVE-255) out=$out"
+handoff_gate DIVE-257
+db "UPDATE tasks SET gate_filed_by=NULL, created_by=NULL WHERE ident='DIVE-257';"
+out=$(wd DIVE-257 ROOT SU=agent-main); rc=$?
+[[ $rc -eq 0 && "$(gate_open DIVE-257)" == "cleared" ]] \
+  && ok_t "T-2382-P9 an all-empty row is STILL retirable by the coordinator (no gate is left with no authorizer)" \
+  || bad_t "T-2382-P9 still retirable" "rc=$rc open=$(gate_open DIVE-257) out=$out"
 
 # T-2382g the DIVE-2106 shape: a carrier row with NO gate_filed_by, created by someone who
 # is not the holder. This is the row two agents read the old refusal on and concluded

--- a/tests/gate_withdraw_unit.sh
+++ b/tests/gate_withdraw_unit.sh
@@ -135,7 +135,7 @@ out=$(wd DIVE-201 ROOT SU=agent-creative); rc=$?
 # T2: an unrelated agent (SUDO_USER=agent-grok) is REFUSED.
 file_secret_gate DIVE-202
 out=$(wd DIVE-202 ROOT SU=agent-grok); rc=$?
-[[ $rc -ne 0 && "$(gate_open DIVE-202)" == "open" && "$out" == *"only the gate's holder"* ]] \
+[[ $rc -ne 0 && "$(gate_open DIVE-202)" == "open" && "$out" == *"only the gate's filer"* ]] \
   && ok_t "T2 unrelated agent REFUSED (gate untouched, actionable msg)" \
   || bad_t "T2 unrelated refused" "rc=$rc open=$(gate_open DIVE-202) out=$out"
 
@@ -227,7 +227,7 @@ out=$(wd DIVE-207 ROOT SU=agent-creative); rc=$?
 # text left behind — the exact shape that shipped. So the message arms are paired with a
 # LIVENESS arm that actually withdraws AS the coordinator, which goes RED on that
 # mutation, and with a DISTINCTNESS arm proving the coordinator is not reachable through
-# the lead condition (in the org above, main is BOTH creative's lead and the coordinator,
+# the lead condition (in the org above, main is BOTH creative's lead AND the coordinator,
 # so T3 cannot tell the two conditions apart and grades neither of them alone).
 db "INSERT INTO agents_org (name, role, reports_to) VALUES ('pi',NULL,'grok');"
 file_pi_gate() { seed_task "$1"; IS_ROOT=1 IDUN=root cmd_task_need "$1" --type=secret --ask="drop the fixture key" --from=pi >/dev/null 2>&1; }
@@ -236,14 +236,14 @@ z_lead=$(_gate_route_reviewer pi); z_coord=$(_task_resolve_coordinator)
   && ok_t "T-2382-DISTINCT pi's lead (grok) is NOT the coordinator (main) — the coordinator arm cannot pass through the lead condition" \
   || bad_t "T-2382-DISTINCT" "lead='$z_lead' coord='$z_coord'"
 
-# T-2382a LIVENESS / mutation-decisive: the coordinator withdraws a gate held by an agent
-# who does NOT report to them. Only condition 4 can authorize this. Delete condition 4
-# from src/cmd_task.sh and this arm goes RED.
+# T-2382a LIVENESS / mutation-decisive: the coordinator withdraws a gate whose filer does
+# NOT report to them. Only condition 4 can authorize this. Delete condition 4 from
+# src/cmd_task.sh and this arm goes RED.
 file_pi_gate DIVE-240
 [[ "$(gate_open DIVE-240)" == "open" ]] || bad_t "T-2382a precond" "open=$(gate_open DIVE-240)"
 out=$(wd DIVE-240 ROOT SU=agent-main); rc=$?
 [[ $rc -eq 0 && "$(gate_open DIVE-240)" == "cleared" ]] \
-  && ok_t "T-2382a org coordinator withdraws a gate held OUTSIDE their reporting line (condition 4 is live)" \
+  && ok_t "T-2382a org coordinator withdraws a gate filed OUTSIDE their reporting line (condition 4 is live)" \
   || bad_t "T-2382a coordinator withdraw" "rc=$rc open=$(gate_open DIVE-240) out=$out"
 
 # T-2382b/c/d: the refusal on the SAME row, from a caller who is none of the four
@@ -252,7 +252,7 @@ out=$(wd DIVE-240 ROOT SU=agent-main); rc=$?
 file_pi_gate DIVE-241
 out=$(wd DIVE-241 ROOT SU=agent-creative); rc=$?
 [[ $rc -ne 0 && "$(gate_open DIVE-241)" == "open" ]] \
-  && ok_t "T-2382b unauthorized caller still refused (the fix is the message, not the policy)" \
+  && ok_t "T-2382b unauthorized caller still refused" \
   || bad_t "T-2382b still refused" "rc=$rc open=$(gate_open DIVE-241) out=$out"
 [[ "$out" == *"the org coordinator (main)"* ]] \
   && ok_t "T-2382c refusal names the ORG COORDINATOR by resolved value (was omitted entirely)" \
@@ -261,37 +261,113 @@ out=$(wd DIVE-241 ROOT SU=agent-creative); rc=$?
   && ok_t "T-2382d refusal names the LEAD by resolved value, not the bare word 'lead'" \
   || bad_t "T-2382d names lead" "out=$out"
 
-# T-2382e: on a row where nothing was handed off, holder IS the filer-of-record — the
-# "filed by" clause must NOT appear. Grading the clause's presence is worthless without
-# this arm: a build that appends it unconditionally would pass every arm below.
-[[ "$(db "SELECT COALESCE(gate_filed_by,'') FROM tasks WHERE ident='DIVE-241';")" == "pi" ]] \
+# T-2382e: filer == holder, so the "held by" clause must be ABSENT. Grading the clause's
+# presence is worthless without this arm: a build that appends it unconditionally would
+# pass every arm below.
+[[ "$(db "SELECT COALESCE(gate_filed_by,'') FROM tasks WHERE ident='DIVE-241';")" == "pi" \
+   && "$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE ident='DIVE-241';")" == "pi" ]] \
   && ok_t "T-2382e precond: DIVE-241 was filed BY its holder (gate_filed_by=assignee=pi)" \
-  || bad_t "T-2382e precond" "gate_filed_by=$(db "SELECT COALESCE(gate_filed_by,'') FROM tasks WHERE ident='DIVE-241';")"
-[[ "$out" == *"holder (assignee pi)"* && "$out" != *"filed by"* ]] \
-  && ok_t "T-2382e no handoff -> refusal names the holder and omits the filer clause (clause is conditional, not decorative)" \
+  || bad_t "T-2382e precond" "filed_by=$(db "SELECT COALESCE(gate_filed_by,'') FROM tasks WHERE ident='DIVE-241';") assignee=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE ident='DIVE-241';")"
+[[ "$out" == *"the gate's filer (pi)"* && "$out" != *"held by"* ]] \
+  && ok_t "T-2382e no handoff -> names the filer and omits the holder clause (clause is conditional, not decorative)" \
   || bad_t "T-2382e no-handoff clause" "out=$out"
 
-# T-2382f HANDOFF (DIVE-1945's case): pi files, the row is then reassigned to creative, so
-# withdraw rights MOVE to creative and pi — who actually filed it — no longer holds them.
-# The old text called creative "the gate's filer", naming as filer someone who never filed
-# it, and gave pi no hint their own ask had left them.
-file_pi_gate DIVE-242
-db "UPDATE tasks SET assignee='creative' WHERE ident='DIVE-242';"   # what a reassign does
-out=$(wd DIVE-242 ROOT SU=agent-grok); rc=$?
-[[ $rc -ne 0 && "$out" == *"holder (assignee creative)"* && "$out" == *"filed by pi"* ]] \
-  && ok_t "T-2382f handoff -> refusal names the HOLDER (creative) and the FILER-OF-RECORD (pi) separately" \
-  || bad_t "T-2382f handoff naming" "rc=$rc out=$out"
+# ══ DIVE-2382 PRINCIPAL REPLACE — the authorization site reads the FILER OF RECORD ══
+# Approved by olivia (org coordinator); shape ruled by main. The site used to authorize on
+# COALESCE(assignee,'') and now reads COALESCE(NULLIF(gate_filed_by,''),NULLIF(created_by,''),'').
+# It was wrong in BOTH directions, so the suite must grade BOTH. The pair below is what
+# makes this a NARROWING rather than a widening — an additive fifth authorizer would pass
+# arm P1 and FAIL arm P2, and P2 is the one that was green before this change.
+#
+# Every arm PERFORMS a withdraw as a DISTINCT agent: filer=pi, holder=creative,
+# filer's lead=grok, coordinator=main, human. A fixture that shares one name across two
+# routes tests their union and neither (see T-2382-DISTINCT).
+handoff_gate() {   # pi files it, then the row is REASSIGNED to creative
+  file_pi_gate "$1"
+  db "UPDATE tasks SET assignee='creative' WHERE ident='$1';"
+}
+handoff_gate DIVE-250
+[[ "$(db "SELECT COALESCE(gate_filed_by,'')||'/'||COALESCE(assignee,'') FROM tasks WHERE ident='DIVE-250';")" == "pi/creative" ]] \
+  && ok_t "T-2382-P precond: filer-of-record (pi) and holder (creative) are DISTINCT on the handoff row" \
+  || bad_t "T-2382-P precond" "$(db "SELECT COALESCE(gate_filed_by,'')||'/'||COALESCE(assignee,'') FROM tasks WHERE ident='DIVE-250';")"
+
+# P1 — UNDER-PERMISSIVE half, RED before this change: the agent who actually filed the
+# gate can retire their own ask after the row was handed off.
+out=$(wd DIVE-250 ROOT SU=agent-pi); rc=$?
+[[ $rc -eq 0 && "$(gate_open DIVE-250)" == "cleared" ]] \
+  && ok_t "T-2382-P1 the FILER OF RECORD withdraws their own ask after a handoff (was REFUSED before the replace)" \
+  || bad_t "T-2382-P1 filer withdraw" "rc=$rc open=$(gate_open DIVE-250) out=$out"
+
+# P2 — OVER-PERMISSIVE half, GREEN before this change and it MUST FLIP. This is the arm
+# that makes the suite grade a narrowing: a build that merely ADDED gate_filed_by as a
+# fifth authorizer leaves this passing-as-authorized, i.e. passes on a widening.
+handoff_gate DIVE-251
+out=$(wd DIVE-251 ROOT SU=agent-creative); rc=$?
+[[ $rc -ne 0 && "$(gate_open DIVE-251)" == "open" ]] \
+  && ok_t "T-2382-P2 the reassigned HOLDER can NO LONGER retire a question they never asked (the DIVE-2133 shape; flipped by the replace)" \
+  || bad_t "T-2382-P2 holder refused" "rc=$rc open=$(gate_open DIVE-251) out=$out"
+[[ "$out" == *"the gate's filer (pi)"* && "$out" == *"held by creative"* && "$out" == *"does NOT authorize"* ]] \
+  && ok_t "T-2382-P3 the refused holder is TOLD they hold it and that holding does not authorize (not omitted from the list)" \
+  || bad_t "T-2382-P3 holder told why" "out=$out"
+
+# P4 — the LEAD route follows the PRINCIPAL. grok is pi's lead and NOT creative's; before
+# the replace this was refused, because the lead was resolved from the holder. Leaving it
+# on the holder would have left a second copy of the same defect one rung up.
+handoff_gate DIVE-252
+out=$(wd DIVE-252 ROOT SU=agent-grok); rc=$?
+[[ $rc -eq 0 && "$(gate_open DIVE-252)" == "cleared" ]] \
+  && ok_t "T-2382-P4 the FILER's lead (grok) withdraws; the lead route moved with the principal" \
+  || bad_t "T-2382-P4 filer lead withdraw" "rc=$rc open=$(gate_open DIVE-252) out=$out"
+
+# P5/P6 — the two FILER-INDEPENDENT routes still work on the same handoff shape, which is
+# what guarantees no gate can be left with no authorizer.
+handoff_gate DIVE-253
+out=$(wd DIVE-253 ROOT SU=agent-main); rc=$?
+[[ $rc -eq 0 && "$(gate_open DIVE-253)" == "cleared" ]] \
+  && ok_t "T-2382-P5 coordinator withdraws a handed-off gate (filer-independent route survives the replace)" \
+  || bad_t "T-2382-P5 coordinator handoff" "rc=$rc open=$(gate_open DIVE-253) out=$out"
+handoff_gate DIVE-254
+out=$(wd DIVE-254 ROOT SD=0); rc=$?
+[[ $rc -eq 0 && "$(gate_open DIVE-254)" == "cleared" ]] \
+  && ok_t "T-2382-P6 human withdraws a handed-off gate (filer-independent route survives the replace)" \
+  || bad_t "T-2382-P6 human handoff" "rc=$rc open=$(gate_open DIVE-254) out=$out"
+
+# P7 — olivia's AMENDMENT, and the arm that pins it. The authorization shape stops at
+# created_by; it does NOT end on `assignee` the way :6154's display shape does. If it did,
+# a row with BOTH gate_filed_by and created_by empty would silently RE-ADMIT the holder —
+# the exact route being removed. Constructed by emptying both columns on a handoff row.
+handoff_gate DIVE-255
+db "UPDATE tasks SET gate_filed_by=NULL, created_by=NULL WHERE ident='DIVE-255';"
+out=$(wd DIVE-255 ROOT SU=agent-creative); rc=$?
+[[ $rc -ne 0 && "$(gate_open DIVE-255)" == "open" ]] \
+  && ok_t "T-2382-P7 filer AND created_by empty -> the HOLDER is still refused (authorization does not fall back to assignee)" \
+  || bad_t "T-2382-P7 no assignee fallback" "rc=$rc open=$(gate_open DIVE-255) out=$out"
+[[ "$out" == *"the gate's filer (unrecorded)"* ]] \
+  && ok_t "T-2382-P8 an unresolvable principal renders as 'unrecorded', a stated absence rather than a '?' placeholder" \
+  || bad_t "T-2382-P8 unrecorded" "out=$out"
+# P9 — and the gate is still retirable, which is why removing the rung costs nothing:
+# conditions 1 and 4 never consult the filer. Reachable by CONFIGURATION, not by data.
+out=$(wd DIVE-255 ROOT SU=agent-main); rc=$?
+[[ $rc -eq 0 && "$(gate_open DIVE-255)" == "cleared" ]] \
+  && ok_t "T-2382-P9 the same all-empty row is STILL retirable by the coordinator (no gate is left with no authorizer)" \
+  || bad_t "T-2382-P9 still retirable" "rc=$rc open=$(gate_open DIVE-255) out=$out"
 
 # T-2382g the DIVE-2106 shape: a carrier row with NO gate_filed_by, created by someone who
 # is not the holder. This is the row two agents read the old refusal on and concluded
-# nobody could ever retire it. The message must now fall back to created_by AND name the
-# coordinator, which is who could in fact have retired it all along.
+# nobody could ever retire it. The principal now falls back to created_by — so on the
+# EXISTING population (gate_filed_by empty in 965 of 990 live rows) the authorizer is the
+# CREATOR, a proxy for the filer, not the filer itself. Stated so nobody reads uniform
+# filer semantics across the whole board.
 file_pi_gate DIVE-243
-db "UPDATE tasks SET gate_filed_by=NULL WHERE ident='DIVE-243';"    # legacy / auto-created row
+db "UPDATE tasks SET gate_filed_by=NULL, created_by='main' WHERE ident='DIVE-243';"
 out=$(wd DIVE-243 ROOT SU=agent-creative); rc=$?
-[[ $rc -ne 0 && "$out" == *"filed by main"* && "$out" == *"the org coordinator (main)"* ]] \
-  && ok_t "T-2382g no gate_filed_by -> falls back to created_by AND still names the coordinator (the DIVE-2106 dead-end)" \
+[[ $rc -ne 0 && "$out" == *"the gate's filer (main)"* && "$out" == *"the org coordinator (main)"* ]] \
+  && ok_t "T-2382g no gate_filed_by -> principal falls back to created_by AND the coordinator is still named (the DIVE-2106 dead-end)" \
   || bad_t "T-2382g legacy row naming" "rc=$rc out=$out"
+out=$(wd DIVE-243 ROOT SU=agent-main); rc=$?
+[[ $rc -eq 0 ]] \
+  && ok_t "T-2382g-live the created_by proxy actually authorizes on a legacy row (not just rendered)" \
+  || bad_t "T-2382g-live" "rc=$rc out=$out"
 
 echo "----"
 echo "PASS=$PASS FAIL=$FAIL"

--- a/tests/gate_withdraw_unit.sh
+++ b/tests/gate_withdraw_unit.sh
@@ -379,6 +379,21 @@ out=$(wd DIVE-243 ROOT SU=agent-main); rc=$?
   && ok_t "T-2382g-live the created_by proxy actually authorizes on a legacy row (not just rendered)" \
   || bad_t "T-2382g-live" "rc=$rc out=$out"
 
+# ── DIVE-2382 red-team: --from is ATTRIBUTION ONLY on this path ────────────────────
+# main's acceptance criterion. _gate_withdraw_actor judges by EUID-gated SUDO_* or the
+# real id -un and NEVER by --from, so an unauthorized agent naming the filer must still
+# be refused. Asserted here rather than left to the code comment.
+handoff_gate DIVE-260
+WD_EXTRA=(--from=pi); out=$(wd DIVE-260 NONROOT ID=agent-creative); rc=$?; WD_EXTRA=()
+[[ $rc -ne 0 && "$(gate_open DIVE-260)" == "open" ]] \
+  && ok_t "T-2382-R1 --from=<filer> spoof by an unauthorized agent REFUSED (--from is attribution, never authorization)" \
+  || bad_t "T-2382-R1 from-spoof refused" "rc=$rc open=$(gate_open DIVE-260) out=$out"
+handoff_gate DIVE-261
+WD_EXTRA=(--from=pi); out=$(wd DIVE-261 ROOT SU=agent-creative); rc=$?; WD_EXTRA=()
+[[ $rc -ne 0 && "$(gate_open DIVE-261)" == "open" ]] \
+  && ok_t "T-2382-R2 same spoof at EUID0 with a real SUDO_USER of the HOLDER still REFUSED" \
+  || bad_t "T-2382-R2 from-spoof root refused" "rc=$rc open=$(gate_open DIVE-261) out=$out"
+
 echo "----"
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
The principal half of DIVE-2382 — the half [#335](https://github.com/5dive-ai/5dive/pull/335) deliberately left open and marked as open at the site rather than ratifying it in a refusal message.

**Approved by olivia as org coordinator. Shape ruled by main. Verifier must be an agent other than me.**

## The defect was wrong in both directions at once

`task need --withdraw` authorized on `COALESCE(assignee,'')` — the **holder**:

| direction | consequence |
|---|---|
| **under-permissive** | an agent who files a gate on someone else's task cannot withdraw their **own** ask. DIVE-2015: `gate_filed_by=codex`, `assignee=main` — main could, codex could not. |
| **over-permissive** | a **reassigned holder** can retire a question they never asked. This is precisely the DIVE-2133 shape the row was filed about. |

A fifth authorizer fixes only the first and **preserves the second**, which is why this **replaces** the principal rather than adding to it. The lead route moves with it — condition 3 is "the *filer's* lead", and resolving it from the holder leaves a second copy of the same defect one rung up.

## Stricter than `:6154` by design — olivia's one amendment

The display/routing readers (`:2857`, `:6154`) end their `COALESCE` on `assignee`. Authorizing on that shape would silently **re-admit the reassigned-holder route** in exactly the state where both other columns are empty — the route being removed. So the authorization site stops at `created_by`:

```sh
w_filer=$(db "SELECT COALESCE(NULLIF(gate_filed_by,''),NULLIF(created_by,''),'') ...")   # authorizes
w_holder=$(db "SELECT COALESCE(assignee,'') ...")                                        # display only
```

Two shapes for two jobs, commented as deliberate. What this ticket retires is **three shapes for one job**. Removing the rung costs nothing: conditions 1 (human) and 4 (coordinator) never consult the filer — probed against an all-columns-empty row — so **no gate can be left with no authorizer**.

## What this means on the existing population

**A reader who assumes uniform filer semantics across 990 rows will be wrong for 965 of them.** Measured on the production store: `gate_filed_by` empty in **965 of 990**; `created_by` empty in **0**. So on older rows the new authorizer resolves to **`created_by`**. For a hand-filed row those coincide; for an auto-created row `created_by` is a **proxy** for the filer and can name an agent who never asked the question.

The honest description is therefore *not* "the filer regains the right" but: **the filer regains it on rows filed after `gate_filed_by` started being stamped, and on older rows the creator inherits it.** Live exposure is zero either way — all six rows where the columns diverge are answered, and `--withdraw` refuses an answered gate — so the effect is **forward-only**.

Also: an unresolvable principal renders `unrecorded` rather than the `?` placeholder #335 shipped. An empty principal is reachable **by configuration** (`created_by` is nullable), not by data, and the reader needs to see a stated absence.

## Grading — the pair that makes this a narrowing, not a widening

**32 arms, was 22.** Every arm **performs** a withdraw as a **distinct** agent: filer `pi`, holder `creative`, filer's lead `grok`, coordinator `main`, human. A fixture that shares one name across two routes tests their union and neither.

| mutation | result | reds |
|---|---|---|
| **the ADDITIVE build** — holder added as a 5th authorizer, principal unchanged | **29 / 3** | `P2`, `P3`, `P7` — and **`P1` still passes** |
| pre-change principal (authorize on `assignee`) | **25 / 7** | `P1`, `P2`, `P3`, `P4`, `P7`, `P8`, `T-2382g` |
| olivia's amendment removed (auth shape ends on `assignee`) | **30 / 2** | `P7`, `P8` |
| lead resolved from the holder | **31 / 1** | `P4` only |
| clean baseline | **32 / 0** | — |

The first row is the one that matters: **an additive build passes `P1` and fails `P2`.** `P1` (filer can withdraw) was **RED** before this change; `P2` (reassigned holder can no longer) was **GREEN** before it and **flips**. A suite carrying only `P1` would have signed off on a widening.

Each mutation was verified as applied (`bash -n` clean, changed line printed, summary line present) after a first attempt produced three void measurements — one `perl` substitution never applied and returned a pristine 32/0, and two others wrote malformed SQL or an interpolated-empty variable, so their reds were artifacts. `git checkout --` between arms, `git status` clean at the end.

`P8`/`P9` were initially read off `P7`'s row, which made them **cascade**: under a mutation authorizing the holder, `P7`'s withdraw succeeds, so `$out` holds a success payload and the row has no gate left. Three reds read as three findings when they were one. Each arm now builds its own row, so the table above is per-arm.

## Checks

- `tests/gate_withdraw_unit.sh` — 32 passed, 0 failed
- `shellcheck -S error` — clean apart from the file's pre-existing `SC2148` (sourced fragment, no shebang)
- `scripts/pii-scan.sh` over the added diff lines — `pii-scan: clean`

## Scope

Fix #5 of DIVE-2382 landed as `20527fd`. This is the principal half. Still open on the row: auto-retire on resolution (**note the constraint in item #1's own text** — a row is not a subject, so the reader must resolve what the *gate* is about and must never inherit the row's commit stream as evidence), dedup/link gates sharing a blocker, render the actual tier requirement, make poller arming visible, and the tier-2 channel-proof question, which is filed as the row's gate and is lodar's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
