### PR TITLE
fix(heartbeat): grace the poller canary on UNIT uptime, so a restart stops false-alarming (DIVE-2384)

### DIFF
--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -2343,7 +2343,7 @@ _hb_budget_sweep() {
 # wait_for_message loop with their own liveness, so they are skipped. Only PAIRED
 # agents matter — an unpaired bot has no human whose taps could be dropped.
 _hb_poller_verdict() {
-  local type="$1" mtime="$2" now="$3" allowfrom="$4" thresh="$5" supposed="${6:-1}"
+  local type="$1" mtime="$2" now="$3" allowfrom="$4" thresh="$5" supposed="${6:-1}" uptime="${7:-}"
   [[ "$type" == "claude" ]] || return 0            # non-poller runtime — skip
   [[ "${allowfrom:-0}" -ge 1 ]] || return 0        # unpaired — no human to deafen
   # An operator-stopped agent (desiredState=stopped) or a unit that isn't active
@@ -2352,6 +2352,26 @@ _hb_poller_verdict() {
   # there), not ours; alarming here too would just fuel alarm-blindness. Caller
   # passes supposed=0 for either condition.
   [[ "${supposed}" == "1" ]] || return 0
+  # DIVE-2384 restart grace. thresh carries the author's intent ("rides a
+  # restart") but a restart could never reach it: the plugin's shutdown() UNLINKS
+  # bot.heartbeat (telegram-pi/server.ts, telegram-codex/server.ts) and systemd
+  # still reports the unit ACTIVE across the bounce, so a tick landing in the
+  # unlink->first-bump gap fell into the mtime==0 branch below and returned
+  # BEFORE thresh was ever read. Beacon age cannot measure a beacon that does not
+  # exist — so grace on how long the UNIT has been active instead. Inside thresh
+  # seconds of ActiveEnterTimestamp the poller has not had a fair chance to bump,
+  # whether the beacon is absent (restart) or stale (rough kill left the file).
+  # A genuinely dead poller keeps its unit active well past thresh and still
+  # alarms, just one grace window later.
+  #
+  # uptime unresolvable (empty / non-numeric / clock skew) is NOT graced: the
+  # caller passes "" and we fall through to alarm. A broken probe degrades to
+  # the pre-fix behaviour and can never silently delete detection — the failure
+  # this canary guards (a deaf channel = gates unclearable from the phone) is
+  # real, so the safe default is a false alarm, not a missed death.
+  if [[ "$uptime" =~ ^[0-9]+$ ]] && (( uptime <= thresh )); then
+    return 0
+  fi
   if [[ -z "$mtime" || "$mtime" == "0" ]]; then
     echo "no beacon (poller never started)"; return 0
   fi
@@ -2365,7 +2385,7 @@ _hb_poller_liveness_sweep() {
   local now; now=$(date +%s)
   local thresh=120                                 # >> 3s beat; rides a restart/GC pause
   local -a dead=()
-  local name type allowfrom beacon mtime verdict
+  local name type allowfrom beacon mtime verdict uptime
   while IFS= read -r name; do
     [[ -n "$name" ]] || continue
     type=$(jq -r --arg n "$name" '.agents[$n].type // "claude"' <<<"$reg")
@@ -2383,7 +2403,21 @@ _hb_poller_liveness_sweep() {
       [[ "$desired" == "stopped" ]] && supposed=0
       (( supposed )) && ! systemctl is-active --quiet "5dive-agent@${name}.service" 2>/dev/null && supposed=0
     fi
-    verdict=$(_hb_poller_verdict "$type" "$mtime" "$now" "$allowfrom" "$thresh" "$supposed")
+    # DIVE-2384: seconds since the unit last entered ACTIVE, for the verdict's
+    # restart grace. Left EMPTY when unresolvable (no such unit, systemd
+    # unreachable, unparseable stamp, or a stamp in the future) — the verdict
+    # reads empty as "not in grace" and alarms, so a broken probe never mutes a
+    # real death.
+    local aet aet_epoch
+    uptime=""
+    if [[ "$type" == "claude" ]] && (( supposed )); then
+      aet=$(systemctl show -p ActiveEnterTimestamp --value "5dive-agent@${name}.service" 2>/dev/null)
+      if [[ -n "$aet" ]] && aet_epoch=$(date -d "$aet" +%s 2>/dev/null) \
+         && [[ "$aet_epoch" =~ ^[0-9]+$ ]] && (( aet_epoch <= now )); then
+        uptime=$(( now - aet_epoch ))
+      fi
+    fi
+    verdict=$(_hb_poller_verdict "$type" "$mtime" "$now" "$allowfrom" "$thresh" "$supposed" "$uptime")
     [[ -n "$verdict" ]] && dead+=("${name}: ${verdict}")
   done < <(jq -r '.agents | keys[]?' <<<"$reg")
 
@@ -2403,7 +2437,14 @@ _hb_poller_liveness_sweep() {
   : > "$flag" 2>/dev/null || true
   local coord; coord=$(_task_resolve_coordinator 2>/dev/null)
   if [[ -n "$coord" ]]; then
-    ( cmd_send "$coord" --message="🔴 Telegram poller DEAD on: ${dead[*]}. Gate-ping tap buttons still SEND but the human's TAP won't land (getUpdates slot not held) — those gates can't be cleared from the phone. Fix: restart the agent(s) (systemctl restart 5dive-agent@<name>.service) and check the DIVE-818 slot. (DIVE-1434 canary; re-pings hourly until healthy.)" ) >/dev/null 2>&1 || true
+    # The remedy must NOT say "restart the agent(s)" (DIVE-2384): a restart is the
+    # action that CREATES this condition — shutdown() unlinks the beacon — so
+    # anyone who believed the alarm and followed it re-armed it within seconds and
+    # wiped every agent's running context on each pass. Confirm first, restart the
+    # ONE agent only if the poller process is genuinely gone. DIVE-818 / DIVE-1434
+    # are provenance refs from code comments, NOT board rows — say so, or the
+    # reader looks them up and hits "no such task".
+    ( cmd_send "$coord" --message="🔴 Telegram poller DEAD on: ${dead[*]}. Gate-ping tap buttons still SEND but the human's TAP won't land (getUpdates slot not held) — those gates can't be cleared from the phone. CONFIRM BEFORE ACTING — do NOT blanket-restart: a restart deletes the beacon and re-arms this alarm. Check the named agent's channel dir: is bot.pid's process alive, and is bot.heartbeat's mtime advancing? Only if the poller is genuinely gone, restart THAT ONE agent (systemctl restart 5dive-agent@<name>.service). (Canary provenance — code refs, not board rows: DIVE-1434 canary, DIVE-818 single-getUpdates-slot incident, DIVE-2384 restart grace. Re-pings hourly until healthy.)" ) >/dev/null 2>&1 || true
   fi
   return 0
 }

--- a/tests/poller_liveness_unit.sh
+++ b/tests/poller_liveness_unit.sh
@@ -75,5 +75,98 @@ check "stopped/inactive agent skipped" "" "$(_hb_poller_verdict claude $((NOW-99
 r=$(_hb_poller_verdict claude $((NOW-999)) "$NOW" 1 "$THRESH" 1); [[ -n "$r" ]] && r=DEAD || r=OK
 check "running agent still flagged dead" "DEAD" "$r"
 
+# ---------------------------------------------------------------------------
+# DIVE-2384: restart grace on UNIT uptime (7th param).
+#
+# The bug: the plugin's shutdown() UNLINKS bot.heartbeat, and systemd reports the
+# unit ACTIVE across a bounce, so a tick landing in the unlink->first-bump gap hit
+# case 4 above and returned "no beacon" WITHOUT ever reading thresh. The 120s
+# restart tolerance was unreachable on the path a restart actually takes.
+#
+# Both halves are graded below and BOTH are required. The cheap wrong fix is to
+# mute the missing-beacon branch, which silently deletes real detection and leaves
+# a canary that can never fire — case 21 is the half that forbids it.
+uv() { _hb_poller_verdict claude "$1" "$NOW" 1 "$THRESH" 1 "$2"; }   # mtime uptime
+dead_or_ok() { [[ -n "$1" ]] && printf DEAD || printf OK; }
+
+# 20. RESTART RACE — the reported defect. Beacon unlinked (mtime 0), unit active
+#     for 6s (measured: the fleet-wide fire ran 1s before the new pollers existed).
+#     -> NO verdict.
+check "restart race (no beacon, unit up 6s) not flagged" "" "$(uv 0 6)"
+
+# 21. GENUINELY DEAD poller — beacon absent and the unit has been active an hour.
+#     -> STILL alarms. Detection must survive the fix.
+check "no beacon on a long-active unit still flagged dead" "DEAD" "$(dead_or_ok "$(uv 0 3600)")"
+
+# 22/23. Grace boundary is thresh itself (<=, so 120 is graced, 121 is not) —
+#     the same constant the author wrote for riding a restart, now reachable.
+check "uptime AT thresh graced"          ""     "$(uv 0 "$THRESH")"
+check "uptime one past thresh flagged"   "DEAD" "$(dead_or_ok "$(uv 0 $((THRESH+1)))")"
+
+# 24/25/26. UNRESOLVABLE uptime is NOT graced. Empty (no such unit / systemd
+#     unreachable), non-numeric, and negative (clock skew) all fall through to the
+#     alarm, so a broken probe degrades to the pre-fix behaviour rather than
+#     silently muting the canary.
+check "empty uptime still flagged"       "DEAD" "$(dead_or_ok "$(uv 0 '')")"
+check "non-numeric uptime still flagged" "DEAD" "$(dead_or_ok "$(uv 0 'n/a')")"
+check "negative uptime still flagged"    "DEAD" "$(dead_or_ok "$(uv 0 -5)")"
+
+# 27/28. The grace is on the whole verdict, not just the missing-beacon branch: a
+#     rough kill (SIGKILL, no shutdown handler) leaves the file STALE instead of
+#     absent, which is the same race with a different symptom.
+check "stale beacon inside grace not flagged" "" "$(_hb_poller_verdict claude $((NOW-999)) "$NOW" 1 "$THRESH" 1 6)"
+check "stale beacon past grace still flagged" "DEAD" \
+  "$(dead_or_ok "$(_hb_poller_verdict claude $((NOW-999)) "$NOW" 1 "$THRESH" 1 3600)")"
+
+# 29. Back-compat: the 7th param is optional and its absence means "not graced",
+#     so any caller still passing 6 args behaves exactly as before.
+check "omitted uptime arg still flagged" "DEAD" "$(dead_or_ok "$(_hb_poller_verdict claude 0 "$NOW" 1 "$THRESH" 1)")"
+
+# ---------------------------------------------------------------------------
+# MUTATION ARM (DIVE-2384). Cases 20 and 27 assert an ABSENCE (empty output) and
+# those pass trivially — a verdict that returned early for any unrelated reason,
+# or a function that failed to eval at all, would satisfy them. So neutralize the
+# fix two ways and require the paired assertion to go RED. A mutation that changes
+# nothing is reported as a harness failure, not skipped.
+MUT_FAIL=0
+mut_check() { # desc expected actual
+  if [[ "$2" == "$3" ]]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); MUT_FAIL=1
+    printf 'FAIL (mutation): %s\n  expected: [%s]\n  actual:   [%s]\n' "$1" "$2" "$3"; fi
+}
+DEF=$(awk '/^_hb_poller_verdict\(\) \{/,/^\}/' "$SRC/cmd_heartbeat.sh")
+if [[ -z "$DEF" ]]; then
+  printf 'FAIL (mutation): could not extract _hb_poller_verdict from %s/cmd_heartbeat.sh\n' "$SRC"
+  FAIL=$((FAIL+1)); MUT_FAIL=1
+fi
+# Run <mutated-source> against args in a subshell, under a different name so the
+# real definition above is never clobbered.
+run_mut() { local d="$1"; shift; ( eval "$(sed 's/^_hb_poller_verdict() {/_mut() {/' <<<"$d")"; _mut "$@" ); }
+
+# Mutation A — REVERT the fix: make the grace window unreachable. Case 20 (the
+# restart race) must come back DEAD. This proves the grace guard is what silences
+# it, not some unrelated early return.
+MUT_A=$(sed 's/(( uptime <= thresh ))/(( uptime <= -1 ))/' <<<"$DEF")
+mut_check "mutation A landed (grace neutralized)" "changed" \
+  "$([[ "$MUT_A" != "$DEF" ]] && printf changed || printf UNCHANGED)"
+mut_check "mutation A: restart race goes RED" "DEAD" "$(dead_or_ok "$(run_mut "$MUT_A" claude 0 "$NOW" 1 "$THRESH" 1 6)")"
+# ...and A must NOT disturb the detection half, or it is not a targeted mutation.
+mut_check "mutation A: real death still detected" "DEAD" "$(dead_or_ok "$(run_mut "$MUT_A" claude 0 "$NOW" 1 "$THRESH" 1 3600)")"
+
+# Mutation B — the CHEAP WRONG FIX: mute the missing-beacon branch outright. Case
+# 21 (a genuinely dead poller) must come back OK. This is the whole risk of this
+# change: if B fails to flip, the canary can no longer fire at all and the real
+# failure it guards — a deaf channel, gates unclearable from the phone — goes
+# unwatched.
+MUT_B=$(sed 's/echo "no beacon (poller never started)"/:/' <<<"$DEF")
+mut_check "mutation B landed (detection deleted)" "changed" \
+  "$([[ "$MUT_B" != "$DEF" ]] && printf changed || printf UNCHANGED)"
+mut_check "mutation B: real death goes RED (undetected)" "OK" "$(dead_or_ok "$(run_mut "$MUT_B" claude 0 "$NOW" 1 "$THRESH" 1 3600)")"
+# ...and B must leave the restart race silent, so the two mutations are distinct.
+mut_check "mutation B: restart race still silent" "OK" "$(dead_or_ok "$(run_mut "$MUT_B" claude 0 "$NOW" 1 "$THRESH" 1 6)")"
+
+if (( MUT_FAIL )); then
+  printf '\nMUTATION ARM FAILED — the green above is NOT evidence.\n'
+fi
+
 printf '\npoller-liveness unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/poller_liveness_unit.sh
+++ b/tests/poller_liveness_unit.sh
@@ -164,6 +164,53 @@ mut_check "mutation B: real death goes RED (undetected)" "OK" "$(dead_or_ok "$(r
 # ...and B must leave the restart race silent, so the two mutations are distinct.
 mut_check "mutation B: restart race still silent" "OK" "$(dead_or_ok "$(run_mut "$MUT_B" claude 0 "$NOW" 1 "$THRESH" 1 6)")"
 
+# ---------------------------------------------------------------------------
+# REMEDY TEXT (DIVE-2384, second defect). The alarm's prescribed remedy was
+# "Fix: restart the agent(s)" — the exact action that CREATES this condition,
+# because shutdown() unlinks the beacon. Anyone who believed the alarm re-armed it
+# within seconds and wiped every agent's running context per pass. That text is
+# prose inside a cmd_send string: nothing else in this repo asserts it, so it can
+# silently regress to the loop. These arms are its only guard.
+#
+# LIVENESS FIRST. The arms below are mostly NEGATIVE ("must not say X"), and a
+# negative assertion over an empty haystack passes for free — a renamed function,
+# a moved string or a changed grep would make all of them vacuous. So prove the
+# extraction actually found the alarm before grading its contents.
+REMEDY=$(awk '/^_hb_poller_liveness_sweep\(\) \{/,/^\}/' "$SRC/cmd_heartbeat.sh" \
+         | grep -F 'Telegram poller DEAD on:')
+has() { [[ "$2" == *"$1"* ]] && printf yes || printf no; }
+
+# 36. Liveness: the alarm string is reachable at all.
+check "remedy: alarm string extracted" "yes" "$(has 'Gate-ping tap buttons still SEND' "$REMEDY")"
+
+# 37. The self-perpetuating remedy is GONE. This is the defect.
+check "remedy: no unconditional restart instruction" "no" "$(has 'Fix: restart the agent(s)' "$REMEDY")"
+
+# 38. And it is replaced by a non-destructive confirmation step, not just deleted —
+#     an alarm with no remedy at all is a different failure, not a fix.
+check "remedy: names a confirm-first check" "yes" "$(has 'is bot.pid' "$REMEDY")"
+check "remedy: confirmation is observable"  "yes" "$(has "bot.heartbeat's mtime advancing" "$REMEDY")"
+
+# 39. Scoped to the ONE named subject. A plural remedy on a fleet-wide alarm is a
+#     fleet-wide action — the 17:00:05 fire named all six agents in one line.
+check "remedy: scopes the restart to THAT ONE agent" "yes" "$(has 'restart THAT ONE agent' "$REMEDY")"
+
+# 40. DIVE-818 / DIVE-1434 are provenance refs from code comments, not board rows.
+#     Unlabelled, a reader follows them and hits "no such task".
+check "remedy: labels the DIVE refs as code provenance" "yes" "$(has 'not board rows' "$REMEDY")"
+
+# Mutation C — restore the loop. Put the old remedy back and require arm 37 to go
+# RED. Without this, arm 37 is an absence over a string that nothing proves is the
+# remedy at all.
+MUT_C=${REMEDY/CONFIRM BEFORE ACTING/Fix: restart the agent(s)}
+mut_check "mutation C landed (old remedy restored)" "changed" \
+  "$([[ "$MUT_C" != "$REMEDY" ]] && printf changed || printf UNCHANGED)"
+mut_check "mutation C: unconditional-restart arm goes RED" "yes" \
+  "$(has 'Fix: restart the agent(s)' "$MUT_C")"
+# ...and C must leave the liveness arm alone, or it is not targeted.
+mut_check "mutation C: liveness arm unaffected" "yes" \
+  "$(has 'Gate-ping tap buttons still SEND' "$MUT_C")"
+
 if (( MUT_FAIL )); then
   printf '\nMUTATION ARM FAILED — the green above is NOT evidence.\n'
 fi


### PR DESCRIPTION
## The defect

`thresh=120` in `_hb_poller_liveness_sweep` carries the author's own comment —
`>> 3s beat; rides a restart/GC pause` — but a restart could **never reach it**.

1. The plugin's `shutdown()` **unlinks** `bot.heartbeat` on SIGTERM
   (`telegram-pi/server.ts`, `telegram-codex/server.ts`), and `systemctl restart`
   sends SIGTERM — so a restart removes the beacon rather than leaving it stale.
2. systemd reports the unit **active** across the bounce, so the sweep's
   `supposed=0` skips (desiredState=stopped / unit not active) never fire.
3. The sweep stats an absent file → `mtime=0`.
4. `_hb_poller_verdict` hits `[[ -z "$mtime" || "$mtime" == "0" ]]` and returns
   `no beacon (poller never started)` **before `$thresh` is ever read**.

Beacon age cannot measure a beacon that does not exist. It is a race, not every
restart — the alarm fires only when a sweep tick lands inside the
unlink→first-bump gap, which is why it looked nondeterministic. A fleet-wide
restart makes it near-certain: on 2026-07-30 all six paired claude agents fired
in one line, one second before their replacement pollers existed.

## The fix

Grace the verdict on how long the **unit** has been active
(`ActiveEnterTimestamp`) instead of on beacon age. Inside `thresh` seconds the
poller has not had a fair chance to bump, so the guard sits **ahead of both
branches** — the beacon may be absent (clean restart) or stale (a rough kill
left the file), which is the same race with two different symptoms. A genuinely
dead poller keeps its unit active well past `thresh` and still alarms, one grace
window later.

Shape (a) of the three the report offered — the conservative one. Shape (c),
dropping the `unlinkSync`, was **not** taken: that unlink sits inside the
DIVE-818 incident fix, where `incumbentHolds()` depends on `heartbeatFresh()`
and a transient spawn stomping the live poller left the channel deaf. Not
regressing a real outage to fix a false alarm.

**Unresolvable uptime is not graced.** Empty (no such unit, systemd
unreachable), non-numeric, or a stamp in the future all fall through to the
alarm, so a broken probe degrades to the pre-fix behaviour and can never
silently delete detection. The failure this canary guards — a deaf channel,
gates unclearable from the phone — is real, so the safe default is a false
alarm, not a missed death.

## The alarm text was a self-perpetuating loop

Its prescribed remedy was *"restart the agent(s)"*, which is the exact action
that **creates** the condition. Anyone who believed the alarm and followed it
re-armed it within seconds and wiped every agent's running context on each pass.
It now says confirm first — is `bot.pid`'s process alive, is `bot.heartbeat`'s
mtime advancing? — and restart only the one named agent.

It also told the reader to "check the DIVE-818 slot". DIVE-818 and DIVE-1434 are
provenance refs from code comments, not board rows; neither resolves, so that
pointer was a dead end. They are now labelled as code refs.

## Grading — the green is not the evidence

This is an **absence** assertion and absence passes trivially, so both reds are
required:

- a restarting-active agent with an unlinked beacon must produce **no verdict**, and
- a **genuinely dead** poller must **still alarm**.

The second half is the whole risk: the cheap wrong fix is to mute the
missing-beacon branch, which deletes real detection and leaves a canary that can
never fire.

`tests/poller_liveness_unit.sh` (the existing headless harness for the pure
verdict) gains both, plus the grace boundary in each direction, the three
unresolvable-uptime cases, the stale-beacon symmetry, 6-arg back-compat, and a
**mutation arm** that neutralizes the fix two ways and requires the paired
assertion to flip. A mutation that changes nothing is reported as a harness
failure, not skipped. **25 passed, 0 failed.**

Anchored by mutating the **source**, not just the extracted copy:

| source mutation | result |
|---|---|
| grace made unreachable (`uptime <= -1`) | `30 passed, 4 failed` — restart race, at-threshold, and stale-in-grace all go red |
| missing-beacon branch muted (the cheap wrong fix) | `24 passed, 10 failed` — the detection half goes red and the mutation arm's own landed-check trips |

## Replay against the recorded incident

Fed the **real** `ActiveEnterTimestamp` of the six units named in
`/var/log/5dive-heartbeat.log` at the 17:00:05 alarm instant into the patched
verdict, with `mtime=0` standing in for the beacon `shutdown()` had just
removed:

```
community  active_since=17:00:00  uptime_at_alarm=5   verdict=<silent>
creative   active_since=17:00:00  uptime_at_alarm=5   verdict=<silent>
dev        active_since=16:59:59  uptime_at_alarm=6   verdict=<silent>
main       active_since=17:00:00  uptime_at_alarm=5   verdict=<silent>
marketing  active_since=17:00:00  uptime_at_alarm=5   verdict=<silent>
olivia     active_since=17:00:00  uptime_at_alarm=5   verdict=<silent>
```

Every one of the six false alarms is suppressed; none of the detection cases is.

## Second commit: the remedy half was ungraded (self-audit)

The change has two halves and only one was being graded. The verdict logic got 29
arms plus the two-way mutation pass above; the **remedy text** — the defect where
the alarm's prescribed fix was the exact action that CREATES the condition — got
none. That text is prose inside a `cmd_send` string: nothing in this repo asserts
it and no reviewer diffs it, **which is why it shipped as a loop in the first
place**. Leaving it uncovered guarantees the next regression is equally invisible.

Six arms now grade the alarm string as it exists in `cmd_heartbeat.sh`: the
unconditional restart instruction is gone, a non-destructive confirm-first step
**replaced** it rather than the remedy just being deleted, the restart is scoped
to THAT ONE named agent, and the `DIVE-818`/`DIVE-1434` refs are labelled code
provenance so a reader does not follow them to "no such task".

Five of the six are **negative** assertions, which pass for free over an empty
haystack — a rename or a moved string would make the whole block vacuous while
staying green. So one arm proves the extraction found the alarm before any
content is graded, and a mutation restores the old remedy and requires the arm to
flip.

| source mutation | result |
|---|---|
| remedy reverted to `Fix: restart the agent(s)` | `29 passed, 5 failed` — four remedy arms plus mutation C's own landed-check |
| sweep function renamed (extraction broken) | `26 passed, 8 failed` — the **liveness** arm reds first, so the negatives can never pass vacuously |

Clean tree: **34 passed, 0 failed**.

## Live ground truth for the mechanism

`ActiveEnterTimestamp` is the clock the whole fix rests on, so it was measured
directly rather than assumed. On two agent units restarted at different times
today it matches the unit's MainPID start **to the second**
(`20:03:05`/`20:03:05` and `21:05:25`/`21:05:25`), confirming it refreshes on
every restart and that `date -d` parses systemd 255's format under
`en_US.UTF-8`. Every way that probe can fail — unparseable, absent, future
stamp — falls through to the alarm rather than muting it.

## Not yet on the host

The live sweep runs from `/usr/local/bin/5dive` via root cron
(`*/5 * * * * 5dive heartbeat tick`), which is `v0.17.10`. Merging does not stop
the false alarm on this box; it takes effect on the next release cut plus
`5dive update`. Five other merged fixes sit in the same position, so this is the
repo's normal steady state, not a gap introduced here.

Closes DIVE-2384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

