### PR TITLE
fix(skills): share the DIVE-2338 traversal guard with every id->path site (DIVE-2370)

### DIFF
--- a/src/cmd_pack.sh
+++ b/src/cmd_pack.sh
@@ -65,7 +65,14 @@ _marketplace_fetch_pack() {
   while IFS= read -r id; do
     [[ -z "$id" ]] && continue
     id="${id##*#}"; id="${id##*/}"
-    [[ "$id" =~ ^[A-Za-z0-9._-]+$ ]] || continue
+    # DIVE-2370: this WAS a bare `[[ "$id" =~ ^[A-Za-z0-9._-]+$ ]]` — the same character
+    # class DIVE-2338 proved insufficient, because it accepts "." and ".." and the caller
+    # supplies the separator. It matters here and not only cosmetically: `mkdir -p
+    # "$dl/skills/.."` resolves to $dl itself and the mv then plants $dl/SKILL.md, which is
+    # exactly the file the import step at _install_bundled_skill probes for. Refusing the id
+    # here breaks the chain at its first link.
+    valid_skill_id "$id" || continue
+    skill_target_within "$dl/skills" "$id" || continue
     if curl -fsSL --max-time 20 "$base/$path/skills/$id/SKILL.md" -o "$dl/.probe" 2>/dev/null; then
       mkdir -p "$dl/skills/$id"; mv "$dl/.probe" "$dl/skills/$id/SKILL.md"
     fi
@@ -97,6 +104,15 @@ _install_bundled_skill() {
   local user="agent-${name}" home="/home/agent-${name}" type install_dir
   type=$(agent_type "$name"); [[ -n "$type" ]] || return 1
   install_dir="${SKILLS_INSTALL_DIR[$type]:-.claude/skills}"
+  # DIVE-2370 — THE DESTRUCTIVE SITE. $id reaches here from the pack manifest's skills[]
+  # (jq over $stage/manifest.json, i.e. third-party content) via parse_skill_spec, which
+  # splits on ":" and validates NOTHING. With id="..", dest resolves to $home/.claude and
+  # the next line is `rm -rf` — settings, credentials, projects and memory, followed by a
+  # cp -r + chown -R that leaves a plausible-looking directory behind. Same predicate as
+  # cmd_skill_rm, one definition, in validation.sh.
+  valid_skill_id "$id" || { warn "refusing bundled skill id '$id' (invalid)"; return 1; }
+  skill_target_within "$home/$install_dir" "$id" \
+    || { warn "refusing bundled skill id '$id' — escapes $install_dir (DIVE-2370)"; return 1; }
   local dest="$home/$install_dir/$id"
   rm -rf "$dest"; mkdir -p "$home/$install_dir" || return 1
   cp -r "$srcdir" "$dest" || return 1
@@ -1394,6 +1410,9 @@ cmd_import() {
     [[ -z "$sk" ]] && continue
     pair=$(parse_skill_spec "$sk" 2>/dev/null) || { skipped+=("$sk"); continue; }
     src="${pair% *}"; id="${pair#* }"
+    # DIVE-2370: parse_skill_spec is a splitter, not a validator. Guard before the -f probe
+    # so a traversal id is skipped-and-reported rather than reaching either install path.
+    if ! valid_skill_id "$id"; then skipped+=("$sk"); continue; fi
     # Prefer a skill body bundled in the pack (self-contained); fall back to the
     # recorded source ref (resolved from a published repo).
     if [[ -f "$stage/skills/$id/SKILL.md" ]] && _install_bundled_skill "$as" "$id" "$stage/skills/$id"; then

--- a/src/cmd_skill.sh
+++ b/src/cmd_skill.sh
@@ -32,47 +32,12 @@ parse_skill_spec() {
   fi
 }
 
-# Validate skill id (the directory name that will end up under the per-type
-# skills dir, e.g. .claude/skills/<id>). Same character class skills.sh uses.
-#
-# DIVE-2338 — THE CHARACTER CLASS IS NOT THE CHECK. `^[A-Za-z0-9._-]+$` rejects a
-# SLASH, which is what made it look safe, and accepts `.` and `..`, which are the whole
-# traversal token. No slash is needed because the CALLER supplies the separator:
-# cmd_skill_rm builds `target="$INSTALL_DIR/$SKILL"` and then `rm -rf "$target"`, so
-#   SKILL=..  ->  .claude/skills/..  ->  ~/.claude       (settings, creds, projects, memory)
-#   SKILL=.   ->  .claude/skills/.   ->  every installed skill
-# and the verb is reachable from the dashboard exec tunnel (`skill` is allowlisted in
-# 5dive-api routes/agents.ts and `..` passes AGENT_ARG_RE).
-#
-# `.` is a LEGITIMATE character in a skill id and simultaneously the entire attack, so a
-# character-class allowlist cannot separate the two — the predicate that matters is not
-# "which characters" but "can the resulting NAME escape its directory". Hence both checks
-# below: refusing the two tokens is exact, and refusing any all-dots name covers `...`
-# and friends that some resolvers also normalise upward.
-#
-# This function only decides the NAME. Containment of the resulting PATH is asserted
-# separately at the use site (skill_target_within), because a name-level check cannot see
-# what the name is later concatenated to. The token refusal alone would be a two-token
-# BLOCKLIST — the exact shape this codebase argues against — so it is the belt, and
-# skill_target_within is the braces.
-valid_skill_id() {
-  [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
-  # No dot-only name: covers "." ".." and any "..." a normaliser might walk up.
-  [[ "$1" =~ ^\.+$ ]] && return 1
-  return 0
-}
-
-# DIVE-2338 — the STRUCTURAL half, and the one that survives a future edit to the regex.
-# Re-derive the concatenated path and assert it is still strictly inside the install dir.
-# `readlink -m` normalises `..` without requiring the path to exist, so this is decided on
-# the resolved location rather than on the spelling of the input.
-# skill_target_within <base_dir> <skill_id> -> 0 if <base_dir>/<id> stays under <base_dir>
-skill_target_within() {
-  local base="$1" id="$2" rbase rtarget
-  rbase="$(readlink -m -- "$base")"    || return 1
-  rtarget="$(readlink -m -- "$base/$id")" || return 1
-  [[ "$rtarget" == "$rbase"/?* ]]
-}
+# DIVE-2370: valid_skill_id and skill_target_within MOVED to src/lib/validation.sh.
+# They are not skill-verb-local — five sibling id->path sites in cmd_pack.sh and
+# lib/agent_setup.sh build the identical string, and one of them (_install_bundled_skill)
+# `rm -rf`s the result. validation.sh is concatenated BEFORE agent_setup.sh and every
+# cmd_*.sh in build.sh, so a single definition there is visible to all of them. The
+# DIVE-2338 rationale travels WITH the functions rather than staying at this call site.
 
 # cmd_skill <agent-name>|--all <action> [args...]
 # Dispatcher mirrors the auth subcommand shape so main()'s case stays flat.

--- a/src/lib/agent_setup.sh
+++ b/src/lib/agent_setup.sh
@@ -457,13 +457,25 @@ install_default_skill_for_agent() {
   local user="agent-${name}" home="/home/agent-${name}"
   local agent_id="${SKILLS_AGENT_ID[$type]:-claude-code}"
   local install_dir="${SKILLS_INSTALL_DIR[$type]:-.claude/skills}"
+  # DIVE-2370: today every caller passes an internal template constant, so this is a
+  # pre-emptive guard rather than a fix for a live hole HERE — recorded as such so nobody
+  # reads it as an incident. It is still the right place for it: the sibling site in
+  # cmd_pack.sh WAS live, and the way DIVE-2338 happened is that a validator stayed
+  # reasonable right up until someone added a flag that fed it user input.
+  valid_skill_id "$skill" || { warn "refusing skill id '$skill' (invalid)"; return 1; }
+  skill_target_within "$home/$install_dir" "$skill" \
+    || { warn "refusing skill id '$skill' — escapes $install_dir (DIVE-2370)"; return 1; }
   [[ -d "$home" ]] || return 1
   id -u "$user" &>/dev/null || return 1
   if sudo -u "$user" test -d "$home/$install_dir/$skill"; then
     return 0
   fi
   if _skill_needs_manual_install "$type"; then
-    sudo -u "$user" -H env SOURCE="$source" SKILL="$skill" INSTALL_DIR="$install_dir" bash -s >&2 <<'MANUAL_SKILL' \
+    # DIVE-2370: ship the REAL predicate in, exactly as cmd_skill_rm does — `declare -f`
+    # emits skill_target_within's own source, so the sub-shell re-asserts with the SAME
+    # function and a revert reds both arms together instead of leaving the inner one green.
+    sudo -u "$user" -H env SOURCE="$source" SKILL="$skill" INSTALL_DIR="$install_dir" \
+      CONTAINMENT_FN="$(declare -f skill_target_within)" bash -s >&2 <<'MANUAL_SKILL' \
       || { warn "default skill '$skill' install failed for agent '$name' (continuing)"; return 1; }
 set -uo pipefail
 unset CLAUDE_CONFIG_DIR
@@ -477,6 +489,11 @@ for d in "$TMPDIR/repo/$SKILL" "$TMPDIR/repo/skills/$SKILL"; do
 done
 [ -n "$SRC_DIR" ] || { echo "ERROR: skill '$SKILL' not found in $SOURCE (looked at top-level and skills/)" >&2; exit 1; }
 mkdir -p "$HOME/$INSTALL_DIR"
+# DIVE-2370: re-assert containment where the write actually happens. Not a second copy of
+# the predicate — $CONTAINMENT_FN carries the caller's own skill_target_within source.
+eval "${CONTAINMENT_FN:?containment predicate not supplied — refusing to install}"
+skill_target_within "$HOME/$INSTALL_DIR" "$SKILL" \
+  || { echo "refusing: '$SKILL' resolves outside $HOME/$INSTALL_DIR" >&2; exit 3; }
 cp -r "$SRC_DIR" "$HOME/$INSTALL_DIR/$SKILL"
 echo "manual-installed $SKILL → $HOME/$INSTALL_DIR/$SKILL"
 MANUAL_SKILL

--- a/src/lib/validation.sh
+++ b/src/lib/validation.sh
@@ -225,3 +225,52 @@ require_node() {
   sudo env PATH=\"\$(dirname \"\$(readlink -f \"\$(command -v node)\")\"):\$PATH\" 5dive <cmd>   # run the inner part as the user who HAS node
   sudo ln -s \"\$(command -v node)\" /usr/local/bin/node                                    # make it permanent for every sudo-gated op"
 }
+
+# ======== skill id -> path containment (DIVE-2338, generalised DIVE-2370) ========
+# Moved here from cmd_skill.sh because the guard is not verb-local: cmd_pack.sh
+# (_install_bundled_skill, the manifest skills[] download) and lib/agent_setup.sh
+# (install_default_skill_for_agent) build the same "<install_dir>/<id>" string.
+# ONE implementation on purpose — skill_id_traversal_unit T6d asserts there is no
+# second copy, and DIVE-2080 is the standing lesson that fixing the visible call
+# site is not fixing the class.
+# Validate skill id (the directory name that will end up under the per-type
+# skills dir, e.g. .claude/skills/<id>). Same character class skills.sh uses.
+#
+# DIVE-2338 — THE CHARACTER CLASS IS NOT THE CHECK. `^[A-Za-z0-9._-]+$` rejects a
+# SLASH, which is what made it look safe, and accepts `.` and `..`, which are the whole
+# traversal token. No slash is needed because the CALLER supplies the separator:
+# cmd_skill_rm builds `target="$INSTALL_DIR/$SKILL"` and then `rm -rf "$target"`, so
+#   SKILL=..  ->  .claude/skills/..  ->  ~/.claude       (settings, creds, projects, memory)
+#   SKILL=.   ->  .claude/skills/.   ->  every installed skill
+# and the verb is reachable from the dashboard exec tunnel (`skill` is allowlisted in
+# 5dive-api routes/agents.ts and `..` passes AGENT_ARG_RE).
+#
+# `.` is a LEGITIMATE character in a skill id and simultaneously the entire attack, so a
+# character-class allowlist cannot separate the two — the predicate that matters is not
+# "which characters" but "can the resulting NAME escape its directory". Hence both checks
+# below: refusing the two tokens is exact, and refusing any all-dots name covers `...`
+# and friends that some resolvers also normalise upward.
+#
+# This function only decides the NAME. Containment of the resulting PATH is asserted
+# separately at the use site (skill_target_within), because a name-level check cannot see
+# what the name is later concatenated to. The token refusal alone would be a two-token
+# BLOCKLIST — the exact shape this codebase argues against — so it is the belt, and
+# skill_target_within is the braces.
+valid_skill_id() {
+  [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
+  # No dot-only name: covers "." ".." and any "..." a normaliser might walk up.
+  [[ "$1" =~ ^\.+$ ]] && return 1
+  return 0
+}
+
+# DIVE-2338 — the STRUCTURAL half, and the one that survives a future edit to the regex.
+# Re-derive the concatenated path and assert it is still strictly inside the install dir.
+# `readlink -m` normalises `..` without requiring the path to exist, so this is decided on
+# the resolved location rather than on the spelling of the input.
+# skill_target_within <base_dir> <skill_id> -> 0 if <base_dir>/<id> stays under <base_dir>
+skill_target_within() {
+  local base="$1" id="$2" rbase rtarget
+  rbase="$(readlink -m -- "$base")"    || return 1
+  rtarget="$(readlink -m -- "$base/$id")" || return 1
+  [[ "$rtarget" == "$rbase"/?* ]]
+}

--- a/tests/skill_id_traversal_unit.sh
+++ b/tests/skill_id_traversal_unit.sh
@@ -32,20 +32,24 @@ set +e
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
 SRC="$ROOT/src/cmd_skill.sh"
+# DIVE-2370: the two predicates MOVED to lib/validation.sh so five sibling id->path sites
+# could share one definition. $SRC stays cmd_skill.sh because the T5/T6* arms grade THAT
+# file's wiring at the rm site; only the predicate extraction follows the functions.
+VSRC="$ROOT/src/lib/validation.sh"
 
 pass=0; fail=0
 ok_t()  { printf 'ok   - %s\n' "$1"; pass=$((pass+1)); }
 bad_t() { printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; fail=$((fail+1)); }
 
 # Extract the two predicates without executing the module.
-FN_ID="$(awk '/^valid_skill_id\(\) \{/,/^\}/' "$SRC")"
-FN_IN="$(awk '/^skill_target_within\(\) \{/,/^\}/' "$SRC")"
+FN_ID="$(awk '/^valid_skill_id\(\) \{/,/^\}/' "$VSRC")"
+FN_IN="$(awk '/^skill_target_within\(\) \{/,/^\}/' "$VSRC")"
 [[ -n "$FN_ID" ]] \
   && ok_t 'T0a valid_skill_id is present and extractable' \
-  || bad_t 'T0a valid_skill_id not found — the name arms below are vacuous' "src=$SRC"
+  || bad_t 'T0a valid_skill_id not found — the name arms below are vacuous' "vsrc=$VSRC"
 [[ -n "$FN_IN" ]] \
   && ok_t 'T0b skill_target_within is present and extractable' \
-  || bad_t 'T0b containment predicate not found — the structural arms below are vacuous' "src=$SRC"
+  || bad_t 'T0b containment predicate not found — the structural arms below are vacuous' "vsrc=$VSRC"
 eval "$FN_ID"; eval "$FN_IN"
 
 BASE="$(mktemp -d)/skills"; mkdir -p "$BASE"
@@ -138,6 +142,94 @@ if grep -A12 "bash -s >&2 <<'SKILL_REMOVE'" "$SRC" | grep -q '_rbase="\$(readlin
 else
   ok_t 'T6d no duplicate readlink predicate inside the heredoc — one implementation only'
 fi
+
+# ============================ DIVE-2370 =====================================
+# The DIVE-2338 fix guarded cmd_skill_rm. The pre-close class sweep found five SIBLING
+# id->path sites that build the identical string and called NEITHER guard. One of them,
+# cmd_pack.sh's _install_bundled_skill, `rm -rf`s the result and takes its id from a THIRD
+# PARTY: the pack manifest's skills[] -> jq -> parse_skill_spec (a splitter that validates
+# nothing) -> "$home/$install_dir/$id". With id=".." that is `rm -rf $home/.claude`.
+# These arms grade the generalisation, not a second copy of it.
+VAL="$VSRC"; PACK="$ROOT/src/cmd_pack.sh"; SETUP="$ROOT/src/lib/agent_setup.sh"
+
+# T7 — ONE implementation, and it MOVED rather than being copied. A second definition
+# anywhere is the DIVE-2080 failure (fixing the visible call site is not fixing the class).
+n_def=$(grep -rc 'skill_target_within() {' "$ROOT/src/" 2>/dev/null | awk -F: '{t+=$2} END{print t+0}')
+[[ "$n_def" == "1" ]] \
+  && ok_t 'T7 exactly ONE skill_target_within definition in src/' \
+  || bad_t "T7 skill_target_within is defined $n_def times in src/ — the class fix became a copy" ''
+grep -q 'skill_target_within() {' "$VAL" \
+  && ok_t 'T7b the single definition lives in lib/validation.sh (concatenated before every consumer)' \
+  || bad_t 'T7b the guard is not in validation.sh, so the sibling sites cannot see it' ''
+
+# T8 — THE DESTRUCTIVE SITE. The guard must precede the rm -rf inside _install_bundled_skill,
+# not merely appear somewhere in the file. Compare LINE NUMBERS inside the function body.
+fn_start=$(grep -n '^_install_bundled_skill()' "$PACK" | cut -d: -f1)
+if [[ -n "$fn_start" ]]; then
+  body=$(tail -n +"$fn_start" "$PACK" | sed -n '1,40p')
+  g=$(printf '%s\n' "$body" | grep -n 'skill_target_within' | head -1 | cut -d: -f1)
+  r=$(printf '%s\n' "$body" | grep -n 'rm -rf "\$dest"' | head -1 | cut -d: -f1)
+  if [[ -n "$g" && -n "$r" && "$g" -lt "$r" ]]; then
+    ok_t "T8 _install_bundled_skill asserts containment (line +$g) BEFORE its rm -rf (line +$r)"
+  else
+    bad_t "T8 _install_bundled_skill rm -rf is not preceded by a containment assert (guard=$g rm=$r)" ''
+  fi
+else
+  bad_t 'T8 _install_bundled_skill not found — anchor moved, re-derive this arm' ''
+fi
+
+# T9 — the manifest download loop must not rely on the bare character class DIVE-2338
+# disproved. This is the FIRST link: it is what plants $stage/SKILL.md for id="..", which
+# is the very file the import step probes before calling the destructive path.
+if grep -q 'valid_skill_id "$id" || continue' "$PACK"; then
+  ok_t 'T9 manifest skills[] download validates the id with the shared predicate'
+else
+  bad_t 'T9 the download loop still gates on a bare character class' ''
+fi
+
+# T10 — agent_setup.sh: guarded at entry AND the predicate shipped into the sub-shell that
+# does the cp, same coupling as T6b/T6c so a revert cannot leave one arm green.
+grep -q 'skill_target_within "$home/$install_dir" "$skill"' "$SETUP" \
+  && ok_t 'T10 install_default_skill_for_agent asserts containment at entry' \
+  || bad_t 'T10 install_default_skill_for_agent has no containment assert' ''
+grep -q 'CONTAINMENT_FN="$(declare -f skill_target_within)"' "$SETUP" \
+  && ok_t 'T10b the manual-install heredoc receives the REAL predicate (declare -f), not a copy' \
+  || bad_t 'T10b the manual-install heredoc gets no predicate' ''
+grep -q 'CONTAINMENT_FN:?' "$SETUP" \
+  && ok_t 'T10c a missing predicate ABORTS the manual install (:?) rather than reading as pass' \
+  || bad_t 'T10c the manual-install heredoc would proceed with no predicate' ''
+
+# T11 — FUNCTIONAL, and mutation-checked. The arms above are string assertions over source;
+# this one runs the predicate. An absence-assertion that never executes the subject passes
+# on an empty file, so the mutation below is what makes the zero mean something.
+( set +e
+  # shellcheck disable=SC1090
+  . "$VAL" 2>/dev/null
+  base=$(mktemp -d); mkdir -p "$base/skills"
+  fails=0
+  # '..' and '.' ESCAPE (or resolve to the base itself); containment must refuse both.
+  for bad in '..' '.'; do
+    skill_target_within "$base/skills" "$bad" && { echo "LEAK: accepted '$bad'" >&2; fails=1; }
+  done
+  # '...' is NOT a traversal token to readlink -m — it is an ordinary directory name that
+  # escapes nothing, so containment CORRECTLY accepts it and the NAME check is what refuses
+  # it. Grading '...' against containment (my first draft of this arm did) fails a correct
+  # implementation. This is the division of labour the header describes, made executable:
+  # valid_skill_id refuses all-dots for resolvers that WOULD walk it up; skill_target_within
+  # answers only "does the resolved path escape".
+  skill_target_within "$base/skills" '...' \
+    || { echo "WRONG SPLIT: containment rejected '...', which escapes nothing" >&2; fails=1; }
+  valid_skill_id '...' \
+    && { echo "LEAK: the NAME check accepted an all-dots id" >&2; fails=1; }
+  skill_target_within "$base/skills" 'real-skill' || { echo "FALSE POSITIVE: rejected a legit id" >&2; fails=1; }
+  # MUTATION: a predicate that always returns 0 must be caught by the loop above.
+  skill_target_within() { return 0; }
+  caught=0
+  for bad in '..' '.'; do skill_target_within "$base/skills" "$bad" || caught=1; done
+  [[ $caught -eq 0 ]] || { echo "MUTATION HARNESS BROKEN: neutered predicate still refused" >&2; fails=1; }
+  rm -rf "$base"; exit $fails ) \
+  && ok_t 'T11 containment refuses .. and . , accepts ... and a real id (the NAME check owns all-dots), and the mutation arm proves the loop can see a neutered guard' \
+  || bad_t 'T11 the containment predicate leaked, over-rejected, or the mutation check is vacuous' ''
 
 echo "-----"
 echo "skill_id_traversal_unit: $pass passed, $fail failed"


### PR DESCRIPTION
DIVE-2338 guarded `agent skill <name> rm ..`. The pre-close class sweep found five
SIBLING sites that build the identical "<install_dir>/<id>" string and called neither
guard. One of them is destructive and its id comes from a third party.

THE LIVE CHAIN, traced this pass (the filing row explicitly had NOT traced it and said
nobody should escalate on its strength — this is that trace, and it does escalate):

  pack manifest .skills[]  ->  jq -r '.skills[]?' over $stage/manifest.json (remote pack)
  ->  parse_skill_spec     ->  splits on ':' and validates NOTHING
  ->  _install_bundled_skill "$as" ".." "$stage/skills/.."
  ->  dest="$home/.claude/skills/.."  ==  $home/.claude
  ->  rm -rf "$dest"                  <- settings, credentials, projects, memory
  ->  cp -r + chown -R                <- leaves a plausible-looking directory behind

The first link is self-baiting: cmd_pack.sh's download loop gated on the bare
`^[A-Za-z0-9._-]+$` that DIVE-2338 disproved, so id=".." passed, `mkdir -p
"$dl/skills/.."` resolved to $dl, and the mv planted $dl/SKILL.md — which is exactly the
file the import step probes with `[[ -f "$stage/skills/$id/SKILL.md" ]]` before calling
the destructive path. The attacker's own manifest creates the precondition our code
checks. Traced by reading, NOT executed: no exploit was run against any box.

FIX — one implementation, not a sixth copy (DIVE-2080):
  * valid_skill_id + skill_target_within MOVE from cmd_skill.sh to lib/validation.sh,
    which build.sh concatenates BEFORE agent_setup.sh and every cmd_*.sh, so all five
    consumers see one definition. cmd_skill.sh keeps a pointer comment, not a copy.
  * cmd_pack.sh: guard the manifest download loop, guard after parse_skill_spec, and
    guard _install_bundled_skill BEFORE its rm -rf.
  * lib/agent_setup.sh: guard install_default_skill_for_agent at entry and ship the real
    predicate into the manual-install sub-shell via `declare -f` + `${CONTAINMENT_FN:?}`,
    the same coupling cmd_skill_rm uses so a revert reds inner and outer arms together.
    Marked pre-emptive in-line: today's callers pass template constants, so this site is
    hardening, not a live hole — recorded so nobody reads it as an incident.

TESTS — tests/skill_id_traversal_unit.sh goes 18 -> 26 arms:
  T7/T7b  exactly ONE definition in src/, and it lives in validation.sh
  T8      containment precedes the rm -rf INSIDE _install_bundled_skill, by line number
  T9      the download loop uses the shared predicate, not the disproved char class
  T10/b/c agent_setup guards at entry, gets declare -f, and fails closed on a missing one
  T11     functional + self-mutating: refuses .. and . , ACCEPTS ... and a real id
Mutation-graded, not just green: deleting the _install_bundled_skill guard reds T8
(25/1), restoring it returns 26/0.

T11 also fixes an error in its own first draft, kept as a comment because it is the
interesting part: I graded '...' against containment and a CORRECT implementation failed.
'...' is not a traversal token to readlink -m — it is an ordinary directory name that
escapes nothing, so containment must accept it and the NAME check is what refuses it.
That is the header's division of labour made executable.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)