### PR TITLE
fix(gate): the done==merged gate searches every shipping repo, and the ACCEPT names its scope (DIVE-2431)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -1453,10 +1453,38 @@ _gate_text_names_a_ref() {
 # coverage AND — worse — an api task naming "PR #6" got a CONFIDENT verdict about an
 # unrelated CLI pull request. Overridable so a new repo is config, not a patch, and
 # so the tests can point the whole gate at fixtures.
+# DIVE-2431: the default was exactly those three, and a delivery to any OTHER repo we
+# ship from was graded by a set that never contained it. Both directions were live and
+# both were measured on DIVE-2303, whose delivery landed in 5dive-ai/character-packs:
+#   FALSE ACCEPT  — the gate found the ident in 5dive-ai/5dive (step 1 of the same
+#                   ticket, days earlier) and closed clean having never looked at
+#                   character-packs. Correct by luck.
+#   FALSE REFUSE  — strip that coincidence and genuinely-landed work is refused with
+#                   "nothing on main in <3 slugs> shows branch ... landed", whose remedy
+#                   is an audited `--force-merge-gate` override for a gate that was
+#                   simply looking in the wrong place.
+#
+# WHY A LIST AND NOT A DERIVATION. Deriving the set from the git remotes on the box, or
+# from the org's repo list, removes the drift but buys a worse property: the gate's
+# verdict would then depend on host filesystem state or on network reachability at close
+# time. A gate that answers differently on two boxes, or refuses when offline, is not a
+# gate. The list is deterministic and auditable; drift is the price.
+#
+# WHAT PAYS FOR THE DRIFT: every verdict names the set it searched — the refusals always
+# did, and DIVE-2431 added it to the ACCEPT, which was the silent half. A stale list now
+# announces itself at the exact moment it matters, to the person it is failing. That is
+# the property to preserve if this list is ever edited; adding a repo without it just
+# moves the blind spot.
 _gate_repo_slugs() {
   local raw="${FIVE_GATE_REPOS:-}"
   if [[ -z "$raw" ]]; then
+    # The repos task deliveries actually land in. Kept to ACTIVE product repos rather
+    # than every repo we own — an inactive repo costs a lookup on every close and has
+    # never received a delivery.
     raw="$(_push_repo_slug "$_PUSH_DEFAULT_REPO") lodar/5dive-api lodar/5dive-frontend"
+    raw="$raw 5dive-ai/character-packs 5dive-ai/skills 5dive-ai/5dive-plugins"
+    raw="$raw 5dive-ai/5dive-mcp 5dive-ai/openagent 5dive-ai/ops"
+    raw="$raw lodar/5dive-blog lodar/5dive-mobile"
   fi
   printf '%s' "$raw" | tr ',' ' ' | tr -s '[:space:]' '\n' | awk 'NF && !seen[$0]++'
 }
@@ -2131,7 +2159,7 @@ _task_status_cmd() {
         # a squash rewrites the sha, so the branch tip is NOT an ancestor of main even
         # though the content is in. Attribution finds it anyway, because the squash
         # commit subject carries the ident.
-        local _slug _bmerged="" _merged_slug="" _searched="" _attr_slug="" _anc="" _attr="" _anc_novac="" _attr_bound="" _attr_unreach=""
+        local _slug _bmerged="" _merged_slug="" _searched="" _attr_slug="" _anc="" _attr="" _anc_novac="" _attr_bound="" _attr_unreach="" _attr_scope=""
         while IFS= read -r _slug; do
           [[ -n "$_slug" ]] || continue
           _searched="${_searched:+$_searched, }$_slug"
@@ -2180,7 +2208,19 @@ _task_status_cmd() {
           # Attribution CANNOT distinguish a delegated push from a squash-merged PR — a
           # squash rewrites the sha, so both look identical to a subject scan. So this
           # states what was measured and claims neither route.
-          warn "$ident: a commit on ${FIVE_GATE_MAIN_BRANCH:-main} in $_attr_slug names $ident in its SUBJECT — the work is on main (attribution, DIVE-2120). This does NOT establish HOW it landed: a delegated push and a squash-merged PR are indistinguishable to a subject scan, because a squash rewrites the sha. done=merged-to-main satisfied."
+          # DIVE-2431: name the SCOPE on the accept, not only on the refusals. The
+          # refusals already said which repos they searched; this line did not, and it
+          # is the half that fails silently — an accept sourced from a repo that is not
+          # where the delivery went reads as a clean close and nothing invites a second
+          # look. Measured on DIVE-2303: accepted on a commit in 5dive-ai/5dive while
+          # the delivery sat in character-packs, which was not in the searched set at
+          # all. Only stated when the task DECLARED no repo, because a declared repo
+          # narrows the scan to itself and there is no unsearched remainder to warn about.
+          _attr_scope=""
+          if [[ -z "$_task_slug" ]]; then
+            _attr_scope=" SCOPE: this task declares no repo, so the gate searched $_searched and stopped at the first hit — repos outside that set were NOT looked at. If the delivery landed somewhere else, this accept is about a DIFFERENT repo's commit; declare it with a \`Repo: <owner>/<repo>\` line or bind the delivery_ref, and re-check."
+          fi
+          warn "$ident: a commit on ${FIVE_GATE_MAIN_BRANCH:-main} in $_attr_slug names $ident in its SUBJECT — the work is on main (attribution, DIVE-2120). This does NOT establish HOW it landed: a delegated push and a squash-merged PR are indistinguishable to a subject scan, because a squash rewrites the sha. done=merged-to-main satisfied.$_attr_scope"
         elif [[ -n "$_attr_bound" && -z "$_bmerged" ]]; then
           # DIVE-2120: the scan stopped AT THE BOUND without finding the ident. That is NOT
           # a miss and must not read as one — a bounded search whose negative looks like an

--- a/tests/task_merge_gate_diagnostic_unit.sh
+++ b/tests/task_merge_gate_diagnostic_unit.sh
@@ -249,11 +249,30 @@ run_done B-5 --result='landed'
 # ---------------------------------------------------------------------------
 clear_fx; a_token
 # EVERY repo in the default search set must answer, or this is T5b's partial-coverage
-# case rather than a genuine miss. _gate_repo_slugs = 5dive-ai/5dive, lodar/5dive-api,
-# lodar/5dive-frontend; the stub keys on the repo NAME.
-export GH_STUB_COMMITS_5dive_main="$(commits 'chore(deps): bump something (DIVE-1)')"
-export GH_STUB_COMMITS_5dive_api_main="$(commits 'chore(deps): bump something else (DIVE-2)')"
-export GH_STUB_COMMITS_5dive_frontend_main="$(commits 'chore(deps): and again (DIVE-3)')"
+# case rather than a genuine miss.
+#
+# DIVE-2431: this used to hardcode the three slugs the default set happened to contain.
+# When the default went 3 -> 11, the eight new repos had no stub, read as UNREACHABLE,
+# and this arm stopped testing what it says it tests — a genuine miss became T5b's
+# partial-coverage refusal and T6 went red for a reason unrelated to its subject. A
+# fixture that names a set the CODE owns is a second copy of that set, and the copy is
+# the one nobody updates. So derive it: whatever `_gate_repo_slugs` returns is what gets
+# stubbed, and this arm keeps its meaning through the next widening without an edit.
+stub_every_default_repo() {
+  local slug name n=0
+  while read -r slug; do
+    [[ -n "$slug" ]] || continue
+    n=$((n+1))
+    name="${slug##*/}"; name="${name//[^A-Za-z0-9]/_}"
+    # A page SHORTER than per_page = history exhausted, which is what makes this a
+    # genuine miss rather than a bounded scan. Distinct idents so no stub can
+    # accidentally name the ident under test.
+    eval "export GH_STUB_COMMITS_${name}_main=\"\$(commits 'chore(deps): bump ${name} (DIVE-90${n})')\""
+  done < <(FIVE_GATE_REPOS='' _gate_repo_slugs)
+  # An empty set would stub nothing and the arm would pass for the wrong reason.
+  (( n >= 3 )) || { echo "T6 fixture: _gate_repo_slugs returned $n repos — refusing to assert a genuine miss against a set that small" >&2; return 1; }
+}
+stub_every_default_repo || bad_t 'T6 fixture could not stub the default repo set' 'see stderr'
 seed B-3 'Branch: dive-2318-genuinely-absent'
 run_done B-3 --result='landed'
 [[ $RC -eq $E_CONFLICT && "$(slugof B-3)" == "done-before-branch-merged" ]] \

--- a/tests/task_merge_gate_inferred_repo_unit.sh
+++ b/tests/task_merge_gate_inferred_repo_unit.sh
@@ -150,12 +150,26 @@ slug_case 'a `Repo:` line given as a URL still declares' \
 # leave the claim resting on an env var the suite itself set. Assert the DEFAULT with
 # the variable cleared, so the claim is pinned rather than assumed. A box that exports
 # a narrower list narrows the sweep with it; that is a config choice, stated here.
+#
+# DIVE-2431 widened this set from three to eleven, and this canary is what forced the
+# change to be deliberate rather than incidental — it went red the moment the list moved,
+# which is the whole reason to pin a default. Updated, not relaxed: the superset claim
+# above is STRONGER with a bigger set, so the precondition still holds; what must not
+# happen is the pin being deleted so the next widening lands unannounced.
 want_default='5dive-ai/5dive
 lodar/5dive-api
-lodar/5dive-frontend'
+lodar/5dive-frontend
+5dive-ai/character-packs
+5dive-ai/skills
+5dive-ai/5dive-plugins
+5dive-ai/5dive-mcp
+5dive-ai/openagent
+5dive-ai/ops
+lodar/5dive-blog
+lodar/5dive-mobile'
 got_default=$(FIVE_GATE_REPOS='' _gate_repo_slugs)
 [[ "$got_default" == "$want_default" ]] \
-  && ok_t 'with FIVE_GATE_REPOS unset the sweep really is all three repos (the superset precondition)' \
+  && ok_t 'with FIVE_GATE_REPOS unset the sweep really is every shipping repo (the superset precondition)' \
   || bad_t 'default repo set changed' "want [$want_default] got [$got_default]"
 
 # --- 1c. the lookup and the sentence share ONE definition --------------------

--- a/tests/task_merge_gate_repo_scope_unit.sh
+++ b/tests/task_merge_gate_repo_scope_unit.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# DIVE-2431: the done==merged gate's repo scope.
+#
+# The defect: _gate_repo_slugs defaulted to exactly three slugs, so a delivery to any
+# other repo we ship from was graded by a set that never contained it — false ACCEPT on
+# an unrelated repo's commit (measured on DIVE-2303, delivered to character-packs and
+# closed on a 5dive-ai/5dive commit), and false REFUSE for genuinely landed work.
+#
+# Two properties are graded here and they are independent:
+#   1. the default set CONTAINS the repos deliveries actually land in;
+#   2. every verdict NAMES the set it searched — the refusals always did, the ACCEPT did
+#      not, and the accept is the half that fails silently. Property 2 is what pays for
+#      the drift in property 1, so a change that widens the list while dropping the
+#      disclosure has not kept this file green.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="${SRC:-$HERE/../src}"
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+pass=0; fail=0
+ok(){ if eval "$2"; then echo "ok   - $1"; pass=$((pass+1)); else echo "FAIL - $1"; fail=$((fail+1)); fi; }
+
+# Source just what we need: _gate_repo_slugs and its one dependency.
+_PUSH_DEFAULT_REPO="https://github.com/5dive-ai/5dive.git"
+_push_repo_slug(){ printf '%s' "$1" | sed -E 's#^https://github\.com/##; s#\.git$##'; }
+# shellcheck disable=SC1090
+eval "$(sed -n '/^_gate_repo_slugs() {/,/^}/p' "$SRC/cmd_task.sh")"
+
+# ---- 1. THE DEFAULT SET ----
+slugs="$(FIVE_GATE_REPOS='' _gate_repo_slugs)"
+n="$(printf '%s\n' "$slugs" | grep -c .)"
+
+ok "the three original slugs are still in the default set (no coverage lost)" \
+  "grep -qx '5dive-ai/5dive' <<<\"\$slugs\" && grep -qx 'lodar/5dive-api' <<<\"\$slugs\" && grep -qx 'lodar/5dive-frontend' <<<\"\$slugs\""
+ok "character-packs is in the default set (the repo whose miss produced DIVE-2431)" \
+  "grep -qx '5dive-ai/character-packs' <<<\"\$slugs\""
+for r in 5dive-ai/skills 5dive-ai/5dive-plugins 5dive-ai/5dive-mcp 5dive-ai/openagent 5dive-ai/ops lodar/5dive-blog lodar/5dive-mobile; do
+  ok "shipping repo $r is searched by default" "grep -qx '$r' <<<\"\$slugs\""
+done
+ok "the set is strictly larger than the original three" "[[ $n -gt 3 ]]"
+ok "no duplicate slugs (the awk dedup still holds)" \
+  "[[ \$(printf '%s\n' \"\$slugs\" | sort | uniq -d | wc -l) -eq 0 ]]"
+ok "the CLI repo is FIRST, so the commonest case costs one lookup" \
+  "[[ \$(printf '%s\n' \"\$slugs\" | head -1) == '5dive-ai/5dive' ]]"
+ok "every entry is a bare owner/repo, not a URL" \
+  "! grep -qE 'https?://|\.git\$' <<<\"\$slugs\""
+
+# ---- 2. FIVE_GATE_REPOS STILL OVERRIDES (the per-ticket escape hatch, DIVE-1955) ----
+# shellcheck disable=SC2034  # used inside the eval'd assertion strings below
+ov="$(FIVE_GATE_REPOS='acme/one,acme/two' _gate_repo_slugs)"
+ok "FIVE_GATE_REPOS replaces the default set entirely" \
+  "[[ \$(printf '%s\n' \"\$ov\" | grep -c .) -eq 2 ]] && grep -qx 'acme/one' <<<\"\$ov\""
+ok "FIVE_GATE_REPOS override does NOT leak the widened defaults" \
+  "! grep -qx '5dive-ai/character-packs' <<<\"\$ov\""
+ok "comma AND whitespace separated overrides both parse" \
+  "[[ \$(FIVE_GATE_REPOS='a/b c/d,e/f' _gate_repo_slugs | grep -c .) -eq 3 ]]"
+
+# ---- 3. THE ACCEPT DISCLOSES ITS SCOPE (the silent half) ----
+# Graded on the source text: this is the one property the widened list depends on, and
+# a future edit that widens further while dropping the disclosure must go red here.
+ok "the attribution ACCEPT line still exists" \
+  "grep -q 'names \$ident in its SUBJECT' \"\$SRC/cmd_task.sh\""
+ok "the ACCEPT interpolates a scope clause" \
+  "grep -q 'done=merged-to-main satisfied.\$_attr_scope' \"\$SRC/cmd_task.sh\""
+ok "the scope clause names the searched set" \
+  "grep -q 'the gate searched \$_searched' \"\$SRC/cmd_task.sh\""
+ok "the scope clause says repos outside the set were NOT looked at" \
+  "grep -q 'repos outside that set were NOT looked at' \"\$SRC/cmd_task.sh\""
+ok "the scope clause offers the terminating remedy (Repo: line / delivery_ref)" \
+  "grep -q 'line or bind the delivery_ref, and re-check' \"\$SRC/cmd_task.sh\""
+ok "the scope clause is CONDITIONAL on the task declaring no repo" \
+  "grep -B3 'the gate searched \$_searched' \"\$SRC/cmd_task.sh\" | grep -q 'if \[\[ -z \"\$_task_slug\" \]\]'"
+ok "_attr_scope is declared local (no global leak under set -u)" \
+  "grep -q 'local _slug _bmerged=.*_attr_scope=' \"\$SRC/cmd_task.sh\""
+
+# ---- 4. THE REFUSALS KEPT THEIR SCOPE DISCLOSURE (no regression) ----
+ok "the DIVE-1830 refusal still names \$_searched" \
+  "grep -q 'nothing on \${FIVE_GATE_MAIN_BRANCH:-main} in \$_searched shows branch' \"\$SRC/cmd_task.sh\""
+ok "the scan-bound refusal still offers the unsearched-repo explanation" \
+  "grep -q 'the branch lives in a repo that was NEVER SCANNED' \"\$SRC/cmd_task.sh\""
+
+echo; echo "$pass passed, $fail failed"; [[ $fail -eq 0 ]]


### PR DESCRIPTION
`_gate_repo_slugs` defaulted to three slugs — `5dive-ai/5dive`, `lodar/5dive-api`, `lodar/5dive-frontend` — so a delivery to any other repo we ship from was graded by a set that never contained it.

Both failure directions were live, measured on DIVE-2303 whose delivery landed in `5dive-ai/character-packs`:

- **False accept.** It closed clean on a `5dive-ai/5dive` commit from step 1 of the same ticket, having never looked at character-packs. Correct by luck.
- **False refuse.** Strip that coincidence and genuinely-landed work is refused, with an audited `--force-merge-gate` as the remedy for a gate that was simply looking in the wrong place.

## What changed

**Widened to the 11 active product repos.** A list and not a derivation: deriving the set from the box's git remotes or the org API removes the drift but makes the verdict depend on host filesystem state or network reachability at close time. A gate that answers differently on two boxes, or refuses when offline, is not a gate.

**Every verdict now names the set it searched.** The refusals always did; the ACCEPT did not, and that was the silent half — an accept sourced from a repo that is not where the delivery went reads as a clean close and nothing invites a second look. Only stated when the task declares no repo, since a declared repo narrows the scan to itself and leaves no unsearched remainder. That disclosure is what pays for the drift in the hardcoded list: a stale set now announces itself at the moment it matters, to the person it is failing.

## Tests

`tests/task_merge_gate_repo_scope_unit.sh` — new, 25 assertions, graded on both properties independently so a future widening that drops the disclosure goes red.

The default-set canary in `task_merge_gate_inferred_repo_unit.sh` went red the moment the list moved, which is exactly its job. Updated rather than relaxed — the superset precondition it guards is stronger with a bigger set.

Local: 25/0, 18/0, 35/0 across the three gate suites; shellcheck clean at `-S warning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)