### PR TITLE
usage: qualify an unverified figure IN the value, not beside it (DIVE-2312)

### DIFF
--- a/src/cmd_usage.sh
+++ b/src/cmd_usage.sh
@@ -393,6 +393,19 @@ USAGE_JQ_HELPERS='
             elif . >= 1000 then ((. / 1000 * 10 | floor) / 10 | tostring) + "k"
             else (. | tostring) end;
   def pct(x): if x == null then "-" else ((x | floor | tostring) + "%") end;
+  # DIVE-2312: a figure the collector has ALREADY flagged unverified must not
+  # render as a bare number a reader can lift. DIVE-2058 put a ⚠ beside the
+  # ident and a caveat under the table; both render correctly and three readers
+  # in a row still quoted the number as fact — one of them the author of the
+  # note warning about it. A marker cannot make a reader read it, so the
+  # uncertainty has to travel INSIDE the value. The qualifier is ATTACHED with
+  # no whitespace, which is the load-bearing part: the number then never
+  # appears as a standalone whitespace-delimited field anywhere in the output,
+  # so lifting the cell carries the word "unverified" with it.
+  # Pass the flag as a bound $variable, not a bare filter — inside a jq
+  # function body `.` is the value being formatted (a number), so `.dispatched`
+  # would be evaluated against it and error.
+  def qtok($unv): if $unv then "~" + htok + "(unverified)" else htok end;
   def shortmodel: if . == null then "-"
                   else (sub("^claude-";"") | sub("-20[0-9]+$";"")) end;
 '
@@ -519,19 +532,23 @@ usage_render_board() {
     else
       (["TASK","AGENT","ITER","OUTPUT","TOTAL","TITLE"] | @tsv),
       (.tasks | sort_by(-.total)[:12][] |
-        [ (.ident + (if .dispatched == false then " ⚠" else "" end)), .assignee,
+        (.dispatched == false) as $unv |
+        [ (.ident + (if $unv then " ⚠" else "" end)), .assignee,
           (if (.iteration // 0) > 0 then (.iteration|tostring) else "-" end),
-          (.output|htok), (.total|htok),
+          (.output|qtok($unv)), (.total|qtok($unv)),
           (.title | if length > 42 then .[:41] + "…" else . end) ] | @tsv)
     end' <<<"$data" | column -t -s $'\t' | sed 's/^/  /'
 
   # DIVE-2058: rows with dispatched==false attribute tokens to a task with no
   # /goal dispatch found in its window — flag rather than let a misattributed
   # number stand unqualified (the DIVE-1817 13.8M incident).
+  # DIVE-2312: this footnote is no longer what carries the caveat — the figures
+  # themselves do. It stays as the explanation of the `~…(unverified)` form and
+  # the pointer to why, not as the only place the reader can learn it.
   local flagged
   flagged=$(jq -r '[.tasks[] | select(.dispatched == false)] | length' <<<"$data" 2>/dev/null)
   if [[ "${flagged:-0}" -gt 0 ]]; then
-    echo "  ⚠ ${flagged} row(s) above show tokens attributed to a task with no /goal dispatch found in its window — likely misattributed, treat as unverified (see DIVE-2058)."
+    echo "  ⚠ ${flagged} row(s) above are marked ~N(unverified): tokens attributed to a task with no /goal dispatch found in its window — likely misattributed. Do not quote those figures as fact (see DIVE-2058, DIVE-2312)."
   fi
 
   # over-budget callout: ⚠ at the soft cap, ⛔ at the ceiling (see `5dive cost`).
@@ -597,7 +614,8 @@ usage_render_agent() {
   jq -r "$USAGE_JQ_HELPERS"'
     if (.tasks | map(select(.assignee==$n)) | length) == 0 then "    (none attributed)"
     else (.tasks | map(select(.assignee==$n)) | sort_by(-.total)[] |
-      "    " + .ident + (if .dispatched == false then " ⚠" else "" end) + "  " + (.total|htok) + "  " + .title) end
+      (.dispatched == false) as $unv |
+      "    " + .ident + (if $unv then " ⚠" else "" end) + "  " + (.total|qtok($unv)) + "  " + .title) end
     ' --arg n "$agent" <<<"$data"
 }
 

--- a/tests/usage_dispatch_flag_unit.sh
+++ b/tests/usage_dispatch_flag_unit.sh
@@ -20,6 +20,14 @@
 # in the window => dispatched=false => the CLI flags the row (⚠) instead of
 # printing it as a confident number.
 #
+# DIVE-2312 (second half of this harness): flagging the ROW turned out not to be
+# enough — the ⚠ and the footer caveat both rendered correctly and three readers
+# in a row still lifted the number beside them as fact, one of them the author of
+# the note warning about it. So the figure itself is now qualified in-cell
+# (`~5.1M(unverified)`), and the assertions at the bottom grade the property that
+# actually matters: a flagged figure never appears as a standalone
+# whitespace-delimited field, which is the token a reader quotes.
+#
 # Isolation (rewritten, DIVE-2069): tasks.db AND the agent-home tree both live in
 # a throwaway dir. The premise of the original note here — "the transcript scan
 # can't be redirected via env" — was FALSE: home_of() has honoured USAGE_HOME_ROOT
@@ -216,6 +224,77 @@ fi
 d4=$(jq -r '.tasks[] | select(.ident=="DIVE-90004") | .dispatched' <<<"$data4")
 [[ "$d4" == "null" ]] && ok_t "in_progress task with zero pins reads dispatched=null, NOT flagged false (verified against a proven-live read)" \
   || bad_t "expected DIVE-90004 dispatched=null (unknown, not accused)" "got $d4"
+
+# =============================================================================
+# DIVE-2312 — the flagged VALUE must not be liftable, not merely marked.
+#
+# The assertions above prove the ⚠ and the caveat render. They rendered
+# correctly for three straight readers who then quoted the number as fact, one
+# of them the author of the note warning about it. So the property to grade is
+# not "does the caveat appear" but "can a reader still lift a bare number".
+#
+# Falsifiable form: for a flagged row, the humanized figure must never appear
+# as a STANDALONE whitespace-delimited field in the TOP TASKS block. That is
+# exactly the token a reader's eye lands on and a copy-paste picks up, and it
+# is only satisfiable if the qualifier is attached with no space.
+#
+# Scope is TOP TASKS (and the per-agent `tasks (...)` list) deliberately. The
+# TOP AGENTS row for this same agent prints the same 5.1M bare and SHOULD: the
+# agent really did burn those tokens. DIVE-2058 misattributes which TASK owns
+# them, not how many there were. Asserting over the whole board would be
+# asserting something the defect never claimed.
+# NOTE the argument order: jq takes the first non-flag word as the PROGRAM, so
+# `jq -rn "$USAGE_JQ_HELPERS" --argjson v ... '$v|htok'` compiles the helper
+# block alone (no top-level expression) and treats the real program as a
+# filename. It fails to stderr and leaves $bare_total EMPTY — under which the
+# "no bare liftable figure" assertion passes for a reason that has nothing to
+# do with the fix. The flags go first; the program is one concatenated word.
+htok_of() { jq -rn --argjson v "$1" "$USAGE_JQ_HELPERS"'$v|htok'; }
+bare_total=$(htok_of "$(jq -r '.total' <<<"$row")")
+bare_out=$(htok_of "$(jq -r '.output' <<<"$row")")
+# Abort rather than assert on empty needles: "the number 5.1M never appears as a
+# standalone field" and "the number '' never appears" are the same assertion to
+# awk, and only one of them is about the fix.
+[[ "$bare_total" =~ ^[0-9] && "$bare_out" =~ ^[0-9] ]] \
+  || { bad_t "humanized figures derived for the assertions below" "bare_total='$bare_total' bare_out='$bare_out' — an empty needle makes every check below vacuous"; printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"; exit 1; }
+
+# `rendered` is the board built from $data, where DIVE-90001 is the flagged row.
+tasks_block=$(printf '%s\n' "$rendered" | sed -n '/^TOP TASKS/,$p')
+[[ -n "$tasks_block" ]] || { bad_t "TOP TASKS block located in rendered board" "sed range matched nothing"; printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"; exit 1; }
+
+lift=$(printf '%s\n' "$tasks_block" | awk -v a="$bare_total" -v b="$bare_out" \
+  '{for(i=1;i<=NF;i++) if($i==a || $i==b) print "  line "NR": "$0}')
+[[ -z "$lift" ]] && ok_t "flagged row prints NO bare liftable figure in TOP TASKS ($bare_total / $bare_out never stand alone)" \
+  || bad_t "a flagged figure is still quotable as a bare number" "$lift"
+
+printf '%s\n' "$tasks_block" | grep -qF "~${bare_total}(unverified)" \
+  && ok_t "flagged TOTAL renders qualified in-cell as ~${bare_total}(unverified)" \
+  || bad_t "expected ~${bare_total}(unverified) in TOP TASKS" "$(printf '%s\n' "$tasks_block" | grep DIVE-90001)"
+printf '%s\n' "$tasks_block" | grep -qF "~${bare_out}(unverified)" \
+  && ok_t "flagged OUTPUT renders qualified in-cell as ~${bare_out}(unverified)" \
+  || bad_t "expected ~${bare_out}(unverified) in TOP TASKS" "$(printf '%s\n' "$tasks_block" | grep DIVE-90001)"
+
+# Same rule on the per-agent view — it is a second render site with its own
+# format string, and a fix applied to only one of them leaves the other lifting.
+agent_view=$(JSON_MODE=0 usage_render_agent "$data" "$AGENT" "24h")
+agent_tasks=$(printf '%s\n' "$agent_view" | sed -n '/^  tasks (/,$p')
+lift2=$(printf '%s\n' "$agent_tasks" | awk -v a="$bare_total" '{for(i=1;i<=NF;i++) if($i==a) print "  line "NR": "$0}')
+[[ -z "$lift2" ]] && ok_t "per-agent 'tasks' list prints no bare liftable figure for the flagged row" \
+  || bad_t "usage_render_agent still prints the flagged total bare" "$lift2"
+
+# CONTROL — without this the assertions above are satisfiable by a render that
+# prints no figures at all, or one that qualifies every row indiscriminately.
+# An UNFLAGGED row must still print its number bare and quotable: that is the
+# whole point of only qualifying what the collector actually doubts.
+rendered4=$(JSON_MODE=0 usage_render_board "$data4" "24h" "{}")
+tasks_block4=$(printf '%s\n' "$rendered4" | sed -n '/^TOP TASKS/,$p')
+ctl_total=$(htok_of "$(jq -r '.tasks[] | select(.ident=="DIVE-90003") | .total' <<<"$data4")")
+ctl_hit=$(printf '%s\n' "$tasks_block4" | awk -v a="$ctl_total" '{for(i=1;i<=NF;i++) if($i==a) print NR}')
+[[ -n "$ctl_hit" ]] && ok_t "control: dispatched=true row still prints its figure bare ($ctl_total) — the qualifier tracks doubt, not every row" \
+  || bad_t "expected DIVE-90003's $ctl_total as a standalone field" "$(printf '%s\n' "$tasks_block4" | grep DIVE-90003)"
+printf '%s\n' "$tasks_block4" | grep -q "DIVE-90003.*(unverified)" \
+  && bad_t "control: an unflagged row was wrongly qualified" "$(printf '%s\n' "$tasks_block4" | grep DIVE-90003)" \
+  || ok_t "control: unflagged row carries no (unverified) marker"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## The defect

`5dive usage` TOP TASKS flags a row whose ident has no `/goal` dispatch in the reporting window (DIVE-2058): a ⚠ on the ident, plus a footer caveat naming the count and saying "treat as unverified". Both render correctly, every time.

Three readers in a row lifted the number beside the marker as fact anyway. The third was the author of the note warning about it, and the figure she quoted (`DIVE-1952: 37.5M`) was used to argue against a change during a live cost decision, then corrected once she went and read the legend herself. The marker was working the whole time. She read the number and did not read the marker.

A better caveat is not the fix. A caveat cannot make a reader read it, and three readers — one of them the warning's author — is not a sample that supports "we just need clearer wording".

## The change

The uncertainty travels **inside** the value. A flagged row renders:

```
TASK          AGENT  ITER  OUTPUT              TOTAL                 TITLE
DIVE-90001 ⚠  main   -     ~5M(unverified)     ~5.1M(unverified)     blocked task with a stale dispatch
DIVE-90003    main   -     300                 310                   genuinely dispatched task
```

in **both** render sites — the board's TOP TASKS and the per-agent `tasks (...)` list, which are separate format strings, and a fix applied to one leaves the other lifting.

The qualifier is attached with **no whitespace**, and that is the load-bearing part rather than a style choice: the figure then never appears as a standalone whitespace-delimited field, so the token a reader's eye lands on — and that a copy-paste picks up — carries the word with it. The footer line stays, demoted from sole carrier of the caveat to the explanation of the form.

## What is deliberately NOT qualified

TOP AGENTS still prints the same 5.1M bare. The agent really did burn those tokens; DIVE-2058 misattributes **which task** owns them, not how many there were. Qualifying every number would make the marker mean nothing, and would assert something the defect never claimed.

`dispatched == null` (no pin data at all) is also untouched — a data gap must not read as an accusation (DIVE-2058's own rule).

JSON mode is unchanged: `.tasks[].dispatched` already rides with the numbers for machine consumers.

## Grading

`tests/usage_dispatch_flag_unit.sh` (extended, +5 assertions). The property graded is not "does the caveat render" — that already passed while the defect was live — but **"can a reader still lift a bare number"**:

- flagged row: its humanized OUTPUT and TOTAL never appear as a standalone field in TOP TASKS, nor in the per-agent list. Satisfiable only by an attached qualifier.
- flagged row: the cells literally read `~N(unverified)`.
- **control** — an unflagged row must still print its figure **bare**. Without it the assertions above are satisfiable by a render that prints no figures at all, or one that qualifies every row.
- **control** — an unflagged row carries no `(unverified)` marker.
- the needles are asserted non-empty before use. The first draft hit exactly this: a jq argument-order slip (`jq -rn "$HELPERS" --argjson v ... 'prog'` compiles the helper block alone and treats the program as a filename) returned `""`, and "the number `''` never appears as a standalone field" passed for a reason with nothing to do with the fix.

**Result: 15 passed / 0 failed** on this branch. Against `src/cmd_usage.sh` restored from `30f73ed` (this branch's base), the four new fix-grading assertions **fail** and both controls still pass.

Sibling presenter harness `tests/usage_presenter_coverage_unit.sh`: 26 passed / 0 failed.

Closes DIVE-2312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)