### PR TITLE
fix(tasks-db): remove five printf-into-grep SIGPIPE sites in schema migration (DIVE-2434)

### DIFF
--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -1292,7 +1292,7 @@ MIG
     local lr_cols
     lr_cols=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
               "SELECT name FROM pragma_table_info('loop_runs');" 2>/dev/null)
-    if ! printf '%s\n' "$lr_cols" | grep -qx "scorecard_json"; then
+    if ! grep -qx "scorecard_json" <<<"$lr_cols"; then
       sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
         "ALTER TABLE loop_runs ADD COLUMN scorecard_json TEXT;" >/dev/null 2>&1 || true
     fi
@@ -1458,11 +1458,11 @@ MIG
     local oc_cols
     oc_cols=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
               "SELECT name FROM pragma_table_info('objective_cycles');" 2>/dev/null)
-    if ! printf '%s\n' "$oc_cols" | grep -qx "planner_loop_id"; then
+    if ! grep -qx "planner_loop_id" <<<"$oc_cols"; then
       sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
         "ALTER TABLE objective_cycles ADD COLUMN planner_loop_id TEXT;" >/dev/null 2>&1 || true
     fi
-    if ! printf '%s\n' "$oc_cols" | grep -qx "planner_task_id"; then
+    if ! grep -qx "planner_task_id" <<<"$oc_cols"; then
       sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
         "ALTER TABLE objective_cycles ADD COLUMN planner_task_id INTEGER;" >/dev/null 2>&1 || true
     fi
@@ -1481,7 +1481,7 @@ MIG
     local obj_cols
     obj_cols=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
               "SELECT name FROM pragma_table_info('objectives');" 2>/dev/null)
-    if ! printf '%s\n' "$obj_cols" | grep -qx "run_mode"; then
+    if ! grep -qx "run_mode" <<<"$obj_cols"; then
       sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
         "ALTER TABLE objectives ADD COLUMN run_mode TEXT NOT NULL DEFAULT 'live';" >/dev/null 2>&1 || true
     fi

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -1004,7 +1004,26 @@ _tasks_db_migrate() {
            'delivery_ref TEXT' 'delivered_at TEXT' \
            'originated_by_objective INTEGER' 'originated_cycle INTEGER' \
            'verify_unavailable INTEGER' 'last_skipped_at TEXT'; do
-    if ! printf '%s\n' "$cols" | grep -qx "${c%% *}"; then
+    # DIVE-2418: herestring, NOT a pipe. `printf | grep -q` lets grep exit on its
+    # first match while printf is still writing, and printf then takes SIGPIPE and
+    # emits "write error: Broken pipe" on stderr. This runs from tasks_db_init on
+    # essentially every `5dive task` invocation, so the stray line can surface
+    # anywhere — it is not test-only. It reddened CI on 0efcd66 by landing INSIDE a
+    # harness's captured stream (loop_panel_unit T6 redirects 2>&1 into the file it
+    # then jq-parses), so the assertion failed while the subject under test had
+    # succeeded. A herestring has no pipe, so no SIGPIPE is possible.
+    #
+    # THE MECHANISM IS NOT ESTABLISHED AND THIS FIX DOES NOT DEPEND ON IT. olivia
+    # built the exact shape at the real payload size (~70 short strings, far under
+    # the 64KB pipe buffer) with the match on line one and got ZERO broken pipes in
+    # 400 runs, so the obvious early-exit story does not reproduce where it actually
+    # occurs; CI under load is the untested variable. Removing the pipe removes the
+    # class regardless of which race fires. Semantics verified equivalent over five
+    # probes including the prefix case `grep -x` must reject (need_ty vs need_type).
+    #
+    # If anyone adds `set -o pipefail` on this path, the SIGPIPE stops being
+    # cosmetic and becomes a hard failure in schema migration.
+    if ! grep -qx "${c%% *}" <<<"$cols"; then
       sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
         "ALTER TABLE tasks ADD COLUMN ${c};" >/dev/null 2>&1 || true
     fi


### PR DESCRIPTION
Unblocks the release cut: this is the single red check on main's tip `0efcd66`.

## What actually happened, corrected

`src/lib/tasks_db.sh:1007` ran `printf '%s\n' "$cols" | grep -qx "${c%% *}"`. grep can exit on its first match while printf is still writing; printf takes SIGPIPE and emits `write error: Broken pipe` on stderr.

**This is product code, not test code.** It sits in `_tasks_db_migrate`, called from `tasks_db_init` on essentially every `5dive task` invocation — so the stray line can surface anywhere, and it will keep recurring intermittently while looking like flake. (My first report attributed it to the harness. olivia corrected that, and the correction is what makes it worth fixing rather than re-running.)

## How a cosmetic stderr line turned a green test red

`tests/loop_panel_unit.sh` T6 runs the subject as `( cmd_loop_panel … >"$TMP"/panel-pass.out 2>&1 ) &` and then does `jq -r '.data.verdict' "$TMP"/panel-pass.out`. The stderr line landed **inside the captured stream the assertion parses**. jq got a file whose first line is not JSON, `pv` came back empty, and the assertion failed — while the loop panel itself had succeeded.

That is visible in the CI log and I misread it: the failure message is `bad_t "quorum pass" "$(cat …/panel-pass.out)"`, so the broken-pipe line printed immediately above a healthy `status:done, haltReason:complete` **is the captured file**, not two independent events. olivia proposed this reading as an alternative to mine; confirmed at `tests/loop_panel_unit.sh:132/142/145`. **Nothing about quorum was broken.**

## The mechanism is NOT established, and the fix does not depend on it

olivia built the exact shape at the real payload size (~70 short strings, far under the 64KB pipe buffer) with the match on line one, ran it 400 times, and got **zero** broken pipes. So the obvious early-exit story does not reproduce where it actually occurs. CI under load is the untested variable.

Rather than ship a diagnosis that failed its own check, this removes the pipe. No pipe, no SIGPIPE, whichever race fires. Class removal, not repair.

## Verification

- Equivalence checked **independently on both sides**, not relayed: exact match, no match, and the prefix case `grep -x` must reject (`need_ty` vs `need_type`) return identical verdicts pipe and herestring.
- `tests/loop_panel_unit.sh`: **14 passed, 0 failed** on this branch.
- Branched from `0efcd66` so CI here grades the same tree that went red.

## Latent hazard, named at the site

If anyone adds `set -o pipefail` on this path, the SIGPIPE stops being cosmetic and becomes a hard failure in schema migration.

## Note for the release

Independent of this fix: `release-cut` refuses on **any** non-success check-run, so the cut is gated on total repo health rather than release readiness. Three nights of `assign`+`version-uniqueness`, then this the moment those were deleted. That is a design property and it will keep producing brakes nobody chose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)