### PR TITLE
feat(agent): agent send --wake, so a scheduled wake is not lost when the target is asleep (DIVE-2385)

### DIFF
--- a/src/cmd_agent_runtime.sh
+++ b/src/cmd_agent_runtime.sh
@@ -487,18 +487,26 @@ declare -A _AGENT_PROMPT_DETECTABLE=(
   [claude]=1 [codex]=1 [devin]=1 [antigravity]=1 [grok]=1
 )
 
+# DIVE-2385 (iteration 2) — extracted verbatim out of wait_agent_input_ready so the
+# WAKE path can tell apart the TWO reasons that function returns 0: "the prompt
+# rendered" and "this runtime has no prompt to detect". Both are `return 0` there
+# and always were; only the wake path needs to distinguish them, and it must read
+# the SAME table rather than a second copy that can drift.
+#
+# An UNKNOWN type (empty lookup) counts as detectable deliberately: paying a bounded
+# wait beats skipping a real readiness check on a type we have not classified.
+agent_prompt_detectable() {
+  local _atype; _atype=$(agent_type "$1" 2>/dev/null || true)
+  [[ -z "$_atype" || -n "${_AGENT_PROMPT_DETECTABLE[$_atype]+x}" ]]
+}
+
 wait_agent_input_ready() {
   local name="$1" timeout="${2:-45}"
   local user="agent-${name}" waited=0 pane
   # Skip the poll for a harness with no marker. Returns 0 (proceed) rather than 1:
   # for these types the 1 never meant "not ready", it meant "undetectable", and the
   # warning it triggered was false — DIVE-348 called that warning out by name.
-  # An UNKNOWN type (empty lookup) falls through to the poll deliberately: paying a
-  # bounded wait beats skipping a real readiness check on a type we have not classified.
-  local _atype; _atype=$(agent_type "$name" 2>/dev/null || true)
-  if [[ -n "$_atype" && -z "${_AGENT_PROMPT_DETECTABLE[$_atype]+x}" ]]; then
-    return 0
-  fi
+  agent_prompt_detectable "$name" || return 0
   while (( waited < timeout )); do
     pane=$(sudo -u "$user" tmux capture-pane -p -t "agent-${name}" 2>/dev/null || true)
     _agent_pane_input_ready "$pane" && return 0
@@ -1417,10 +1425,22 @@ _envelope_caller() {
 # appears inside the budget, the caller still gets E_NOT_RUNNING — with the reason
 # named, rather than the bare "is the agent running?" that was true but useless to
 # a systemd unit.
+#
+# ONE DEADLINE, NOT TWO STACKED ONES (iteration 2). Waking and then waiting for the
+# prompt are two waits on the same send, and a caller sizing a systemd
+# TimeoutStartSec should not have to discover that by adding 60 and 45 out of two
+# different functions. AGENT_WAKE_BUDGET_SECS is the ONLY number a scheduler needs:
+# the wake half spends what it needs (capped at 60 so a hung session-appear cannot
+# starve the readiness wait of the 45s it had), records it in AGENT_WAKE_ELAPSED, and
+# the readiness wait gets the REMAINDER. A fast wake therefore buys the prompt more
+# time rather than throwing it away, and the pair can never exceed the budget.
+AGENT_WAKE_BUDGET_SECS="${AGENT_WAKE_BUDGET_SECS:-105}"
 AGENT_WAKE_FAIL_REASON=""
+AGENT_WAKE_ELAPSED=0
 agent_wake_for_send() {
   local name="$1" timeout="${2:-60}"
   AGENT_WAKE_FAIL_REASON=""
+  AGENT_WAKE_ELAPSED=0
   local desired
   desired=$(registry_read | jq -r --arg n "$name" '.agents[$n].desiredState // ""' 2>/dev/null) || desired=""
   if [[ "$desired" == "stopped" ]]; then
@@ -1433,11 +1453,68 @@ agent_wake_for_send() {
   fi
   local waited=0
   while (( waited < timeout )); do
-    sudo -u "agent-${name}" tmux has-session -t "agent-${name}" 2>/dev/null && return 0
+    if sudo -u "agent-${name}" tmux has-session -t "agent-${name}" 2>/dev/null; then
+      AGENT_WAKE_ELAPSED="$waited"
+      return 0
+    fi
     sleep 1; waited=$((waited+1))
   done
+  AGENT_WAKE_ELAPSED="$waited"
   AGENT_WAKE_FAIL_REASON="started 5dive-agent@${name}.service but its tmux session did not appear within ${timeout}s"
   return 1
+}
+
+# DIVE-2385 (iteration 2) — ON THE WAKE PATH, READINESS IS FATAL.
+#
+# The default path's readiness wait is deliberately NON-fatal: on timeout it warns
+# and delivers best-effort, because a busy-but-healthy agent that never parks at a
+# prompt should still get its message. That is the right trade for a caller who is
+# watching a terminal. It is the WRONG trade for the only caller --wake exists for.
+#
+# THE DEFECT THIS REMOVES, and it was introduced by --wake itself. `wait_agent_input_ready`
+# is a tail that cmd_send already had; adding a new ENTRY into that tail silently
+# inherited its best-effort contract. agent_wake_for_send returns the instant
+# `tmux has-session` succeeds — the EARLIEST moment of a cold boot, long before the
+# TUI renders an input prompt. On a cold boot slower than the readiness budget —
+# the common cold-boot outcome — the old code warned, fired keystrokes into a
+# booting TUI (which its own comment says are dropped and the message lost), and
+# then ended at `sent:true`, exit 0. That is strictly WORSE than the incident this
+# ticket was filed for: there, the send failed in 190ms and left a unit in `failed`
+# state that something could see. A scheduler with no reader needs a truthful rc far
+# more than a delivered-maybe keystroke, and the hard rc is precisely what puts the
+# transient unit into failed state where it is observable at all.
+#
+# Gated on `woken` by its caller, so the DEFAULT path keeps its behaviour, its
+# warning and its best-effort delivery byte for byte.
+#
+# THE HOLE THIS DOES NOT CLOSE, named rather than papered over. For a runtime with
+# no prompt marker (anything outside _AGENT_PROMPT_DETECTABLE — see
+# agent_prompt_detectable) readiness is not slow, it is UNOBSERVABLE: the poll is
+# skipped and 0 means "nothing to detect", never "ready". Failing there would refuse
+# every delivery that would in fact have worked; passing silently would re-create
+# exactly the green-on-a-dropped-message this function exists to remove. So it
+# proceeds and SAYS SO — on stderr, and as ready:"unprovable" in the --json payload,
+# so a scheduler can tell a proven delivery from an assumed one instead of reading
+# one `sent:true` for both.
+#
+# It computes the remaining deadline ITSELF, from AGENT_WAKE_ELAPSED, rather than
+# taking it from the caller. One function owns the budget arithmetic, so there is no
+# second place for a plain 45 to reappear and quietly double the worst case back to
+# 105+45.
+AGENT_WAKE_READY=""
+agent_wake_gate_ready() {
+  local name="$1"
+  local budget=$(( AGENT_WAKE_BUDGET_SECS - AGENT_WAKE_ELAPSED ))
+  (( budget > 0 )) || budget=1
+  if ! agent_prompt_detectable "$name"; then
+    AGENT_WAKE_READY="unprovable"
+    step "agent '$name' woke, but this runtime has no detectable input prompt — delivering WITHOUT proof it is ready (reported as ready=unprovable)"
+    return 0
+  fi
+  if ! wait_agent_input_ready "$name" "$budget"; then
+    fail "$E_NOT_RUNNING" "woke agent '$name' but its input prompt never rendered within ${budget}s — refusing to type into a booting TUI and report a send that would be lost. --wake budgets ${AGENT_WAKE_BUDGET_SECS}s in total for the wake and this wait; size a scheduler's timeout against that."
+  fi
+  AGENT_WAKE_READY="proven"
 }
 
 cmd_send() {
@@ -1584,7 +1661,15 @@ cmd_send() {
   # Don't fire keystrokes into a still-booting TUI — they'd be dropped and the
   # message lost. Wait for the input prompt to render (fast no-op when already
   # up). On timeout we still send best-effort and warn, rather than hang.
-  if ! wait_agent_input_ready "$name"; then
+  #
+  # DIVE-2385 (iteration 2): the WAKE path takes a different branch, because on it
+  # "still booting" is the EXPECTED state rather than a surprise, and its caller is
+  # a scheduler that will never read the warning. See agent_wake_gate_ready. The
+  # elif keeps the default branch — its condition, its message, its best-effort
+  # fallthrough — exactly as it was.
+  if (( woken )); then
+    agent_wake_gate_ready "$name"
+  elif ! wait_agent_input_ready "$name"; then
     step "agent '$name' input prompt not detected after 45s — sending best-effort (may be lost if still booting)"
   fi
 
@@ -1604,9 +1689,15 @@ cmd_send() {
   # agent in order to deliver". A scheduled caller that logs this line can tell,
   # after the fact, that its wake was needed — the fact the failed transient unit
   # could not tell anyone.
+  #
+  # `ready` appears on the WAKE path only, and exists so `sent:true` does not have to
+  # carry two different meanings. "proven" = the input prompt was observed before a
+  # key was typed. "unprovable" = this runtime has no prompt marker, so the delivery
+  # is an assumption. A scheduler that treats those the same is making the exact
+  # mistake this ticket is about.
   ok "sent to agent '$name'." \
-     '{name:$n, sent:true, bytes:($p|length), woken:($w=="1"), from:($s|select(length>0)), msg_id:($i|select(length>0)), reply_to_chat:($rc|select(length>0)), reply_to_msg:($rm|select(length>0))}' \
-     --arg n "$name" --arg p "$payload" --arg s "$sender" --arg i "$msg_id" --arg rc "$reply_to_chat" --arg rm "$reply_to_msg" --arg w "$woken"
+     '{name:$n, sent:true, bytes:($p|length), woken:($w=="1"), ready:($rd|select(length>0)), from:($s|select(length>0)), msg_id:($i|select(length>0)), reply_to_chat:($rc|select(length>0)), reply_to_msg:($rm|select(length>0))}' \
+     --arg n "$name" --arg p "$payload" --arg s "$sender" --arg i "$msg_id" --arg rc "$reply_to_chat" --arg rm "$reply_to_msg" --arg w "$woken" --arg rd "$AGENT_WAKE_READY"
 }
 
 # Synchronous send + wait — the inter-agent counterpart to cmd_send. Drops the

--- a/src/cmd_agent_runtime.sh
+++ b/src/cmd_agent_runtime.sh
@@ -506,7 +506,17 @@ wait_agent_input_ready() {
   # Skip the poll for a harness with no marker. Returns 0 (proceed) rather than 1:
   # for these types the 1 never meant "not ready", it meant "undetectable", and the
   # warning it triggered was false — DIVE-348 called that warning out by name.
-  agent_prompt_detectable "$name" || return 0
+  #
+  # ONLY rc 1 means "undetectable". This test used to be an inline [[ ]] that could
+  # not fail; a function CALL can (unavailable, extracted without its helper, a
+  # future error path), and `|| return 0` would have turned the predicate's own
+  # breakage into a blanket skip of the readiness check for EVERY agent — fail-open
+  # in the worst direction, and silent. Measured: extracting this function without
+  # its new helper made claude and codex skip the poll in 0s. Anything other than a
+  # clean 1 falls through to the poll, which is the same call the UNKNOWN-type case
+  # already makes: pay a bounded wait rather than skip a real check.
+  local _det=0; agent_prompt_detectable "$name" || _det=$?
+  (( _det == 1 )) && return 0
   while (( waited < timeout )); do
     pane=$(sudo -u "$user" tmux capture-pane -p -t "agent-${name}" 2>/dev/null || true)
     _agent_pane_input_ready "$pane" && return 0

--- a/src/cmd_agent_runtime.sh
+++ b/src/cmd_agent_runtime.sh
@@ -1584,6 +1584,12 @@ cmd_send() {
 
   require_agent "$name"
   local woken=0
+  # Reset at entry, like AGENT_WAKE_FAIL_REASON and AGENT_WAKE_ELAPSED do in
+  # agent_wake_for_send. Today cmd_send has exactly one in-process caller (main.sh's
+  # dispatch), so a stale value cannot be reached — but `ready` is a claim about what
+  # this send PROVED, and a claim carried over from a previous call is a false one.
+  # That is the defect class this ticket is about; do not leave it to a call-count.
+  AGENT_WAKE_READY=""
   if ! sudo -u "agent-${name}" tmux has-session -t "agent-${name}" 2>/dev/null; then
     # DIVE-2385: default behaviour is unchanged — same code, same message, same
     # sub-second latency that _task_need_route_deliver's rc poll depends on.

--- a/src/cmd_agent_runtime.sh
+++ b/src/cmd_agent_runtime.sh
@@ -1373,8 +1373,75 @@ _envelope_caller() {
   printf '%s' "$who"
 }
 
+# DIVE-2385 — WAKE-THEN-SEND, so deferred work does not depend on the recipient
+# being awake at the instant the scheduler fires.
+#
+# `agent send` needs the target to have a LIVE tmux session. Send to an agent that
+# simply is not running and it fails in ~190ms with E_NOT_RUNNING: no queue, no
+# retry, no persistence. Survivable when a human is watching a terminal; load-
+# bearing when the caller is SYSTEMD.
+#
+# MEASURED, 2026-07-30 (marketing). An approved blog post was scheduled the
+# documented way — a transient unit whose ExecStart was
+#   systemd-run --on-calendar=... 5dive agent send marketing '<publish pointer>'
+# The timer fired exactly on time at 23:45:02 UTC and the unit died on the spot
+# (status=8) because marketing was asleep. Three properties then compounded: the
+# message was dropped unqueued and unalarmed; a one-shot .timer is CONSUMED once
+# it fires, so there was no second attempt; and the only surviving evidence was a
+# .service in `failed` state under /run/systemd/transient/, a path nobody greps.
+# The approved post silently did not publish. It was caught 17 minutes later
+# because an unrelated cron woke marketing and a same-day guard tripped over the
+# uncommitted .mdx — luck, not a mechanism. This is NOT the known
+# transient-units-die-on-reboot caveat: the host had been up 7+ weeks. It needs
+# nothing to go wrong except the target being asleep at one instant.
+#
+# WHY OPT-IN AND NOT THE NEW DEFAULT. E_NOT_RUNNING is load-bearing elsewhere
+# precisely BECAUSE it is a sub-second failure: _task_need_route_deliver
+# (DIVE-2011) polls a detached send's own rc for exactly this shape to decide
+# whether a gate handoff was observed to fail, and it can only do that because a
+# dead session is decided long before the 45s readiness wait. Waking on every
+# send would turn those observed failures into a 30s+ boot wait and then report
+# them as delivered — re-manufacturing the DIVE-1968 mis-measurement in the one
+# rail that was cleaned up. So the default path keeps its rc and its latency byte
+# for byte, and a caller that is scheduling DEFERRED work asks for the wake.
+#
+# REFUSES on desiredState=stopped. That field is the operator's recorded intent
+# (cmd_stop writes it; the supervisor reads it when it decides whether a dead unit
+# is a crash or a deliberate stop), so waking past it would let a scheduler
+# override a human's explicit stop — and the supervisor would then be entitled to
+# stop the agent back, mid-turn. ABSENT is NOT stopped (DIVE-2318: unknown is not
+# a negative): an agent that has never been start/stop'd through the CLI carries
+# no field at all, which is the common case, so absent wakes.
+#
+# It never reports a send it did not make: if the unit starts but no session
+# appears inside the budget, the caller still gets E_NOT_RUNNING — with the reason
+# named, rather than the bare "is the agent running?" that was true but useless to
+# a systemd unit.
+AGENT_WAKE_FAIL_REASON=""
+agent_wake_for_send() {
+  local name="$1" timeout="${2:-60}"
+  AGENT_WAKE_FAIL_REASON=""
+  local desired
+  desired=$(registry_read | jq -r --arg n "$name" '.agents[$n].desiredState // ""' 2>/dev/null) || desired=""
+  if [[ "$desired" == "stopped" ]]; then
+    AGENT_WAKE_FAIL_REASON="agent '$name' is stopped by operator intent (desiredState=stopped), so --wake will not start it; clear that intent with '5dive agent start $name' if it is stale"
+    return 1
+  fi
+  if ! systemctl start "5dive-agent@${name}.service" >&2; then
+    AGENT_WAKE_FAIL_REASON="systemctl start 5dive-agent@${name}.service failed"
+    return 1
+  fi
+  local waited=0
+  while (( waited < timeout )); do
+    sudo -u "agent-${name}" tmux has-session -t "agent-${name}" 2>/dev/null && return 0
+    sleep 1; waited=$((waited+1))
+  done
+  AGENT_WAKE_FAIL_REASON="started 5dive-agent@${name}.service but its tmux session did not appear within ${timeout}s"
+  return 1
+}
+
 cmd_send() {
-  local name="" message="" from="" from_set=0 raw=0
+  local name="" message="" from="" from_set=0 raw=0 wake=0
   local reply_to_chat="" reply_to_msg=""
   local -a positional=()
   while [[ $# -gt 0 ]]; do
@@ -1382,6 +1449,7 @@ cmd_send() {
       --message=*)        message="${1#--message=}" ;;
       --from=*)           from="${1#--from=}"; from_set=1 ;;
       --raw)              raw=1 ;;
+      --wake)             wake=1 ;;
       --reply-to-chat=*)  reply_to_chat="${1#--reply-to-chat=}" ;;
       --reply-to-msg=*)   reply_to_msg="${1#--reply-to-msg=}" ;;
       --)                 shift; positional+=("$@"); break ;;
@@ -1394,7 +1462,7 @@ cmd_send() {
     name="${positional[0]}"
     positional=("${positional[@]:1}")
   fi
-  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent send <name> <text...> | --message=<text> [--from=<sender>] [--raw] [--reply-to-chat=<id> [--reply-to-msg=<id>]]"
+  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent send <name> <text...> | --message=<text> [--from=<sender>] [--raw] [--wake] [--reply-to-chat=<id> [--reply-to-msg=<id>]]"
   if [[ -z "$message" && ${#positional[@]} -gt 0 ]]; then
     message="${positional[*]}"
   fi
@@ -1414,13 +1482,31 @@ cmd_send() {
   # (NOPASSWD:ALL) and root/internal callers keep the direct path below (and their
   # --from/--reply-to-chat plumbing). A scoped a2a send is peer-to-peer, so it
   # carries no channel plumbing. sudo -n = fail-closed, never prompts.
+  # DIVE-2385: --wake starts a systemd unit, which a scoped a2a caller cannot do —
+  # its whole grant is `/usr/local/bin/5dive agent _deliver *`, and _deliver
+  # deliberately carries no lifecycle powers. REFUSE rather than exec into
+  # `_deliver` and drop the flag: a silently-ignored --wake is the same lost
+  # message the flag exists to prevent, with an exit 0 printed over it. Checked
+  # BEFORE the exec for that reason.
+  if (( wake )) && a2a_needs_scoped "$name"; then
+    fail "$E_PERMISSION" "--wake starts the target's systemd unit and needs admin/root; this caller only holds the scoped a2a delivery grant. Re-run via sudo, or schedule the work as a task row instead."
+  fi
   if a2a_needs_scoped "$name"; then
     exec sudo -n /usr/local/bin/5dive agent _deliver "$name" "$message"
   fi
 
   require_agent "$name"
-  sudo -u "agent-${name}" tmux has-session -t "agent-${name}" 2>/dev/null \
-    || fail "$E_NOT_RUNNING" "tmux session 'agent-${name}' not found (is the agent running?)"
+  local woken=0
+  if ! sudo -u "agent-${name}" tmux has-session -t "agent-${name}" 2>/dev/null; then
+    # DIVE-2385: default behaviour is unchanged — same code, same message, same
+    # sub-second latency that _task_need_route_deliver's rc poll depends on.
+    (( wake )) \
+      || fail "$E_NOT_RUNNING" "tmux session 'agent-${name}' not found (is the agent running?)"
+    step "agent '$name' is not running — starting it to deliver (--wake)"
+    agent_wake_for_send "$name" \
+      || fail "$E_NOT_RUNNING" "tmux session 'agent-${name}' not found and --wake could not bring it up: ${AGENT_WAKE_FAIL_REASON}"
+    woken=1
+  fi
 
   # Optional reply-target hint. If present, it tells the receiver: "the user is
   # reachable in this chat — reply there directly via your own bot rather than
@@ -1514,9 +1600,13 @@ cmd_send() {
   # real envelope: a raw/anonymous send has no sender identity to mirror under.
   (( raw )) || mirror_interagent_outbound "$name" "$message"
 
+  # DIVE-2385: `woken` distinguishes "delivered to a live agent" from "started the
+  # agent in order to deliver". A scheduled caller that logs this line can tell,
+  # after the fact, that its wake was needed — the fact the failed transient unit
+  # could not tell anyone.
   ok "sent to agent '$name'." \
-     '{name:$n, sent:true, bytes:($p|length), from:($s|select(length>0)), msg_id:($i|select(length>0)), reply_to_chat:($rc|select(length>0)), reply_to_msg:($rm|select(length>0))}' \
-     --arg n "$name" --arg p "$payload" --arg s "$sender" --arg i "$msg_id" --arg rc "$reply_to_chat" --arg rm "$reply_to_msg"
+     '{name:$n, sent:true, bytes:($p|length), woken:($w=="1"), from:($s|select(length>0)), msg_id:($i|select(length>0)), reply_to_chat:($rc|select(length>0)), reply_to_msg:($rm|select(length>0))}' \
+     --arg n "$name" --arg p "$payload" --arg s "$sender" --arg i "$msg_id" --arg rc "$reply_to_chat" --arg rm "$reply_to_msg" --arg w "$woken"
 }
 
 # Synchronous send + wait — the inter-agent counterpart to cmd_send. Drops the

--- a/src/main.sh
+++ b/src/main.sh
@@ -151,6 +151,16 @@ Agents:
                                                      # sleeping agent is dropped with no queue and no
                                                      # retry. Needs root; refuses if the agent was
                                                      # deliberately stopped (desiredState=stopped).
+                                                     # WORST CASE 105s: the wake and the wait for the
+                                                     # agent's input prompt share ONE budget, so size a
+                                                     # timer's TimeoutStartSec above that (override with
+                                                     # AGENT_WAKE_BUDGET_SECS). On this path a prompt that
+                                                     # never renders is FATAL (exit 8) rather than
+                                                     # best-effort: a scheduler with nobody reading its
+                                                     # output needs a truthful exit code more than a
+                                                     # keystroke that may have been dropped. --json then
+                                                     # reports ready=proven, or ready=unprovable for a
+                                                     # runtime whose prompt cannot be detected at all.
   5dive agent ask <name> <text...> [--from=<sender>] [--timeout=120] [--idle-secs=5] [--poll-secs=2]
                                    [--reply-to-chat=<id> [--reply-to-msg=<id>]]
                                                      # synchronous send + wait. Polls scrollback after

--- a/src/main.sh
+++ b/src/main.sh
@@ -135,7 +135,7 @@ Agents:
                                                      # handle instead of numeric id.
   5dive agent <name> tui                             # attach your terminal to the agent's tmux session
   5dive agent logs <name> [--follow] [--lines=N] [--tmux]
-  5dive agent send <name> <text...> [--from=<sender>] [--raw]
+  5dive agent send <name> <text...> [--from=<sender>] [--raw] [--wake]
                                     [--reply-to-chat=<id> [--reply-to-msg=<id>]]
                                                      # inject a message (tmux send-keys + Enter).
                                                      # When called from another agent, auto-wraps as
@@ -144,6 +144,13 @@ Agents:
                                                      # --reply-to-chat adds a hint telling the receiver
                                                      # to reply directly in that Telegram/Discord chat
                                                      # via its own bot (see SKILL.md).
+                                                     # --wake: if the target is NOT running, start its unit
+                                                     # and deliver once its session is up, instead of
+                                                     # failing with exit 8. Use it for SCHEDULED work
+                                                     # (cron / systemd timers), where a send into a
+                                                     # sleeping agent is dropped with no queue and no
+                                                     # retry. Needs root; refuses if the agent was
+                                                     # deliberately stopped (desiredState=stopped).
   5dive agent ask <name> <text...> [--from=<sender>] [--timeout=120] [--idle-secs=5] [--poll-secs=2]
                                    [--reply-to-chat=<id> [--reply-to-msg=<id>]]
                                                      # synchronous send + wait. Polls scrollback after

--- a/tests/agent_prompt_wait_skip_unit.sh
+++ b/tests/agent_prompt_wait_skip_unit.sh
@@ -31,6 +31,25 @@ agent_type(){ printf '%s' "$want_type"; }
 sudo(){ :; }
 $(sed -n '/^_agent_pane_input_ready()/,/^}/p'                      "$SRC/src/cmd_agent_runtime.sh")
 $(sed -n '/^declare -A _AGENT_PROMPT_DETECTABLE=(/,/^)/p'          "$SRC/src/cmd_agent_runtime.sh")
+$(sed -n '/^agent_prompt_detectable()/,/^}/p'                      "$SRC/src/cmd_agent_runtime.sh")
+$(sed -n '/^wait_agent_input_ready()/,/^}/p'                       "$SRC/src/cmd_agent_runtime.sh")
+SH
+}
+
+# DIVE-2385: the skip predicate moved out of wait_agent_input_ready into
+# agent_prompt_detectable so the wake path could tell "prompt rendered" from
+# "nothing to detect" — both of which are rc 0 there. A function call can fail in
+# ways an inline [[ ]] could not, and `|| return 0` would read that failure as
+# "undetectable" and skip the readiness check for EVERY agent. This harness omits
+# the helper on purpose, so the arm below grades the direction that fail resolves
+# in. It must be TOWARD the poll.
+harness_without_predicate() {
+  local want_type="$1"
+  cat <<SH
+agent_type(){ printf '%s' "$want_type"; }
+sudo(){ :; }
+$(sed -n '/^_agent_pane_input_ready()/,/^}/p'                      "$SRC/src/cmd_agent_runtime.sh")
+$(sed -n '/^declare -A _AGENT_PROMPT_DETECTABLE=(/,/^)/p'          "$SRC/src/cmd_agent_runtime.sh")
 $(sed -n '/^wait_agent_input_ready()/,/^}/p'                       "$SRC/src/cmd_agent_runtime.sh")
 SH
 }
@@ -74,5 +93,31 @@ for t in $set_types; do
 done
 grep -qE '\[opencode\]|\[pi\]|\[hermes\]|\[openclaw\]' <<<"$(sed -n '/^declare -A _AGENT_PROMPT_DETECTABLE=(/,/^)/p' "$SRC/src/cmd_agent_runtime.sh")" \
   && no "a markerless type is listed as detectable" || ok "no markerless type claims detectability"
+
+
+echo "== 5. DIRECTION OF FAILURE: an unavailable predicate must not become a blanket skip =="
+# The skip is `agent_prompt_detectable ... || return 0`-shaped, so any non-zero rc
+# from the predicate would read as "undetectable". Only a clean rc 1 may skip.
+# claude is DETECTABLE, so a correct build ignores the broken predicate and polls
+# (rc 1 after the timeout); a fail-open build returns 0 instantly, exactly as it did
+# when this helper was first extracted without updating the harness above.
+start=$(date +%s)
+bash -c "$(harness_without_predicate claude); wait_agent_input_ready x 3" >/dev/null 2>&1; rc=$?
+el=$(( $(date +%s) - start ))
+if (( rc == 1 && el >= 2 )); then
+  ok "a broken predicate falls through to the poll rather than skipping it"
+else
+  no "predicate failure fails OPEN — readiness skipped for a detectable type (rc=$rc ${el}s)"
+fi
+# LIVENESS for the arm above: with the predicate PRESENT the same undetectable type
+# still skips, so arm 5 is not just asserting "everything polls".
+start=$(date +%s)
+bash -c "$(harness opencode); wait_agent_input_ready x 3" >/dev/null 2>&1; rc=$?
+el=$(( $(date +%s) - start ))
+if (( rc == 0 && el <= 1 )); then
+  ok "and a working predicate still skips a genuinely undetectable type"
+else
+  no "the real skip stopped working (rc=$rc ${el}s)"
+fi
 
 echo; echo "$pass passed, $fail failed"; (( fail == 0 ))

--- a/tests/agent_send_wake_unit.sh
+++ b/tests/agent_send_wake_unit.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# DIVE-2385 unit: `agent send --wake` — deferred work must not depend on the
+# recipient being awake at the instant the scheduler fires.
+#
+# THE DEFECT this grades. `agent send` needs a live tmux session. Send to an agent
+# that is not running and it dies in ~190ms with E_NOT_RUNNING: no queue, no
+# retry, no persistence. On 2026-07-30 a transient `systemd-run --on-calendar`
+# unit carrying an approved blog post's publish pointer fired exactly on time,
+# hit status=8 because the target was asleep, and the message was gone. A one-shot
+# .timer is consumed once it fires, so there was no second attempt; the only
+# evidence was a .service in `failed` state under /run/systemd/transient/.
+#
+# WHAT IS ACTUALLY WORTH ASSERTING HERE, and why the obvious test is not it.
+# "--wake starts the unit" is the cheap arm and it is nearly worthless on its own:
+# it stays green on a build where --wake ALSO starts an agent a human deliberately
+# stopped, and on a build where the wake is accepted, ignored, and the send is
+# reported as delivered anyway. Both are one direction away from what shipped. So
+# every arm below is paired with the mutation it is supposed to catch, and two of
+# them (the DISTINCTNESS arm on the failure reason, and the ORDER arm on the
+# scoped refusal) exist only because their absence is what would let a wrong build
+# pass:
+#
+#   * refusal-vs-wake are graded as SEPARATE arms with a stub that records whether
+#     systemctl was reached, so "refuses on desiredState=stopped" cannot be
+#     satisfied by a build that refuses everything;
+#   * ABSENT desiredState is its own arm (DIVE-2318, unknown is not a negative) —
+#     an agent never start/stop'd through the CLI carries no field at all, which is
+#     the common case, and reading absent as "stopped" would make --wake a no-op on
+#     exactly the agents that need it;
+#   * the reason string is asserted NON-EMPTY on each failure AND asserted EMPTY on
+#     success, because a reason that is always set carries no information;
+#   * the default path is asserted to still carry the ORIGINAL rc and message,
+#     since _task_need_route_deliver (DIVE-2011) polls a detached send's rc for
+#     that exact sub-second E_NOT_RUNNING to decide a gate handoff was observed to
+#     fail. A --wake that leaked into the default path would convert those into a
+#     30s+ boot wait reported as delivered.
+#
+# Pure: sources the shipped function out of src/, stubs systemctl/sudo/sleep, no
+# root, no tmux, no network.
+#   bash tests/agent_send_wake_unit.sh
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades. No 2>/dev/null — the helper's own
+# stderr line IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+eq_t()  { # eq_t <label> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then ok_t "$1"; else bad_t "$1 (expected '$2', got '$3')"; fi
+}
+
+RT=src/cmd_agent_runtime.sh
+
+# Source the SHIPPED function out of the real source file so this test cannot
+# drift from the code that runs. Same awk technique as
+# envelope_tier_provenance_unit.sh / agent_send_credential_guard_unit.sh: from the
+# function's opening line to the first line that is exactly "}". The declare -F
+# guard is what turns a silently-empty extraction into a hard failure.
+for fn in agent_wake_for_send; do
+  eval "$(awk -v f="^${fn}\\\\(\\\\) \\\\{$" '$0 ~ f { on=1 } on { print } on && $0 == "}" { exit }' "$RT")"
+  declare -F "$fn" >/dev/null \
+    || { printf 'FATAL - could not extract %s from %s\n' "$fn" "$RT"; exit 1; }
+done
+
+# ---------------------------------------------------------------------------
+# Stubs. SYSTEMCTL_CALLS is the instrument: an arm that claims "refused" is only
+# meaningful if we can see that the unit was never started.
+# ---------------------------------------------------------------------------
+SYSTEMCTL_CALLS=""
+SYSTEMCTL_RC=0
+SESSION_UP=0        # what `tmux has-session` reports (0 = up, 1 = absent)
+DESIRED=""          # registry desiredState for the target
+
+systemctl() { SYSTEMCTL_CALLS+="$* "; return "$SYSTEMCTL_RC"; }
+sleep()     { :; }   # the timeout loop must not actually wait
+sudo()      {        # only shape used by the function: sudo -u agent-X tmux has-session -t ...
+  local a
+  for a in "$@"; do [[ "$a" == "has-session" ]] && return "$SESSION_UP"; done
+  return 0
+}
+registry_read() {
+  if [[ -z "$DESIRED" ]]; then
+    printf '{"agents":{"marketing":{"type":"claude"}}}'
+  else
+    printf '{"agents":{"marketing":{"type":"claude","desiredState":"%s"}}}' "$DESIRED"
+  fi
+}
+
+reset_stubs() { SYSTEMCTL_CALLS=""; SYSTEMCTL_RC=0; AGENT_WAKE_FAIL_REASON=""; }
+
+# --- ARM 1: operator intent. desiredState=stopped must REFUSE, and must not have
+# touched the unit. The "did not start it" half is the load-bearing one: without
+# it, a build that refuses unconditionally scores identically.
+reset_stubs; DESIRED="stopped"; SESSION_UP=1
+agent_wake_for_send marketing 2 >/dev/null 2>&1; rc=$?
+eq_t "desiredState=stopped refuses" "1" "$rc"
+eq_t "desiredState=stopped never starts the unit" "" "$SYSTEMCTL_CALLS"
+if [[ "$AGENT_WAKE_FAIL_REASON" == *"desiredState=stopped"* ]]; then
+  ok_t "refusal names the operator intent it is honouring"
+else
+  bad_t "refusal reason does not name desiredState=stopped (got '$AGENT_WAKE_FAIL_REASON')"
+fi
+
+# --- ARM 2: DIVE-2318. ABSENT is not "stopped". An agent never start/stop'd
+# through the CLI has no desiredState at all; if absent read as stopped, --wake
+# would no-op on precisely the agents it exists for.
+reset_stubs; DESIRED=""; SESSION_UP=0
+agent_wake_for_send marketing 2 >/dev/null 2>&1; rc=$?
+eq_t "absent desiredState wakes (unknown is not a negative)" "0" "$rc"
+if [[ "$SYSTEMCTL_CALLS" == *"start 5dive-agent@marketing.service"* ]]; then
+  ok_t "wake starts the target's own template unit"
+else
+  bad_t "wake did not start 5dive-agent@marketing.service (calls: '$SYSTEMCTL_CALLS')"
+fi
+
+# --- ARM 3: the crash case. desiredState=running + dead unit is exactly what the
+# operator asked for, so it wakes.
+reset_stubs; DESIRED="running"; SESSION_UP=0
+agent_wake_for_send marketing 2 >/dev/null 2>&1
+eq_t "desiredState=running wakes" "0" "$?"
+
+# --- ARM 4: DISTINCTNESS. On the success path the reason must be EMPTY. A reason
+# that is set unconditionally makes every "reason is non-empty" arm below vacuous.
+reset_stubs; DESIRED="running"; SESSION_UP=0
+agent_wake_for_send marketing 2 >/dev/null 2>&1
+eq_t "success leaves no failure reason" "" "$AGENT_WAKE_FAIL_REASON"
+
+# --- ARM 5: unit starts, session never appears. The caller must NOT be told the
+# message was sent, and the reason must say which half failed — the bare
+# "is the agent running?" was true and useless to a systemd unit.
+reset_stubs; DESIRED="running"; SESSION_UP=1
+agent_wake_for_send marketing 2 >/dev/null 2>&1; rc=$?
+eq_t "started-but-no-session fails" "1" "$rc"
+if [[ "$AGENT_WAKE_FAIL_REASON" == *"did not appear"* ]]; then
+  ok_t "no-session reason distinguishes started-but-dead from never-started"
+else
+  bad_t "no-session reason is uninformative (got '$AGENT_WAKE_FAIL_REASON')"
+fi
+
+# --- ARM 6: systemctl itself fails. Distinct reason from ARM 5, so the two
+# failure modes are not collapsed into one message.
+reset_stubs; DESIRED="running"; SESSION_UP=1; SYSTEMCTL_RC=1
+agent_wake_for_send marketing 2 >/dev/null 2>&1; rc=$?
+eq_t "systemctl start failure fails" "1" "$rc"
+if [[ "$AGENT_WAKE_FAIL_REASON" == *"systemctl start"* ]]; then
+  ok_t "start-failure reason names systemctl"
+else
+  bad_t "start-failure reason does not name systemctl (got '$AGENT_WAKE_FAIL_REASON')"
+fi
+SYSTEMCTL_RC=0
+
+# ---------------------------------------------------------------------------
+# Source-shape arms. These grade properties of cmd_send that a pure unit cannot
+# exercise (it needs a real tmux + root), and each one is a mutation that the
+# behavioural arms above would NOT catch.
+# ---------------------------------------------------------------------------
+
+# The default path must be untouched: same rc, same message, and reached only when
+# --wake was NOT passed. _task_need_route_deliver polls for this exact sub-second
+# E_NOT_RUNNING.
+_default_guard=$(grep -c 'wake )) \\$' "$RT")
+if (( _default_guard >= 1 )); then
+  ok_t "the E_NOT_RUNNING fail is guarded by (( wake )) rather than replaced"
+else
+  bad_t "no (( wake )) guard found in front of the default E_NOT_RUNNING fail"
+fi
+_orig_msg=$(grep -c "fail \"\$E_NOT_RUNNING\" \"tmux session 'agent-\${name}' not found (is the agent running?)\"" "$RT")
+if (( _orig_msg >= 1 )); then
+  ok_t "the original not-running message survives verbatim on the default path"
+else
+  bad_t "the default-path E_NOT_RUNNING message was altered or removed"
+fi
+
+# The scoped refusal must come BEFORE the exec into _deliver. If it moved after,
+# a scoped caller's --wake would be silently dropped and the send reported OK —
+# the same lost message, with an exit 0 over it. Order is the property; a grep
+# that only checks presence stays green on the broken build.
+_refusal_line=$(grep -n 'wake )) && a2a_needs_scoped' "$RT" | head -1 | cut -d: -f1)
+_exec_line=$(grep -n 'exec sudo -n /usr/local/bin/5dive agent _deliver' "$RT" | head -1 | cut -d: -f1)
+if [[ -n "$_refusal_line" && -n "$_exec_line" ]] && (( _refusal_line < _exec_line )); then
+  ok_t "--wake is refused for scoped callers BEFORE the exec into _deliver"
+else
+  bad_t "scoped --wake refusal is missing or sits after the _deliver exec (refusal=$_refusal_line exec=$_exec_line)"
+fi
+
+# The success line must report WHETHER it had to wake the agent. That is the fact
+# the failed transient unit could not tell anyone.
+if grep -q 'woken:(\$w=="1")' "$RT"; then
+  ok_t "the send's ok payload reports woken"
+else
+  bad_t "the send's ok payload does not carry a woken field"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+(( FAIL == 0 ))

--- a/tests/agent_send_wake_unit.sh
+++ b/tests/agent_send_wake_unit.sh
@@ -77,9 +77,20 @@ DESIRED=""          # registry desiredState for the target
 
 systemctl() { SYSTEMCTL_CALLS+="$* "; return "$SYSTEMCTL_RC"; }
 sleep()     { :; }   # the timeout loop must not actually wait
+SESSION_UP_AFTER=""  # when set, has-session is ABSENT for this many polls, then UP
+HAS_SESSION_CALLS=0
 sudo()      {        # only shape used by the function: sudo -u agent-X tmux has-session -t ...
   local a
-  for a in "$@"; do [[ "$a" == "has-session" ]] && return "$SESSION_UP"; done
+  for a in "$@"; do
+    if [[ "$a" == "has-session" ]]; then
+      HAS_SESSION_CALLS=$((HAS_SESSION_CALLS+1))
+      if [[ -n "$SESSION_UP_AFTER" ]]; then
+        (( HAS_SESSION_CALLS > SESSION_UP_AFTER )) && return 0
+        return 1
+      fi
+      return "$SESSION_UP"
+    fi
+  done
   return 0
 }
 registry_read() {
@@ -90,7 +101,8 @@ registry_read() {
   fi
 }
 
-reset_stubs() { SYSTEMCTL_CALLS=""; SYSTEMCTL_RC=0; AGENT_WAKE_FAIL_REASON=""; }
+reset_stubs() { SYSTEMCTL_CALLS=""; SYSTEMCTL_RC=0; AGENT_WAKE_FAIL_REASON=""
+                SESSION_UP_AFTER=""; HAS_SESSION_CALLS=0; }
 
 # --- ARM 1: operator intent. desiredState=stopped must REFUSE, and must not have
 # touched the unit. The "did not start it" half is the load-bearing one: without
@@ -228,9 +240,22 @@ agent_type()             { printf '%s' "$ATYPE"; }
 wait_agent_input_ready() { READY_BUDGET_SEEN="${2:-}"; return "$READY_RC"; }
 step()                   { :; }
 
-# Run the gate in a subshell with `fail` stubbed to exit, exactly as the real one
-# does. Echoes the reason on stdout so an arm can grade the message too.
-run_gate() { ( fail() { printf '%s' "$2"; exit "$1"; }; agent_wake_gate_ready "$1" ); }
+# EVERY gate arm goes through this, and that is deliberate. Called in the test's own
+# scope, `fail` is undefined: bash returns 127 and EXECUTION CONTINUES to the
+# function's tail, so an arm asserting rc=0 would pass on a build whose refusal
+# fired. That is the vacuous-refusal shape, arrived at from the other direction —
+# measured here, it hid a mutant that made the undetectable path fatal. So the gate
+# runs in a SUBSHELL where `fail` exits, exactly as the real one does, and the arm
+# reads the rc a scheduler would actually get.
+#
+# On failure it prints the reason; on success, the state the arm needs to inspect
+# (a subshell's variables do not survive, so they come back over stdout).
+run_gate() {
+  ( fail() { printf 'FAILMSG:%s' "$2"; exit "$1"; }
+    AGENT_WAKE_READY=""; READY_BUDGET_SEEN=""
+    agent_wake_gate_ready "$1"
+    printf 'READY:%s BUDGET:%s' "$AGENT_WAKE_READY" "$READY_BUDGET_SEEN" ) 2>/dev/null
+}
 
 # --- ARM A (THE MISSING ARM olivia named): session appears, prompt NEVER renders.
 # This is the likeliest real cold-boot shape and the one the suite lacked. It must
@@ -247,29 +272,28 @@ fi
 # --- ARM B: LIVENESS, the differential half of ARM A. Same call, prompt DOES
 # render: it must proceed (rc 0) and record proof. Without this arm, a build that
 # fails the wake path unconditionally scores identically on ARM A.
-AGENT_WAKE_READY=""; READY_RC=0
-agent_wake_gate_ready marketing >/dev/null 2>&1; rc=$?
+READY_RC=0
+_out=$(run_gate marketing); rc=$?
 eq_t "prompt renders => gate proceeds" "0" "$rc"
-eq_t "a proven-ready delivery is recorded as proven" "proven" "$AGENT_WAKE_READY"
+eq_t "a proven-ready delivery is recorded as proven" "READY:proven BUDGET:105" "$_out"
 
 # --- ARM C: the hole, made OBSERVABLE rather than silent. A runtime with no prompt
 # marker cannot be proven ready at all (wait_agent_input_ready returns 0 meaning
-# "nothing to detect", never "ready"). Failing would refuse deliveries that work;
+# "nothing to detect", never "ready"). Failing would refuse deliveries that WORK;
 # passing silently would re-create the very green-on-a-dropped-message ARM A
-# removes. So it proceeds AND says so.
-AGENT_WAKE_READY=""; ATYPE="opencode"; READY_RC=1   # RC=1 proves the poll is not even consulted
-agent_wake_gate_ready marketing >/dev/null 2>&1; rc=$?
+# removes. So it proceeds AND says so. READY_RC=1 proves the poll is not consulted:
+# a build that dropped this branch would fall into ARM A's fatal refusal.
+ATYPE="opencode"; READY_RC=1
+_out=$(run_gate marketing); rc=$?
 eq_t "undetectable runtime still delivers (refusing would break working sends)" "0" "$rc"
-eq_t "...but is reported unprovable, not proven" "unprovable" "$AGENT_WAKE_READY"
+eq_t "...but is reported unprovable, not proven" "READY:unprovable BUDGET:" "$_out"
 
 # --- ARM D: DISTINCTNESS. proven and unprovable must not collapse into one value —
 # a build that hardcodes either passes ARM B or ARM C but never both, and this arm
 # is what states the requirement directly.
-AGENT_WAKE_READY=""; ATYPE="claude"; READY_RC=0
-agent_wake_gate_ready marketing >/dev/null 2>&1; _proven="$AGENT_WAKE_READY"
-AGENT_WAKE_READY=""; ATYPE="opencode"
-agent_wake_gate_ready marketing >/dev/null 2>&1; _unprov="$AGENT_WAKE_READY"
-if [[ -n "$_proven" && -n "$_unprov" && "$_proven" != "$_unprov" ]]; then
+ATYPE="claude"; READY_RC=0; _proven=$(run_gate marketing)
+ATYPE="opencode";            _unprov=$(run_gate marketing)
+if [[ "$_proven" == READY:?* && "$_unprov" == READY:?* && "$_proven" != "$_unprov" ]]; then
   ok_t "proven and unprovable are distinguishable in the payload"
 else
   bad_t "ready values collapse ('$_proven' vs '$_unprov')"
@@ -280,36 +304,40 @@ fi
 # hands it a fresh 45 (or the whole budget) silently doubles the worst case a
 # scheduler is sizing TimeoutStartSec against.
 ATYPE="claude"; READY_RC=0; AGENT_WAKE_BUDGET_SECS=105; AGENT_WAKE_ELAPSED=40
-READY_BUDGET_SEEN=""
-agent_wake_gate_ready marketing >/dev/null 2>&1
-eq_t "readiness gets the REMAINING budget, not a second fresh one" "65" "$READY_BUDGET_SEEN"
+eq_t "readiness gets the REMAINING budget, not a second fresh one" \
+     "READY:proven BUDGET:65" "$(run_gate marketing)"
 
 # --- ARM F: a wake that burned the whole budget must not hand the poll a zero or
 # negative timeout (`while (( waited < 0 ))` never runs, and a negative reads as a
 # bug rather than a deadline).
-AGENT_WAKE_ELAPSED=105; READY_BUDGET_SEEN=""
-agent_wake_gate_ready marketing >/dev/null 2>&1
-if [[ -n "$READY_BUDGET_SEEN" ]] && (( READY_BUDGET_SEEN >= 1 )); then
+AGENT_WAKE_ELAPSED=105
+_seen=$(run_gate marketing); _seen="${_seen##*BUDGET:}"
+if [[ "$_seen" =~ ^[0-9]+$ ]] && (( _seen >= 1 )); then
   ok_t "an exhausted budget floors at 1s rather than going 0 or negative"
 else
-  bad_t "exhausted budget produced a non-positive timeout ('$READY_BUDGET_SEEN')"
+  bad_t "exhausted budget produced a non-positive timeout ('$_seen')"
 fi
 AGENT_WAKE_ELAPSED=0
 
-# --- ARM G: agent_wake_for_send must RECORD what it spent, or the budget above is
-# arithmetic over a constant. Graded differentially: a wake that returns late must
-# report more elapsed than one that returns immediately.
-reset_stubs; DESIRED="running"; SESSION_UP=0; AGENT_WAKE_ELAPSED=-1
-agent_wake_for_send marketing 5 >/dev/null 2>&1
-_fast="$AGENT_WAKE_ELAPSED"
-reset_stubs; DESIRED="running"; SESSION_UP=1; AGENT_WAKE_ELAPSED=-1
-agent_wake_for_send marketing 5 >/dev/null 2>&1
-_slow="$AGENT_WAKE_ELAPSED"
-if [[ "$_fast" == "0" ]] && (( _slow > _fast )); then
-  ok_t "the wake records the time it actually spent (fast=$_fast slow=$_slow)"
+# --- ARM G: agent_wake_for_send must RECORD what it spent, or ARM E is arithmetic
+# over a constant. Graded DIFFERENTIALLY, and the session must appear on a LATER
+# poll rather than the first: at waited=0 a build that never assigns is
+# indistinguishable from one that does, because the function zeroes the field on
+# entry. Measured — that is exactly the mutant an appears-immediately arm missed.
+reset_stubs; DESIRED="running"; SESSION_UP_AFTER=0     # up on the first poll
+agent_wake_for_send marketing 9 >/dev/null 2>&1; _fast="$AGENT_WAKE_ELAPSED"
+reset_stubs; DESIRED="running"; SESSION_UP_AFTER=3     # up on the fourth
+agent_wake_for_send marketing 9 >/dev/null 2>&1; _slow="$AGENT_WAKE_ELAPSED"
+if [[ "$_fast" == "0" && "$_slow" == "3" ]]; then
+  ok_t "the wake records the polls it actually spent (fast=$_fast slow=$_slow)"
 else
-  bad_t "AGENT_WAKE_ELAPSED does not track the wake (fast='$_fast' slow='$_slow')"
+  bad_t "AGENT_WAKE_ELAPSED does not track a slow wake (fast='$_fast' slow='$_slow', want 0 and 3)"
 fi
+# ...and on the timeout path too, or a wake that burned its whole share reports 0
+# and hands the readiness wait the full budget on top of it.
+reset_stubs; DESIRED="running"; SESSION_UP=1
+agent_wake_for_send marketing 7 >/dev/null 2>&1
+eq_t "a timed-out wake reports its full spend" "7" "$AGENT_WAKE_ELAPSED"
 
 # --- ARM H: ORDER. The gate must sit BEFORE inject_and_submit, or it grades nothing:
 # keystrokes already fired cannot be un-fired by a later refusal. Same technique as

--- a/tests/agent_send_wake_unit.sh
+++ b/tests/agent_send_wake_unit.sh
@@ -60,7 +60,7 @@ RT=src/cmd_agent_runtime.sh
 # envelope_tier_provenance_unit.sh / agent_send_credential_guard_unit.sh: from the
 # function's opening line to the first line that is exactly "}". The declare -F
 # guard is what turns a silently-empty extraction into a hard failure.
-for fn in agent_wake_for_send; do
+for fn in agent_wake_for_send agent_prompt_detectable agent_wake_gate_ready; do
   eval "$(awk -v f="^${fn}\\\\(\\\\) \\\\{$" '$0 ~ f { on=1 } on { print } on && $0 == "}" { exit }' "$RT")"
   declare -F "$fn" >/dev/null \
     || { printf 'FATAL - could not extract %s from %s\n' "$fn" "$RT"; exit 1; }
@@ -193,6 +193,149 @@ if grep -q 'woken:(\$w=="1")' "$RT"; then
   ok_t "the send's ok payload reports woken"
 else
   bad_t "the send's ok payload does not carry a woken field"
+fi
+
+
+# ---------------------------------------------------------------------------
+# ITERATION 2 — THE POST-WAKE DELIVERY HALF.
+#
+# Every arm above stops at agent_wake_for_send, which returns the instant
+# `tmux has-session` succeeds: the EARLIEST moment of a cold boot, well before the
+# TUI renders an input prompt. Delivery then continued into wait_agent_input_ready,
+# which is NON-FATAL by design — on timeout it warns and types anyway — and the run
+# ended at `sent:true`, exit 0. So a --wake send to an agent whose cold boot outran
+# the readiness budget reported success on a message its own comment says was
+# dropped: the defect this ticket exists to remove, made quieter than the 190ms
+# failure it replaced. The reason the 15 arms above could not see it is that ZERO of
+# them reference wait_agent_input_ready and both live ones terminate BEFORE
+# delivery. These arms are that missing half.
+#
+# The real `fail` exits, so stubbing it as an exit is faithful, and running the gate
+# in a SUBSHELL lets the arm read the rc a scheduler would actually get.
+# ---------------------------------------------------------------------------
+E_NOT_RUNNING=8   # src/lib/error_codes.sh
+
+# The real detectability table, extracted from source for the same
+# cannot-drift reason as the functions.
+eval "$(awk '/^declare -A _AGENT_PROMPT_DETECTABLE=\(/ { on=1 } on { print } on && /^\)/ { exit }' "$RT")"
+[[ -n "${_AGENT_PROMPT_DETECTABLE[claude]+x}" ]] \
+  || { printf 'FATAL - could not extract _AGENT_PROMPT_DETECTABLE from %s\n' "$RT"; exit 1; }
+
+ATYPE="claude"      # what agent_type reports for the target
+READY_RC=0          # what wait_agent_input_ready returns
+READY_BUDGET_SEEN="" # the timeout it was handed — the budget instrument
+agent_type()             { printf '%s' "$ATYPE"; }
+wait_agent_input_ready() { READY_BUDGET_SEEN="${2:-}"; return "$READY_RC"; }
+step()                   { :; }
+
+# Run the gate in a subshell with `fail` stubbed to exit, exactly as the real one
+# does. Echoes the reason on stdout so an arm can grade the message too.
+run_gate() { ( fail() { printf '%s' "$2"; exit "$1"; }; agent_wake_gate_ready "$1" ); }
+
+# --- ARM A (THE MISSING ARM olivia named): session appears, prompt NEVER renders.
+# This is the likeliest real cold-boot shape and the one the suite lacked. It must
+# be FATAL — not a warning followed by keystrokes and sent:true.
+AGENT_WAKE_BUDGET_SECS=105; AGENT_WAKE_ELAPSED=0; ATYPE="claude"; READY_RC=1
+_msg=$(run_gate marketing); rc=$?
+eq_t "woke but prompt never rendered => FATAL E_NOT_RUNNING" "$E_NOT_RUNNING" "$rc"
+if [[ "$_msg" == *"input prompt never rendered"* && "$_msg" == *"105s"* ]]; then
+  ok_t "the fatal reason names the unrendered prompt AND the total budget"
+else
+  bad_t "fatal reason is uninformative (got '$_msg')"
+fi
+
+# --- ARM B: LIVENESS, the differential half of ARM A. Same call, prompt DOES
+# render: it must proceed (rc 0) and record proof. Without this arm, a build that
+# fails the wake path unconditionally scores identically on ARM A.
+AGENT_WAKE_READY=""; READY_RC=0
+agent_wake_gate_ready marketing >/dev/null 2>&1; rc=$?
+eq_t "prompt renders => gate proceeds" "0" "$rc"
+eq_t "a proven-ready delivery is recorded as proven" "proven" "$AGENT_WAKE_READY"
+
+# --- ARM C: the hole, made OBSERVABLE rather than silent. A runtime with no prompt
+# marker cannot be proven ready at all (wait_agent_input_ready returns 0 meaning
+# "nothing to detect", never "ready"). Failing would refuse deliveries that work;
+# passing silently would re-create the very green-on-a-dropped-message ARM A
+# removes. So it proceeds AND says so.
+AGENT_WAKE_READY=""; ATYPE="opencode"; READY_RC=1   # RC=1 proves the poll is not even consulted
+agent_wake_gate_ready marketing >/dev/null 2>&1; rc=$?
+eq_t "undetectable runtime still delivers (refusing would break working sends)" "0" "$rc"
+eq_t "...but is reported unprovable, not proven" "unprovable" "$AGENT_WAKE_READY"
+
+# --- ARM D: DISTINCTNESS. proven and unprovable must not collapse into one value —
+# a build that hardcodes either passes ARM B or ARM C but never both, and this arm
+# is what states the requirement directly.
+AGENT_WAKE_READY=""; ATYPE="claude"; READY_RC=0
+agent_wake_gate_ready marketing >/dev/null 2>&1; _proven="$AGENT_WAKE_READY"
+AGENT_WAKE_READY=""; ATYPE="opencode"
+agent_wake_gate_ready marketing >/dev/null 2>&1; _unprov="$AGENT_WAKE_READY"
+if [[ -n "$_proven" && -n "$_unprov" && "$_proven" != "$_unprov" ]]; then
+  ok_t "proven and unprovable are distinguishable in the payload"
+else
+  bad_t "ready values collapse ('$_proven' vs '$_unprov')"
+fi
+
+# --- ARM E: ONE budget, not two stacked ones. The readiness wait must get the
+# REMAINDER of AGENT_WAKE_BUDGET_SECS after the wake spent its share. A build that
+# hands it a fresh 45 (or the whole budget) silently doubles the worst case a
+# scheduler is sizing TimeoutStartSec against.
+ATYPE="claude"; READY_RC=0; AGENT_WAKE_BUDGET_SECS=105; AGENT_WAKE_ELAPSED=40
+READY_BUDGET_SEEN=""
+agent_wake_gate_ready marketing >/dev/null 2>&1
+eq_t "readiness gets the REMAINING budget, not a second fresh one" "65" "$READY_BUDGET_SEEN"
+
+# --- ARM F: a wake that burned the whole budget must not hand the poll a zero or
+# negative timeout (`while (( waited < 0 ))` never runs, and a negative reads as a
+# bug rather than a deadline).
+AGENT_WAKE_ELAPSED=105; READY_BUDGET_SEEN=""
+agent_wake_gate_ready marketing >/dev/null 2>&1
+if [[ -n "$READY_BUDGET_SEEN" ]] && (( READY_BUDGET_SEEN >= 1 )); then
+  ok_t "an exhausted budget floors at 1s rather than going 0 or negative"
+else
+  bad_t "exhausted budget produced a non-positive timeout ('$READY_BUDGET_SEEN')"
+fi
+AGENT_WAKE_ELAPSED=0
+
+# --- ARM G: agent_wake_for_send must RECORD what it spent, or the budget above is
+# arithmetic over a constant. Graded differentially: a wake that returns late must
+# report more elapsed than one that returns immediately.
+reset_stubs; DESIRED="running"; SESSION_UP=0; AGENT_WAKE_ELAPSED=-1
+agent_wake_for_send marketing 5 >/dev/null 2>&1
+_fast="$AGENT_WAKE_ELAPSED"
+reset_stubs; DESIRED="running"; SESSION_UP=1; AGENT_WAKE_ELAPSED=-1
+agent_wake_for_send marketing 5 >/dev/null 2>&1
+_slow="$AGENT_WAKE_ELAPSED"
+if [[ "$_fast" == "0" ]] && (( _slow > _fast )); then
+  ok_t "the wake records the time it actually spent (fast=$_fast slow=$_slow)"
+else
+  bad_t "AGENT_WAKE_ELAPSED does not track the wake (fast='$_fast' slow='$_slow')"
+fi
+
+# --- ARM H: ORDER. The gate must sit BEFORE inject_and_submit, or it grades nothing:
+# keystrokes already fired cannot be un-fired by a later refusal. Same technique as
+# the scoped-refusal order arm above — presence alone stays green on the broken build.
+_gate_line=$(grep -n 'agent_wake_gate_ready "\$name"$' "$RT" | head -1 | cut -d: -f1)
+_inject_line=$(grep -n 'inject_and_submit "\$name" "\$payload"' "$RT" | head -1 | cut -d: -f1)
+if [[ -n "$_gate_line" && -n "$_inject_line" ]] && (( _gate_line < _inject_line )); then
+  ok_t "the readiness gate runs BEFORE inject_and_submit"
+else
+  bad_t "readiness gate is missing or sits after inject_and_submit (gate=$_gate_line inject=$_inject_line)"
+fi
+
+# --- ARM I: the DEFAULT path keeps its best-effort readiness byte for byte. The
+# fatal branch is gated on `woken`; the original warn-and-send-anyway must survive
+# as the else. A busy-but-healthy live agent that never parks at a prompt still gets
+# its message, and _task_need_route_deliver's contract is untouched.
+if grep -q 'elif ! wait_agent_input_ready "\$name"; then' "$RT" \
+   && grep -q "input prompt not detected after 45s — sending best-effort" "$RT"; then
+  ok_t "the default path keeps its non-fatal readiness warning verbatim"
+else
+  bad_t "the default path's best-effort readiness branch was altered or removed"
+fi
+if grep -q 'if (( woken )); then' "$RT"; then
+  ok_t "the fatal readiness branch is gated on woken, not applied to every send"
+else
+  bad_t "no (( woken )) gate found in front of the fatal readiness branch"
 fi
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## DIVE-2385 — iteration 2, after olivia's reject

`5dive agent send --wake` starts a sleeping target's unit and delivers once its session is live, so a scheduled hand-off stops depending on the recipient being awake at the instant a timer fires.

### What iteration 1 got wrong

The defect was in the half iteration 1 declared *unproven*, and it made the flag **worse than the bug it fixes**.

`agent_wake_for_send` returns the instant `tmux has-session` succeeds — the earliest moment of a cold boot, long before the TUI renders an input prompt. Delivery then fell through `wait_agent_input_ready`, a tail `cmd_send` already had, which is **non-fatal by design**: on timeout it warns and types anyway. So on a cold boot slower than the readiness budget (the common cold-boot outcome), `--wake` fired keystrokes into a booting TUI — which the code's own comment says are dropped and the message lost — and ended at `sent:true`, exit 0.

Measured against the incident: today a scheduled send to a sleeping agent fails **loudly in 190ms** and leaves a transient unit in `failed` state on disk. With `--wake` it could fail **silently at exit 0**. For a systemd caller, the only caller this flag is for, that is a regression in observability rather than a fix.

The general shape, which is the part worth keeping: **adding a new entry into an existing best-effort tail silently inherits its contract.**

### Changes

1. **Readiness is FATAL on the wake path.** `agent_wake_gate_ready` refuses with `E_NOT_RUNNING` naming the unrendered prompt and the budget. Gated on `woken`, so the **default path keeps its condition, message and best-effort fallthrough byte for byte** — DIVE-2011's rc poll is untouched, and so is its sub-second latency.
2. **One deadline, not two stacked ones.** `AGENT_WAKE_BUDGET_SECS` (105) is the only number a scheduler sizes `TimeoutStartSec` against. The wake records what it spent in `AGENT_WAKE_ELAPSED`; readiness gets the remainder, so a fast wake buys the prompt more time instead of discarding it. `agent_wake_gate_ready` owns that arithmetic alone, so a plain `45` cannot reappear elsewhere and double the worst case.
3. **A hole named rather than papered over.** For a runtime outside `_AGENT_PROMPT_DETECTABLE`, readiness is not slow, it is *unobservable*: `wait_agent_input_ready` returns 0 meaning "nothing to detect", never "ready". Failing there would refuse deliveries that work; passing silently would re-create the same green-on-a-dropped-message. It delivers **and says so** — on stderr and as `ready:"unprovable"` in `--json`, against `ready:"proven"` when the prompt was observed.
4. **A fail-open the refactor introduced, caught by an existing test.** Extracting the skip predicate into `agent_prompt_detectable` turned an inline `[[ ]]` that cannot fail into a call that can, and `|| return 0` read every non-zero rc as "undetectable" — so with the helper unavailable, claude and codex **skipped the readiness poll entirely**. `agent_prompt_wait_skip_unit.sh` went 19/0 → 14/5 and that is how it surfaced. Only a clean rc 1 may skip now; anything else falls through to the poll.

### Tests: 15 arms → 29, plus 2 on the existing suite

The missing arm olivia named — *session appears, prompt never renders* — is now **behavioural, not a grep**: the gate runs in a subshell where `fail` exits, as the real one does, so an arm reads the rc a scheduler would actually get.

Two weaknesses found by mutation-grading the new arms, both the same species as the defect above:

- **ARM C's rc assertion was vacuous.** Called in the test's own scope `fail` is undefined, so bash returns 127 and *execution continues to the function tail* — an arm asserting rc=0 passed on a build whose refusal had fired. Measured: the mutant making the undetectable path fatal left it green.
- **ARM G could not see** a mutant dropping the elapsed assignment, because the session appeared on the *first* poll and the function zeroes the field on entry — 0 either way. It now appears on the fourth.

Eight mutants, each caught by the intended arm:

| mutant | red arms |
|---|---|
| fatal readiness → best-effort (the iteration-1 defect) | 2 |
| `woken` gate removed (fatal on every send) | 2 |
| readiness handed a fresh 45 | 2 |
| undetectable branch dropped | 3 |
| `ready` collapsed to always `proven` | 1 |
| elapsed never recorded | 1 |
| budget floor removed | 1 |
| gate moved after `inject_and_submit` | 1 |
| `\|\| return 0` fail-open restored | 1 |

### Ownership items, filed rather than fixed

- **DIVE-2424** (marketing) — no scheduler anywhere passes `--wake`, so the incident recurs unchanged until the blog publish recipe and any other timer adopt it. Marketing owns that recipe.
- **DIVE-2425** (dev) — `5dive-unit-alert@.service` delivers unit-failure alerts to `main` by this same bare path, so an asleep `main` loses the alert, including recursively the alert about a send that just failed this way.

Rebased onto `main` (57fa70e, past the 0efcd66 olivia named).