### PR TITLE
task: each accepting arm of the done==merged gate emits its own receipt (DIVE-2217)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -2130,7 +2130,7 @@ _task_status_cmd() {
         # a squash rewrites the sha, so the branch tip is NOT an ancestor of main even
         # though the content is in. Attribution finds it anyway, because the squash
         # commit subject carries the ident.
-        local _slug _bmerged="" _searched="" _attr_slug="" _anc="" _attr="" _anc_novac="" _attr_bound="" _attr_unreach=""
+        local _slug _bmerged="" _merged_slug="" _searched="" _attr_slug="" _anc="" _attr="" _anc_novac="" _attr_bound="" _attr_unreach=""
         while IFS= read -r _slug; do
           [[ -n "$_slug" ]] || continue
           _searched="${_searched:+$_searched, }$_slug"
@@ -2158,7 +2158,10 @@ _task_status_cmd() {
           # them is a finding. Carry it so the refusal below can tell them apart.
           [[ -z "$_attr" ]] && _attr_unreach="$_slug"
           _bmerged=$(GH_TOKEN="$_ghtok" gh pr list --repo "$_slug" --head "$_branch" --state merged --json number,mergedAt -q '.[0].mergedAt' 2>/dev/null || echo "")
-          [[ -n "$_bmerged" && "$_bmerged" != "null" ]] && break
+          if [[ -n "$_bmerged" && "$_bmerged" != "null" ]]; then
+            _merged_slug="$_slug"
+            break
+          fi
           _bmerged=""
         done < <(if [[ -n "$_task_slug" ]]; then printf '%s\n' "$_task_slug"; else _gate_repo_slugs; fi)
         if [[ -n "$_attr_slug" ]]; then
@@ -2220,6 +2223,12 @@ _task_status_cmd() {
           # DIVE-2301. So: state what was actually measured (no commit subject on main
           # names the ident, no merged PR for the branch) and give the remedy that works.
           policy_refuse "$E_CONFLICT" done-before-branch-merged DIVE-1830 "$ident" "$ident cannot close: nothing on ${FIVE_GATE_MAIN_BRANCH:-main} in $_searched shows branch '$_branch' landed. MEASURED, both ways that can accept: (a) no commit SUBJECT on main names $ident (attribution, DIVE-2120 — the only test that accepts here), and (b) no MERGED PR has '$_branch' as its head. Ancestry is NOT one of the ways: a squash rewrites the sha, so a branch tip is never an ancestor of a squash-merged main — do not go looking for the branch. done=merged-to-main (DIVE-1830) — land it (delegated push: \`5dive push $ident\`, or open and merge a PR) with the ident in the commit SUBJECT, then run task done. If it lives in a repo not listed there, add a \`Repo: <owner>/<repo>\` line to the body. Use \`task cancel\` to abandon."
+        else
+          # DIVE-2217: this is the OTHER accepting arm. Keep its repo in a variable
+          # named for the evidence that assigned it, just as _attr_slug is owned by
+          # _gate_branch_ident_on_main above. A silent success here made a merged-PR
+          # close indistinguishable from attribution in the durable operator record.
+          warn "$ident: branch '$_branch' is the head of a MERGED PR in $_merged_slug (merged at $_bmerged) — GitHub's merged-PR record is the accepting evidence. done=merged-to-main satisfied."
         fi
       fi
     fi

--- a/tests/task_merge_gate_ancestry_unit.sh
+++ b/tests/task_merge_gate_ancestry_unit.sh
@@ -25,10 +25,11 @@
 #   4. ancestry UNREACHABLE (gh/network/token) is not "no": with a merged PR it still
 #      closes, and WITHOUT one it still refuses — an outage can never invent either
 #      verdict.
-#   5. the ATTRIBUTION pass is AUDIBLE in the close (which evidence closed it), and
-#      the refusal text names both roads it tried. DIVE-2184: it said "ancestry pass"
-#      and the close line said ANCESTOR, so the assertion and the message agreed with
-#      each other and with nothing else.
+#   5. EACH accepting pass is AUDIBLE in the close (which evidence closed it):
+#      attribution names its subject scan and a merged PR names its own repo, branch,
+#      and merged_at receipt. DIVE-2184: attribution said "ancestry pass" and the close
+#      line said ANCESTOR, so the assertion and the message agreed with each other and
+#      with nothing else. DIVE-2217: the separate merged-PR pass remained silent.
 #
 # MUTATION GRADE (run by hand against src/cmd_task.sh, both must go red):
 #   * neuter the ATTRIBUTION acceptance — `_gate_branch_ident_on_main() { printf '0'; }`
@@ -45,6 +46,8 @@
 #   * DIVE-2266: change the bound-hit accumulator back to last-write-wins
 #     (`_attr_bound="$_slug:${_attr#bound:}"`) -> ANC-2266 FAILS because the first two
 #     bound-hit repos and their own walked counts disappear from the refusal.
+#   * delete the merged-PR acceptance warning -> case 2's receipt assertion FAILS
+#     while the state transition still passes (the silent record defect reproduced).
 # Isolation matches the sibling gate harnesses: source src/ into a throwaway
 # STATE_DIR (the live tasks.db is NEVER touched); gh is STUBBED on PATH.
 # Run: bash tests/task_merge_gate_ancestry_unit.sh  (no root, no network).
@@ -231,6 +234,12 @@ fi
 [[ "$OUT" != *ANCESTOR* ]] \
   && ok_t 'the squash close does NOT claim ancestry evidence it does not have' \
   || bad_t 'squash close must not claim ancestry' "out=$OUT"
+[[ "$OUT" == *"branch 'dive-1999-squashed' is the head of a MERGED PR"* \
+   && "$OUT" == *"in 5dive-ai/5dive"* \
+   && "$OUT" == *"merged at 2026-07-26T09:00:00Z"* \
+   && "$OUT" != *"names SQ-1 in its SUBJECT"* ]] \
+  && ok_t 'the squash close names only its MERGED-PR evidence, repo, branch, and timestamp' \
+  || bad_t 'merged-PR pass must emit its own receipt' "out=$OUT"
 
 # --- 3. NON-VACUITY: genuinely unmerged commits, no PR -> STILL REFUSES --------
 clear_fx; export GH_STUB_CMP_5dive_dive_2101_wip="$AHEAD"


### PR DESCRIPTION
## DIVE-2217 — each accepting arm of the done==merged gate emits its OWN receipt

The declared-branch gate had two accepting arms and only one receipt. A close that
passed on GitHub's **merged-PR** record printed nothing, so in the durable operator
record it was indistinguishable from a close that passed on **ident attribution**
(the DIVE-2120 main-subject scan). DIVE-2184 is the live case: the message said
ANCESTOR while attribution was what actually accepted.

This adds the missing merged-PR receipt, owned by its own `_merged_slug` variable so
the name matches the evidence that assigned it, and names repo + branch + `merged_at`.
Ancestry has **no** accepting arm by design (deliberately non-accepting since
DIVE-2101 — a squash rewrites the sha), so its silence is correct, not an omission.

Maker: codex. Verifier: olivia.

### Verification (olivia, independent — not taken from the maker report)
- Cherry-picked `d6049a5` onto current `main` (`57fa70e`, which also touches
  `src/cmd_task.sh` via DIVE-2406): applies **clean**, diff identical at +13/-2 and
  +17/-4, `bash -n` clean.
- All five focused suites on that merged tree: ancestry **35/0**, deliver **11/0**,
  multirepo **36/0**, diagnostic **17/0**, result-PR **29/0** — **128/0**.
- Mutation-graded **both** directions, with the applied mutation measured rather than
  asserted (baseline occurrence count taken first, diff shown, `bash -n` re-checked so
  a parse-error red could not be mistaken for a real one):
  - neuter the new receipt to a no-op → **34/1**, the one red being *"merged-PR pass
    must emit its own receipt"* while the state transition still passes — the silent
    record defect reproduced.
  - make the receipt **also** claim the attribution evidence → **34/1** on the same
    arm via its negative clause, so the assertion is not presence-only.
- The test is committed in the diff and asserts the negative too (a merged-PR close
  must NOT also claim it names the ident in its SUBJECT).

### Known limits, stated rather than implied
Historical impact is **bounded at three** known false-ancestry emissions across two
repos and cannot be reconstructed further: the warning was console/session output, not
task-result data, so the tasks table holds zero copies. That is a limit of the
question, not of the instrument.

Refs DIVE-2217, DIVE-2184, DIVE-2120, DIVE-2101, DIVE-1830.
