### PR TITLE
fix(release-cut): grade the release commit before publishing it, and stop the tag claiming CI it never had (DIVE-2433)

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -261,6 +261,11 @@ jobs:
           git add -f 5dive 5dive.sha256 src/header.sh
           git -c user.name=lodar -c user.email=markounik@gmail.com \
               commit -q -m "release ${tag}: assign ${version} + built bundle (DIVE-2091 bundle-at-tag-time, DIVE-2247 version-at-tag-time)"
+          # DIVE-2433: `sha` is about to stop meaning "the commit whose check-runs we
+          # read". Keep the graded one under its own name so the tag can say which
+          # object each claim is about instead of silently attributing the parent's
+          # CI to the release commit.
+          parent_sha="$sha"
           sha=$(git rev-parse HEAD)
           # Prove the TREE BEING TAGGED carries what install.sh will fetch — read it
           # back out of the object store rather than trusting the working tree.
@@ -271,10 +276,65 @@ jobs:
           echo "release commit ${sha} carries bundle ${_want} (FIVE_VERSION=${_bundle_ver})"
           # <<< DIVE-2091 release-commit block
 
+          # ── DIVE-2433: GRADE THE RELEASE COMMIT ──────────────────────────────
+          #
+          # THE GAP. Everything above proves the bundle is INTACT — it matches its own
+          # sha256, it is in the tagged tree, it is byte-correct over the CDN. Not one
+          # of those runs it. The release commit is pushed detached and carries ZERO
+          # check-runs (measured on v0.17.10: release commit d7db754 = 0, parent
+          # 2e36516 = 10), so `test`, `install-smoke` and `docker-install` never touch
+          # the exact artifact customers install. Integrity is not function: a bundle
+          # can hash correctly and still be broken.
+          #
+          # AND THE GRADE CI *DOES* PERFORM IS OF A DIFFERENT OBJECT. unit-tests.yml
+          # runs `./build.sh` first, because main carries no bundle (DIVE-2091) — so it
+          # grades a REBUILD, never the released artifact. Here the bundle in the tree
+          # IS the artifact, which makes this the only place the real one can be run.
+          #
+          # WHY NOT JUST TRIGGER THE EXISTING WORKFLOWS ON THE TAG — the obvious fix,
+          # and it is a NO-OP. A push authenticated with GITHUB_TOKEN does not trigger
+          # workflows (GitHub's recursion guard; this file already says so at the
+          # CI-NOT-REACHED refusal above). Adding `push: tags:` to unit-tests.yml would
+          # look like coverage and fire never. Grading here, BEFORE the tag is pushed,
+          # is also strictly better than a post-hoc check-run: a red after publication
+          # is a red on bytes boxes are already installing.
+          # The grade itself lives in scripts/grade-release-commit.sh — a workflow body
+          # cannot be unit-tested and .github/workflows/ needs a credential most agents
+          # do not hold, so the logic sits where it can be graded and repaired on the
+          # normal rail (tests/grade_release_commit_unit.sh, 20 assertions). Same split
+          # as scripts/pii-scan-range.sh (DIVE-2267).
+          echo "--- grading the release commit ${sha:0:12} (DIVE-2433) ---"
+          bash scripts/grade-release-commit.sh "${version}"
+          _grc=$?
+          case "$_grc" in
+            0) echo "release commit ${sha:0:12}: PASS on the exact artifact (DIVE-2433)" ;;
+            1) echo "::error::${tag} was NOT published — the release commit FAILED its own grade. Boxes keep installing ${incumbent:-the previous tag}."
+               exit 1 ;;
+            # UNDETERMINED must refuse exactly as hard as a failure. A grader that could
+            # not run tells us nothing about the artifact, and treating "could not look"
+            # as "looks fine" is the defect this row exists to close.
+            *) echo "::error::${tag} was NOT published — the release-commit grade could not RUN (rc=${_grc}), so this artifact is UNGRADED. That is not a pass. Boxes keep installing ${incumbent:-the previous tag}."
+               exit 1 ;;
+          esac
+          # ── end DIVE-2433 ────────────────────────────────────────────────────
+
+          # DIVE-2433: this message used to read "CI green on this exact sha:
+          # ${total} completed check-runs" — and that was FALSE about the object it
+          # names. `sha` is reassigned to the release commit above, while `total`
+          # counts check-runs on the PARENT, so the tag asserted a measurement that
+          # was never taken on the commit it publishes. v0.17.10 carries that claim
+          # verbatim about a sha with zero check-runs. An ungraded object is a gap;
+          # an ungraded object carrying a permanent, published claim that it WAS
+          # graded is what stops anyone finding the gap. Say which sha was measured
+          # by whom, and name the grade this job performed rather than borrowing the
+          # parent's.
           git tag -a "$tag" "$sha" -m "${tag} — ${note}
 
-          Publishes ${sha} as the tree every box installs (DIVE-2144). CI green on
-          this exact sha: ${total} completed check-runs, none failing."
+          Publishes ${sha} as the tree every box installs (DIVE-2144).
+          Parent ${parent_sha} carried ${total} completed check-runs, none failing.
+          This release commit is not graded by GitHub CI (a GITHUB_TOKEN push does not
+          trigger workflows); it was graded IN THIS JOB before publication — tests/*.sh,
+          \`5dive selfcheck\`, and --version/--help run against this exact bundle."
           if ! git push origin "refs/tags/${tag}"; then
             echo "::error::tag push rejected — ${tag} was NOT published. Nothing changed for any box; they keep installing ${incumbent:-the previous tag}."
             exit 1

--- a/scripts/grade-release-commit.sh
+++ b/scripts/grade-release-commit.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Grade the RELEASE COMMIT's own artifact (DIVE-2433).
+#
+# WHY THIS EXISTS. release-cut.yml builds a release commit, pushes it detached and
+# tags it. Nothing grades that commit: measured on v0.17.10, the release commit
+# d7db754 carries ZERO check-runs while its parent 2e36516 carries 10. So `test`,
+# `install-smoke` and `docker-install` never touch the exact artifact customers
+# install. Everything the cut already asserts is INTEGRITY — the bundle matches its
+# own sha256, it is in the tagged tree, it is byte-correct over the CDN — and none
+# of it is FUNCTION. A bundle can hash correctly and still be broken.
+#
+# AND CI'S OWN BUNDLE GRADE IS OF A DIFFERENT OBJECT: unit-tests.yml runs
+# `./build.sh` first, because main carries no bundle at all since DIVE-2091, so it
+# grades a REBUILD. Here the bundle in the tree IS the artifact, which makes the cut
+# the only place the real one can be run.
+#
+# WHY NOT TRIGGER THE EXISTING WORKFLOWS ON THE TAG — the obvious fix, and a NO-OP.
+# A push authenticated with GITHUB_TOKEN does not trigger workflows (GitHub's
+# recursion guard). `push: tags:` in unit-tests.yml would look like coverage and fire
+# never. Grading before the tag is pushed is also strictly better than a post-hoc
+# check-run: a red after publication is a red on bytes boxes already install.
+#
+# WHY A SCRIPT AND NOT INLINE YAML, the same two reasons as scripts/pii-scan-range.sh
+# (DIVE-2267): a workflow body cannot be unit-tested, and .github/workflows/ needs a
+# credential most agents do not hold — so logic living in YAML is logic that cannot be
+# repaired on the normal rail. This can, and is (tests/grade_release_commit_unit.sh).
+#
+# Usage: grade-release-commit.sh <expected-version>   # run from the release tree root
+#
+# Exits, matching scripts/pii-scan.sh's contract so a caller can tell "clean" from
+# "could not look":
+#   0  graded, clean
+#   1  a grade FAILED — do not publish
+#   2  UNDETERMINED — could not grade. This is NOT a pass.
+set -uo pipefail
+
+WANT_VERSION="${1:-}"
+BUNDLE="${GRC_BUNDLE:-./5dive}"
+TESTS_GLOB="${GRC_TESTS_GLOB:-tests/*.sh}"
+
+if [[ -z "$WANT_VERSION" ]]; then
+  echo "grade-release-commit: UNDETERMINED — no expected version given. This is NOT a pass." >&2
+  exit 2
+fi
+if [[ ! -f "$BUNDLE" ]]; then
+  echo "grade-release-commit: UNDETERMINED — no bundle at '$BUNDLE', so the released artifact was never run. This is NOT a pass." >&2
+  exit 2
+fi
+
+rc=0
+
+# 1. THE ARTIFACT ITSELF, not a rebuild of it. Ordered first because it is the whole
+#    point of this script; the corpus below mostly re-covers the parent's tree.
+#    --allow=snapshot-rails matches unit-tests.yml, so this is the same bar and not a
+#    softer one invented here.
+if bash "$BUNDLE" selfcheck --allow=snapshot-rails --label=release-commit; then
+  echo "grade-release-commit: selfcheck PASS on the released bundle"
+else
+  echo "grade-release-commit: FAIL — selfcheck did not pass on the released bundle" >&2
+  rc=1
+fi
+
+# 2. Bundle smoke: the two invocations every box makes first. A bundle that cannot
+#    state its own version is one nobody can diagnose later.
+_got_ver="$(bash "$BUNDLE" --version 2>/dev/null | awk '{print $2}')"
+if [[ "$_got_ver" == "$WANT_VERSION" ]]; then
+  echo "grade-release-commit: --version reports $_got_ver"
+else
+  echo "grade-release-commit: FAIL — released bundle reports '${_got_ver:-<nothing>}' from --version, expected '$WANT_VERSION'" >&2
+  rc=1
+fi
+if bash "$BUNDLE" --help >/dev/null 2>&1; then
+  echo "grade-release-commit: --help runs"
+else
+  echo "grade-release-commit: FAIL — released bundle cannot print --help" >&2
+  rc=1
+fi
+
+# 3. The corpus, same invocation as unit-tests.yml's `test` job, against the RELEASE
+#    tree rather than main's.
+#
+#    An EMPTY glob is UNDETERMINED, never clean: a `for t in tests/*.sh` over nothing
+#    iterates the literal pattern once, and a caller that only reads the exit code
+#    cannot tell "every harness passed" from "no harness ran". That is the DIVE-2264
+#    shape and it is exactly the failure this whole row is about, so it is refused
+#    here rather than reported as a pass.
+_ran=0 _failed=0
+for _t in $TESTS_GLOB; do
+  [[ -f "$_t" ]] || continue
+  _ran=$((_ran + 1))
+  bash "$_t" >/dev/null 2>&1 || { echo "grade-release-commit: FAIL — $_t" >&2; _failed=$((_failed + 1)); }
+done
+if (( _ran == 0 )); then
+  echo "grade-release-commit: UNDETERMINED — no harness matched '$TESTS_GLOB', so the corpus never ran. This is NOT a pass." >&2
+  exit 2
+fi
+(( _failed == 0 )) || rc=1
+echo "grade-release-commit: corpus ran $_ran harness(es), $_failed failed"
+
+if (( rc == 0 )); then
+  echo "grade-release-commit: PASS — $WANT_VERSION graded on the exact artifact ($_ran harnesses + selfcheck + smoke)"
+fi
+exit "$rc"

--- a/tests/grade_release_commit_unit.sh
+++ b/tests/grade_release_commit_unit.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# DIVE-2433: scripts/grade-release-commit.sh — the grade the release commit never had.
+#
+# The property under test is NOT "does it run the tests". It is the three-state exit
+# contract, because the defect this row exists to close is an object that was never
+# graded while a published record said it was. A grader that cannot tell "clean" from
+# "never ran" reproduces that defect one layer down, so every arm below is about
+# keeping those two apart.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GRADE="${GRADE:-$HERE/../scripts/grade-release-commit.sh}"
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+pass=0; fail=0
+ok(){ if eval "$2"; then echo "ok   - $1"; pass=$((pass+1)); else echo "FAIL - $1"; fail=$((fail+1)); fi; }
+
+T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
+
+# A stand-in bundle whose behaviour each arm controls. The real bundle is 53k lines;
+# what is being graded here is the GRADER, so the artifact is stubbed deliberately.
+mk_bundle() { # $1=version-line $2=selfcheck-rc $3=help-rc
+  cat > "$T/5dive" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+  --version)  printf '5dive %s\n' "$1" ;;
+  --help)     exit $3 ;;
+  selfcheck)  exit $2 ;;
+  *)          exit 0 ;;
+esac
+EOF
+  chmod +x "$T/5dive"
+}
+mk_tests() { # $@ = exit codes, one harness each
+  rm -rf "$T/tests"; mkdir -p "$T/tests"; local i=0 c
+  for c in "$@"; do i=$((i+1)); printf '#!/usr/bin/env bash\nexit %s\n' "$c" > "$T/tests/t$i.sh"; done
+}
+# shellcheck disable=SC2034  # OUT/RC are read inside the eval'd assertion strings
+run() { OUT=$(cd "$T" && GRC_BUNDLE=./5dive GRC_TESTS_GLOB='tests/*.sh' bash "$GRADE" "$@" 2>&1); RC=$?; }
+
+# ---- 1. THE CLEAN PATH ----
+mk_bundle 0.17.10 0 0; mk_tests 0 0 0
+run 0.17.10
+ok "CLEAN: exits 0 when the artifact and the corpus both pass" "[[ $RC -eq 0 ]]"
+ok "CLEAN: says PASS and names the version it graded" "grep -q 'PASS — 0.17.10 graded on the exact artifact' <<<\"\$OUT\""
+ok "CLEAN: reports how many harnesses actually ran" "grep -q 'corpus ran 3 harness' <<<\"\$OUT\""
+
+# ---- 2. FAILURES ARE 1, AND EACH IS NAMED ----
+mk_bundle 0.17.10 1 0; mk_tests 0
+run 0.17.10
+ok "SELFCHECK-FAIL: exits 1" "[[ $RC -eq 1 ]]"
+ok "SELFCHECK-FAIL: names selfcheck as the failure" "grep -q 'selfcheck did not pass' <<<\"\$OUT\""
+ok "SELFCHECK-FAIL: does NOT report PASS" "! grep -q 'PASS —' <<<\"\$OUT\""
+
+mk_bundle 0.17.9 0 0; mk_tests 0
+run 0.17.10
+ok "VERSION-MISMATCH: a bundle reporting the WRONG version exits 1" "[[ $RC -eq 1 ]]"
+ok "VERSION-MISMATCH: names both the got and the expected version" \
+  "grep -q \"reports '0.17.9' from --version, expected '0.17.10'\" <<<\"\$OUT\""
+
+mk_bundle 0.17.10 0 1; mk_tests 0
+run 0.17.10
+ok "HELP-FAIL: a bundle that cannot print --help exits 1" "[[ $RC -eq 1 ]]"
+
+mk_bundle 0.17.10 0 0; mk_tests 0 1 0
+run 0.17.10
+ok "CORPUS-FAIL: one red harness exits 1" "[[ $RC -eq 1 ]]"
+ok "CORPUS-FAIL: names the failing harness" "grep -q 'FAIL — tests/t2.sh' <<<\"\$OUT\""
+ok "CORPUS-FAIL: still reports the counts, so the reader sees 3 ran / 1 failed" \
+  "grep -q 'corpus ran 3 harness(es), 1 failed' <<<\"\$OUT\""
+
+# ---- 3. UNDETERMINED IS 2 AND IS NEVER A PASS — the point of the row ----
+mk_bundle 0.17.10 0 0; mk_tests   # no harnesses at all
+run 0.17.10
+ok "EMPTY-CORPUS: exits 2, NOT 0 — no harness ran, so nothing was graded" "[[ $RC -eq 2 ]]"
+ok "EMPTY-CORPUS: says UNDETERMINED and NOT a pass" \
+  "grep -q 'UNDETERMINED' <<<\"\$OUT\" && grep -q 'NOT a pass' <<<\"\$OUT\""
+ok "EMPTY-CORPUS: does NOT report PASS" "! grep -q 'PASS —' <<<\"\$OUT\""
+
+rm -f "$T/5dive"; mk_tests 0
+run 0.17.10
+ok "NO-BUNDLE: exits 2 rather than grading nothing and reporting clean" "[[ $RC -eq 2 ]]"
+ok "NO-BUNDLE: says the released artifact was never run" \
+  "grep -q 'never run' <<<\"\$OUT\" && grep -q 'NOT a pass' <<<\"\$OUT\""
+
+mk_bundle 0.17.10 0 0; mk_tests 0
+run
+ok "NO-VERSION-ARG: exits 2 rather than defaulting to something and passing" "[[ $RC -eq 2 ]]"
+ok "NO-VERSION-ARG: says UNDETERMINED" "grep -q 'UNDETERMINED' <<<\"\$OUT\""
+
+# ---- 4. THE THREE STATES ARE DISTINCT (a caller can act on each) ----
+ok "0, 1 and 2 are three DIFFERENT codes, so 'clean' and 'could not look' never collide" \
+  "[[ 0 -ne 1 && 1 -ne 2 && 0 -ne 2 ]]"
+
+echo; echo "$pass passed, $fail failed"; [[ $fail -eq 0 ]]


### PR DESCRIPTION
The release commit is pushed detached and carries **zero check-runs**. Measured on v0.17.10: release commit `d7db754` = 0, parent `2e36516` = 10. So `test`, `install-smoke` and `docker-install` never touch the exact artifact customers install.

Everything the cut already asserts is **integrity** — the bundle matches its own sha256, it is in the tagged tree, it is byte-correct over the CDN. None of it is **function**. A bundle can hash correctly and still be broken.

And CI's own bundle grade is of a *different object*: `unit-tests.yml` runs `./build.sh` first, because main carries no bundle since DIVE-2091, so it grades a **rebuild**. In the cut, the bundle in the tree **is** the artifact — which makes this the only place the real one can be run.

## Worse than the row said: the tag asserted CI it never had

The annotation read:

> Publishes ${sha} as the tree every box installs. **CI green on this exact sha: ${total} completed check-runs, none failing.**

`sha` is reassigned to the release commit before that line, while `total` counts check-runs on the **parent**. So the sentence names one object and the number describes another. **v0.17.10 carries that claim verbatim about a sha with zero check-runs.**

An ungraded object is a gap. An ungraded object carrying a permanent, published claim that it *was* graded is what stops anyone finding the gap. The tag now names which sha was measured, and states plainly that the release commit is graded in-job rather than by GitHub CI.

## Why not just trigger the existing workflows on the tag

Because it is a **no-op**. A push authenticated with `GITHUB_TOKEN` does not trigger workflows — GitHub's recursion guard, which this file already documents at its CI-NOT-REACHED refusal. Adding `push: tags:` to `unit-tests.yml` would look like coverage and fire never.

Grading before the tag is pushed is also strictly better than a post-hoc check-run: **a red after publication is a red on bytes boxes are already installing.**

## Shape

Logic in `scripts/grade-release-commit.sh`, not inline YAML, for the DIVE-2267 reasons — a workflow body cannot be unit-tested, and `.github/workflows/` needs a credential most agents do not hold, so logic in YAML is logic that cannot be repaired on the normal rail.

Three-state exit contract (`0` clean / `1` failed / `2` UNDETERMINED), and **the caller refuses on 2 exactly as hard as on 1** — a grader that could not run tells you nothing about the artifact, and treating "could not look" as "looks fine" is the defect this row exists to close. An empty test glob is UNDETERMINED, not clean.

## Checked

- `tests/grade_release_commit_unit.sh` — 20 assertions, most of them about keeping *clean* and *never ran* apart. 20/0.
- End-to-end against a **real** built bundle (53,168 lines): selfcheck PASS, `--version`, `--help`, corpus, overall PASS.
- YAML parses; the run body is `bash -n` clean; shellcheck clean at `-S warning` on both new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)