### PR TITLE
fix(task): retire a settled gate's inline buttons at close time (DIVE-2410)

### DIFF
--- a/src/cmd_agent_runtime.sh
+++ b/src/cmd_agent_runtime.sh
@@ -390,6 +390,36 @@ _mirror_send() {
   curl -s --connect-timeout 5 --max-time 10 -X POST "https://api.telegram.org/bot${token}/sendMessage" "${args[@]}" 2>/dev/null
 }
 
+# _mirror_edit_markup — DIVE-2410: change (by default REMOVE) the inline keyboard
+# on a message that was ALREADY delivered. Sibling of _mirror_send, deliberately
+# next to it and under the SAME dry-run guard, because an edit lands in the same
+# human's chat a send does: a fixture harness that can edit a real message can
+# rewrite a real conversation, which is the DIVE-1500 risk shape verbatim.
+# Bot API: editMessageReplyMarkup with reply_markup OMITTED removes the keyboard.
+#
+# Two Bot API refusals are BENIGN here and callers must not read them as breakage:
+# "message is not modified" (the keyboard is already gone — the desired end state)
+# and "message to edit not found" (deleted, or older than Telegram will let a bot
+# edit). Both mean the button can no longer be tapped, which is the whole point.
+_mirror_edit_markup() { # <token> <chat> <message_id> [reply_markup]
+  local token="$1" chat="$2" mid="$3" reply_markup="${4:-}"
+  if [[ -n "${FIVEDIVE_NOTIFY_DRYRUN:-}" && "${FIVEDIVE_NOTIFY_DRYRUN}" != "0" ]]; then
+    local dry_line
+    dry_line=$(printf 'notify-dryrun edit_markup chat=%s message_id=%s markup=%s' \
+      "$chat" "$mid" "$([[ -n "$reply_markup" ]] && echo replace || echo strip)")
+    if [[ -n "${FIVEDIVE_NOTIFY_DRYRUN_LOG:-}" ]]; then
+      printf '%s\n' "$dry_line" >>"$FIVEDIVE_NOTIFY_DRYRUN_LOG" 2>/dev/null || true
+    fi
+    printf '%s\n' "$dry_line" >&2 || true
+    printf '%s' '{"ok":true,"dry_run":true}'
+    return 0
+  fi
+  local args=(--data-urlencode "chat_id=${chat}" --data-urlencode "message_id=${mid}")
+  [[ -n "$reply_markup" ]] && args+=(--data-urlencode "reply_markup=${reply_markup}")
+  curl -s --connect-timeout 5 --max-time 10 -X POST \
+    "https://api.telegram.org/bot${token}/editMessageReplyMarkup" "${args[@]}" 2>/dev/null
+}
+
 # Rename a migrated group's key (old→new) in access.json, preserving the policy
 # value (incl. message_thread_id) and the file's owner/mode. Runs as root (the
 # mirror only fires under sudo), so chowning back to the agent owner is required

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -2676,6 +2676,17 @@ $_body"
   # recap; only the redundant live ping is dropped. Manual/delegated closes
   # (no template parent) still notify. Cheap single-column read, fail-open to
   # "notify" so a DB hiccup never silently swallows a real finish line.
+  # DIVE-2410: closing a task MOOTS any gate still open on it — the question can
+  # never be answered now, so its button must stop looking answerable. Conditional
+  # on the gate being UNANSWERED on purpose: an answered gate had its buttons
+  # retired at answer time, and re-editing would only add a "not modified" row.
+  # Independent of --notify (that flag governs the human's ✅/⚠️ ping, a different
+  # question from whether a dead control is still on their screen).
+  if [[ "$verb" == "done" || "$verb" == "cancel" ]]; then
+    local _open_gate
+    _open_gate=$(db "SELECT 1 FROM tasks WHERE id=${id} AND need_type IS NOT NULL AND need_answered_at IS NULL;" 2>/dev/null || echo "")
+    [[ -n "$_open_gate" ]] && { _task_gate_retire_buttons "$ident" "task ${verb} with the gate still open" || true; }
+  fi
   if (( notify )) && [[ "$verb" == "done" || "$verb" == "cancel" ]]; then
     local from_tmpl
     from_tmpl=$(db "SELECT COALESCE(from_template_id,'') FROM tasks WHERE id=${id};" 2>/dev/null || echo "")
@@ -3076,6 +3087,11 @@ cmd_task_reject() {
         WHERE id=${id} AND need_answered_at IS NULL;"
     # DIVE-2054: task-store state — fenced.
     _task_store_audit_log "task reject gate-supersede" "ok" 0 -- "task=$ident" || true
+    # DIVE-2410: superseded is settled. This one is the worst stale button of the
+    # set — the gate now reads '(superseded ...)' with provenance auto:reject, so
+    # a human tapping it would believe they authorized something an agent already
+    # closed on their behalf.
+    _task_gate_retire_buttons "$ident" "superseded by auto:reject" || true
   fi
   # max_iterations reached -> stop bouncing, park it on a human to decide.
   if (( maxi > 0 && iter >= maxi )); then
@@ -3839,6 +3855,9 @@ cmd_task_park() {
             need_type=NULL, ask=NULL, need_options=NULL, recommend=NULL
       WHERE id=${tid} AND status NOT IN ('done','cancelled');
       COMMIT;"
+  # DIVE-2410: park clears the gate columns, so whatever button that gate put in a
+  # human's chat now points at a question the task no longer holds.
+  _task_gate_retire_buttons "$tident" "parked" || true
   local wake_note=""; [[ "$wake_sql" != "NULL" ]] && wake_note=" — wakes $(db "SELECT wake_at FROM tasks WHERE id=${tid};") UTC"
   ok "$tident parked (no action needed)${reason:+ — $reason}${wake_note}" \
      '{task:($t|tonumber), task_ident:$ti, parked:true, reason:$r, wake_at:(($w|select(length>0)) // null)}' \
@@ -4998,6 +5017,11 @@ cmd_task_need() {
     # suppress it (fencing here would trade a contamination bug for an
     # evidence-suppression bug, the DIVE-1968 fail-open family). See DIVE-2054 wiki.
     audit_log "task need withdraw" "ok" 0 -- "task=$ident" "type=$w_type" "by=${w_name:-$w_kind}" "asserted_from=${from:-}" || true
+    # DIVE-2410: a withdrawn gate is a settled gate from the human's side — the
+    # question is gone, so the button must go with it. A withdrawal is the path
+    # most likely to leave a stale button standing, because unlike an answer
+    # nothing about it ever reaches the human's chat.
+    _task_gate_retire_buttons "$ident" "withdrawn by ${w_name:-$w_kind}" || true
     local w_new; w_new=$(db "SELECT status FROM tasks WHERE id=${id};")
     ok "$ident gate withdrawn (${w_type}) — moot request cleared, no secret/grant recorded; task now ${w_new}" \
        '{ident:$id, withdrawn:true, was_type:$wt, status:$st}' \
@@ -6793,6 +6817,147 @@ _task_gate_delivery_log() { # <ok|error> <task_ids> <chat> <message_id> <detail>
   [[ "$result" == "ok" ]] || warn "$idents: gate alert delivery FAILED for chat ${chat:-none} (${detail:-unknown}); ${next_step}"
 }
 
+# ---- DIVE-2410: retire a settled gate's buttons -----------------------------
+#
+# THE DEFECT. A gate's approve button outlived its gate. Confirmed on DIVE-2400:
+# two buttons delivered (03:20:02Z message_id=15491, 04:05:02Z message_id=15492,
+# both via=marketing), gate closed 04:28:41Z, and NOTHING edited, disabled or
+# expired either keyboard. From the close onward there were two live-LOOKING
+# approve buttons in the human's chat for a question already settled.
+#
+# WHY THAT IS A DEFECT AND NOT COSMETIC. A tap on a closed gate correctly records
+# nothing. But the human gets no error, no "already closed", no visual change, so
+# the only conclusion available to them is that they approved. The record and the
+# human's belief diverge, and the human has no way to see it — the same class of
+# harm as DIVE-2406 approached from the other side (there the record claimed an
+# approval nobody gave; here the human believes an approval the record lacks).
+# Read a human's frustration with a control as data about the control: lodar's
+# "I tap the approve again. wtf is the human gate. I hate it" is the symptom.
+#
+# The plugin's `tna:` handler ALREADY answers a stale tap with a toast and strips
+# the keyboard (server.ts, resolveTnaAnswer -> already/nogate). That is the wrong
+# layer to rely on alone, for two reasons: it fires only if the human taps (so
+# until then the chat keeps showing a live control), and a toast is a 2-second
+# mobile banner that is genuinely easy to miss. The button must stop LOOKING
+# tappable at CLOSE time, from the process that did the closing.
+#
+# WHY THIS LIVES IN THE CLI. Gates close from paths with no Telegram session at
+# all: `task answer` on the dashboard, a lead-clear, `task need --withdraw`,
+# `task park`, the verifier's auto:reject, a done/cancel that moots an open gate.
+# Every one of those runs here. A plugin-side fix cannot cover any of them.
+
+# The token for the bot that CARRIED a delivery. Deliberately NOT
+# _task_agent_channel: that clobbers TASK_CH_* (token, access, type, agent),
+# which live callers are mid-flight on — _task_close_notify sends through those
+# globals and retirement can run beside it. We need only the token, and
+# connector files are the same group-claude-readable source _task_agent_channel
+# reads, so read it directly and leave the globals alone.
+# via=<agent> matters and is not decorative: message_id is scoped to a bot-chat
+# PAIR, so editing 15491 with the wrong bot's token edits a different message or
+# nothing (DIVE-2073 is why the delivery row carries `via` at all).
+_task_gate_bot_token() { # <agent-name> -> token on stdout
+  local name="${1:-}" token="" f
+  if [[ -n "$name" && "$name" != "none" ]]; then
+    f="${CONNECTORS_DIR}/telegram-${name}.env"
+    [[ -r "$f" ]] && token=$(sed -n 's/^TELEGRAM_BOT_TOKEN=//p' "$f" | head -1)
+  fi
+  [[ -n "$token" ]] || token="${TELEGRAM_BOT_TOKEN:-}"
+  printf '%s' "$token"
+}
+
+# Every button-bearing message this task's gate put in a human chat, as
+# chat<TAB>message_id<TAB>via, deduped. The set is already knowable: the
+# gate-delivery log records chat + message_id + via per delivery, which is
+# exactly what DIVE-2410 needs and nobody had read back yet.
+#
+# Four exclusions, each for its own reason — a wrong row here edits a message
+# that was never this gate's:
+#   result=error rows      no message exists to edit (message_id is empty).
+#   message_id 0 / none    a dry-run receipt or an ok-without-id; not a real message.
+#   chat=agent:<name>      the maker->verifier handoff leg (see the reviewer-ping
+#                          delivery rows). An agent inbox, not a Telegram chat.
+#   another task's ident   `tasks=` is a COMMA LIST — the re-nag batches several
+#                          gates into one message. Match a whole field, never a
+#                          substring, or DIVE-24 retires DIVE-2410's button.
+# A batched message covering a still-open gate is retired too, and that is
+# correct-but-blunt: its keyboard carries a button per task, and the Bot API
+# cannot remove one button without rebuilding the whole markup. Losing a live
+# button is recoverable — the re-nag re-delivers pending gates — while leaving a
+# settled one tappable is the bug being fixed. Noted, not silently accepted.
+_task_gate_deliveries() { # <ident>
+  local ident="$1"
+  local logf="${FIVEDIVE_GATE_NOTIFY_LOG:-}"
+  [[ -n "$logf" ]] || logf=/var/log/5dive/notify/gate-notify.log
+  [[ -r "$logf" ]] || return 0
+  awk -v want="$ident" '
+    /gate-delivery result=ok/ {
+      tasks=""; chat=""; mid=""; via=""
+      for (i = 1; i <= NF; i++) {
+        if      (substr($i, 1, 6)  == "tasks=")      tasks = substr($i, 7)
+        else if (substr($i, 1, 5)  == "chat=")       chat  = substr($i, 6)
+        else if (substr($i, 1, 11) == "message_id=") mid   = substr($i, 12)
+        else if (substr($i, 1, 4)  == "via=")        via   = substr($i, 5)
+      }
+      if (chat == "" || chat == "none" || chat ~ /^agent:/) next
+      if (mid == "" || mid == "none" || mid == "0") next
+      n = split(tasks, T, ",")
+      for (j = 1; j <= n; j++) if (T[j] == want) { print chat "\t" mid "\t" via; next }
+    }
+  ' "$logf" 2>/dev/null | awk -F'\t' '!seen[$1 FS $2]++'
+}
+
+# Strip the inline keyboard off every message that delivered this gate. Call it
+# AFTER the settling write has committed, always best-effort: a gate is settled
+# by the DB row, and a Telegram edit that fails must never unsettle it or fail
+# the caller's command.
+#
+# FENCE. Same rail as the send whose message it edits — refuse unless the active
+# store is the prod store (_task_human_send_allowed, the DIVE-1506 positive
+# allowlist), EXCEPT when the dry-run quarantine is on, which is the one case a
+# harness can exercise this end to end while being physically unable to reach
+# Telegram (_mirror_edit_markup enforces that itself). An opt-in-only fence is
+# the mistake DIVE-1968 removed; this is store identity first, as there.
+_task_gate_retire_buttons() { # <ident> <why>
+  local ident="$1" why="${2:-gate closed}"
+  local _dry=0
+  [[ -n "${FIVEDIVE_NOTIFY_DRYRUN:-}" && "${FIVEDIVE_NOTIFY_DRYRUN}" != "0" ]] && _dry=1
+  if ! _task_human_send_allowed && (( ! _dry )); then
+    return 0
+  fi
+  local rows; rows=$(_task_gate_deliveries "$ident") || return 0
+  [[ -n "$rows" ]] || return 0
+  local chat mid via token resp ok desc result
+  while IFS=$'\t' read -r chat mid via; do
+    [[ -n "$chat" && -n "$mid" ]] || continue
+    token=$(_task_gate_bot_token "$via")
+    if [[ -z "$token" ]]; then
+      # Name the miss. A retirement that cannot resolve the delivering bot leaves
+      # a tappable button behind, which is the defect — so it is a row, not a
+      # shrug. (Reachable when the delivering agent was torn down after filing.)
+      _task_store_audit_log "gate button retire" "error" 1 -- \
+        "task=$ident" "chat=$chat" "message_id=$mid" "via=${via:-none}" \
+        "detail=no bot token for delivering agent; button left live" || true
+      continue
+    fi
+    resp=$(_mirror_edit_markup "$token" "$chat" "$mid") || resp="${resp:-}"
+    ok=$(jq -r '.ok // false' <<<"$resp" 2>/dev/null) || ok=false
+    desc=$(jq -r '.description // empty' <<<"$resp" 2>/dev/null) || desc=""
+    result=error
+    if [[ "$ok" == "true" ]]; then
+      result=ok; desc="keyboard removed"
+    elif [[ "$desc" == *"not modified"* || "$desc" == *"message to edit not found"* ]]; then
+      # Already un-tappable — the end state we wanted, reached without us.
+      result=ok
+    fi
+    _task_store_audit_log "gate button retire" "$result" \
+      "$([[ "$result" == "ok" ]] && echo 0 || echo 1)" -- \
+      "task=$ident" "chat=$chat" "message_id=$mid" "via=${via:-none}" \
+      "why=$why" "detail=${desc:-unconfirmed Bot API edit}" || true
+    [[ "$result" == "ok" ]] || warn "$ident: could not retire the gate button on message $mid in chat $chat (${desc:-unknown}) — a settled gate may still show a live approve button there."
+  done <<<"$rows"
+  return 0
+}
+
 # DIVE-1506 — fail-closed guard: a gate alert (task_need_notify) or an /inbox digest
 # (_task_inbox_send) may reach the PAIRED HUMAN only from the canonical PROD task DB. This is a
 # POSITIVE ALLOWLIST, not a fixture blocklist — a rotted blocklist is exactly how DIVE-1500's guard
@@ -8539,6 +8704,12 @@ cmd_task_answer() {
     (( value_set )) || fail "$E_USAGE" "--value is required (the human's answer)"
     db "UPDATE tasks SET need_answer=$(sqlq "$value"), need_answered_at=$(sqlq "$_ts"), need_answered_by=$(sqlq "$answered_by"), need_answered_uid=${_uidsql}, need_answer_sig=$(sqlq "$_sig") WHERE id=${id};"
   fi
+
+  # DIVE-2410: the gate is settled, so its buttons must stop looking tappable.
+  # AFTER the write, never before — the settled state is the DB row, and a
+  # Telegram edit is best-effort. Covers the human tap, a lead-clear, and a
+  # dashboard/CLI answer, since all three land in this one function.
+  _task_gate_retire_buttons "$ident" "answered by ${answered_by}" || true
 
   # INST-4: the gate CLEAR — the row that decides whether this task's timeline
   # reads "zero-human" or "a human authorized it", so it is worth more care than

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -5616,6 +5616,14 @@ cmd_task_need() {
     fail "$E_GENERIC" "$ident: refusing to file a tier-2 gate that cannot mint its own human proof — openssl and /dev/urandom are both unusable on this box, so the tier-2 human floor could not be enforced on it. Filing it anyway would create a gate that LOOKS hard-gated and is not (DIVE-2131). Fix the box's RNG, or file this at a lower --tier if it genuinely is not a human-only call."
   fi
 
+  # DIVE-2410: filing REPLACES any gate already on this task (that is what the
+  # archive-and-clear is for), so whatever button the OUTGOING gate put in a human
+  # chat now asks a question this task no longer holds. Retire BEFORE the new
+  # delivery, not after: the delivery log is the input, so once task_need_notify
+  # has run, the gate's own fresh button is in there too and would be stripped by
+  # its own filing. Order is the correctness condition here, not a preference.
+  _task_gate_retire_buttons "$ident" "superseded by a re-filed gate" || true
+
   db "BEGIN IMMEDIATE;
       $(_gate_archive_and_clear_sql file "id=${id}")
       UPDATE tasks
@@ -6888,7 +6896,19 @@ _task_gate_deliveries() { # <ident>
   local ident="$1"
   local logf="${FIVEDIVE_GATE_NOTIFY_LOG:-}"
   [[ -n "$logf" ]] || logf=/var/log/5dive/notify/gate-notify.log
-  [[ -r "$logf" ]] || return 0
+  if [[ ! -r "$logf" ]]; then
+    # Make the absence observable ONCE per process. This log is the ONLY record of
+    # which messages a gate put in a human's chat, so if it cannot be read the
+    # retirement is a total silent no-op — every settled button stays tappable and
+    # nothing anywhere says so. It is 0664 today, but "unreadable" and "no
+    # deliveries" must never share an answer in a function whose failure mode is
+    # invisible (the DIVE-1927 absent-vs-forbidden rule, one layer over).
+    if [[ -e "$logf" && -z "${_TASK_GATE_RETIRE_BLIND:-}" ]]; then
+      _TASK_GATE_RETIRE_BLIND=1
+      warn "cannot read the gate-delivery log ($logf) — settled gates' buttons cannot be retired from this process, so a closed gate may keep showing a live approve button (DIVE-2410)."
+    fi
+    return 0
+  fi
   awk -v want="$ident" '
     /gate-delivery result=ok/ {
       tasks=""; chat=""; mid=""; via=""

--- a/tests/gate_button_retire_unit.sh
+++ b/tests/gate_button_retire_unit.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# DIVE-2410: a settled gate must stop showing a live-looking approve button.
+#
+# WHAT THIS GRADES, and why each arm exists rather than just "it edits something":
+#   selection   the right messages, and ONLY those (four exclusions, each probed)
+#   liveness    every exclusion is probed POSITIVELY too — an arm that asserts
+#               "444 was not edited" is worthless unless another arm proves 444
+#               CAN be edited. A filter that rejects everything passes the first
+#               and fails the second.
+#   substring   `tasks=` is a comma list; DIVE-A must not match DIVE-AA
+#   wiring      the real `task answer` / `--withdraw` / done-moot paths CALL it.
+#               A helper nobody calls is the bug with extra steps.
+#   format      the wiring arm reads a log written by the REAL emitter, so the
+#               awk parser is coupled to the producer, not to a format invented here
+#   fence       a non-prod store makes zero edits, AND the same input under
+#               dry-run makes edits (so the fence-holds arm is not vacuous)
+#   dryrun      _mirror_edit_markup physically cannot reach Telegram under dry-run
+#   token       the DELIVERING bot's token is used, not the caller's (message_id is
+#               scoped to a bot-chat pair — the wrong token edits the wrong message)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+TMP=$(mktemp -d /tmp/gate-button-retire.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh cmd_agent_runtime.sh cmd_task.sh; do
+  source "$SRC/$f"
+done
+set +e
+
+PASS=0; FAIL=0
+chk() { # <desc> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then PASS=$((PASS+1)); printf 'ok   %s\n' "$1"
+  else FAIL=$((FAIL+1)); printf 'FAIL %s\n       expected: %s\n       actual:   %s\n' "$1" "$2" "$3"; fi
+}
+
+STATE_DIR="$TMP"; TASKS_DIR="$TMP/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+# DIVE-1506 positive allowlist: this harness deliberately drives the human-facing
+# retire path, so declare its ISOLATED db as prod. Nothing here can reach Telegram
+# — every edit is captured by the stub below, and the one arm that exercises the
+# real primitive runs under FIVEDIVE_NOTIFY_DRYRUN with curl itself stubbed.
+export FIVEDIVE_PROD_TASKS_DB="$TASKS_DB"
+mkdir -p "$TASKS_DIR"
+tasks_db_init; _tasks_db_migrate >/dev/null 2>&1
+
+LOG="$TMP/gate-notify.log"
+FIVEDIVE_GATE_NOTIFY_LOG="$LOG"
+CONNECTORS_DIR="$TMP/connectors"; mkdir -p "$CONNECTORS_DIR"
+printf 'TELEGRAM_BOT_TOKEN=tok-marketing\n' >"$CONNECTORS_DIR/telegram-marketing.env"
+printf 'TELEGRAM_BOT_TOKEN=tok-creative\n'  >"$CONNECTORS_DIR/telegram-creative.env"
+
+# Capture the edits instead of performing them. token|chat|message_id per line.
+EDITS="$TMP/edits"; : >"$EDITS"
+EDIT_RESP='{"ok":true}'
+_mirror_edit_markup() {
+  printf '%s|%s|%s\n' "$1" "$2" "$3" >>"$EDITS"
+  printf '%s' "$EDIT_RESP"
+}
+edits() { sort "$EDITS" | tr '\n' ' ' | sed 's/ $//'; }
+reset_edits() { : >"$EDITS"; }
+
+row() { # <result> <tasks> <chat> <message_id> <via>
+  printf '2026-07-30T04:00:00Z gate-delivery result=%s tasks=%s chat=%s message_id=%s via=%s path=owner-dm detail=%q\n' \
+    "$1" "$2" "$3" "$4" "$5" "confirmed Bot API send" >>"$LOG"
+}
+
+# ---------------------------------------------------------------- selection ---
+: >"$LOG"
+row ok    DIVE-A       424242       111  marketing   # retire
+row ok    DIVE-A       424242       222  marketing   # retire
+row ok    DIVE-A       424242       111  marketing   # duplicate -> dedup
+row error DIVE-A       424242       none marketing   # no message exists
+row ok    DIVE-A       agent:olivia 333  marketing   # verifier leg, not a chat
+row ok    DIVE-A       424242       0    marketing   # dry-run receipt, not a message
+row ok    DIVE-B       424242       444  creative    # a different task
+row ok    DIVE-B,DIVE-A -1001       555  marketing   # batched re-nag, whole-field match
+row ok    DIVE-AA      424242       666  marketing   # substring trap: DIVE-A is a prefix
+
+reset_edits
+_task_gate_retire_buttons DIVE-A "answered by human:test" >/dev/null 2>&1
+chk "retires exactly this gate's real messages, deduped" \
+    "tok-marketing|-1001|555 tok-marketing|424242|111 tok-marketing|424242|222" "$(edits)"
+
+# LIVENESS for every exclusion above. Each excluded message_id is now REQUIRED to
+# be editable when it is genuinely in scope, so "444 was skipped" is a property of
+# the filter and not of a helper that edits nothing.
+reset_edits
+_task_gate_retire_buttons DIVE-B "answered by human:test" >/dev/null 2>&1
+chk "liveness: the other task's 444 and the shared batch 555 ARE editable for DIVE-B" \
+    "tok-creative|424242|444 tok-marketing|-1001|555" "$(edits)"
+
+reset_edits
+_task_gate_retire_buttons DIVE-AA "answered by human:test" >/dev/null 2>&1
+chk "liveness: 666 IS editable for DIVE-AA (so its absence above is the whole-field match)" \
+    "tok-marketing|424242|666" "$(edits)"
+
+reset_edits
+_task_gate_retire_buttons DIVE-NOSUCH "answered by human:test" >/dev/null 2>&1
+chk "a task with no deliveries edits nothing" "" "$(edits)"
+
+# ------------------------------------------------------------------- token ---
+# message_id is scoped to a bot-chat PAIR. Using the caller's token instead of the
+# delivering bot's edits a different message or nothing at all (DIVE-2073).
+reset_edits
+TELEGRAM_BOT_TOKEN=tok-CALLER
+_task_gate_retire_buttons DIVE-B "answered by human:test" >/dev/null 2>&1
+chk "uses the DELIVERING bot's token (via=), never the caller's" \
+    "tok-creative|424242|444 tok-marketing|-1001|555" "$(edits)"
+unset TELEGRAM_BOT_TOKEN
+
+: >"$LOG"; row ok DIVE-T 424242 777 ghostagent
+reset_edits
+_task_gate_retire_buttons DIVE-T "answered by human:test" >/dev/null 2>&1
+chk "an unresolvable delivering bot performs no edit (rather than a wrong one)" "" "$(edits)"
+
+# --------------------------------------------------------- benign refusals ---
+# Two Bot API refusals mean the button is ALREADY un-tappable, which is the desired
+# end state. Grading them as failures would fill the audit with false alarms and
+# train readers to ignore the row that matters.
+: >"$LOG"; row ok DIVE-R 424242 888 marketing
+for pair in \
+  '{"ok":false,"description":"Bad Request: message is not modified"}|ok' \
+  '{"ok":false,"description":"Bad Request: message to edit not found"}|ok' \
+  '{"ok":false,"description":"Bad Request: chat not found"}|error'; do
+  EDIT_RESP="${pair%|*}"; want="${pair##*|}"
+  reset_edits
+  out=$(_task_gate_retire_buttons DIVE-R "answered by human:test" 2>&1)
+  got=ok; grep -q 'could not retire the gate button' <<<"$out" && got=error
+  chk "Bot API '$(jq -r '.description // "ok"' <<<"${pair%|*}")' grades as $want" "$want" "$got"
+done
+EDIT_RESP='{"ok":true}'
+
+# ------------------------------------------------------------------- fence ---
+# Store identity first (DIVE-1968): a fixture store must not edit a real chat. The
+# fence-HOLDS arm is paired with a fence-RELEASED arm on the SAME input, so a
+# helper that silently edits nothing cannot pass the holds arm.
+: >"$LOG"; row ok DIVE-F 424242 999 marketing
+reset_edits
+FIVEDIVE_PROD_TASKS_DB="$TMP/not-the-prod-store.db" \
+  _task_gate_retire_buttons DIVE-F "answered by human:test" >/dev/null 2>&1
+chk "fence holds: a non-prod store performs no edit" "" "$(edits)"
+
+reset_edits
+FIVEDIVE_PROD_TASKS_DB="$TMP/not-the-prod-store.db" FIVEDIVE_NOTIFY_DRYRUN=1 \
+  _task_gate_retire_buttons DIVE-F "answered by human:test" >/dev/null 2>&1
+chk "fence is not vacuous: the SAME input under dry-run does edit" \
+    "tok-marketing|424242|999" "$(edits)"
+
+# ------------------------------- the real primitive honours the dry-run rail ---
+# _mirror_edit_markup is the one function that can physically reach Telegram, and
+# it is what a fixture harness would reach through if its stub were missed. Prove
+# the guard is inside the primitive by stubbing curl and asserting it never runs.
+CURL_HIT="$TMP/curl-hit"; : >"$CURL_HIT"
+curl() { printf 'CALLED %s\n' "$*" >>"$CURL_HIT"; printf '%s' '{"ok":true}'; }
+unset -f _mirror_edit_markup
+# shellcheck disable=SC1090
+source "$SRC/cmd_agent_runtime.sh"
+FIVEDIVE_NOTIFY_DRYRUN=1 FIVEDIVE_NOTIFY_DRYRUN_LOG="$TMP/dry.log" \
+  _mirror_edit_markup tok-marketing 424242 111 >/dev/null 2>&1
+chk "under dry-run the real _mirror_edit_markup never calls the Bot API" "" "$(cat "$CURL_HIT")"
+chk "and it records the would-be edit" "1" \
+    "$(grep -c 'edit_markup chat=424242 message_id=111 markup=strip' "$TMP/dry.log" 2>/dev/null)"
+
+FIVEDIVE_NOTIFY_DRYRUN=0 _mirror_edit_markup tok-marketing 424242 111 >/dev/null 2>&1
+chk "with dry-run off it DOES call editMessageReplyMarkup (guard is not always-on)" "1" \
+    "$(grep -c 'editMessageReplyMarkup' "$CURL_HIT" 2>/dev/null)"
+chk "and omits reply_markup, which is how the Bot API removes a keyboard" "0" \
+    "$(grep -c 'reply_markup' "$CURL_HIT" 2>/dev/null)"
+unset -f curl
+
+# ------------------------------------------------------------------ wiring ---
+# The arms above grade the helper. These grade whether the CLOSE PATHS call it —
+# and they read a delivery log written by the REAL emitter, so the awk parser is
+# coupled to its producer. A format drift in _task_gate_delivery_log breaks these,
+# which is the point: the hand-built rows above cannot catch that.
+_mirror_edit_markup() { printf '%s|%s|%s\n' "$1" "$2" "$3" >>"$EDITS"; printf '%s' '{"ok":true}'; }
+ACCESS="$TMP/access.json"
+printf '%s\n' '{"allowFrom":["1234567890"],"groups":{}}' >"$ACCESS"
+_task_owner_channel() { TASK_CH_TOKEN=tok-marketing TASK_CH_ACCESS="$ACCESS" TASK_CH_TYPE=claude TASK_CH_AGENT=marketing; return 0; }
+_task_agent_channel() { _task_owner_channel; }
+_mirror_send() { printf '%s' '{"ok":true,"result":{"message_id":15491}}'; }
+_mirror_log_button_reject() { :; }
+_mirror_follow_migration() { :; }
+
+# cmd_task_answer fires a REAL inter-agent resume ping through cmd_send, and this
+# harness declares its fixture store as prod to get past the DIVE-1506 send fence
+# — so the ping is NOT fenced and lands in a live agent's inbox. Measured, not
+# theorised: the first run of this file delivered
+# "DIVE-1 gate cleared — your 'decision' ask was answered" to agent-dev, because a
+# fresh store numbers from 1 and DIVE-1 is a plausible-looking real ident.
+# Same reflex the fixture-identifier convention exists for. Stub it, and COUNT the
+# calls so the stub cannot rot into a no-op nobody notices.
+# Counted in a FILE, not a variable: every close path below runs in a subshell, so
+# an in-shell counter increments in the child and is lost — which reads as "the
+# stub was never reached" and would have retired this assertion as a false alarm.
+PINGLOG="$TMP/pings"; : >"$PINGLOG"
+cmd_send() { printf 'x\n' >>"$PINGLOG"; return 0; }
+
+seed_gate() { # <title> -> ident on stdout; files a real gate through the real notify path
+  local id ident
+  id=$( ( JSON_MODE=1 cmd_task_add "$1" ) 2>/dev/null | jq -r '.data.id // empty')
+  [[ -n "$id" ]] || { printf ''; return 1; }
+  ident=$(db "SELECT ident FROM tasks WHERE id=${id};" 2>/dev/null)
+  [[ -n "$ident" ]] || { printf ''; return 1; }
+  : >"$LOG"
+  ( cmd_task_need "$ident" --type=decision --ask="proceed?" --options="A|B" --recommend=A ) >/dev/null 2>&1
+  printf '%s' "$ident"
+}
+
+for arm in answer withdraw done; do
+  ident=$(seed_gate "DIVE-2410 wiring arm: $arm")
+  if [[ -z "$ident" ]]; then chk "wiring/$arm: seeded a gate" "yes" "no"; continue; fi
+  chk "wiring/$arm: the real emitter logged a retirable delivery" "1" \
+      "$(_task_gate_deliveries "$ident" | grep -c '15491')"
+  reset_edits
+  case "$arm" in
+    answer)   ( cmd_task_answer   "$ident" --value=A ) >/dev/null 2>&1 ;;
+    withdraw) ( cmd_task_need     "$ident" --withdraw ) >/dev/null 2>&1 ;;
+    done)     ( cmd_task_cancel   "$ident" --result="moot" ) >/dev/null 2>&1 ;;
+  esac
+  chk "wiring/$arm: the close path retired the delivered button" \
+      "tok-marketing|1234567890|15491" "$(edits)"
+done
+
+# The stub above is load-bearing containment, not decoration: if cmd_send stops
+# being the resume path, this reads 0 and the next reader learns the harness lost
+# its containment BEFORE a fixture ident reaches a real inbox again.
+chk "the resume ping went through the stub (containment is live, not rotted)" "1" \
+    "$([[ -s "$PINGLOG" ]] && echo 1 || echo 0)"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" == "0" ]]

--- a/tests/gate_button_retire_unit.sh
+++ b/tests/gate_button_retire_unit.sh
@@ -284,6 +284,60 @@ if [[ -z "$ident" ]]; then chk "wiring/reject: seeded a gate" "yes" "no"; else
       "$(db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident=$(sqlq "$ident");")"
 fi
 
+# ------------------------------------------ file-time settle site: tier-0 ----
+# olivia's open question on iteration 1: cmd_task_need can itself SETTLE a gate at
+# FILE time — the DIVE-891 tier-0 auto-clear — and it is wired to no retire. That is
+# correct only because such a gate never DELIVERS: it self-answers and returns before
+# task_need_notify, so there is no button of its own to retire, and any button the
+# OUTGOING gate left is already stripped by the re-file retire that runs first. If
+# that stops holding it becomes a seventh settle path closing a delivered gate with
+# no retire — a silent no-op, which is the whole failure mode of this ticket.
+#
+# Graded behaviourally on purpose, and the observable was chosen the hard way — TWO
+# drafts of this arm passed against a file whose tier-0 return had been deleted:
+#   1. Static (assert the `return` sits above the first notify). `the first bare
+#      return after the write` just re-resolved to the NEXT branch's return, still
+#      above the notify. A reachability claim needs the run, not the line order.
+#   2. Behavioural but reading `_task_gate_deliveries`. That view DEDUPES identical
+#      lines (see the first arm in this file), and the mock Bot API hands back the
+#      same message_id every time — so a genuine SECOND delivery collapsed into the
+#      first and the count never moved. A deduped view cannot count deliveries.
+# Measured 2026-07-31 by deleting src/cmd_task.sh:5533: task_need_notify calls go
+# 1 -> 2 and the RAW log goes 1 -> 2, while the deduped view stays 1 either way. So
+# the raw undeduped log below is the differential observable, and the tier-0 return
+# is confirmed load-bearing — deleting it puts a real second button in the chat.
+ident=$(seed_gate "DIVE-2410 file-time arm: tier0")
+if [[ -z "$ident" ]]; then chk "file-time/tier-0: seeded a gate" "yes" "no"; else
+  reset_edits
+  ( cmd_task_need "$ident" --type=decision --ask="t0 proceed?" \
+      --options="A|B" --recommend=A --tier=0 ) >/dev/null 2>&1
+  chk "file-time/tier-0: the OUTGOING gate's button was retired by the re-file retire" \
+      "tok-marketing|1234567890|15491" "$(edits)"
+  chk "file-time/tier-0: and the auto-cleared gate delivered NO button of its own" "1" \
+      "$(grep -c 'gate-delivery result=ok' "$LOG")"
+  chk "file-time/tier-0: it really did auto-clear (the arm graded a settle, not a refusal)" \
+      "auto:t0" \
+      "$(db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident=$(sqlq "$ident");")"
+fi
+
+# The OSS-21 tier-1 precedent auto-clear is the OTHER file-time settle site and is
+# NOT graded here — say so rather than let its absence read as coverage. It needs two
+# distinct nonce-bearing prior gates on an identical ask_shape to qualify, which this
+# harness cannot seed cheaply. What bounds it today is that it is pref-gated and the
+# pref defaults OFF, so in the default fleet posture it cannot fire at all; that
+# default IS graded, because it is the thing that makes the gap survivable.
+chk "file-time/precedent: OSS-21 auto-clear is inert by default (ungraded path, fenced)" \
+    "off" "$(_p=$(_task_pref_get precedent_autoclear); printf '%s' "${_p:-off}")"
+# LIVENESS for the arm above. Its `${_p:-off}` fallback is exactly the shape that
+# passes when the reader is broken: a _task_pref_get that errored, was renamed, or
+# returned nothing collapses to "off" and the inertness arm stays green while
+# grading nothing. So prove the reader can report the OTHER value before trusting it
+# to report this one — without this arm, the fence claim above is unfalsifiable.
+_task_pref_set precedent_autoclear on >/dev/null 2>&1
+chk "file-time/precedent: liveness — the pref reader really reads (not a stuck default)" \
+    "on" "$(_p=$(_task_pref_get precedent_autoclear); printf '%s' "${_p:-off}")"
+_task_pref_set precedent_autoclear off >/dev/null 2>&1
+
 # ------------------------------------------------- blind-log observability ---
 # The delivery log is the ONLY record of which messages a gate put in a chat, so an
 # unreadable one makes retirement a total silent no-op. Absence and denial must not

--- a/tests/gate_button_retire_unit.sh
+++ b/tests/gate_button_retire_unit.sh
@@ -247,6 +247,43 @@ if [[ -z "$ident" ]]; then chk "wiring/refile: seeded a gate" "yes" "no"; else
       "$(_task_gate_deliveries "$ident" | grep -c '15491')"
 fi
 
+# park and verifier-reject are the two wirings the first pass shipped UNGRADED
+# (olivia, iteration 1: deleting either call left 26/26 green). Both need setup the
+# loop above cannot express — park REFUSES a live gate, and reject needs a
+# maker→verifier loop — so they get their own arms rather than a fourth loop case.
+#
+# park: the gate must already be ANSWERED (cmd_task_park refuses to park over a live
+# one, DIVE-1453), so the answer retires the button first. reset_edits AFTER that, so
+# what this arm sees is park's OWN retire re-reading the same delivery log — not the
+# answer's edit leaking forward.
+ident=$(seed_gate "DIVE-2410 wiring arm: park")
+if [[ -z "$ident" ]]; then chk "wiring/park: seeded a gate" "yes" "no"; else
+  ( cmd_task_answer "$ident" --value=A ) >/dev/null 2>&1
+  reset_edits
+  ( cmd_task_park "$ident" --reason="fixture park" --wake=+7d ) >/dev/null 2>&1
+  chk "wiring/park: park NULLs the gate columns and retires the delivered button" \
+      "tok-marketing|1234567890|15491" "$(edits)"
+fi
+
+# verifier auto:reject: the gate is still OPEN and the reject stamps it
+# '(superseded — task rejected, bounced to maker)' with provenance 'auto:reject'.
+# Worst stale button of the set: a human tapping it would believe they authorized
+# something an agent closed on their behalf. The maker must NOT be this harness's
+# actor — a maker reject is refused as self-grading (DIVE-2112), which would make
+# the arm pass on a refusal instead of on the retire.
+ident=$(seed_gate "DIVE-2410 wiring arm: reject")
+if [[ -z "$ident" ]]; then chk "wiring/reject: seeded a gate" "yes" "no"; else
+  db "UPDATE tasks SET maker_agent='fixture-maker', verifier=$(sqlq "$(task_actor "")"),
+        status='todo' WHERE ident=$(sqlq "$ident");"
+  reset_edits
+  ( cmd_task_reject "$ident" --feedback="fixture bounce" ) >/dev/null 2>&1
+  chk "wiring/reject: auto:reject supersedes the gate and retires its button" \
+      "tok-marketing|1234567890|15491" "$(edits)"
+  chk "wiring/reject: and the gate really was superseded (the arm graded the retire, not a refusal)" \
+      "auto:reject" \
+      "$(db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident=$(sqlq "$ident");")"
+fi
+
 # ------------------------------------------------- blind-log observability ---
 # The delivery log is the ONLY record of which messages a gate put in a chat, so an
 # unreadable one makes retirement a total silent no-op. Absence and denial must not

--- a/tests/gate_button_retire_unit.sh
+++ b/tests/gate_button_retire_unit.sh
@@ -302,10 +302,14 @@ fi
 #      lines (see the first arm in this file), and the mock Bot API hands back the
 #      same message_id every time — so a genuine SECOND delivery collapsed into the
 #      first and the count never moved. A deduped view cannot count deliveries.
-# Measured 2026-07-31 by deleting src/cmd_task.sh:5533: task_need_notify calls go
-# 1 -> 2 and the RAW log goes 1 -> 2, while the deduped view stays 1 either way. So
-# the raw undeduped log below is the differential observable, and the tier-0 return
-# is confirmed load-bearing — deleting it puts a real second button in the chat.
+# Measured 2026-07-31 by deleting the `return` that closes cmd_task_need's
+# `if [[ "$tier" == "0" ]]` auto-clear block (named by target, not by line: a cited
+# line number rots the moment anything above it moves, which is how olivia's :5437
+# ended up pointing at unrelated code by the time this was written). Deleting it
+# takes task_need_notify calls 1 -> 2 and the RAW log 1 -> 2, while the deduped view
+# stays 1 either way. So the raw undeduped log below is the differential observable,
+# and the tier-0 return is confirmed load-bearing — deleting it puts a real second
+# button in the chat.
 ident=$(seed_gate "DIVE-2410 file-time arm: tier0")
 if [[ -z "$ident" ]]; then chk "file-time/tier-0: seeded a gate" "yes" "no"; else
   reset_edits

--- a/tests/gate_button_retire_unit.sh
+++ b/tests/gate_button_retire_unit.sh
@@ -234,5 +234,40 @@ done
 chk "the resume ping went through the stub (containment is live, not rotted)" "1" \
     "$([[ -s "$PINGLOG" ]] && echo 1 || echo 0)"
 
+# A RE-FILED gate replaces the old one, so the outgoing gate's button asks a question
+# the task no longer holds. Ordering is the correctness condition: retirement must
+# run BEFORE the new delivery, or the fresh button is stripped by its own filing.
+ident=$(seed_gate "DIVE-2410 wiring arm: refile")
+if [[ -z "$ident" ]]; then chk "wiring/refile: seeded a gate" "yes" "no"; else
+  reset_edits
+  ( cmd_task_need "$ident" --type=approval --ask="really proceed?" ) >/dev/null 2>&1
+  chk "wiring/refile: the outgoing gate's button was retired" \
+      "tok-marketing|1234567890|15491" "$(edits)"
+  chk "wiring/refile: and the REPLACEMENT gate's own button survives its filing" "1" \
+      "$(_task_gate_deliveries "$ident" | grep -c '15491')"
+fi
+
+# ------------------------------------------------- blind-log observability ---
+# The delivery log is the ONLY record of which messages a gate put in a chat, so an
+# unreadable one makes retirement a total silent no-op. Absence and denial must not
+# share an answer: a MISSING log is silent (nothing was ever delivered), an
+# EXISTING-but-unreadable one warns.
+reset_edits
+out=$(FIVEDIVE_GATE_NOTIFY_LOG="$TMP/never-written.log" _task_gate_retire_buttons DIVE-A x 2>&1)
+chk "a MISSING delivery log is silent (nothing was delivered — not a fault)" "0" \
+    "$(grep -c 'cannot read the gate-delivery log' <<<"$out")"
+
+# chmod is inert against root, so this arm cannot be arranged as uid 0. Skip it
+# LOUDLY rather than let it pass vacuously — a silent skip reads as coverage.
+BLIND="$TMP/blind.log"; printf 'x\n' >"$BLIND"; chmod 000 "$BLIND"
+if [[ "$(id -u)" == "0" ]] || [[ -r "$BLIND" ]]; then
+  printf 'SKIP an unreadable delivery log warns — cannot make a file unreadable as uid %s\n' "$(id -u)"
+else
+  _TASK_GATE_RETIRE_BLIND=""
+  out=$(FIVEDIVE_GATE_NOTIFY_LOG="$BLIND" _task_gate_retire_buttons DIVE-A x 2>&1)
+  chk "an EXISTING but unreadable delivery log warns (the no-op is observable)" "1" \
+      "$(grep -c 'cannot read the gate-delivery log' <<<"$out")"
+fi
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" == "0" ]]

--- a/tests/gate_button_retire_unit.sh
+++ b/tests/gate_button_retire_unit.sh
@@ -320,13 +320,16 @@ if [[ -z "$ident" ]]; then chk "file-time/tier-0: seeded a gate" "yes" "no"; els
       "$(db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident=$(sqlq "$ident");")"
 fi
 
-# The OSS-21 tier-1 precedent auto-clear is the OTHER file-time settle site and is
-# NOT graded here — say so rather than let its absence read as coverage. It needs two
-# distinct nonce-bearing prior gates on an identical ask_shape to qualify, which this
-# harness cannot seed cheaply. What bounds it today is that it is pref-gated and the
-# pref defaults OFF, so in the default fleet posture it cannot fire at all; that
-# default IS graded, because it is the thing that makes the gap survivable.
-chk "file-time/precedent: OSS-21 auto-clear is inert by default (ungraded path, fenced)" \
+# ---------------------------------------- file-time settle site: precedent ---
+# The OSS-21 tier-1 precedent auto-clear is the OTHER file-time settle site. It is
+# pref-gated OFF by default, and an earlier draft of this file leaned on that and left
+# the path ungraded. A default is a posture, not a proof: the pref is fleet-settable,
+# so "cannot fire today" is not "cannot deliver an unretired button". Graded properly.
+#
+# Enumerated by target, not by line: the two writes of need_answered_by inside
+# cmd_task_need are 'auto:t0' and 'auto:precedent' — those are the only file-time
+# settle sites, so with both graded there is no seventh settle path.
+chk "file-time/precedent: OSS-21 auto-clear is inert by default (the shipped posture)" \
     "off" "$(_p=$(_task_pref_get precedent_autoclear); printf '%s' "${_p:-off}")"
 # LIVENESS for the arm above. Its `${_p:-off}` fallback is exactly the shape that
 # passes when the reader is broken: a _task_pref_get that errored, was renamed, or
@@ -336,6 +339,36 @@ chk "file-time/precedent: OSS-21 auto-clear is inert by default (ungraded path, 
 _task_pref_set precedent_autoclear on >/dev/null 2>&1
 chk "file-time/precedent: liveness — the pref reader really reads (not a stuck default)" \
     "on" "$(_p=$(_task_pref_get precedent_autoclear); printf '%s' "${_p:-off}")"
+
+# Now turn the fence OFF and actually drive the path. Two prior gates on an IDENTICAL
+# ask_shape, each answered by a nonce-verified human with the SAME answer, is what
+# qualifies a precedent; the harness files them for real and then stamps the human
+# provenance the human rail would have written. ask_shape is copied off a real filed
+# gate rather than recomputed, so the arm cannot drift from the CLI's own hashing.
+_pshape=""
+for _i in 1 2; do
+  _pid=$(seed_gate "DIVE-2410 precedent seed $_i")
+  [[ -n "$_pid" ]] || continue
+  db "UPDATE tasks SET need_answer='A', need_answered_at=datetime('now','-1 day'),
+        need_answered_by='human:1234567890', human_nonce_hash='deadbeef',
+        precedent_kind=NULL, tier=1 WHERE ident=$(sqlq "$_pid");"
+  _pshape=$(db "SELECT COALESCE(ask_shape,'') FROM tasks WHERE ident=$(sqlq "$_pid");")
+done
+_tid=$( ( JSON_MODE=1 cmd_task_add "DIVE-2410 precedent target" ) 2>/dev/null | jq -r '.data.id // empty')
+_tident=$(db "SELECT ident FROM tasks WHERE id=${_tid};" 2>/dev/null)
+if [[ -z "$_pshape" || -z "$_tident" ]]; then
+  chk "file-time/precedent: seeded two nonce-verified precedents" "yes" "no"
+else
+  : >"$LOG"          # fresh target, never gated before: ANY delivery here is its own
+  reset_edits
+  ( cmd_task_need "$_tident" --type=decision --ask="proceed?" \
+      --options="A|B" --recommend=A --tier=1 ) >/dev/null 2>&1
+  chk "file-time/precedent: it really did auto-clear (the arm graded a settle, not a refusal)" \
+      "auto:precedent" \
+      "$(db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident=$(sqlq "$_tident");")"
+  chk "file-time/precedent: and the auto-cleared gate delivered NO button of its own" "0" \
+      "$(grep -c 'gate-delivery result=ok' "$LOG")"
+fi
 _task_pref_set precedent_autoclear off >/dev/null 2>&1
 
 # ------------------------------------------------- blind-log observability ---


### PR DESCRIPTION
## The defect (confirmed, not inferred)

DIVE-2400's two approve buttons — `message_id=15491` (03:20:02Z) and `message_id=15492` (04:05:02Z), both `via=marketing`, both confirmed Bot API sends — were delivered **before** the gate closed at 04:28:41Z. Nothing edited, disabled, or expired either keyboard at close time. From 04:28:41 onward the human's chat held two live-**looking** approve buttons for a question that was already settled.

A tap on a closed gate correctly records nothing. But it returns no error, no "already closed", no visual change — so the only conclusion available to the human is that they approved. That is a silent divergence between what the human believes the record says and what it says, and it is DIVE-2406's harm approached from the opposite side: there the record claimed a human approval that never happened; here the human believes in an approval the record does not hold.

Observable symptom already collected: *"I tap the approve again. wtf is the human gate. I hate it"*. A human's frustration with a control is data about the control.

## The fix

`_mirror_edit_markup` — sibling of `_mirror_send`, deliberately beside it and under the **same** dry-run guard, because an edit reaches the same human chat a send does.

`_task_gate_retire_buttons` — reads the gate-delivery log back for `chat` + `message_id` + `via` per delivery and strips each keyboard through the **delivering** bot's token. `via=` is load-bearing, not decorative: `message_id` is scoped to a bot-chat *pair*, so the caller's token would edit a different message or none (DIVE-2073 is why the delivery row carries `via` at all). The set of messages to edit was already knowable — nobody had read it back yet.

Wired into **every** settle path, because not one of them has a Telegram session:

| path | why it settles the gate |
|---|---|
| `task answer` | human tap, lead-clear, dashboard/CLI — all three land in one function |
| `task need --withdraw` | the question is gone; the path most likely to leave a stale button, since unlike an answer nothing about it ever reaches the human's chat |
| `task need` (re-file) | filing **replaces** the old gate; the outgoing button asks a question the task no longer holds |
| `task park` | park clears the gate columns |
| verifier `auto:reject` | the worst of the set — the gate now reads `(superseded)` with agent provenance, so a tap would have the human believing they authorized what an agent closed for them |
| `done` / `cancel` | moots a still-open gate; conditional on unanswered, so an already-retired gate adds no "not modified" row |

**Ordering is a correctness condition on the re-file path, not a preference**: retirement runs *before* the new delivery, because the delivery log is the input — after `task_need_notify` the fresh button is in there too and would be stripped by its own filing. Both directions are asserted.

Fenced on store identity first (DIVE-1968), with the dry-run quarantine as the one release, so a fixture store cannot edit a real conversation. Two Bot API refusals grade as success — `message is not modified` and `message to edit not found` both mean the button can no longer be tapped, which is the whole point; grading them red would train readers to ignore the row that matters.

## What the test grades

`tests/gate_button_retire_unit.sh`, 26 arms. Beyond "it edits something":

- **Every exclusion is probed positively as well as negatively.** "444 was not edited" is worthless unless another arm proves 444 *can* be edited — a filter that rejects everything passes the first and fails the second. All four exclusions (error rows, `chat=agent:`, `message_id=0`, another task's ident) have a liveness pair.
- **The substring trap.** `tasks=` is a comma list, so `DIVE-A` must not match `DIVE-AA`; asserted in both directions.
- **The wiring arms read a log written by the REAL emitter**, so the awk parser is coupled to its producer. A format drift in `_task_gate_delivery_log` breaks these — which the hand-built rows cannot catch.
- **The fence has a non-vacuous released arm** on the same input, so a helper that silently edits nothing cannot pass the fence-holds arm.
- **The dry-run guard is proven to live inside the primitive**, by stubbing `curl` and asserting it never runs — then asserting it *does* run with the guard off, so the guard is not simply always-on.
- The unreadable-log arm **skips loudly** as uid 0 rather than passing vacuously, since `chmod` is inert against root.

Two gaps came from the pre-close self-audit and are in the second commit: the **re-file** path was missed entirely, and an unreadable delivery log made retirement a total silent no-op with nothing anywhere saying so (missing log stays silent — nothing was delivered; existing-but-unreadable warns once).

The harness also stubs `cmd_send`, and this was **measured, not theorised**: its first run delivered `"DIVE-1 gate cleared — your 'decision' ask was answered"` into a live agent inbox, because declaring a fixture store as prod to get past the DIVE-1506 send fence unfences the resume ping too. The stub counts its calls so it cannot rot into a no-op nobody notices.

## Verification

- `tests/gate_button_retire_unit.sh` — 26/26
- 33 gate/task/audit/notify suites — all green, zero regressions
- differential `shellcheck` against `main` — **0** new findings in `src/`

## Scope held

Whether this lifecycle defect caused lodar's 04:38:55Z tap is **not** settled and is **not** this PR — that stays on DIVE-2408, gated on which chat he tapped in. Two defects, one confirmed and one open.

**Not in this PR, and stated rather than quietly dropped:** the ticket's second bullet asked that a stale tap be answered with *"already closed (answered `<when>` by `<who>`)"*. The plugin already answers both stale-tap branches with a toast **and** a permanent message edit (`resolveTnaAnswer` → `already` / `nogate` in `server.ts`), so a dead tap is already distinguishable from a live one; what is missing is only the *when/who* detail. That lives in `5dive-plugins`, whose tree currently carries another session's uncommitted `server.ts` changes and a local wip commit ahead of `origin/main` — landing there would entangle unrelated work. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Iteration 2 — olivia's bounce (verification PASSED on the class defect; this closes the ship + two coverage gaps)

**Rebased onto `origin/main`** (was 10 behind, now 0) and re-graded there, so the green is on what will actually ship. DIVE-2412's channel-proof tier-2 clear landed after the old base; it settles through the same `cmd_task_answer` write site, so the retire covers it unchanged.

**park and verifier `auto:reject` are now mutation-covered.** They were the two wirings no arm graded — deleting either call left 26/26 green. Each needed setup the answer/withdraw/done loop cannot express:

- **park** refuses to park over a *live* gate (DIVE-1453), so its gate is answered first and `reset_edits` runs *after* that — what the arm sees is park's own retire re-reading the delivery log, not the answer's edit leaking forward.
- **reject** needs a maker→verifier loop, and the maker must **not** be the harness's own actor: a maker reject is refused as self-grading (DIVE-2112), which would have passed the arm on a *refusal* instead of on the retire. The arm additionally asserts `need_answered_by='auto:reject'`, so it cannot grade green through a refusal that never reached the retire.

Full 6-way mutation matrix at this head — each deletion kills **exactly** its own arm and nothing else:

| mutant (retire call deleted) | result |
|---|---|
| answer (human tap / lead-clear / dashboard) | `FAIL wiring/answer` — 28/1 |
| done/cancel over an open gate | `FAIL wiring/done` — 28/1 |
| `need --withdraw` | `FAIL wiring/withdraw` — 28/1 |
| re-file | `FAIL wiring/refile` — 28/1 |
| **park** | `FAIL wiring/park` — 28/1 |
| **verifier auto:reject** | `FAIL wiring/reject` — 28/1 |

Baseline **29/29** pass.

**No seventh settle path.** olivia asked whether the two file-time settle sites inside `cmd_task_need` can deliver a button before self-answering. They cannot: `auto:t0` (`cmd_task.sh:5524`) and `auto:precedent` (`:5648`) both sit *after* the re-file retire at `:5476` and *before* both `task_need_notify` sites (`:5838` routed, `:5978` human), and each returns immediately. So no button is ever delivered for a gate that settles at filing time — and a re-file that auto-clears still retires the *outgoing* gate's button, because the retire precedes the auto-clear rather than following it. Ordering already carries this; it is not a new path.
