### PR TITLE
fix(task): bind pronoun gate options to an account frame (DIVE-2212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased — fix(task): pronoun options resolve to an account frame (DIVE-2212)
+
+Two parties can no longer select the same second-person gate option and receive
+only a confirmation whose actor silently changes with the reader. `task need`
+now warns when a decision option contains `you`/`your`-family wording and asks
+the filer to name accounts, while remaining backward-compatible with free text.
+
+When such an option is answered, the prose receipt names the filer and answerer
+and declares that second-person terms use the filer-addressing-answerer frame;
+JSON callers receive the same mapping in `option_account_frame` while retaining
+the raw `need_answer`. `tests/gate_option_account_frame_unit.sh` reproduces the
+dev3-to-main incident, checks prose and JSON receipts, and guards word boundaries.
+
 ## Unreleased — feat(ledger): one append-only lifecycle log with the authority envelope (INST-4, phase A)
 
 We were already event-sourcing, in four separate append-only silos — `supervisor_events`,

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -91,6 +91,7 @@ _task_usage() {
                                                      # --type=access: manager-clearable "grant me X" gate — routes to the org lead first (any tier), lead-clearable; add --probe='test -w /path' to self-check the block
   5dive task need <id|DIVE-N> --withdraw            # DIVE-1401: cancel a still-pending gate the team filed but that's now moot — filer or org lead, no human tap. NOT a grant (never records a secret/approval); genuine clears stay human-only.
     --ask: ONE crisp question + ~1 line essential context, recommendation up front. Heavy detail goes in the task BODY, not the ask.
+    --options: name accounts/actors, not "you/your". Pronoun-bearing choices warn at filing and their answer receipt renders the filer/answerer account frame.
     --discusses="<why>" (DIVE-2089, --type=decision ONLY): appeal a T2 floor that fired on SUBJECT MATTER. A design question that merely NAMES secrets/publishing/deletion performs none of them; declare that and the gate goes to your lead at tier 1 instead of the human. The declaration is recorded on the gate, shown to the reviewer, and audited — unlike rewording the ask, which reaches the same audience with no record of how. Refused, loudly, for money / customer comms / irreversible infra, for a pinned --tier=2, and when no lead sits above you.
     --needs=<capability> (DIVE-2241): DECLARE what this ask consumes. human_tap (a person's call: brand, strategy, irreversible), spend_authority (billing, paid accounts), secret_provision (a new token/credential) resolve to the paired human as CONSTANTS — the gate skips lead- AND verifier-routing and cannot be agent-cleared. Fixes: a gate on a verifier-loop task otherwise routes to whoever is GRADING the ticket, whatever it asks. Declared, never guessed from your wording; any other value is undeclared-equivalent and changes nothing (it never refuses).
     --recommend: your advised choice (strongly encouraged for decision/approval). Leads the alert as '✅ Recommended: <X>' and ⭐-marks its button. For a decision it must match one of --options.
@@ -4636,6 +4637,15 @@ _gate_shape_jaccard() {
     }'
 }
 
+# DIVE-2212: decision options are authored by the filer but read and selected by
+# the answerer. Second-person wording therefore has two natural frames on the
+# same bytes ("you" can be read as either side). Keep options free-form, but make
+# that risky shape observable at filing and render the concrete account frame on
+# answer. Boundaries deliberately exclude innocent substrings such as "youtube".
+_gate_option_has_second_person() {
+  LC_ALL=C grep -Eiq '(^|[^[:alnum:]_])(you|your|yours|yourself|yourselves)([^[:alnum:]_]|$)' <<<"${1:-}"
+}
+
 cmd_task_need() {
   tasks_db_init
   local type="" ask="" options="" recommend="" from="" tier="" secret_key="" connector="" probe="" withdraw="" discusses="" needs=""
@@ -5271,6 +5281,9 @@ cmd_task_need() {
   # `task answer` knows who to ping to resume. The inbox is defined by the gate
   # (need_type set), not by assignee, so it still surfaces to the human.
   local actor; actor=$(task_actor "$from")
+  if [[ "$type" == "decision" ]] && _gate_option_has_second_person "$options"; then
+    warn "--options contains second-person wording whose referent can invert between filer and answerer. Prefer account names (for example, main-runs-task-done|dev3-gets-a-credential). Filing continues; the answer receipt will name filer ${actor} and the concrete answerer (DIVE-2212)."
+  fi
   # DIVE-2196: filing a gate on a task DELIVERED to you IS an act of review — the
   # verifier demonstrably opened it and escalated. Stamp the handoff ACK in the same
   # transaction, so "reviewed it and escalated to a human" stops being byte-identical
@@ -8203,9 +8216,28 @@ cmd_task_answer() {
 
   local note=""
   [[ $pinged -eq 1 ]] && note=" + pinged $owner"
-  ok "$ident answered ($nt) — now ${newstatus}${note}" \
-     '{id:($i|tonumber), status:$st, need_type:$nt, provided:true, need_answer:(if $nt=="secret" then null else $v end), owner:(($o|select(length>0)) // null), pinged:($p=="1")}' \
-     --arg i "$id" --arg st "$newstatus" --arg nt "$nt" --arg v "$value" --arg o "$owner" --arg p "$pinged"
+  # DIVE-2212: do not make the answerer re-read the ambiguous option as the only
+  # confirmation. Name both accounts and declare the authored frame. The raw
+  # value remains in the structured need_answer field for compatibility, but the
+  # human receipt does not merely echo it back and leave both readings intact.
+  local _account_frame=0 _frame_filer="" _frame_answerer="" _frame_note=""
+  if [[ "$nt" == "decision" ]] && _gate_option_has_second_person "$value"; then
+    _account_frame=1
+    _frame_filer=$(db "SELECT COALESCE(NULLIF(gate_filed_by,''), NULLIF(assignee,''), NULLIF(created_by,''), 'unknown') FROM tasks WHERE id=${id};")
+    case "$answered_by" in
+      human:*)         _frame_answerer="${answered_by#human:}" ;;
+      lead:standing:*) _frame_answerer="${answered_by#lead:standing:}" ;;
+      lead:*)          _frame_answerer="${answered_by#lead:}" ;;
+      auto:*)          _frame_answerer="${answered_by#auto:}" ;;
+      *)               _frame_answerer="$answered_by" ;;
+    esac
+    [[ -n "$_frame_answerer" ]] || _frame_answerer="unknown"
+    _frame_note=" — account frame: filer=${_frame_filer}, answerer=${_frame_answerer}; second-person terms in the selected filer-authored option refer to ${_frame_answerer}"
+  fi
+  ok "$ident answered ($nt) — now ${newstatus}${note}${_frame_note}" \
+     '{id:($i|tonumber), status:$st, need_type:$nt, provided:true, need_answer:(if $nt=="secret" then null else $v end), owner:(($o|select(length>0)) // null), pinged:($p=="1"), option_account_frame:(if $af=="1" then {filer:$gf, answerer:$ga, second_person_refers_to:$ga} else null end)}' \
+     --arg i "$id" --arg st "$newstatus" --arg nt "$nt" --arg v "$value" --arg o "$owner" --arg p "$pinged" \
+     --arg af "$_account_frame" --arg gf "$_frame_filer" --arg ga "$_frame_answerer"
 }
 
 # cmd_task_escalate — DIVE-449: the /task_<id> Telegram "Escalate" button (and a

--- a/tests/gate_option_account_frame_unit.sh
+++ b/tests/gate_option_account_frame_unit.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# DIVE-2212: gate options cross an author/reader boundary. A second-person
+# pronoun can naturally point at the answerer when written and at the filer when
+# read, so two agents can believe they agreed while selecting the same bytes.
+#
+# This isolated harness proves both halves of the fix:
+#   * filing warns but remains backward-compatible (free-text options still file);
+#   * answering a pronoun option renders concrete filer/answerer accounts and a
+#     declared frame, without merely echoing the ambiguous option in prose;
+#   * word-boundary matching does not warn on innocent substrings.
+# Run: bash tests/gate_option_account_frame_unit.sh
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/gate-option-frame.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh cmd_task.sh; do
+  source "$SRC/$f"
+done
+set +e
+
+STATE_DIR="$TMP"; TASKS_DIR="$TMP/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+mkdir -p "$TASKS_DIR"
+tasks_db_init; _tasks_db_migrate
+JSON_MODE=0
+
+# No fixture may notify the live paired human or a live agent.
+task_need_notify() { :; }
+cmd_send() { return 1; }
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+db "INSERT INTO tasks (ident,title,priority,assignee,created_by,kind,status)
+    VALUES ('DIVE-9212','ambiguous option','medium','dev3','main','standard','todo');"
+
+# The exact incident shape: dev3 writes "you" addressing main. The warning must
+# make the risk visible without rejecting an existing free-text gate workflow.
+need_out=$(cmd_task_need DIVE-9212 --type=decision --tier=1 \
+  --ask="Who should close it?" \
+  --options="you-close-it|grant-me-a-token" --recommend="you-close-it" \
+  --from=dev3 2>&1); need_rc=$?
+
+[[ "$need_rc" == "0" && "$(db "SELECT status||'|'||need_options||'|'||gate_filed_by FROM tasks WHERE ident='DIVE-9212';")" == "blocked|you-close-it|grant-me-a-token|dev3" ]] \
+  && ok_t "pronoun-bearing options warn but still file with dev3 as filer" \
+  || bad_t "warning path remains backward-compatible" "rc=$need_rc row=$(db "SELECT status||'|'||COALESCE(need_options,'')||'|'||COALESCE(gate_filed_by,'') FROM tasks WHERE ident='DIVE-9212';") out=$need_out"
+[[ "$need_out" == *"second-person"* && "$need_out" == *"Prefer account names"* && "$need_out" == *"filer dev3"* ]] \
+  && ok_t "filing warning explains the frame defect and names the filer" \
+  || bad_t "filing warning" "$need_out"
+
+# main selects the same bytes. The rendered receipt must resolve the parties by
+# account and declare that second-person text in dev3's authored option means
+# main. It intentionally must NOT make the raw ambiguous label the receipt.
+answer_out=$(cmd_task_answer DIVE-9212 --value="you-close-it" --from=main 2>&1); answer_rc=$?
+[[ "$answer_rc" == "0" && "$answer_out" == *"filer=dev3"* && "$answer_out" == *"answerer=main"* && "$answer_out" == *"refer to main"* ]] \
+  && ok_t "answer receipt names dev3/main and resolves the authored account frame" \
+  || bad_t "account-resolved answer receipt" "rc=$answer_rc out=$answer_out"
+[[ "$answer_out" != *"you-close-it"* ]] \
+  && ok_t "prose receipt does not merely echo the ambiguous option" \
+  || bad_t "ambiguous option leaked back as the prose confirmation" "$answer_out"
+
+# Structured callers keep the raw answer for compatibility, while receiving the
+# same explicit account frame as machine-readable fields.
+db "INSERT INTO tasks (ident,title,priority,assignee,created_by,kind,status)
+    VALUES ('DIVE-9214','json frame','medium','dev3','main','standard','todo');"
+cmd_task_need DIVE-9214 --type=decision --tier=1 --ask="Who closes it?" \
+  --options="you-close-it|dev3-closes-it" --recommend="you-close-it" \
+  --from=dev3 >/dev/null 2>&1
+JSON_MODE=1
+json_out=$(cmd_task_answer DIVE-9214 --value="you-close-it" --from=main 2>"$TMP/json.err"); json_rc=$?
+JSON_MODE=0
+[[ "$json_rc" == "0" && "$(jq -r '.data.need_answer' <<<"$json_out")" == "you-close-it" \
+   && "$(jq -r '.data.option_account_frame.filer' <<<"$json_out")" == "dev3" \
+   && "$(jq -r '.data.option_account_frame.answerer' <<<"$json_out")" == "main" \
+   && "$(jq -r '.data.option_account_frame.second_person_refers_to' <<<"$json_out")" == "main" ]] \
+  && ok_t "JSON receipt preserves the answer and adds the concrete account frame" \
+  || bad_t "JSON account frame" "rc=$json_rc json=$json_out err=$(cat "$TMP/json.err")"
+
+# Non-vacuity control: the boundary matcher must not flag product/action words
+# that merely contain the letters "you".
+db "INSERT INTO tasks (ident,title,priority,assignee,created_by,kind,status)
+    VALUES ('DIVE-9213','clean option','medium','dev3','main','standard','todo');"
+clean_out=$(cmd_task_need DIVE-9213 --type=decision --tier=1 \
+  --ask="Which path?" --options="youtube-run|young-team-runs" \
+  --recommend="youtube-run" --from=dev3 2>&1); clean_rc=$?
+[[ "$clean_rc" == "0" && "$clean_out" != *"second-person wording"* ]] \
+  && ok_t "word boundaries avoid false-positive warnings" \
+  || bad_t "pronoun boundary" "rc=$clean_rc out=$clean_out"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" == "0" ]]


### PR DESCRIPTION
Maker: **codex** (verifier-PASSED on DIVE-2212). Landed by **main** under DIVE-2377 — codex has
no ssh key and no gh auth, and neither does olivia, so the maker structurally cannot push or
open a PR. This is a delegated push, not a re-authored change.

## What it does

A decision gate's `--options` are authored by the **filer** but read and selected by the
**answerer**, so second-person wording has two natural frames on the same bytes — "you" reads
as either side depending on who is looking. This does not fix that by banning free text; it
makes the risky shape observable at filing and renders the concrete account frame on answer:

* `_gate_option_has_second_person` — word-boundary matcher over the `you`/`your` family, so
  innocent substrings like "youtube" do not trip it.
* `task need`: warns when a `decision`'s options carry that wording, names the filer, and
  suggests account-shaped options (`main-runs-task-done|dev3-gets-a-credential`). Filing still
  proceeds — backward-compatible with every gate already in flight.
* `task answer`: the prose receipt names filer and answerer and states which one the
  second-person terms refer to, instead of echoing the ambiguous option back and leaving both
  readings intact. JSON callers get the same mapping in a new `option_account_frame`, and the
  raw `need_answer` field is unchanged.

## Verification

* `tests/gate_option_account_frame_unit.sh` (new, 99 lines) — 6/6 against the **real**
  `cmd_task_need`/`cmd_task_answer` on an isolated DB, mutation-graded non-vacuous in both
  directions per DIVE-2212's verifier result.
* Re-run by main on the **rebased** base (not just the maker's), because a passing suite at the
  authoring base says nothing about the current one: new suite 6/6, plus the adjacent suites
  over the same touched function — `gate_history_unit` 32/0, `gate_t2_nonce_proof_unit` 25/0,
  `gate_verifier_route_unit` 9/0.

## Notes for the reviewer

* **Rebased.** The ticket names `a1cb1e9`; that commit's base (`6cd0242`) is an ancestor of
  `origin/main` but main has moved, and `git merge-tree` showed a real **CHANGELOG.md**
  conflict against the INST-4 entry. Rebased onto `2638014` as `e6a7aef`, resolving the
  CHANGELOG by keeping **both** entries. Diffstat is byte-identical across the rebase
  (147 insertions, 3 deletions), and the 3 deletions are the original `ok ...` call being
  extended, not a revert of anything.
* **Known coverage boundary, called out rather than papered over** (olivia, DIVE-2377): the two
  auto-answer direct-write paths in `cmd_task.sh` (recommend auto-apply, standing-lead rule)
  bypass `cmd_task_answer` and therefore render no account frame. Not a blocker — no party
  *selects* an option on those paths, so the ambiguity this fixes cannot arise there.
* Rebase had to happen in a worktree main owns: `.git/worktrees/5dive-cli-wt-2212` is
  `agent-codex`-owned with no group write, so `git rebase` there fails with EACCES on
  `rebase-merge`. Worth knowing for the next delegated push — a reader can see the branch and
  still be unable to rewrite it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)