### PR TITLE
task: a lead-cleared gate is an AGENT clear, so stop stamping it human: (DIVE-2406)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -7528,6 +7528,14 @@ cmd_task_answer() {
   fi
   (( _cp_ok )) && human=1
 
+  # DIVE-2406: the two PER-GATE human-evidence forms (valid nonce, non-agent
+  # SUDO_UID) are computed inside the hard-gate block below, but the provenance
+  # stamp near the end of this function needs them too — a `--human` claim with
+  # no evidence behind it must not be labelled `human:*`. Declared at function
+  # scope so that stamp reads an initialized 0 on the gate types that never enter
+  # that block, rather than an unset variable. Values are still set there, once.
+  local _hp=0 _su=0
+
   # DIVE-394: approval/secret are HUMAN-ONLY gates. Reject answers that come from
   # an agent acting as itself — that's the DIVE-391 incident, where an Olivia
   # endorsement (running as agent-<name>) silently cleared a human approval gate.
@@ -7711,7 +7719,7 @@ cmd_task_answer() {
     # raised the bar no higher than the sudo it already required. This still
     # supersedes the DIVE-519 "proof OR bare --human" rule: a bare --human is NOT
     # sufficient — that was the sudo→--human forge (DIVE-916 threat).
-    local _hp=0 _su=0
+    # (_hp/_su declared at function scope above — DIVE-2406 reads them at the stamp.)
     [[ -n "$human_proof" ]] && _human_nonce_verify "$id" "$human_proof" && _hp=1
     _gate_sudo_uid_nonagent && _su=1
     # DIVE-1305: a verified paired-human channel proof is the fourth evidence
@@ -7877,6 +7885,43 @@ cmd_task_answer() {
   # DIVE-394 provenance: record WHO answered. `human:` prefix when a trusted path
   # passed --human; otherwise the resolved actor label.
   local answered_by; answered_by=$(task_actor "$from")
+  # DIVE-2406: `--human` is a SELF-ASSERTED flag — it is argv and nothing more. On
+  # a lead-clearable gate it is the label, never the authority: the DIVE-1182/1243
+  # routed lead-clear (or the DIVE-2099 standing clear) is what authorized the
+  # answer, and that is an AGENT clear by construction. Before this, a lead who
+  # also passed --human was stamped `human:<lead>` — and the `(( ! human ))`
+  # guards just below, written on the assumption that human=1 meant a real human,
+  # suppressed the honest `lead:` label that was already sitting right there.
+  #
+  # DIVE-2400 is the live case, and the cost was not cosmetic: the row read
+  # `answered_by=human:marketing` with channel_proof absent, nonce_valid=0 and
+  # sudo_nonagent=0 — every evidence form of a human absent — and the task's
+  # result text then asserted "lodar approved all 7" when he had never answered.
+  # The AUTHORITY was correct by design (the DIVE-1381 curation carve-out routes
+  # a persona batch to the lead on purpose); it is the stamp that lied about who
+  # exercised it, to `human:%` consumers that count human touches (cmd_trace,
+  # cmd_digest, cmd_proof) and to the precedent engine, which auto-applies a
+  # PRIOR HUMAN ANSWER to later gates and had a lead-clear to hand it.
+  #
+  # So an UNCORROBORATED --human on a lead-cleared gate is demoted here. Note
+  # what is deliberately NOT in _human_evid: `_lead_clear`. It is a legitimate
+  # AUTHORIZATION form for the block above (a lead-clear must not be refused for
+  # lacking human evidence) and is precisely NOT evidence of a human here — that
+  # conflation is the whole bug. A corroborated --human (valid per-gate nonce,
+  # non-agent SUDO_UID, or verified channel proof) is untouched, so no genuine
+  # Telegram tap, dashboard answer or human-on-box login is ever relabelled.
+  # Conditioned on `_lead_clear` ALONE, and that is not an oversight about the
+  # DIVE-2099 standing path: an eligible standing clear sets `_lead_clear=1` too
+  # (see that block above), so one condition covers both and a second `||
+  # _lead_standing` clause would be dead — untestable by mutation and green
+  # forever. `_lead_clear=1` also implies nt is approval|manual|access, the types
+  # that always enter the evidence block, so _hp/_su are measured values here and
+  # never their declaration defaults.
+  local _human_evid=$(( _hp || _su || _cp_ok ))
+  local _human_claim="$human"
+  if (( human && ! _human_evid )) && [[ "$_lead_clear" == "1" ]]; then
+    human=0
+  fi
   (( human )) && answered_by="human:${answered_by}"
   # DIVE-1182: a routed builder gate cleared by its designated lead is recorded as
   # lead-sourced provenance (NOT human:*) — honest that an agent lead, not a human,
@@ -8008,6 +8053,7 @@ cmd_task_answer() {
     "task=$ident" "type=$nt" "tier=${gtier:-}" "answered_by=$answered_by" \
     "uid=${_uid:-}" "sig=$([[ -n "$_sig" ]] && echo present || echo absent)" \
     "human=$human" "lead_clear=$_lead_clear" "cp_ok=$_cp_ok" \
+    "human_claim=$_human_claim" \
     "caller=$_caller4" "sudo_uid=${SUDO_UID:-}" || true
 
   # DIVE-909: a standalone MANUAL gate answered "done" is the human saying "this
@@ -8059,6 +8105,18 @@ cmd_task_answer() {
   # simply doesn't advance. manual gates stay agent-answerable (agents
   # legitimately resolve those), so they're exempt. Falling through here without
   # advancing still records the answer + emits the success output below.
+  # DIVE-2406 made this branch REACHABLE for a case that used to slip past it: a
+  # lead-cleared loop approval gate whose clearer also passed `--human` was
+  # stamped `human:<lead>` and advanced the relay. It is now stamped `lead:<lead>`
+  # and does NOT advance — which is what the paragraph above always said should
+  # happen ("if a non-human path ever clears it ... the relay simply doesn't
+  # advance"); the advance was previously bought with a label that was not true.
+  # Deliberately NOT widened to `lead:*`: that would hand a lead the loop-advance
+  # authority DIVE-560 reserves for the human, which is a grant, not a relabel.
+  # Measured before shipping: 2 answers fleet-wide have ever carried
+  # lead_clear=1 + human=1 (DIVE-2121, DIVE-2400) and neither was a loop step, so
+  # no live loop changes behaviour — but a future routed loop gate will stall here
+  # rather than advance, and that is the intended reading of DIVE-560.
   local _gate_may_advance=1
   if [[ "$_lk" == "gate:approval" ]]; then
     local _ab; _ab=$(db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE id=${id};")

--- a/tests/gate_lead_clear_stamp_unit.sh
+++ b/tests/gate_lead_clear_stamp_unit.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# DIVE-2406 isolated unit harness — a LEAD-CLEARED gate must not be stamped as a
+# HUMAN answer.
+#
+# WHY THIS EXISTS. `--human` is a self-asserted argv flag; nothing validates it.
+# The provenance stamp read it directly (`(( human )) && answered_by="human:..."`)
+# and the honest `lead:` label right below was guarded by `(( ! human ))`. So a
+# lead who cleared a routed approval gate AND passed --human was recorded
+# `answered_by=human:<lead>` with every evidence form of a human absent:
+#
+#   DIVE-2400, 2026-07-30 04:28:04Z, user=agent-marketing
+#   answered_by=human:marketing tier=1 human=1 lead_clear=1
+#   channel_proof=absent cp_ok=0 nonce_valid=0 sudo_nonagent=0
+#
+# The AUTHORITY was correct — the DIVE-1381 curation carve-out routes a persona
+# batch to the lead deliberately — and no authority was escalated. The STAMP was
+# the defect, and it is not cosmetic: that task's result then asserted "lodar
+# approved all 7" when he had never answered, and `human:%` is a load-bearing
+# predicate for cmd_trace, cmd_digest's human-touch count, cmd_proof's ledger and
+# the precedent engine, which auto-applies a PRIOR HUMAN ANSWER to later gates.
+#
+# WHAT IS PINNED, and note the SHAPE of it. This fix REMOVES a label, so the arm
+# that grades it (case 1) is NEW, but the arm that catches over-reach (case 2) was
+# ALREADY GREEN before the change and has to STAY green — a suite built only from
+# case 1 signs off happily on a build that demotes every human tap in the fleet.
+# Both directions are mutation-measured in the PR body.
+#   1. lead-clear + UNCORROBORATED --human  -> `lead:<lead>`, row human=0
+#   2. lead-clear + CORROBORATED --human    -> `human:<lead>`  (already green)
+#   3. the two labels are DISTINCT (neither case is trivially satisfied)
+#   4. a non-lead human answer is UNTOUCHED -> `human:<actor>`
+#   5. the DIVE-2099 STANDING clear takes the same demotion (it sets
+#      _lead_clear=1, which is why the fix needs no second condition)
+#   6. the row carries the CLAIM alongside the verdict (human=0 human_claim=1),
+#      so the demotion is observable in the log and countable fleet-wide
+#   7. no fixture row reaches the real fleet audit log (graded by MARKER, not
+#      by byte offset — the offset moves on a live box because siblings write to it).
+# Run: bash tests/gate_lead_clear_stamp_unit.sh   (no root, no network)
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/gate-lead-clear-stamp.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+  source "$SRC/$f"
+done
+
+# Suite guard: remember the REAL log's length up front, so the check at the bottom
+# fails if THIS run grew it.
+REALLOG=/var/log/5dive/agent-audit.log
+REALLOG_OFFSET=0
+# One marker in every fixture title, so a leak is greppable in the real log.
+FIXTURE_MARK="dive2406-fixture"
+[[ -r "$REALLOG" ]] && REALLOG_OFFSET=$(wc -c <"$REALLOG" 2>/dev/null || echo 0)
+
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"
+set +e   # AFTER sourcing: header.sh turns `set -e` back on.
+tasks_db_init
+export FIVEDIVE_PROD_TASKS_DB="$TASKS_DB"   # DIVE-2010 fence: let the row through
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+addt()  { ( cmd_task_add "$@" ) 2>/dev/null | jq -r '.data.id'; }
+nby()   { db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE id=${1};"; }
+row()   { grep 'task answer gate.*answered_by=' "$AUDIT_CALLS" | head -1; }
+
+AUDIT_CALLS="$TMP/audit.calls"; : >"$AUDIT_CALLS"
+audit_log() { printf '%s\n' "$*" >>"$AUDIT_CALLS"; }
+# Preconditions, not observables. AUTH is the seam that decides _lead_clear: the
+# production resolver reads the KERNEL-enforced caller (DIVE-2004) and cannot be
+# driven from a test, so we drive it here and leave every OTHER condition real.
+task_need_notify() { return 0; }
+_gate_proof_enforced() { return 0; }
+AUTH="main"
+_gate_authenticated_actor() { printf '%s' "$AUTH"; }
+# The DIVE-2233 sealed reader decides nothing in this release; stub it so the
+# harness measures the stamp and not the constitution's availability on this box.
+_gate_clear_lead_allowed() { return 0; }
+_gate_clear_lead_denied_reason() { printf 'n/a'; }
+# The two human-evidence forms. Default: NEITHER present — the DIVE-2400 shape.
+SUDO_NONAGENT=1
+_gate_sudo_uid_nonagent() { return "$SUDO_NONAGENT"; }
+reset() { : >"$AUDIT_CALLS"; unset _TASK_STORE_AUDIT_FENCED; }
+
+# A routed approval gate: `task need` does the routing from preferences we cannot
+# rely on in a fixture, so the reviewer is set directly — routed_reviewer is the
+# INPUT to the path under test, not part of what it decides.
+mkgate() {
+  local _t; _t=$(addt --assignee=dev -- "$2")
+  cmd_task_need "$_t" --type=approval --ask="$1" --tier=1 >/dev/null 2>&1
+  db "UPDATE tasks SET routed_reviewer='main' WHERE id=${_t};" >/dev/null 2>&1
+  printf '%s' "$_t"
+}
+
+# --- 1+6. lead-clear + UNCORROBORATED --human -> lead:, and the row says so ----
+reset
+SUDO_NONAGENT=1
+t1=$(mkgate "ship the persona batch" "fixture routed approval $FIXTURE_MARK")
+cmd_task_answer "$t1" --value="approved" --human --from=main >/dev/null 2>&1
+BY1=$(nby "$t1"); ROW1=$(row)
+if [[ "$BY1" == "lead:main" ]]; then
+  ok_t "an uncorroborated --human on a lead-cleared gate stamps lead:main"
+else
+  bad_t "a lead-clear with NO human evidence must not be stamped human:*" \
+        "need_answered_by='$BY1' (expected lead:main)"
+fi
+if [[ "$ROW1" == *"human=0"* && "$ROW1" == *"lead_clear=1"* ]]; then
+  ok_t "the audit row records human=0 lead_clear=1"
+else
+  bad_t "row must report the demoted verdict" "row='$ROW1'"
+fi
+if [[ "$ROW1" == *"human_claim=1"* ]]; then
+  ok_t "the row carries the CLAIM beside the verdict (demotion is countable)"
+else
+  bad_t "a demotion the log cannot show is a demotion nobody can audit" "row='$ROW1'"
+fi
+
+# --- 2. lead-clear + CORROBORATED --human -> human:. ALREADY GREEN before the --
+#        fix; this is the arm that fails if the demotion is made unconditional.
+reset
+SUDO_NONAGENT=0            # non-agent SUDO_UID: a real human-evidence form
+t2=$(mkgate "ship the persona batch" "fixture routed approval, real human $FIXTURE_MARK")
+cmd_task_answer "$t2" --value="approved" --human --from=main >/dev/null 2>&1
+BY2=$(nby "$t2")
+if [[ "$BY2" == "human:main" ]]; then
+  ok_t "a CORROBORATED --human still stamps human:main (no genuine tap relabelled)"
+else
+  bad_t "the fix must not demote an evidenced human answer" \
+        "need_answered_by='$BY2' (expected human:main)"
+fi
+
+# --- 3. DISTINCTNESS: the two cases must not be the same string ---------------
+if [[ -n "$BY1" && -n "$BY2" && "$BY1" != "$BY2" ]]; then
+  ok_t "the evidenced and unevidenced clears are recorded DIFFERENTLY"
+else
+  bad_t "both cases produced the same provenance — one of the arms is vacuous" \
+        "unevidenced='$BY1' evidenced='$BY2'"
+fi
+
+# --- 4. a NON-lead human answer is untouched ---------------------------------
+#        A tier-1 `decision` gate, chosen deliberately over an approval one: it
+#        never enters the human-evidence block, so _hp/_su sit at the function-scope
+#        DEFAULTS the fix introduced and _human_evid is 0 here. This is therefore
+#        the arm that catches a demotion conditioned on evidence ALONE — drop the
+#        `_lead_clear` guard from the fix and every ordinary human answer in the
+#        fleet loses its human: stamp, and this is what says so.
+reset
+SUDO_NONAGENT=1
+AUTH="nobody"
+t4=$(addt --assignee=dev -- "fixture unrouted decision $FIXTURE_MARK")
+cmd_task_need "$t4" --type=decision --options="A|B" --recommend="A" \
+  --ask="pick one" --tier=1 >/dev/null 2>&1
+cmd_task_answer "$t4" --value="A" --human --from=lodar >/dev/null 2>&1
+BY4=$(nby "$t4")
+if [[ "$BY4" == "human:lodar" ]]; then
+  ok_t "a non-lead human answer keeps its human: stamp (fix is scoped to leads)"
+else
+  bad_t "the demotion escaped the lead-clear paths" \
+        "need_answered_by='$BY4' (expected human:lodar)"
+fi
+AUTH="main"
+
+# --- 5. the DIVE-2099 STANDING clear takes the same demotion ------------------
+#        Standing needs no routed_reviewer; it sets _lead_clear=1 itself, which is
+#        why the fix carries ONE condition. `_gate_standing_lead` reads the sealed
+#        constitution (unavailable in a fixture) so it is the seam; ELIGIBILITY is
+#        the real predicate and runs unstubbed.
+reset
+SUDO_NONAGENT=1
+_gate_standing_lead() { printf 'main'; }
+t5=$(addt --assignee=dev -- "fixture standing approval $FIXTURE_MARK")
+cmd_task_need "$t5" --type=approval --ask="merge the CLI fix to main" --tier=1 >/dev/null 2>&1
+cmd_task_answer "$t5" --value="approved" --human --from=main >/dev/null 2>&1
+BY5=$(nby "$t5"); ROW5=$(row)
+if [[ "$BY5" == "lead:standing:main" ]]; then
+  ok_t "a standing clear with no human evidence stamps lead:standing:main"
+elif [[ "$BY5" == "human:main" ]]; then
+  bad_t "the standing path escaped the demotion" "need_answered_by='$BY5'"
+else
+  # Eligibility is a conjunction of real predicates; if the fixture ask does not
+  # classify, say so rather than scoring a pass on a path that never ran.
+  bad_t "standing clear did not engage — this arm graded nothing" \
+        "need_answered_by='$BY5' row='$ROW5'"
+fi
+
+# --- 7. suite guard: no fixture row reached the real fleet log ----------------
+# Graded by CONTENT, not by byte offset. The offset comparison other harnesses use
+# is racy on a live box — measured here 2026-07-30: it "failed" on 273 bytes that
+# agent-olivia wrote to the shared log while this suite ran, with nothing of ours
+# in them. An offset guard cannot tell a leak from a sibling; a marker grep can,
+# and it stays meaningful when a real leak is one row among a hundred.
+# Three-state on purpose: `grep -c` EXITS 1 on zero matches while still printing
+# "0", so the reflexive `|| echo 0` yields the string "0\n0" and the arm fails on a
+# clean run. And an unreadable log is not a pass — it is an unprobed guard, and it
+# says so instead of scoring green.
+LEAKED=""
+if [[ -r "$REALLOG" ]]; then
+  LEAKED=$(grep -c "$FIXTURE_MARK" "$REALLOG" 2>/dev/null)
+  [[ "$LEAKED" =~ ^[0-9]+$ ]] || LEAKED=""
+fi
+if [[ -z "$LEAKED" ]]; then
+  printf 'skip - real fleet log not readable here; leak guard UNPROBED (not a pass)\n'
+elif [[ "$LEAKED" == "0" ]]; then
+  ok_t "no fixture row from this suite reached the real fleet audit log"
+else
+  bad_t "fixture rows LEAKED into the real audit log" "$LEAKED row(s) matching $FIXTURE_MARK"
+fi
+# Report the offset delta as CONTEXT so a reader is not misled into thinking the
+# suite proved the file never moved. It moves; other agents write to it.
+[[ -r "$REALLOG" ]] && printf '# note: real log grew %s bytes during this run (concurrent agents; see above)\n' \
+  "$(( $(wc -c <"$REALLOG" 2>/dev/null || echo 0) - REALLOG_OFFSET ))"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## The defect

`--human` is a self-asserted argv flag — nothing validates it. The provenance stamp read it directly, and the honest `lead:` label sitting immediately below it was guarded by `(( ! human ))`. So a lead who cleared a routed approval gate **and** passed `--human` was recorded as a human answer with every evidence form of a human absent.

DIVE-2400, the live case:

```
2026-07-30T04:28:04Z user=agent-marketing cmd='task answer gate'
  task=DIVE-2400 type=approval tier=1 answered_by=human:marketing
  human=1 lead_clear=1 channel_proof=absent cp_ok=0 nonce_valid=0 sudo_nonagent=0
```

The **authority was correct by design** — the DIVE-1381 content-curation carve-out routes a persona batch to the lead deliberately, and nothing escalated. Two agents read this row as a forgery before anyone read the source, and both were wrong. The **stamp** is what lied about who exercised it, and the cost was not cosmetic:

- That task's result text went on to assert *"lodar approved all 7"* when he had never answered.
- `need_answered_by LIKE 'human:%'` is load-bearing for `cmd_trace`, `cmd_digest`'s human-touch count, `cmd_proof`'s ledger, and **the precedent engine — which auto-applies a prior HUMAN answer to later gates** and had a lead-clear to hand it.

## The fix

An uncorroborated `--human` on a lead-cleared gate is demoted at the stamp. The existing `lead:` / `lead:standing:` labels then apply on their own, and the audit row reads `human=0 human_claim=1 lead_clear=1`.

What is deliberately **not** in the corroboration set: `_lead_clear` itself. It is a legitimate *authorization* form for the evidence block above (a lead-clear must not be refused for lacking human evidence) and is precisely **not** evidence of a human at the stamp. That conflation is the whole bug.

Three notes on scope:

- **One condition, on `_lead_clear` alone.** An eligible DIVE-2099 standing clear sets `_lead_clear=1` itself, so a second `|| _lead_standing` clause would be dead code — untestable by mutation and green forever.
- **`_hp`/`_su` hoisted to function scope** so the stamp reads initialized zeros on gate types that never enter the evidence block, rather than unset variables. Values are still set there, once. No third `_human_nonce_verify` call.
- **A corroborated `--human` is untouched** (valid per-gate nonce, non-agent `SUDO_UID`, or verified channel proof), so no genuine Telegram tap, dashboard answer, or human-on-box login is relabelled.

## Blast radius, measured before writing the fix

```
lead_clear=1 AND human=1   ->  2 answers, fleet-wide, ever   (DIVE-2121, DIVE-2400)
lead_clear=1 AND human=0   -> 26 answers                     (already honest today)
```

The honest `lead:` path is already the dominant one; the mislabel is the rare case where the lead *also* passed `--human`. Not retroactive — existing rows are unchanged.

## Consequence declared rather than glossed

DIVE-560 advances a **loop** approval gate only on `human:*`. With the relabel, a lead-cleared loop gate now **stalls** there instead of advancing. That is what that block always said should happen for a non-human clear ("if a non-human path ever clears it … the relay simply doesn't advance"); the advance was previously bought with a label that was not true. Neither of the two measured rows was a loop step, so no live loop changes behaviour. Deliberately **not** widened to `lead:*` — that would hand a lead the loop-advance authority DIVE-560 reserves for the human, which is a grant, not a relabel. Commented at the site.

Second disclosure, because it runs in my favour: relabelling reduces the counted human touches, which **raises** the published zero-human badge. Two rows' worth, but the direction is self-serving and belongs in the open.

## Grading

`tests/gate_lead_clear_stamp_unit.sh` — 8 arms, all green. This fix **removes** a label, so the arm that grades it is new while the arm that catches over-reach was **already green** and has to stay green. A suite built only from the new arm signs off happily on a build that demotes every human tap in the fleet.

Three mutants, measured on the committed tree, tree restored after each:

| mutant | expected catcher | result |
| --- | --- | --- |
| demotion made **unconditional** (drop the evidence test) | the already-green corroborated arm | **6/2** — corroborated arm + distinctness arm flip red |
| demotion **removed entirely** | the new arm | **4/4** — lead arm, row verdict, distinctness, standing arm flip red |
| **`_lead_clear` guard dropped** (demote on evidence alone) | the non-lead arm | **7/1** — the `decision`-gate arm flips red |

The third mutant exists because case 4 uses a tier-1 `decision` gate on purpose: it never enters the evidence block, so `_hp`/`_su` sit at the function-scope defaults this change introduced and `_human_evid` is 0 there. Without the `_lead_clear` guard, every ordinary human answer in the fleet loses its `human:` stamp, and that arm is what says so. I wrote that claim in the test comment, so I measured it rather than asserting it.

One honest gap: the `human_claim=1` arm stays green under all three mutants. It grades the new audit field, not the demotion — it is an observability arm, not a demotion-grading one.

Neighbouring suites, all green (244 arms): `gate_answer_audit_unit` 12, `gate_lead_standing_unit` 73, `gate_nonce_unit` 19, `gate_actor_path_forgery_unit` 5, `gate_channel_proof_unit` 16, `gate_precedent_unit` 74, `gate_approval_routing_unit` 9, `gate_clear_leads_reader_unit` 20, `gate_proof_verify_unit` 10, `gate_json_envelope_unit` 6.

`gate_answer_audit_unit`'s case 1 is worth naming: a tier-1 `decision` gate answered with a bare `--human` and no evidence still stamps `human:*`. That is not collateral, it is the pre-existing regression guard for exactly the scoping this change had to respect.

## Also fixed in passing (test hygiene)

My suite's leak guard is graded by **marker grep, not byte offset**. The offset comparison other harnesses use is racy on a live box: it "failed" here on 273 bytes that `agent-olivia` wrote to the shared log while the suite ran, with nothing of ours in them. An offset guard cannot tell a leak from a sibling. Three-state — an unreadable log reports `UNPROBED`, not a pass. (`grep -c` exits 1 while printing `0`, so the reflexive `|| echo 0` yields `"0\n0"` and fails on a clean run; that is handled.)

## Out of scope, deliberately

Fix A from the original filing — *"approval must land at tier=2"* — is **withdrawn** and not implemented here. It would rebuild the exact wall DIVE-1381 removed and push every persona batch back onto the paired human, who said the same morning that he does not want them. Authority correct by design; this PR is scoped to the stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
