### PR TITLE
feat(task): CHANNEL PROOF of the human's answer clears a tier-2 gate, not only a button tap (DIVE-2412)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -177,12 +177,54 @@ jobs:
   # environment ever does.
   #
   # This job owns the invariant that survives that: every harness in tests/*.sh is
+  # DIVE-2412: A HARNESS CAN BE UNPROBED FOR TIME RATHER THAN FOR SHAPE, and the
+  # two want different answers. The probe's per-harness `timeout` is 180s, which is
+  # what stops one hung harness from stalling a 255-file sweep. A mutation grader
+  # re-runs its whole unit suite once per mutant, so this one costs ~14 x 23s and is
+  # killed by that timeout in EVERY environment — canary never printed, so
+  # `not-reached` everywhere, which is precisely the permanently-unprobed limit case
+  # the union job exists to catch. It caught it.
+  #
+  # The allowlist is the WRONG instrument here and using it would have been a false
+  # reason on the record: ALLOW_UNPROBEABLE means "no identifiable verdict variable",
+  # and this harness has one — measured `wired` at PROBE_TIMEOUT=900. It is probeable
+  # and slow, not unprobeable. So it gets a lane that pays the time instead of an
+  # exemption that excuses the coverage, and the union still asserts the same
+  # invariant over the same corpus.
+  #
+  # Scoped with --only on purpose: raising PROBE_TIMEOUT for the whole sweep would
+  # also raise how long a genuinely hung harness can stall CI, which is the property
+  # the 180s default is buying. Named harnesses pay 900s; nothing else changes.
+  harness-verdict-slow:
+    runs-on: ubuntu-latest
+    needs: test
+    env:
+      # One name per slow harness, comma-separated — the probe's own --only format.
+      # Keep this list SHORT and justified; a harness landing here is saying its
+      # verdict costs minutes, not that it may go ungraded.
+      SLOW_HARNESSES: gate_channel_session_t2_mutation.sh
+    steps:
+      # DIVE-2229: full history — pinned baselines must resolve here too.
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Slow harnesses must be able to FAIL too (long lane)
+        env: { PROBE_TIMEOUT: '900' }
+        run: |
+          bash tests/meta/harness-verdict-probe.sh --assume-clean \
+            --only="$SLOW_HARNESSES" --label=slow --report=probe-slow.txt
+      # `if: always()` for the same reason as the pristine lane: a run that found
+      # UNWIRED still made a valid coverage observation, and losing the report would
+      # let a red probe silently shrink the union instead of reddening it.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with: { name: probe-slow, path: probe-slow.txt, if-no-files-found: error }
+
   # probed in AT LEAST ONE environment, or is allowlisted by name with a reason.
   # A skip in one environment is still not an accusation; a skip in all of them is
   # now a failure.
   harness-verdict-union:
     runs-on: ubuntu-latest
-    needs: [harness-verdict, test-installed-host]
+    needs: [harness-verdict, test-installed-host, harness-verdict-slow]
     steps:
       # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
@@ -194,7 +236,11 @@ jobs:
       # we claim to cover — the check would otherwise have the same shape of hole
       # it exists to close.
       - name: Every harness must be probed in SOME environment
-        run: bash tests/meta/harness-verdict-union.sh probe-pristine.txt probe-installed.txt
+        # probe-slow.txt is named EXPLICITLY, not globbed: union fails closed on a
+        # missing or unreadable report, so a slow lane that died has to red this job
+        # rather than quietly drop back to the two-environment corpus it used to
+        # cover — the same shrink-in-silence hole this check exists to close.
+        run: bash tests/meta/harness-verdict-union.sh probe-pristine.txt probe-installed.txt probe-slow.txt
 
   # DIVE-2039: the same invariant one level out, over the RAILS rather than the
   # harnesses. `5dive selfcheck` reports pass | fail | NOT-REACHED and NOT-REACHED

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,24 @@ agent box the column read `channel-session` and on a CI runner the identical cod
 is this feature's whole premise, and CS13 flips the pin both ways so the pin is differential
 rather than a way to keep the harness quiet.
 
+AND THE MUTATION GRADER ITSELF WAS UNGRADED, which `harness-verdict-union` caught and reded the
+build for. A mutation grader re-runs its whole unit suite once per mutant, so this one costs
+~14 x 23s and the probe's 180s per-harness `timeout` killed it before its verdict line ever
+executed - `not-reached` on BOTH the pristine and installed-host lanes, i.e. probed in no
+environment at all. That is the permanently-unprobed limit case the union job was written for,
+arriving on a harness whose own job is to catch tests that grade nothing.
+
+It is fixed with a lane, not an exemption. `ALLOW_UNPROBEABLE` means "no identifiable verdict
+variable" and this harness has one - measured `wired` at `PROBE_TIMEOUT=900` - so allowlisting it
+would have put a false reason on the record and excused the coverage it was claiming. Instead a
+`harness-verdict-slow` job probes the named slow harnesses with `--only` at 900s, and the union
+consumes its report as a third environment. `--only` is deliberate: raising `PROBE_TIMEOUT` for
+the whole 255-file sweep would also raise how long a genuinely hung harness can stall CI, which
+is the property the 180s default buys. `probe-slow.txt` is named explicitly in the union call
+rather than globbed, so a slow lane that dies reds the union instead of silently dropping back to
+the two-environment corpus. Verified differentially against the real CI reports from the red run:
+with the third report 252 probed / 0 NEVER PROBED / rc 0, without it 1 NEVER PROBED / rc 1.
+
 Consumers are NOT wired yet and this ships inert until they are: the telegram plugin does not
 pass `--channel-msg`, and the dashboard (DIVE-2371) is the second surface on the same rail.
 DIVE-2371's fail-closed prefix change must still land AFTER them, or the dashboard's tier-2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,11 +56,17 @@ RESIDUAL, stated rather than buried: a human message naming this ident and this 
 inside the hour, cited for this gate, is taken as the human answering this gate. Only a per-gate
 nonce ties the two harder, and that nonce is the tap this exists to avoid.
 
-Graded by `tests/gate_channel_session_t2_unit.sh` (19 arms) plus
+Graded by `tests/gate_channel_session_t2_unit.sh` (33 arms) plus
 `tests/gate_channel_session_t2_mutation.sh`, which deletes each condition in turn and requires
-the named arm to go red - 9 mutants, 9 killed. Two arms were rewritten because that pass showed
-they graded nothing: the hidden-origin fixture was being caught by the sender check one
-condition down, and the "invented message id" refusal was passing on rc alone.
+the named arm to go red - 14 mutants, 14 killed. Three arms were rewritten because that pass, and
+then CI, showed they graded nothing: the hidden-origin fixture was being caught by the sender
+check one condition down, the "invented message id" refusal was passing on rc alone, and the two
+`human_evidence` arms were grading THE RUNNER. `_gate_sudo_uid_nonagent` answers "is this a
+human?" by asking the host's passwd database whether the account is named `agent-*`, so on an
+agent box the column read `channel-session` and on a CI runner the identical code appended
+`+sudo-uid` and the exact-string arms went red. The seam is now pinned to the agent caller that
+is this feature's whole premise, and CS13 flips the pin both ways so the pin is differential
+rather than a way to keep the harness quiet.
 
 Consumers are NOT wired yet and this ships inert until they are: the telegram plugin does not
 pass `--channel-msg`, and the dashboard (DIVE-2371) is the second surface on the same rail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## Unreleased — feat(task): CHANNEL PROOF of the human's answer clears a tier-2 gate, so a decision already made in chat is not re-entered as a button tap (DIVE-2412)
+
+DIVE-2382 fix #4, approved 2026-07-30 04:27. A tier-2 gate could be cleared by exactly two
+things: a per-gate nonce (the Telegram button) or a non-agent SUDO_UID (the dashboard exec).
+Neither is what the human usually produces. The live illustration is DIVE-2247: the answer
+`hold-schedule` was recorded at 05:14:26 with `human_nonce_hash=NULL`, and the only reason it
+was credible at all was lodar's own chat message 27 seconds later saying he pressed it. Grading
+that took a human-judgement pass, and the alternative on offer was asking him to re-enter as a
+tap a decision he had already made in prose - the rubber-stamping he refused on 2026-07-29.
+
+`task answer` now takes `--channel-msg=<message_id>` alongside `--channel-proof=<chat_id>`, and
+that pair is a fourth evidence form that a TIER-2 gate accepts.
+
+WHAT MAKES IT EVIDENCE RATHER THAN A CLAIM, because that boundary is the whole design. The
+chat id on its own is not evidence and stays tier<2 exactly as DIVE-1305 scoped it: the calling
+agent's session already knows that number, so alone it proves only that this bot has a paired
+human. A citation is different in kind. The message id is checked against TELEGRAM, via
+`forwardMessage` on the cited id, and the forwarded copy is deleted immediately - it is a probe,
+not a post. Four conditions must all hold: the chat is the paired human's verified DM, the
+message is live, its `forward_origin` is a USER whose id is that human (a bot's own message, a
+third party and a privacy-hidden origin are all refused), and it is fresh and names BOTH the
+task ident and the answer. Anything unresolvable - no readable token, no response, no attribution - REFUSES. An agent
+asserting that a human answered is refused with the gate left open, because `--from` and a
+quoted line are caller-supplied and are not evidence.
+
+The reason the check is remote is that no local one exists: the plugin and the agent share a
+unix user, so no file, uid or cgroup separates them. What an agent cannot do is make Telegram's
+servers report a message that was never sent.
+
+WHERE IT IS ADMITTED, because a tier-2 clear passes two guards and not one. Raising the human
+flag only clears the first (the DIVE-1117 provenance floor). The second is DIVE-2233's evidence
+site, which refuses a tier-2 `--human` claim that carries neither a valid per-gate nonce nor a
+non-agent `SUDO_UID` - and it is scoped to gates that HAVE a minted nonce, which is every
+approval and manual gate, i.e. exactly the ones this feature is for. The citation is therefore
+listed there as a third evidence form, on the same footing: the other two are local to the box,
+while this one is attested by Telegram, the party the caller cannot speak for. Its refusal
+message and audit row now name it (`channel_session=`).
+
+The row now carries `human_evidence`, so `nonce` (a tap), `sudo-uid` (dashboard/on-box),
+`channel-chat` (the tier<2 form) and `channel-session` (this one) stay tellable apart after the
+fact - all four persist as `need_answered_by=human:*`, and only the last cleared a tier-2 gate
+with nobody touching a button. Stored on the row rather than derived from a log, per DIVE-2090.
+
+THE FRESHNESS BOUND IS NOT THE CALLER'S TO SET. `task answer` is run by the agent, so the
+freshness window may not be read from its environment - and the first cut of this change did
+exactly that, then named that window as what bounded a replay of a non-unique answer value. Both
+halves are fixed: the ceiling is hardcoded at 3600s and `GATE_CHANNEL_SESSION_MAX_AGE` can only
+TIGHTEN it (wider, zero, negative and non-numeric all fall back to the ceiling), and the cited
+message must name the task IDENT as well as the answer. An ident is unique to one gate; a value
+is unique to none, and an ident on its own would attest only that the human spoke about the gate
+while `--value` still came from the agent.
+
+RESIDUAL, stated rather than buried: a human message naming this ident and this answer, sent
+inside the hour, cited for this gate, is taken as the human answering this gate. Only a per-gate
+nonce ties the two harder, and that nonce is the tap this exists to avoid.
+
+Graded by `tests/gate_channel_session_t2_unit.sh` (19 arms) plus
+`tests/gate_channel_session_t2_mutation.sh`, which deletes each condition in turn and requires
+the named arm to go red - 9 mutants, 9 killed. Two arms were rewritten because that pass showed
+they graded nothing: the hidden-origin fixture was being caught by the sender check one
+condition down, and the "invented message id" refusal was passing on rc alone.
+
+Consumers are NOT wired yet and this ships inert until they are: the telegram plugin does not
+pass `--channel-msg`, and the dashboard (DIVE-2371) is the second surface on the same rail.
+DIVE-2371's fail-closed prefix change must still land AFTER them, or the dashboard's tier-2
+clear goes offline with it.
 ## Unreleased — fix(task): pronoun options resolve to an account frame (DIVE-2212)
 
 Two parties can no longer select the same second-person gate option and receive

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -108,6 +108,12 @@ _task_usage() {
   5dive task inbox --send [--channel-proof=<chat>]   # DM the owner ONE tap-button digest of those gates (root-side; nonce never printed)
   5dive task coordinator [--json]                     # print the resolved org coordinator (DIVE-333/1568) — the one agent that fronts the pinned needs-you banner
   5dive task answer <id|DIVE-N> --value="..."        # record the human's answer, unblock, ping the owning agent
+  5dive task answer <id|DIVE-N> --value="..." --channel-proof=<chat_id> [--channel-msg=<message_id>]
+                                                     # the CHANNEL forms. --channel-proof alone is the DIVE-1305 paired-human DM proof: clears tier<2 gates only.
+                                                     # ADD --channel-msg (the id of the human's OWN message in that DM) and a TIER-2 gate clears with NO button tap
+                                                     # (DIVE-2412): the citation is checked against Telegram itself - the message must be live, sent by that human,
+                                                     # fresh (<=3600s, a hardcoded ceiling GATE_CHANNEL_SESSION_MAX_AGE can only TIGHTEN) and name BOTH the task ident and the answer.
+                                                     # An agent ASSERTING that a human answered is not evidence and is refused. The row records which form cleared it.
   5dive task clear-recs --channel-proof=<chat_id> [--only=<id|DIVE-N>]
                                                      # DIVE-1305: paired-human bulk-clear — apply each pending gate's --recommend as a HUMAN clear,
                                                      # driven by the human's own verified DM ("go with recs"). Clears only tier<2 (agent-clearable) gates;
@@ -6290,6 +6296,163 @@ _gate_channel_proof_ok() {
   jq -e --arg c "$chat" '(.allowFrom // []) | index($c) != null' "$TASK_CH_ACCESS" >/dev/null 2>&1
 }
 
+# DIVE-2412: the Bot API seam for a channel citation, isolated in ONE function so
+# a unit harness can drive every branch of the verifier below with no network and
+# no bot token. Every attestation call goes through here.
+_gate_channel_api() { # <token> <method> [curl -d args...]
+  local token="$1" method="$2"; shift 2
+  curl -sS --max-time 15 "https://api.telegram.org/bot${token}/${method}" "$@" 2>/dev/null
+}
+
+# DIVE-2412 (DIVE-2382 fix #4): CITED-MESSAGE channel proof — the evidence form a
+# TIER-2 gate accepts, so a decision the human already made in prose clears
+# WITHOUT re-entering it as a button tap (the rubber-stamp lodar refused
+# 2026-07-29 01:06).
+#
+# WHY THE DIVE-1305 FORM IS NOT ENOUGH HERE, said plainly because the ticket's
+# premise reads the other way: _gate_channel_proof_ok proves the cited CHAT is the
+# paired human's own verified DM. It does NOT prove the human said anything. The
+# chat id is a number the calling agent's own session already knows, so on its own
+# it is exactly the agent-relayed assertion this must refuse ("he told me").
+# At tier<2 that weaker bar is lodar's deliberate scope; at tier 2 it is not
+# evidence, so tier 2 requires a CITATION on top: the message_id of the human's
+# OWN message, attested by TELEGRAM rather than by us.
+#
+# THE ATTESTATION IS REMOTE, which is the entire reason the caller cannot forge
+# it. The plugin and the agent share a unix user, so NO local artifact separates
+# them — same uid, same cgroup, same files (community/wiki/
+# the-dashboard-t2-clear-and-the-t2-forge-are-one-path.md). What an agent cannot do
+# is make Telegram's servers claim a message exists that does not: forwardMessage
+# on the cited id returns the message's forward_origin (who really sent it) and its
+# original date. The forwarded echo is deleted immediately — this is a probe, not a
+# post.
+#
+# FOUR CONDITIONS, all required, each with its own refusal reason:
+#   1. the chat is the paired human's verified DM (the DIVE-1305 anchor),
+#   2. Telegram confirms the cited message EXISTS in that chat,
+#   3. its forward origin is a USER whose id is that chat's human — a bot's own
+#      message and a third party both refuse (in a DM the human's user id IS the
+#      chat id), and a privacy-HIDDEN origin refuses because it attests nobody,
+#   4. it is FRESH (<= 3600s, a HARDCODED ceiling — see below) and it NAMES BOTH
+#      this task's ident and this answer, so neither a stale "yes" nor a live one
+#      about another gate can be replayed onto this one.
+# Anything unresolvable — no token, no response, malformed JSON — REFUSES. The
+# ticket's rule is explicit and is the whole boundary: if a verified-session
+# message cannot be told apart from an agent's report of one, refuse.
+#
+# THE FRESHNESS BOUND IS NOT THE CALLER'S TO SET, and the shared-value replay is
+# closed by BINDING, not by the window. Iteration 1 shipped both the other way
+# round and olivia's reject measured the consequence: the window was read from
+# GATE_CHANNEL_SESSION_MAX_AGE in the environment of the agent that runs
+# `task answer`, and the residual note named that window as what bounded a replay
+# of a non-unique value — a mitigation set by the party it defends against. Now
+# the ident is REQUIRED (a value is unique to no gate; an ident is unique to one)
+# and the env knob can only TIGHTEN a hardcoded 3600s ceiling. What remains is
+# genuinely residual: a human message naming this ident and this value, inside the
+# hour, cited for this gate, is the human answering this gate.
+#
+# Sets TASK_CS_REASON (why refused), TASK_CS_ORIGIN, TASK_CS_AGE. Returns 0 only
+# when all four conditions hold.
+_gate_channel_session_ok() { # <chat_id> <message_id> <answer_value> <ident>
+  local chat="$1" msg="$2" bind="$3" ident="$4"
+  TASK_CS_REASON="" TASK_CS_ORIGIN="" TASK_CS_AGE=""
+  # (1) same trust anchor as DIVE-1305 — and it resolves TASK_CH_TOKEN for us.
+  if ! _gate_channel_proof_ok "$chat"; then
+    TASK_CS_REASON="chat $chat is not this bot's paired-human DM (not in access.json allowFrom)"
+    return 1
+  fi
+  if [[ ! "$msg" =~ ^[0-9]+$ ]]; then
+    TASK_CS_REASON="--channel-msg is not a numeric Telegram message id"
+    return 1
+  fi
+  if [[ -z "${TASK_CH_TOKEN:-}" ]]; then
+    TASK_CS_REASON="no readable bot token for this channel, so the citation cannot be attested — refused rather than assumed (fail closed)"
+    return 1
+  fi
+  # (2) does Telegram say this message exists in that chat? The forward is the
+  # probe; its own copy is deleted right after, whatever the verdict below.
+  local resp; resp=$(_gate_channel_api "$TASK_CH_TOKEN" forwardMessage     -d "chat_id=${chat}" -d "from_chat_id=${chat}" -d "message_id=${msg}" -d "disable_notification=true")
+  if [[ -z "$resp" ]]; then
+    TASK_CS_REASON="the Bot API returned nothing for forwardMessage (unreachable) — the citation is UNVERIFIED, not accepted"
+    return 1
+  fi
+  local _echo_id; _echo_id=$(jq -r '.result.message_id // empty' <<<"$resp" 2>/dev/null)
+  if [[ -n "$_echo_id" ]]; then
+    _gate_channel_api "$TASK_CH_TOKEN" deleteMessage -d "chat_id=${chat}" -d "message_id=${_echo_id}" >/dev/null 2>&1 || true
+  fi
+  if ! jq -e '.ok == true' <<<"$resp" >/dev/null 2>&1; then
+    local _desc; _desc=$(jq -r '.description // "no description"' <<<"$resp" 2>/dev/null || echo "unparseable response")
+    TASK_CS_REASON="Telegram refused the citation (${_desc}) — message ${msg} is not a live message in chat ${chat}"
+    return 1
+  fi
+  # (3) WHO sent it. forward_origin is Telegram's attribution, not the caller's.
+  local otype osender odate otext
+  otype=$(jq -r '.result.forward_origin.type // empty' <<<"$resp" 2>/dev/null)
+  osender=$(jq -r '.result.forward_origin.sender_user.id // empty' <<<"$resp" 2>/dev/null)
+  odate=$(jq -r '.result.forward_origin.date // empty' <<<"$resp" 2>/dev/null)
+  otext=$(jq -r '.result.text // .result.caption // ""' <<<"$resp" 2>/dev/null)
+  TASK_CS_ORIGIN="${otype:-none}:${osender:-none}"
+  if [[ "$otype" != "user" ]]; then
+    TASK_CS_REASON="the cited message's forward origin is '${otype:-absent}', not a named user — no human sender is attested (a hidden-origin forward attests nobody)"
+    return 1
+  fi
+  if [[ "$osender" != "$chat" ]]; then
+    TASK_CS_REASON="the cited message was sent by user ${osender:-unknown}, not by the paired human of chat ${chat} — the bot's own messages and any third party are refused"
+    return 1
+  fi
+  # (4) FRESH, and about THIS gate.
+  if [[ ! "$odate" =~ ^[0-9]+$ ]]; then
+    TASK_CS_REASON="the cited message carries no usable timestamp, so its freshness cannot be established"
+    return 1
+  fi
+  # THE BOUND MUST NOT COME FROM THE CALLER (olivia, iteration-1 reject). This
+  # window is what stops a stale human line being replayed onto a newer gate, and
+  # the caller of `task answer` IS the agent — so reading it straight from the
+  # environment made the mitigation settable by the party it defends against, with
+  # no forgery needed. Measured on 8312851: a 400-day-old "approved" in the human's
+  # own chat refused at the default (rc=6, gate open) and CLEARED under
+  # GATE_CHANNEL_SESSION_MAX_AGE=999999999 (rc=0, human_evidence=channel-session) —
+  # a row affirmatively attesting a human cleared a tier-2 gate nobody touched.
+  # So the ceiling is hardcoded here and the env knob may only TIGHTEN it: a
+  # deployment that wants a stricter window still gets one, while wider, zero,
+  # negative and non-numeric all fall back to the ceiling itself.
+  local _ceil=3600 _max="${GATE_CHANNEL_SESSION_MAX_AGE:-}"
+  if [[ ! "$_max" =~ ^[0-9]+$ ]] || (( _max <= 0 || _max > _ceil )); then _max=$_ceil; fi
+  local _now _age
+  _now=$(date +%s)
+  _age=$(( _now - odate )); (( _age < 0 )) && _age=0
+  TASK_CS_AGE="$_age"
+  if (( _age > _max )); then
+    TASK_CS_REASON="the cited message is ${_age}s old (limit ${_max}s) — a stale human message must not be replayed onto a newer gate"
+    return 1
+  fi
+  # WHICH GATE, AND WHICH ANSWER — both, not either (olivia, iteration-1 reject).
+  # The first cut cleared on the answer value OR the ident, and each alone leaves a
+  # hole: the VALUE is not unique (an ordinary "approved"/"yes" fits any number of
+  # open gates, which is the shared-value replay the window was wrongly asked to
+  # bound), and the IDENT alone attests only that the human spoke ABOUT this gate —
+  # `--value` still comes from the agent, so a human writing "DIVE-x, no" would
+  # clear it with value=yes. The ident is unique per gate and the value is the
+  # decision, so tier 2 requires the message to carry both. An empty `--value`
+  # (a bare approval) requires the ident alone, because there is no answer string
+  # to corroborate. tier<2 callers who want the loose form already have the
+  # citation-free DIVE-1305 chat-only path, so nothing is lost by making this one
+  # strict for everybody.
+  local _hay _nv _ni
+  _hay=$(printf '%s' "$otext" | tr '[:upper:]' '[:lower:]')
+  _nv=$(printf '%s' "$bind" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+  _ni=$(printf '%s' "$ident" | tr '[:upper:]' '[:lower:]')
+  if [[ -z "$_ni" || "$_hay" != *"$_ni"* ]]; then
+    TASK_CS_REASON="the cited message does not name ${ident}, so it is not attributable to THIS gate — the answer value alone is not unique to one gate"
+    return 1
+  fi
+  if [[ -n "$_nv" && "$_hay" != *"$_nv"* ]]; then
+    TASK_CS_REASON="the cited message names ${ident} but not the answer ('${bind}'), so it does not attest WHICH answer the human gave"
+    return 1
+  fi
+  return 0
+}
+
 # DIVE-1490: append a queryable delivery event for a gate alert. The purpose-
 # built notify log is group-writable for agent-filed gates (DIVE-1345), while
 # audit_log provides the tamper-evident event stream. Failures are ALSO loud on
@@ -7476,7 +7639,7 @@ cmd_task_clear_recs() {
 
 cmd_task_answer() {
   tasks_db_init
-  local value="" value_set=0 from="" human=0 human_proof="" channel_proof=""
+  local value="" value_set=0 from="" human=0 human_proof="" channel_proof="" channel_msg=""
   local -a positional=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -7506,6 +7669,11 @@ cmd_task_answer() {
       # per-gate button tap. This is the "go with recs from your own channel"
       # clear (lodar's chosen scope, DIVE-1305 decision 2026-07-16).
       --channel-proof=*) channel_proof="${1#*=}" ;;
+      # DIVE-2412: the message_id of the human's OWN message in that verified DM.
+      # This is the citation the tier-2 form is built on: the chat id above says
+      # WHICH conversation, and only this says the human actually spoke in it —
+      # and it is checked against Telegram, not against the caller's word.
+      --channel-msg=*) channel_msg="${1#*=}" ;;
       --)        shift; positional+=("$@"); break ;;
       -*)        fail "$E_USAGE" "unknown flag: $1" ;;
       *)         positional+=("$1") ;;
@@ -7597,6 +7765,37 @@ cmd_task_answer() {
   # scope so that stamp reads an initialized 0 on the gate types that never enter
   # that block, rather than an unset variable. Values are still set there, once.
   local _hp=0 _su=0
+
+  # DIVE-2412 (DIVE-2382 fix #4): the CITED-MESSAGE form, which a tier-2 gate DOES
+  # accept. The chat-only proof above stays tier<2 for the reason lodar scoped it
+  # that way — an agent's session already knows the chat id, so alone it proves
+  # only that this bot has a paired human. A citation is different in kind: the
+  # message_id is checked against TELEGRAM (_gate_channel_session_ok), which is the
+  # one party in this system the caller cannot speak for. So the tier-2 floor below
+  # is satisfied by CHANNEL PROOF of the answer, not only by a button tap.
+  #
+  # Order matters: this runs BEFORE the evidence block and the tier-2 floor, and it
+  # is the only thing here that can raise `human` on a tier-2 gate.
+  local _cs_ok=0
+  if [[ -n "$channel_msg" ]]; then
+    [[ -n "$channel_proof" ]] || fail "$E_USAGE" "--channel-msg=<message_id> also needs --channel-proof=<chat_id> — the verified DM the message was sent in"
+    if _gate_channel_session_ok "$channel_proof" "$channel_msg" "${value:-}" "$ident"; then
+      _cs_ok=1
+    else
+      # FAIL CLOSED, AND NAME THE CONDITION. A citation that does not attest must
+      # never fall through to the weaker chat-only form, nor to the generic floor
+      # message below: the caller asserted a human answer and the assertion did
+      # not hold, which is the refusal this ticket is graded on. Nothing above
+      # this point writes to the row, so the gate is still unanswered — that is
+      # the property the refusal arm checks, not merely a non-zero rc.
+      _task_store_audit_log "task answer gate" error 0 -- \
+        "task=$ident" "type=$nt" "tier=$gtier" "reason=channel-session citation did not attest" \
+        "channel_proof=${channel_proof}" "channel_msg=${channel_msg}" "origin=${TASK_CS_ORIGIN:-none}" \
+        "age=${TASK_CS_AGE:-unknown}" "detail=${TASK_CS_REASON:-unknown}" 2>/dev/null || true
+      fail "$E_AUTH_REQUIRED" "$ident: the cited channel message is not usable as the human's answer — ${TASK_CS_REASON:-unattested}. An agent's report of a human answer is not evidence (DIVE-2412), so the gate is still open."
+    fi
+  fi
+  (( _cs_ok )) && human=1
 
   # DIVE-394: approval/secret are HUMAN-ONLY gates. Reject answers that come from
   # an agent acting as itself — that's the DIVE-391 incident, where an Olivia
@@ -7794,13 +7993,16 @@ cmd_task_answer() {
     # "no human evidence ⇒ reject" rule) does not block the very exception granted
     # by the uid block above. Scoped to approval/manual with a matching
     # routed_reviewer (never secret), so no un-routed human gate is affected.
-    local _evid=$(( _hp || _su || _lead_clear || _cp_ok ))
+    # DIVE-2412: _cs_ok is the attested cited-message form. Unlike _cp_ok it is
+    # NOT tier-fenced, so it satisfies the evidence rule on a tier-2 approval too.
+    local _evid=$(( _hp || _su || _lead_clear || _cp_ok || _cs_ok ))
     local _caller2; _caller2=$(id -un 2>/dev/null || echo '?')
     # DIVE-2054: the human-proof/nonce evidence being scored here is stored
     # against $ident in TASKS_DB (not an independent channel/delivery fact like
     # the 3 named exemptions) — fenced.
     _task_store_audit_log "task answer gate" "$([[ $_evid -eq 1 ]] && echo ok || echo error)" 0 -- \
       "task=$ident" "type=$nt" "channel_proof=$([[ -n "$channel_proof" ]] && echo present || echo absent)" "cp_ok=$_cp_ok" \
+      "channel_msg=${channel_msg:-none}" "cs_ok=$_cs_ok" "cs_origin=${TASK_CS_ORIGIN:-none}" "cs_age=${TASK_CS_AGE:-none}" \
       "human_proof=$([[ -n "$human_proof" ]] && echo present || echo absent)" "nonce_valid=$_hp" \
       "sudo_nonagent=$_su" "human=$human" "caller=$_caller2" "sudo_uid=${SUDO_UID:-}" \
       "enforce=$(_gate_proof_enforced && echo on || echo off)"
@@ -7929,15 +8131,28 @@ cmd_task_answer() {
       local _t2_hp=0 _t2_su=0
       [[ -n "$human_proof" ]] && _human_nonce_verify "$id" "$human_proof" && _t2_hp=1
       _gate_sudo_uid_nonagent && _t2_su=1
+      # DIVE-2412: THE CITATION IS THE THIRD EVIDENCE FORM, and it has to be named
+      # HERE rather than only in the `human` flag it also raises. This site is what
+      # decides whether a tier-2 `--human` claim was PROVED, and it is scoped to
+      # gates that HAVE a minted nonce — which is every approval and manual gate,
+      # i.e. exactly the ones this feature exists for. Omitted from this list, the
+      # citation would raise `human`, clear the floor above, and then be refused
+      # here as an unproven claim: the feature would be dead on its main case.
+      # It is admitted on the same footing as the other two because it is not
+      # weaker in kind — the nonce and the non-agent SUDO_UID are both local to
+      # this box, while the citation is attested by Telegram, the one party the
+      # caller cannot speak for (_gate_channel_session_ok).
+      local _t2_cs="${_cs_ok:-0}"
       local _t2_caller; _t2_caller=$(id -un 2>/dev/null || echo '?')
       # DIVE-2054: the nonce being scored is task-store state for $ident — fenced.
       _task_store_audit_log "task answer t2-human-evidence" \
-        "$([[ $(( _t2_hp || _t2_su )) -eq 1 ]] && echo ok || echo error)" 0 -- \
+        "$([[ $(( _t2_hp || _t2_su || _t2_cs )) -eq 1 ]] && echo ok || echo error)" 0 -- \
         "task=$ident" "type=$nt" "tier=$gtier" "nonce_valid=$_t2_hp" "sudo_nonagent=$_t2_su" \
+        "channel_session=$_t2_cs" \
         "human_proof=$([[ -n "$human_proof" ]] && echo present || echo absent)" \
         "caller=$_t2_caller" "sudo_uid=${SUDO_UID:-}" 2>/dev/null || true
-      if (( ! _t2_hp && ! _t2_su )); then
-        fail "$E_AUTH_REQUIRED" "$ident is a tier-2 human gate ($nt) and the --human claim is unproven: no valid per-gate proof and no non-agent SUDO_UID. Tap the button in Telegram (it carries the proof) or answer from the dashboard. A bare 'sudo 5dive task answer --human' is exactly the forge this refuses."
+      if (( ! _t2_hp && ! _t2_su && ! _t2_cs )); then
+        fail "$E_AUTH_REQUIRED" "$ident is a tier-2 human gate ($nt) and the --human claim is unproven: no valid per-gate proof, no non-agent SUDO_UID and no attested channel citation. Tap the button in Telegram (it carries the proof), cite the human's own message with --channel-msg, or answer from the dashboard. A bare 'sudo 5dive task answer --human' is exactly the forge this refuses."
       fi
     fi
   fi
@@ -8053,6 +8268,27 @@ cmd_task_answer() {
   ledger_emit gate.answered ident="$ident" task_id="$id" actor="${_lg_prov:-unknown}" \
     policy="tier${gtier}:${nt}" out="$_vfs" \
     detail="${nt} gate cleared by ${_lg_prov:-<unrecorded>}$([[ "$_lg_prov" == human:* ]] && echo ' (human touchpoint)')"
+
+  # DIVE-2412 acceptance: WHICH evidence form cleared this gate must be
+  # recoverable FROM THE ROW, not only from a log line that can rotate or diverge
+  # from it (DIVE-2090). A tap (`nonce`), a dashboard/on-box exec (`sudo-uid`), the
+  # tier<2 chat-only proof (`channel-chat`) and the tier-2 citation
+  # (`channel-session`) all persist as need_answered_by=human:*, so without this
+  # column the four are indistinguishable afterwards — and `channel-session` is the
+  # only one that cleared a tier-2 gate with nobody touching a button. That
+  # distinction is the audit question this feature creates, so it is stored, not
+  # derived. `+`-joined when more than one form was present; `none` when a
+  # non-human path (a decision gate, an auto-answer) wrote the row.
+  # _hp/_su are function-scope locals initialized to 0 since DIVE-2406, and the
+  # other flags are set only on the paths that raise them — hence the :-0
+  # defaults, which are belt-and-braces rather than a guess.
+  local _evform=""
+  [[ "${_hp:-0}" == "1" ]] && _evform="${_evform:+$_evform+}nonce"
+  [[ "${_su:-0}" == "1" ]] && _evform="${_evform:+$_evform+}sudo-uid"
+  [[ "${_cs_ok:-0}" == "1" ]] && _evform="${_evform:+$_evform+}channel-session"
+  [[ "${_cp_ok:-0}" == "1" ]] && _evform="${_evform:+$_evform+}channel-chat"
+  [[ "${_lead_clear:-0}" == "1" ]] && _evform="${_evform:+$_evform+}lead"
+  db "UPDATE tasks SET human_evidence=$(sqlq "${_evform:-none}") WHERE id=${id};"
 
   # DIVE-2099: the authoritative record of a STANDING-authority clear. Emitted
   # AFTER the write and reading `need_answered_by` BACK OUT of the row, so it

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -1003,7 +1003,8 @@ _tasks_db_migrate() {
            'shipped_flag_at TEXT' 'routed_reviewer TEXT' \
            'delivery_ref TEXT' 'delivered_at TEXT' \
            'originated_by_objective INTEGER' 'originated_cycle INTEGER' \
-           'verify_unavailable INTEGER' 'last_skipped_at TEXT'; do
+           'verify_unavailable INTEGER' 'last_skipped_at TEXT' \
+           'human_evidence TEXT'; do
     # DIVE-2418: herestring, NOT a pipe. `printf | grep -q` lets grep exit on its
     # first match while printf is still writing, and printf then takes SIGPIPE and
     # emits "write error: Broken pipe" on stderr. This runs from tasks_db_init on

--- a/tests/gate_channel_session_t2_mutation.sh
+++ b/tests/gate_channel_session_t2_mutation.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# DIVE-2412 mutation grader for tests/gate_channel_session_t2_unit.sh.
+#
+# WHY THIS FILE EXISTS. Most of what DIVE-2412 ships is REFUSALS, and "it must
+# not accept an agent's claim" is an absence-assertion: an arm that only checks a
+# non-zero rc stays green when the condition it is supposed to be guarding is
+# deleted, because some other refusal fires instead and the rc is the same. The
+# ticket asks for exactly this: force each path and confirm the refusal is the
+# one being claimed. So each mutant below DELETES ONE condition from a copy of
+# src and requires the NAMED arm to go red. A mutant that leaves the suite green
+# means that arm grades nothing.
+#
+# The acceptance direction is graded too (M6, M7): a suite made only of refusals
+# passes trivially on code that refuses everything, which would ship a tier-2
+# gate that no channel proof can ever clear.
+#
+# Every mutant asserts its own application (exactly one occurrence, or the run
+# fails loudly) — a mutation that silently no-ops after a refactor would
+# otherwise read as a passing grade.
+# Run: bash tests/gate_channel_session_t2_mutation.sh
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source.
+# NOTE the absence of `2>/dev/null`. Redirecting the source's stderr would also
+# swallow the helper's own stderr line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+TMP="$(mktemp -d /tmp/gate-cs-mut.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# grade <name> <expected-red-arm-substring> <old> <new>
+grade() {
+  local name="$1" want="$2" old="$3" new="$4"
+  local dir="$TMP/$name"; rm -rf "$dir"; mkdir -p "$dir"
+  cp -r src "$dir/src"
+  if ! OLD="$old" NEW="$new" F="$dir/src/cmd_task.sh" python3 - <<'PY'
+import os, sys
+p, old, new = os.environ["F"], os.environ["OLD"], os.environ["NEW"]
+s = open(p).read()
+n = s.count(old)
+if n != 1:
+    sys.stderr.write("mutation did not apply cleanly: %d occurrences of %r\n" % (n, old[:90]))
+    sys.exit(1)
+open(p, "w").write(s.replace(old, new))
+PY
+  then
+    bad_t "$name — mutation applies to the current source" "the anchor is gone or duplicated; this mutant graded NOTHING"
+    return
+  fi
+  local out rc
+  out=$(CS_SRC_DIR="$dir/src" CS_MUTATED="$name" bash tests/gate_channel_session_t2_unit.sh 2>&1); rc=$?
+  if [[ $rc -eq 0 ]]; then
+    bad_t "$name — the suite must go RED" "suite stayed GREEN with the condition removed: the '$want' arm grades nothing"
+    return
+  fi
+  if grep -q "FAIL - .*${want}" <<<"$out"; then
+    ok_t "$name — kills the '$want' arm"
+  else
+    bad_t "$name — kills the '$want' arm" "suite failed, but NOT on that arm: $(grep '^FAIL' <<<"$out" | head -3)"
+  fi
+}
+
+# ── the refusal conditions, one at a time ────────────────────────────────────
+grade "M1-sender-check" "CS4 a message from a DIFFERENT sender" \
+  '  if [[ "$osender" != "$chat" ]]; then' \
+  '  if false; then'
+
+grade "M2-freshness" "CS6 a STALE cited message" \
+  '  if (( _age > _max )); then' \
+  '  if false; then'
+
+grade "M3-origin-type" "CS5 a HIDDEN forward origin" \
+  '  if [[ "$otype" != "user" ]]; then' \
+  '  if false; then'
+
+# NOTE the expected arm: not CS3's rc arm but its REASON arm. Deleting the
+# existence check still yields a non-zero rc (the error payload has no
+# forward_origin, so the attribution check refuses instead), so only the arm that
+# reads the reason can tell which condition fired. Measured on this tree.
+grade "M4-existence" "CS3 the refusal names the condition" \
+  "  if ! jq -e '.ok == true' <<<\"\$resp\" >/dev/null 2>&1; then" \
+  '  if false; then'
+
+# The binding is now TWO conditions (iteration 2), so it takes two mutants: one
+# for "which gate" and one for "which answer". A single either/or mutant would
+# have left whichever half survived ungraded — which is how the value-only clear
+# reached iteration 1.
+grade "M5a-ident-required" "CS7 a message naming the ANSWER VALUE only" \
+  '  if [[ -z "$_ni" || "$_hay" != *"$_ni"* ]]; then' \
+  '  if false; then'
+
+grade "M5b-answer-required" "CS7 a message naming the IDENT only" \
+  '  if [[ -n "$_nv" && "$_hay" != *"$_nv"* ]]; then' \
+  '  if false; then'
+
+grade "M6-token-failclosed" "CS8 an UNATTESTABLE citation" \
+  '  if [[ -z "${TASK_CH_TOKEN:-}" ]]; then' \
+  '  if false; then'
+
+# ── the tier fence: chat-only proof must NOT reach tier 2 ────────────────────
+# This is the mutant that matters most, because it is the shape of the bug the
+# ticket warns against — widening the DIVE-1305 form instead of adding an
+# attested one.
+#
+# THE EXPECTED ARM IS THE DECISION ONE, and which arm that is changed on the
+# rebase onto main. On an APPROVAL gate the widened fence is now caught one guard
+# further down as well (main's DIVE-2233 site refuses an unproven tier-2 --human
+# claim, and every approval gate has a minted nonce), so CS2 stays green and no
+# longer isolates the fence. A tier-2 DECISION gate mints no nonce, so that site
+# is skipped and the fence is the ONLY thing standing there — measured: with the
+# fence widened, CS11's uncited relay CLEARS. That is the arm that grades it.
+grade "M7-tier-fence-widened" "CS11 the same tier-2 DECISION gate REFUSES" \
+  '  if [[ -n "$channel_proof" && "$gtier" != "2" ]]; then' \
+  '  if [[ -n "$channel_proof" ]]; then'
+
+# ── the acceptance direction, so the suite is not "refuses everything" ───────
+grade "M8-accept-path-dead" "CS1 tier-2 gate CLEARS" \
+  '      _cs_ok=1' \
+  '      _cs_ok=0'
+
+grade "M9-form-not-recorded" "CS1 records the form as channel-session" \
+  '  db "UPDATE tasks SET human_evidence=$(sqlq "${_evform:-none}") WHERE id=${id};"' \
+  '  : "${_evform:-none}"'
+
+# ── the tier-2 floor itself, which is the ONLY guard on a decision gate ──────
+# The approval/secret/manual evidence block does not run for `decision`, so if the
+# citation stopped raising `human` the decision arms would be the ones to notice.
+grade "M10-floor-provenance" "CS11 the same tier-2 DECISION gate REFUSES" \
+  '  if [[ "$gtier" == "2" ]] && (( ! human )) && _gate_proof_enforced; then' \
+  '  if false; then'
+
+# ── the freshness bound, which iteration 1 let the caller set ────────────────
+# M11 removes the clamp and leaves the raw env read that olivia measured the
+# bypass on; the CS12 red-team arm must be what goes red. M12 kills the env read
+# entirely, which must take the LIVENESS arm red instead — without it, "clamped"
+# and "hardcoded, env ignored" would be indistinguishable and the tighten-only
+# contract would be an untested claim.
+grade "M11-window-clamp-removed" "CS12 a caller-WIDENED window" \
+  '|| (( _max <= 0 || _max > _ceil )); then _max=$_ceil; fi' \
+  '; then _max=$_ceil; fi'
+
+grade "M12-window-knob-dead" "CS12 a TIGHTER window from the env" \
+  '  local _ceil=3600 _max="${GATE_CHANNEL_SESSION_MAX_AGE:-}"' \
+  '  local _ceil=3600 _max=""'
+
+# ── the DIVE-2233 tier-2 evidence site, which is where the citation is ADMITTED ──
+# Found on the rebase onto main: raising `human` clears the floor, and then this
+# site refuses the claim as unproven unless the citation is listed among the
+# evidence forms. Every approval/manual gate has a minted nonce, so every one of
+# them lands inside that branch — dropping `_t2_cs` kills the feature on its main
+# case while leaving all twelve mutants above green.
+grade "M13-t2-evidence-omits-citation" "CS1 tier-2 gate CLEARS" \
+  '      if (( ! _t2_hp && ! _t2_su && ! _t2_cs )); then' \
+  '      if (( ! _t2_hp && ! _t2_su )); then'
+
+printf '\ngate_channel_session_t2_mutation: %d mutants killed, %d ungraded\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/gate_channel_session_t2_unit.sh
+++ b/tests/gate_channel_session_t2_unit.sh
@@ -61,9 +61,27 @@ tasks_db_init
 task_need_notify() { :; }
 audit_log() { :; }
 # Post-sudo human context: the immediate caller is root, which passes the
-# DIVE-394 agent-uid block. `id -u` is NOT stubbed, so _gate_sudo_uid_nonagent
-# still resolves this harness's real (agent-*) uid and stays 0 — the accept arm
-# below therefore cannot pass through the sudo-uid form by accident.
+# DIVE-394 agent-uid block.
+#
+# THE SUDO-UID SEAM IS PINNED, and iteration 2 is where that stopped being
+# optional. `_gate_sudo_uid_nonagent` (src/lib/tasks_db.sh) resolves the caller's
+# uid through the HOST's passwd database and answers "is this a human?" with
+# "the account is not named agent-*". Leaving it unstubbed did not model an agent
+# caller — it modelled WHOEVER RAN THE SUITE. On an agent-* box it returned false
+# and the evform arms read `channel-session` / `nonce` exactly; on a CI runner
+# (account `runner`) the very same code returns TRUE, `_su=1`, and every human
+# form silently gains `+sudo-uid`. Measured, not reasoned: run 30542542143 failed
+# exactly the two exact-string arms with `sudo-uid+channel-session` and
+# `nonce+sudo-uid`, and `sudo -u claude` on this box reproduces both. That is
+# tests/test_that_needs_the_host_is_not_a_test — the arm graded the runner.
+#
+# So the answer is a pin, not a looser assertion: an agent-* caller is the
+# PREMISE of this whole feature (the tier-2 citation exists because the caller is
+# an agent that cannot speak for the human), and CS13 below flips the pin to the
+# non-agent case so the pin is differential rather than a way to keep quiet.
+# 1 = false = an agent-* caller contributes no sudo-uid evidence.
+_PIN_SUDO_HUMAN=1
+_gate_sudo_uid_nonagent() { return "$_PIN_SUDO_HUMAN"; }
 FAKE_CALLER="root"
 id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
 # ...and the UID SEAM, which is what the human-only block actually reads since
@@ -74,8 +92,8 @@ id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@";
 # sibling harnesses do (gate_channel_proof_unit, gate_nonce_unit). 0 is the
 # root-side invocation the channel forms run under: `task inbox --send` and the
 # plugin's clear path are root-side, as the DIVE-1305 help line says. It grants
-# nothing on its own — SUDO_UID is unset here, so _gate_sudo_uid_nonagent stays 0
-# and the CS1 evform arm below still requires channel-session ALONE.
+# nothing on its own — the sudo-uid form is pinned off above, so the CS1 evform
+# arm below still requires channel-session ALONE.
 _PIN_UID=0
 _gate_caller_uid() { printf '%s' "$_PIN_UID"; }
 
@@ -368,6 +386,33 @@ unset GATE_CHANNEL_SESSION_MAX_AGE
 [[ $rc -eq 0 && "$(answered DIVE-2412020)" == "closed" ]] \
   && ok_t "CS12 a NON-NUMERIC window falls back to the ceiling (neither wider nor bricked)" \
   || bad_t "CS12 a NON-NUMERIC window falls back to the ceiling (neither wider nor bricked)" "rc=$rc state=$(answered DIVE-2412020) out=$out"
+
+# ── CS13 the sudo-uid pin is DIFFERENTIAL, not a way to keep the harness quiet ─
+# Every exact-string evform arm above depends on `_PIN_SUDO_HUMAN=1`. A pin that
+# is never flipped is indistinguishable from deleting the condition it pins, so
+# flip it: model the non-agent caller (the CI runner, a dashboard exec) and
+# require the column to GAIN the sudo-uid term and keep the citation term. This
+# is the state run 30542542143 was actually in, so the arm doubles as the
+# regression the iteration-2 CI red is named after: if the pin ever stops
+# controlling this, one of the two directions goes red instead of the host
+# deciding which.
+seed_t2_approval DIVE-2412021
+CS_RESP=$(fwd user "$HUMAN_CHAT" 30 "DIVE-2412021 approved")
+_PIN_SUDO_HUMAN=0
+out=$(cmd_task_answer DIVE-2412021 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15510 2>&1); rc=$?
+_PIN_SUDO_HUMAN=1
+[[ $rc -eq 0 && "$(evform DIVE-2412021)" == "sudo-uid+channel-session" ]] \
+  && ok_t "CS13 a NON-agent caller records sudo-uid ALONGSIDE channel-session (the pin is live)" \
+  || bad_t "CS13 a NON-agent caller records sudo-uid ALONGSIDE channel-session (the pin is live)" "rc=$rc form='$(evform DIVE-2412021)' out=$out"
+
+# ...and the agent-caller direction re-asserted on a FRESH gate, so the pair is a
+# genuine A/B on one seam rather than one measurement and one memory.
+seed_t2_approval DIVE-2412022
+CS_RESP=$(fwd user "$HUMAN_CHAT" 30 "DIVE-2412022 approved")
+out=$(cmd_task_answer DIVE-2412022 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15511 2>&1); rc=$?
+[[ $rc -eq 0 && "$(evform DIVE-2412022)" == "channel-session" ]] \
+  && ok_t "CS13 the SAME citation as an agent-* caller records channel-session ALONE" \
+  || bad_t "CS13 the SAME citation as an agent-* caller records channel-session ALONE" "rc=$rc form='$(evform DIVE-2412022)' out=$out"
 
 printf '\ngate_channel_session_t2_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/gate_channel_session_t2_unit.sh
+++ b/tests/gate_channel_session_t2_unit.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# DIVE-2412 (DIVE-2382 fix #4) isolated unit harness: a TIER-2 gate cleared by
+# CHANNEL PROOF of the human's answer instead of a button tap.
+#
+# What is under test — `_gate_channel_session_ok` + its use in `task answer`:
+#   * a tier-2 gate answered from the human's OWN verified DM, citing the
+#     human's OWN message id, clears with NO tap and NO nonce, and the row
+#     records WHICH form cleared it (human_evidence=channel-session),
+#   * every way the citation can fail to attest REFUSES, each with its own
+#     reason: no such message, wrong sender, hidden origin, stale, unrelated
+#     text, unreadable token, un-allowlisted chat,
+#   * the agent-relayed assertion — a chat id with no citation, i.e. "he told
+#     me" — is still refused on tier 2, exactly as before DIVE-2412,
+#   * the tier<2 chat-only form (DIVE-1305) is UNCHANGED and stays
+#     distinguishable from this one on the row.
+#
+# The refusal arms assert MORE than a non-zero rc: they assert the guarded
+# action never happened (the gate is still unanswered, no evidence recorded).
+# An rc-only refusal arm stays green when the refusal's CONDITION is deleted.
+# Their grading is tests/gate_channel_session_t2_mutation.sh, which deletes each
+# condition in turn and requires the named arm below to go red.
+#
+# Isolation matches the sibling harnesses: source src/ libs, throwaway
+# STATE_DIR, no network (the Bot API seam is stubbed), the live shared tasks.db
+# is NEVER touched.  Run: bash tests/gate_channel_session_t2_unit.sh
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+TMP="$(mktemp -d /tmp/gate-cs-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# The harness sources a COPY of src, and CS_SRC_DIR lets the mutation runner
+# point it at a staged defect without touching the tree. CS_MUTATED is named in
+# the banner, so a mutant log can never be mistaken for a clean run.
+SRC="$TMP/src"
+cp -r "${CS_SRC_DIR:-src}" "$SRC"
+if [[ -n "${CS_MUTATED:-}" ]]; then
+  printf 'NOTE: running against a MUTATED source (%s)\n' "$CS_MUTATED" >&2
+fi
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh cmd_task.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+GATE_PROOF_KEY="$STATE_DIR/gate-proof.key"
+GATE_PROOF_ENFORCE="$STATE_DIR/gate-proof.enforce"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"; set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+tasks_db_init
+task_need_notify() { :; }
+audit_log() { :; }
+# Post-sudo human context: the immediate caller is root, which passes the
+# DIVE-394 agent-uid block. `id -u` is NOT stubbed, so _gate_sudo_uid_nonagent
+# still resolves this harness's real (agent-*) uid and stays 0 — the accept arm
+# below therefore cannot pass through the sudo-uid form by accident.
+FAKE_CALLER="root"
+id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+# ...and the UID SEAM, which is what the human-only block actually reads since
+# DIVE-2330 iteration 2 replaced its `id -un` with _gate_caller_uid (EUID). Pinning
+# only the NAME above stopped modelling the caller at that point: on an agent-*
+# runner the guard fired on the RUNNER'S OWN uid and `fail` exited this sourced
+# harness mid-suite — the shape DIVE-2330's own comment names. Pinned the way the
+# sibling harnesses do (gate_channel_proof_unit, gate_nonce_unit). 0 is the
+# root-side invocation the channel forms run under: `task inbox --send` and the
+# plugin's clear path are root-side, as the DIVE-1305 help line says. It grants
+# nothing on its own — SUDO_UID is unset here, so _gate_sudo_uid_nonagent stays 0
+# and the CS1 evform arm below still requires channel-session ALONE.
+_PIN_UID=0
+_gate_caller_uid() { printf '%s' "$_PIN_UID"; }
+
+seed_task() { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
+answered() { db "SELECT CASE WHEN need_answered_at IS NULL THEN 'open' ELSE 'closed' END FROM tasks WHERE ident='$1';"; }
+prov()     { db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident='$1';"; }
+evform()   { db "SELECT COALESCE(human_evidence,'') FROM tasks WHERE ident='$1';"; }
+
+# A tier-2 hard gate, seeded the way the sibling harness does it (file at tier 1,
+# then set the stored tier) so the T2 category heuristic and the lead-routing
+# path are not what is under test here.
+seed_t2_approval() {
+  seed_task "$1"
+  cmd_task_need "$1" --type=approval --ask="ship it?" --recommend=approved --tier=1 >/dev/null 2>&1
+  db "UPDATE tasks SET tier='2' WHERE ident='$1';"
+}
+
+# ── the paired human's verified DM, and the Bot API seam ──────────────────────
+HUMAN_CHAT=555            # reserved fake; see CLAUDE.md "never use a real identifier"
+ACCESS="$TMP/access.json"
+printf '{"allowFrom":["555"],"groups":{"-100200":{}}}' > "$ACCESS"
+CS_TOKEN="TESTTOKEN"
+_task_owner_channel() { TASK_CH_ACCESS="$ACCESS"; TASK_CH_TOKEN="$CS_TOKEN"; TASK_CH_TYPE="claude"; return 0; }
+
+API_LOG="$TMP/api.log"; : > "$API_LOG"
+CS_RESP=""
+_gate_channel_api() { # <token> <method> [args...]
+  local method="$2"; shift 2
+  printf '%s %s\n' "$method" "$*" >> "$API_LOG"
+  case "$method" in
+    forwardMessage) printf '%s' "$CS_RESP" ;;
+    deleteMessage)  printf '{"ok":true,"result":true}' ;;
+    *)              printf '{"ok":false,"description":"unexpected method"}' ;;
+  esac
+}
+
+# Telegram's forwardMessage reply for a message sent <age>s ago.
+fwd() { # <origin_type> <sender_id> <age_sec> <text>
+  local now; now=$(date +%s)
+  jq -nc --arg t "$1" --argjson s "$2" --argjson d "$(( now - $3 ))" --arg x "$4" \
+    '{ok:true, result:{message_id:9001, text:$x, forward_origin:{type:$t, sender_user:{id:$s}, date:$d}}}'
+}
+
+touch "$GATE_PROOF_ENFORCE"   # enforcement ON for every clear below
+
+# ── CS1 ACCEPT: a tier-2 gate clears from the channel, with no tap ────────────
+# The live illustration from the ticket: the human says what they chose in their
+# own chat, and that message — not a re-entered button press — is the evidence.
+seed_t2_approval DIVE-2412001
+CS_RESP=$(fwd user "$HUMAN_CHAT" 30 "DIVE-2412001 yes, approved - go ahead and ship it")
+out=$(cmd_task_answer DIVE-2412001 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15495 2>&1); rc=$?
+[[ $rc -eq 0 && "$(answered DIVE-2412001)" == "closed" ]] \
+  && ok_t "CS1 tier-2 gate CLEARS on an attested channel citation (no tap, no nonce)" \
+  || bad_t "CS1 tier-2 gate CLEARS on an attested channel citation (no tap, no nonce)" "rc=$rc state=$(answered DIVE-2412001) out=$out"
+[[ "$(prov DIVE-2412001)" == human:* ]] \
+  && ok_t "CS1 provenance is human-sourced" || bad_t "CS1 provenance is human-sourced" "got '$(prov DIVE-2412001)'"
+# Non-vacuity anchor: the clear must be attributable to THIS form alone. If
+# nonce or sudo-uid had also been present, the arm above would pass without the
+# new code doing anything.
+[[ "$(evform DIVE-2412001)" == "channel-session" ]] \
+  && ok_t "CS1 records the form as channel-session ONLY (no nonce, no sudo-uid)" \
+  || bad_t "CS1 records the form as channel-session ONLY (no nonce, no sudo-uid)" "got '$(evform DIVE-2412001)'"
+grep -q "deleteMessage .*message_id=9001" "$API_LOG" \
+  && ok_t "CS1 the forwarded probe copy is deleted (a probe, not a post)" \
+  || bad_t "CS1 the forwarded probe copy is deleted (a probe, not a post)" "$(cat "$API_LOG")"
+
+# ── CS2 REFUSE: the agent-relayed assertion — a chat id and no citation ───────
+# This is the boundary the ticket says not to soften: `from=`/a quoted claim is
+# caller-supplied. Nothing here attests the human spoke, so tier 2 refuses.
+seed_t2_approval DIVE-2412002
+out=$(cmd_task_answer DIVE-2412002 --value=approved --channel-proof=$HUMAN_CHAT 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-2412002)" == "open" ]] \
+  && ok_t "CS2 agent-relayed assertion (chat id, no citation) is REFUSED on tier 2" \
+  || bad_t "CS2 agent-relayed assertion (chat id, no citation) is REFUSED on tier 2" "rc=$rc state=$(answered DIVE-2412002) out=$out"
+[[ -z "$(evform DIVE-2412002)" ]] \
+  && ok_t "CS2 no evidence form was recorded for the refused relay" \
+  || bad_t "CS2 no evidence form was recorded for the refused relay" "got '$(evform DIVE-2412002)'"
+
+# ── CS3 REFUSE: the cited message does not exist ──────────────────────────────
+seed_t2_approval DIVE-2412003
+CS_RESP='{"ok":false,"description":"Bad Request: message to forward not found"}'
+out=$(cmd_task_answer DIVE-2412003 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=999999 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-2412003)" == "open" ]] \
+  && ok_t "CS3 an invented message id is REFUSED (Telegram says no such message)" \
+  || bad_t "CS3 an invented message id is REFUSED (Telegram says no such message)" "rc=$rc state=$(answered DIVE-2412003) out=$out"
+# The rc arm above is NOT the grader for the existence check, and this is
+# measured, not assumed: with `.ok == true` deleted the run still refused (the
+# error payload carries no forward_origin, so the attribution check fired) and
+# the rc stayed non-zero. Only the REASON arm below distinguishes which refusal
+# happened, which is why it exists.
+[[ "$out" == *"not a live message"* ]] \
+  && ok_t "CS3 the refusal names the condition (message not live)" \
+  || bad_t "CS3 the refusal names the condition (message not live)" "out=$out"
+
+# ── CS4 REFUSE: the cited message was sent by someone else (or by the bot) ────
+seed_t2_approval DIVE-2412004
+CS_RESP=$(fwd user 1234567890 30 "DIVE-2412004 approved, go ahead")
+out=$(cmd_task_answer DIVE-2412004 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15496 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-2412004)" == "open" ]] \
+  && ok_t "CS4 a message from a DIFFERENT sender is REFUSED" \
+  || bad_t "CS4 a message from a DIFFERENT sender is REFUSED" "rc=$rc state=$(answered DIVE-2412004) out=$out"
+[[ "$out" == *"not by the paired human"* ]] \
+  && ok_t "CS4 the refusal names the condition (sender mismatch)" \
+  || bad_t "CS4 the refusal names the condition (sender mismatch)" "out=$out"
+
+# ── CS5 REFUSE: forward origin hidden by the sender's privacy setting ─────────
+# THE FIXTURE CARRIES A MATCHING sender_user.id ON PURPOSE, and the reason is the
+# whole value of this arm. A real hidden_user origin has no sender_user at all,
+# so the natural fixture is refused by the SENDER check one condition down and
+# this arm would grade that instead — measured: deleting the origin-type check
+# left the suite green (M3). Pairing a non-user origin with a present, matching
+# sender id isolates the one condition named here: the code must require an
+# explicitly attributed USER origin, not merely a sender field that happens to
+# sit next to an origin type Telegram did not attribute to a person.
+seed_t2_approval DIVE-2412005
+CS_RESP='{"ok":true,"result":{"message_id":9001,"text":"DIVE-2412005 approved","forward_origin":{"type":"hidden_user","sender_user_name":"Someone","sender_user":{"id":555},"date":'"$(date +%s)"'}}}'
+out=$(cmd_task_answer DIVE-2412005 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15497 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-2412005)" == "open" ]] \
+  && ok_t "CS5 a HIDDEN forward origin is REFUSED (it attests nobody)" \
+  || bad_t "CS5 a HIDDEN forward origin is REFUSED (it attests nobody)" "rc=$rc state=$(answered DIVE-2412005) out=$out"
+[[ "$out" == *"not a named user"* ]] \
+  && ok_t "CS5 the refusal names the condition (origin attributed to no user)" \
+  || bad_t "CS5 the refusal names the condition (origin attributed to no user)" "out=$out"
+
+# ── CS6 REFUSE: a stale message replayed onto a newer gate ───────────────────
+seed_t2_approval DIVE-2412006
+CS_RESP=$(fwd user "$HUMAN_CHAT" 7200 "DIVE-2412006 approved")
+out=$(cmd_task_answer DIVE-2412006 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15498 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-2412006)" == "open" ]] \
+  && ok_t "CS6 a STALE cited message is REFUSED (no replay onto a newer gate)" \
+  || bad_t "CS6 a STALE cited message is REFUSED (no replay onto a newer gate)" "rc=$rc state=$(answered DIVE-2412006) out=$out"
+[[ "$out" == *"limit 3600s"* ]] \
+  && ok_t "CS6 the refusal names the condition (age vs limit)" \
+  || bad_t "CS6 the refusal names the condition (age vs limit)" "out=$out"
+
+# ── CS7 REFUSE: a real, fresh human message about something else ─────────────
+seed_t2_approval DIVE-2412007
+CS_RESP=$(fwd user "$HUMAN_CHAT" 30 "morning, what is on the board today")
+out=$(cmd_task_answer DIVE-2412007 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15499 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-2412007)" == "open" ]] \
+  && ok_t "CS7 a human message naming neither the answer nor the task is REFUSED" \
+  || bad_t "CS7 a human message naming neither the answer nor the task is REFUSED" "rc=$rc state=$(answered DIVE-2412007) out=$out"
+# ── CS7 REFUSE: it names the ANSWER but no gate — the shared-value replay ────
+# olivia's iteration-1 note: a value is unique to NO gate. "approved"/"yes" fits
+# every open approval, so accepting it made an ordinary old agreement in the
+# human's chat sufficient for a gate they never saw. The ident is required.
+seed_t2_approval DIVE-2412015
+CS_RESP=$(fwd user "$HUMAN_CHAT" 30 "yes, approved, go ahead")
+out=$(cmd_task_answer DIVE-2412015 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15504 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-2412015)" == "open" ]] \
+  && ok_t "CS7 a message naming the ANSWER VALUE only is REFUSED (a value is unique to no gate)" \
+  || bad_t "CS7 a message naming the ANSWER VALUE only is REFUSED (a value is unique to no gate)" "rc=$rc state=$(answered DIVE-2412015) out=$out"
+[[ "$out" == *"does not name DIVE-2412015"* ]] \
+  && ok_t "CS7 the refusal names the condition (ident missing)" \
+  || bad_t "CS7 the refusal names the condition (ident missing)" "out=$out"
+
+# ── CS7 REFUSE: it names the GATE but not the answer — `--value` is the agent's ─
+# The ident alone attests only that the human spoke ABOUT this gate. The answer
+# still arrives from the agent, so a human writing "DIVE-x, no" would otherwise
+# clear it with --value=yes.
+seed_t2_approval DIVE-2412008
+CS_RESP=$(fwd user "$HUMAN_CHAT" 30 "go ahead on DIVE-2412008")
+out=$(cmd_task_answer DIVE-2412008 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15500 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-2412008)" == "open" ]] \
+  && ok_t "CS7 a message naming the IDENT only is REFUSED (it does not attest WHICH answer)" \
+  || bad_t "CS7 a message naming the IDENT only is REFUSED (it does not attest WHICH answer)" "rc=$rc state=$(answered DIVE-2412008) out=$out"
+[[ "$out" == *"not the answer"* ]] \
+  && ok_t "CS7 the refusal names the condition (answer missing)" \
+  || bad_t "CS7 the refusal names the condition (answer missing)" "out=$out"
+
+# ...and BOTH together clear, which is what keeps the two arms above binding
+# checks rather than a suite that refuses everything.
+seed_t2_approval DIVE-2412016
+CS_RESP=$(fwd user "$HUMAN_CHAT" 30 "on DIVE-2412016: approved, go ahead")
+out=$(cmd_task_answer DIVE-2412016 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15505 2>&1); rc=$?
+[[ $rc -eq 0 && "$(answered DIVE-2412016)" == "closed" ]] \
+  && ok_t "CS7 a message naming BOTH the ident and the answer is accepted (binding, not text luck)" \
+  || bad_t "CS7 a message naming BOTH the ident and the answer is accepted (binding, not text luck)" "rc=$rc state=$(answered DIVE-2412016) out=$out"
+
+# ── CS8 REFUSE: the citation cannot be attested at all ───────────────────────
+seed_t2_approval DIVE-2412009
+CS_TOKEN=""; CS_RESP=$(fwd user "$HUMAN_CHAT" 30 "DIVE-2412009 approved")
+out=$(cmd_task_answer DIVE-2412009 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15501 2>&1); rc=$?
+CS_TOKEN="TESTTOKEN"
+[[ $rc -ne 0 && "$(answered DIVE-2412009)" == "open" ]] \
+  && ok_t "CS8 an UNATTESTABLE citation (no token) REFUSES rather than assumes" \
+  || bad_t "CS8 an UNATTESTABLE citation (no token) REFUSES rather than assumes" "rc=$rc state=$(answered DIVE-2412009) out=$out"
+
+# ── CS9 REFUSE: a chat that is not the paired human's DM ─────────────────────
+seed_t2_approval DIVE-2412010
+CS_RESP=$(fwd user 999 30 "DIVE-2412010 approved")
+out=$(cmd_task_answer DIVE-2412010 --value=approved --channel-proof=999 --channel-msg=15502 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-2412010)" == "open" ]] \
+  && ok_t "CS9 a citation in a NON-allowlisted chat is REFUSED" \
+  || bad_t "CS9 a citation in a NON-allowlisted chat is REFUSED" "rc=$rc state=$(answered DIVE-2412010) out=$out"
+
+# ── CS10 DISTINCTNESS: the three human forms stay tellable apart on the row ──
+# Without this, "records which form" would pass on a column that says the same
+# thing for a tap, a dashboard clear and a channel citation.
+seed_task DIVE-2412011
+cmd_task_need DIVE-2412011 --type=decision --ask="pick" --options="A|B" --recommend="A" --tier=1 >/dev/null 2>&1
+cmd_task_answer DIVE-2412011 --value=A --channel-proof=$HUMAN_CHAT >/dev/null 2>&1
+[[ "$(answered DIVE-2412011)" == "closed" && "$(evform DIVE-2412011)" == "channel-chat" ]] \
+  && ok_t "CS10 the tier<2 chat-only form (DIVE-1305) still clears and records channel-chat" \
+  || bad_t "CS10 the tier<2 chat-only form (DIVE-1305) still clears and records channel-chat" "state=$(answered DIVE-2412011) form='$(evform DIVE-2412011)'"
+
+seed_t2_approval DIVE-2412012
+db "UPDATE tasks SET human_nonce_hash=$(sqlq "$(_human_nonce_sha NONCE123)") WHERE ident='DIVE-2412012';"
+cmd_task_answer DIVE-2412012 --value=approved --human --human-proof=NONCE123 >/dev/null 2>&1
+[[ "$(answered DIVE-2412012)" == "closed" && "$(evform DIVE-2412012)" == "nonce" ]] \
+  && ok_t "CS10 a real TAP records nonce — distinct from channel-session" \
+  || bad_t "CS10 a real TAP records nonce — distinct from channel-session" "state=$(answered DIVE-2412012) form='$(evform DIVE-2412012)'"
+
+# ── CS11 the MOTIVATING SHAPE: a tier-2 DECISION gate, not an approval ───────
+# Every arm above uses a tier-2 approval, and that is NOT the case the ticket was
+# filed from. DIVE-2247 was a `decision` gate floored to tier 2, and decision
+# takes a different route through cmd_task_answer: the approval/secret/manual
+# evidence block is skipped entirely, so the tier-2 provenance floor is the only
+# thing standing there. A suite that only ever files approvals would leave the
+# path this feature exists for ungraded in both directions.
+seed_task DIVE-2412013
+cmd_task_need DIVE-2412013 --type=decision --ask="ship tonight or hold?" --options="ship-now|hold-schedule" --recommend="hold-schedule" --tier=1 >/dev/null 2>&1
+db "UPDATE tasks SET tier='2' WHERE ident='DIVE-2412013';"
+CS_RESP=$(fwd user "$HUMAN_CHAT" 45 "DIVE-2412013: went with hold-schedule, do that")
+out=$(cmd_task_answer DIVE-2412013 --value=hold-schedule --channel-proof=$HUMAN_CHAT --channel-msg=15503 2>&1); rc=$?
+[[ $rc -eq 0 && "$(answered DIVE-2412013)" == "closed" && "$(evform DIVE-2412013)" == "channel-session" ]] \
+  && ok_t "CS11 a tier-2 DECISION gate (the DIVE-2247 shape) clears on the citation" \
+  || bad_t "CS11 a tier-2 DECISION gate (the DIVE-2247 shape) clears on the citation" "rc=$rc state=$(answered DIVE-2412013) form='$(evform DIVE-2412013)' out=$out"
+
+seed_task DIVE-2412014
+cmd_task_need DIVE-2412014 --type=decision --ask="ship tonight or hold?" --options="ship-now|hold-schedule" --recommend="hold-schedule" --tier=1 >/dev/null 2>&1
+db "UPDATE tasks SET tier='2' WHERE ident='DIVE-2412014';"
+out=$(cmd_task_answer DIVE-2412014 --value=hold-schedule --channel-proof=$HUMAN_CHAT 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-2412014)" == "open" ]] \
+  && ok_t "CS11 the same tier-2 DECISION gate REFUSES the uncited relay" \
+  || bad_t "CS11 the same tier-2 DECISION gate REFUSES the uncited relay" "rc=$rc state=$(answered DIVE-2412014) out=$out"
+
+# ── CS12 RED TEAM: the CALLER cannot widen the freshness window ──────────────
+# olivia's iteration-1 reject, reproduced as an arm. `task answer` is run BY the
+# agent, so a window read from the caller's environment is a bypass with no
+# forgery in it — measured on 8312851: a 400-day-old "approved" in the human's own
+# chat refused at the default and CLEARED under
+# GATE_CHANNEL_SESSION_MAX_AGE=999999999, recording human_evidence=channel-session
+# for a gate no human had touched. `export` here is deliberate: it is exactly the
+# environment `task answer` inherits from the agent that runs it.
+#
+# The REASON arm carries as much weight as the rc one (see
+# feedback_refusal_graded_by_rc_alone_passes_the_wrong_refusal): if the refusal
+# fired on some other condition, an rc-only arm would stay green while the clamp
+# did nothing. "limit 3600s" is only printable if the ceiling — not the caller's
+# 999999999 — is what bounded the comparison.
+seed_t2_approval DIVE-2412017
+CS_RESP=$(fwd user "$HUMAN_CHAT" 34560000 "DIVE-2412017 approved")   # 400 days old
+export GATE_CHANNEL_SESSION_MAX_AGE=999999999
+out=$(cmd_task_answer DIVE-2412017 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15506 2>&1); rc=$?
+unset GATE_CHANNEL_SESSION_MAX_AGE
+[[ $rc -ne 0 && "$(answered DIVE-2412017)" == "open" && -z "$(evform DIVE-2412017)" ]] \
+  && ok_t "CS12 a caller-WIDENED window does NOT clear the gate (the bound is not the caller's to set)" \
+  || bad_t "CS12 a caller-WIDENED window does NOT clear the gate (the bound is not the caller's to set)" "rc=$rc state=$(answered DIVE-2412017) form='$(evform DIVE-2412017)' out=$out"
+[[ "$out" == *"limit 3600s"* ]] \
+  && ok_t "CS12 the limit that fired is the hardcoded ceiling, not the caller's value" \
+  || bad_t "CS12 the limit that fired is the hardcoded ceiling, not the caller's value" "out=$out"
+
+# LIVENESS, so the clamp is not "ignore the env entirely": an env value BELOW the
+# ceiling must still apply, because a deployment wanting a stricter window is the
+# legitimate use of this knob. Graded against the anchor below — without it, code
+# that refused every 300s citation would pass this arm.
+seed_t2_approval DIVE-2412018
+CS_RESP=$(fwd user "$HUMAN_CHAT" 300 "DIVE-2412018 approved")
+export GATE_CHANNEL_SESSION_MAX_AGE=60
+out=$(cmd_task_answer DIVE-2412018 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15507 2>&1); rc=$?
+unset GATE_CHANNEL_SESSION_MAX_AGE
+[[ $rc -ne 0 && "$(answered DIVE-2412018)" == "open" && "$out" == *"limit 60s"* ]] \
+  && ok_t "CS12 a TIGHTER window from the env still applies (the knob can only narrow, it is not ignored)" \
+  || bad_t "CS12 a TIGHTER window from the env still applies (the knob can only narrow, it is not ignored)" "rc=$rc state=$(answered DIVE-2412018) out=$out"
+
+seed_t2_approval DIVE-2412019
+CS_RESP=$(fwd user "$HUMAN_CHAT" 300 "DIVE-2412019 approved")
+out=$(cmd_task_answer DIVE-2412019 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15508 2>&1); rc=$?
+[[ $rc -eq 0 && "$(answered DIVE-2412019)" == "closed" ]] \
+  && ok_t "CS12 ANCHOR: the same 300s-old citation DOES clear at the default window" \
+  || bad_t "CS12 ANCHOR: the same 300s-old citation DOES clear at the default window" "rc=$rc state=$(answered DIVE-2412019) out=$out"
+
+# A junk value must fall back to the ceiling rather than brick the rail or open it.
+seed_t2_approval DIVE-2412020
+CS_RESP=$(fwd user "$HUMAN_CHAT" 300 "DIVE-2412020 approved")
+export GATE_CHANNEL_SESSION_MAX_AGE=not-a-number
+out=$(cmd_task_answer DIVE-2412020 --value=approved --channel-proof=$HUMAN_CHAT --channel-msg=15509 2>&1); rc=$?
+unset GATE_CHANNEL_SESSION_MAX_AGE
+[[ $rc -eq 0 && "$(answered DIVE-2412020)" == "closed" ]] \
+  && ok_t "CS12 a NON-NUMERIC window falls back to the ceiling (neither wider nor bricked)" \
+  || bad_t "CS12 a NON-NUMERIC window falls back to the ceiling (neither wider nor bricked)" "rc=$rc state=$(answered DIVE-2412020) out=$out"
+
+printf '\ngate_channel_session_t2_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
DIVE-2382 fix #4 (lodar approved 2026-07-30 04:27). A tier-2 gate could be cleared by exactly two things — a per-gate nonce (the Telegram button) or a non-agent `SUDO_UID` (the dashboard exec). Neither is what the human usually produces. This adds a third: **channel proof of the human's own answer**, so a decision already made in chat is not re-entered as a button tap.

`task answer` takes `--channel-msg=<message_id>` beside `--channel-proof=<chat_id>`.

## What makes it evidence rather than a claim

The chat id alone is **not** evidence — the calling agent's session already knows that number, so it stays tier<2 exactly as DIVE-1305 scoped it. The citation is different in kind: it is checked against **Telegram**, via `forwardMessage` on the cited id, and the forwarded copy is deleted immediately (a probe, not a post). The check has to be remote because no local one exists — the plugin and the agent share a unix user, so no file, uid or cgroup separates them.

Four conditions, each with its own refusal reason: the chat is the paired human's verified DM; Telegram confirms the message is live; its `forward_origin` is a **user** whose id is that human (a bot's own message, a third party and a privacy-hidden origin all refuse); and it is **fresh** and names **both the task ident and the answer**. Anything unresolvable — no token, no response, malformed JSON — refuses.

Admitted at **two** sites, not one. Raising the human flag clears the DIVE-1117 provenance floor; DIVE-2233's evidence site then refuses a tier-2 `--human` claim carrying neither a valid nonce nor a non-agent `SUDO_UID`, and it is scoped to gates that HAVE a minted nonce — every approval and manual gate, i.e. exactly the ones this feature is for. The citation is listed there as a third form, on the same footing (the other two are local to this box; this one is attested by the party the caller cannot speak for). Its refusal message and audit row name it (`channel_session=`).

New column `human_evidence` (`nonce` | `sudo-uid` | `channel-chat` | `channel-session` | `lead`, `+`-joined) keeps the human forms tellable apart on the **row**, per DIVE-2090 — all four persist as `need_answered_by=human:*`, and only the last cleared a tier-2 gate with nobody touching a button.

## Iteration 2 — olivia's reject, both halves

1. **The freshness bound was the caller's to set.** It was read from `GATE_CHANNEL_SESSION_MAX_AGE` in the environment of the agent that runs `task answer`, so the mitigation was settable by the party it defends against — no forgery required. Measured on 8312851: a 400-day-old "approved" in the human's own chat refused at the default (rc=6, gate open) and **cleared** under `GATE_CHANNEL_SESSION_MAX_AGE=999999999` (rc=0, `human_evidence=channel-session`) — a row affirmatively attesting that a human cleared a tier-2 gate nobody touched. The 3600s ceiling is now **hardcoded**; the env knob may only **tighten** it, and wider, zero, negative and non-numeric all fall back to the ceiling.
2. **The binding accepted the value OR the ident.** Each alone leaves a hole: a value is unique to **no** gate (the shared-value replay the window was wrongly asked to bound), and an ident alone attests only that the human spoke *about* the gate while `--value` still comes from the agent. Tier 2 now requires **both**, with a distinct refusal reason for each.

## Grading

- `tests/gate_channel_session_t2_unit.sh` — **31 arms** (was 21), 0 failed.
- `tests/gate_channel_session_t2_mutation.sh` — **14 mutants, 14 killed** (was 10), 0 ungraded.

New arms: the caller-widened window refuses **and names the ceiling** as the limit that fired (an rc-only arm would stay green if some other condition refused); a tighter env window still applies, with a default-window **anchor** so the liveness arm is differential; a non-numeric value falls back rather than bricking the rail; value-only and ident-only citations each refuse with their own reason.

Four refusal fixtures were **not differential** and are fixed: they named neither ident nor value, so with the condition under test deleted the new binding refused instead and M1/M2/M3/M6 graded nothing. Each now names ident+value, so only the condition under test can refuse it. New mutants: M5a/M5b (one per binding half), M11 (clamp removed → the red-team arm must go red), M12 (env read killed → the liveness arm must go red), M13 (the DIVE-2233 site omits the citation → the accept arm must go red). M7's expected arm moved to the **decision** shape: on an approval gate the widened fence is now caught a second time by the DIVE-2233 site, so CS2 no longer isolates the fence, while a tier-2 decision gate mints no nonce and the fence is the only thing standing there.

## Rebase, and olivia's two smaller notes

- The branch is **rebased onto main (35f4840) as a single commit**. The DIVE-2249 commit it used to carry (0a5904c) is gone: that ticket is already on main as the squashed `edb449d` (#294), so it was a duplicate, not an unlanded ticket riding along.
- The rebase surfaced two real integration items that were invisible on the old base: main's DIVE-2233 evidence site (above), and main's DIVE-2330 iteration-2 change from `id -un` to `_gate_caller_uid`, which the harness now pins the way the sibling harnesses do.
- A **latent CI red** from iteration 1 is fixed: `tests/gate_channel_session_t2_mutation.sh` was missing the DIVE-2211 `grading_tree.sh` source line. `tests/names_the_tree_contract_unit.sh` (253 harnesses) is green.
- Sibling suites re-run on the rebased tree: `gate_channel_proof_unit` 16/16, `gate_nonce_unit` 19/19, `gate_filer_own_channel_unit` 9/9, `gate_channelless_escalation_unit` 25/25, `tasks_store_fence_unit` 12/12, `gate_verifier_route_unit` 9/9, `gate_t2_routed_escalate_unit` 17/17, `gate_sudo_uid_forge_unit` 8/8, `gate_lead_standing_unit` 73/73.

## The mutation grader was itself ungraded — `harness-verdict-union` caught it

olivia's note (2) said this needed a non-maker CI run. It got one, and CI found a real defect that no local run could have: `harness-verdict-union` reded the build with the exact case it exists to catch — **a harness probed in NO environment**.

`tests/gate_channel_session_t2_mutation.sh` re-runs its whole 33-arm unit suite once per mutant (~14 × 23s), and the probe's per-harness `timeout` is **180s**. So it was killed before its verdict line ever executed — the canary never printed, giving `not-reached` on **both** the pristine and installed-host lanes. Reported as "skipped here, probed where it runs", with no environment where it runs. Permanently unprobed, green about it — landing on the one harness whose own job is to catch tests that grade nothing.

**Fixed with a lane, not an exemption.** One line in `ALLOW_UNPROBEABLE` would have gone green in seconds, and would have been a **false reason on the record**: that allowlist means "no identifiable verdict variable", and this harness has one — measured `wired` at `PROBE_TIMEOUT=900`. It is probeable and slow, not unprobeable, and allowlisting it would have excused the coverage it claims to provide. So a new `harness-verdict-slow` job probes the **named** slow harnesses via `--only` at 900s, and the union consumes its report as a third environment.

`--only` is deliberate: raising `PROBE_TIMEOUT` for the whole 255-file sweep would also raise how long a genuinely hung harness can stall CI, which is the property the 180s default buys. `probe-slow.txt` is named **explicitly** in the union call rather than globbed, so a slow lane that dies reds the union instead of silently dropping back to the two-environment corpus — the same shrink-in-silence hole this check exists to close.

**Graded differentially against the real reports from the red run (30562090895)**, not against a fixture: with the third report → `255 in corpus, 252 probed across 3 environment(s), 0 NEVER PROBED`, rc 0. Without it → `1 NEVER PROBED  gate_channel_session_t2_mutation.sh`, rc 1. So the green is the lane working, not the check being switched off. `harness-verdict-slow` is confirmed `success` on CI.

## Still unmeasured, on purpose and stated

No **live Bot API probe** was run. Whether a self-forward inside a DM returns `forward_origin`, and whether a human's restrict-forwarding privacy setting makes every citation `hidden_user`, is unknown. The failure direction is REFUSE (absent origin ⇒ empty type ⇒ refused), so the unknown can make the rail inert, never wrongly accept. The feature also ships **inert**: no consumer passes `--channel-msg` yet (DIVE-2436).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

