### PR TITLE
fix(task): a secret gate must name a delivery path, at filing AND at answer (DIVE-2411)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -89,6 +89,7 @@ _task_usage() {
   # Human Task Inbox — park a task on a human and clear it
   5dive task need <id|DIVE-N> --type=decision|secret|approval|manual|access --ask="..." [--options=A|B] [--recommend="A"] [--tier=0|1|2]
                                                      # --type=access: manager-clearable "grant me X" gate — routes to the org lead first (any tier), lead-clearable; add --probe='test -w /path' to self-check the block
+                                                     # --type=secret MUST name a delivery path (DIVE-2411): --secret-key=<ENV_NAME> --connector=<stem> mints a one-time drop link, or --out-of-band="<where the value lands>" declares out-of-band delivery explicitly. Neither = refused at filing (the ask would read complete with nowhere for the value to go).
   5dive task need <id|DIVE-N> --withdraw            # DIVE-1401: cancel a still-pending gate the team filed but that's now moot — filer or org lead, no human tap. NOT a grant (never records a secret/approval); genuine clears stay human-only.
     --ask: ONE crisp question + ~1 line essential context, recommendation up front. Heavy detail goes in the task BODY, not the ask.
     --options: name accounts/actors, not "you/your". Pronoun-bearing choices warn at filing and their answer receipt renders the filer/answerer account frame.
@@ -4694,7 +4695,7 @@ _gate_option_has_second_person() {
 
 cmd_task_need() {
   tasks_db_init
-  local type="" ask="" options="" recommend="" from="" tier="" secret_key="" connector="" probe="" withdraw="" discusses="" needs=""
+  local type="" ask="" options="" recommend="" from="" tier="" secret_key="" connector="" probe="" withdraw="" discusses="" needs="" oob=""
   local -a positional=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -4713,6 +4714,10 @@ cmd_task_need() {
       # Both together enable the burnable drop link in the gate message.
       --secret-key=*) secret_key="${1#*=}" ;;
       --connector=*)  connector="${1#*=}" ;;
+      # DIVE-2411: the explicit opt-in to out-of-band delivery, and it must NAME
+      # the channel. A secret gate with no drop target used to be the DEFAULT
+      # (both flags omitted) — see the refusal below.
+      --out-of-band=*) oob="${1#*=}" ;;
       # DIVE-1243: opt-in self-check for --type=access. The command MUST FAIL
       # (non-zero) for the gate to file; if it SUCCEEDS the block isn't real.
       --probe=*)     probe="${1#*=}" ;;
@@ -4731,7 +4736,7 @@ cmd_task_need() {
     esac
     shift
   done
-  [[ ${#positional[@]} -gt 0 ]] || fail "$E_USAGE" "usage: 5dive task need <id|DIVE-N> --type=decision|secret|approval|manual --ask=\"...\" [--options=A|B] [--recommend=\"A\"] [--needs=human_tap|spend_authority|secret_provision] [--discusses=\"why this decision only DISCUSSES a floored category\"]  (or --withdraw to cancel a moot pending gate)"
+  [[ ${#positional[@]} -gt 0 ]] || fail "$E_USAGE" "usage: 5dive task need <id|DIVE-N> --type=decision|secret|approval|manual --ask=\"...\" [--options=A|B] [--recommend=\"A\"] [--needs=human_tap|spend_authority|secret_provision] [--discusses=\"why this decision only DISCUSSES a floored category\"]  (--type=secret also needs a delivery path: --secret-key=<ENV_NAME> --connector=<stem>, or --out-of-band=\"<where the value lands>\"; or --withdraw to cancel a moot pending gate)"
   resolve_task_id "${positional[0]}"; local id="$RESOLVED_TASK_ID" ident="$RESOLVED_TASK_IDENT"
 
   # DIVE-1401: --withdraw path. Secret/approval/manual gates are human-only to
@@ -4743,7 +4748,7 @@ cmd_task_need() {
   # coordinator, or a human caller (non-agent unix id). Genuine GRANT-clears stay
   # human-only via cmd_task_answer — this branch never touches that path.
   if [[ -n "$withdraw" ]]; then
-    [[ -z "$type$ask$options$recommend$tier$secret_key$connector$probe$discusses$needs" ]] \
+    [[ -z "$type$ask$options$recommend$tier$secret_key$connector$oob$probe$discusses$needs" ]] \
       || fail "$E_USAGE" "--withdraw takes no other gate flags (it cancels the existing gate, not re-files one)"
     local w_type w_ans w_status
     w_type=$(db "SELECT COALESCE(need_type,'')        FROM tasks WHERE id=${id};")
@@ -4830,7 +4835,7 @@ cmd_task_need() {
         $(_gate_archive_and_clear_sql withdraw "id=${id}")
         UPDATE tasks
           SET need_type=NULL, ask=NULL, need_options=NULL, recommend=NULL,
-              secret_key=NULL, connector=NULL, ask_shape=NULL,
+              secret_key=NULL, connector=NULL, secret_oob=NULL, ask_shape=NULL,
               precedent_ref=NULL, precedent_kind=NULL, routed_reviewer=NULL,
               needs_capability=NULL,
               need_asked_at=NULL, gate_pinged_at=NULL, gate_filed_by=NULL
@@ -4909,7 +4914,55 @@ cmd_task_need() {
   # on a secret gate. Require them together (a key with no connector has nowhere
   # to land, and vice versa) and validate against the same charsets the box-side
   # `secret write` + the api /drop/mint enforce, so a bad value fails here rather
-  # than at mint time. Both omitted = legacy secret gate (out-of-band delivery).
+  # than at mint time.
+  #
+  # DIVE-2411: both omitted used to mean "legacy secret gate, out-of-band
+  # delivery" — a DEFAULT nobody chose. Measured on DIVE-2232: the gate pinged
+  # correctly, the ask read as complete, and there was NO PATH for the value to
+  # reach the box, so the only remaining answer was pasting a live credential
+  # into a persistent chat log. main nearly received one.
+  #
+  # WHY THE REFUSAL BELONGS AT FILING TIME. The gate is complete in APPEARANCE and
+  # only the delivery MECHANISM is missing. A human staring at the ask cannot see
+  # that the drop is absent — nothing in the message is about the drop. Only the
+  # filer can see it, and only here. So an omission must not select the shape with
+  # no delivery path: name a drop target (DIVE-931) or declare the out-of-band
+  # channel explicitly.
+  # DIVE-2411: a RE-FILE inherits the delivery path the row already carries. A
+  # re-file otherwise DESTROYS it (DIVE-2119 resets the gate columns from the
+  # flags given), and the programmatic re-filers pass no delivery flags at all:
+  # the council escalation builds `task need <ident> --type=secret --tier=2
+  # --ask=...` (src/council/engine.mjs, preserving the TYPE and nothing else). So
+  # before this ticket, escalating a properly-targeted secret gate through the
+  # council silently converted it into the DIVE-2232 shape — the defect had a
+  # generator, not just an author. Inheriting is not "defaulting into no delivery
+  # path": it carries forward a path a filer CHOSE, and a row with nothing to
+  # inherit still falls through to the refusal below.
+  if [[ "$type" == "secret" && -z "$secret_key$connector$oob" ]]; then
+    local _pv; _pv=$(db "SELECT COALESCE(secret_key,'')||x'1f'||COALESCE(connector,'')||x'1f'||COALESCE(secret_oob,'') FROM tasks WHERE id=${id};")
+    local _pv_sk="${_pv%%$'\x1f'*}" _pv_rest="${_pv#*$'\x1f'}"
+    local _pv_conn="${_pv_rest%%$'\x1f'*}" _pv_oob="${_pv_rest#*$'\x1f'}"
+    if [[ -n "$_pv_sk" && -n "$_pv_conn" ]]; then
+      secret_key="$_pv_sk"; connector="$_pv_conn"
+      warn "$ident: re-filed secret gate inherits the existing drop target (${secret_key} -> ${connector}); pass --secret-key/--connector to change it (DIVE-2411)"
+    elif [[ -n "$_pv_oob" ]]; then
+      oob="$_pv_oob"
+      warn "$ident: re-filed secret gate inherits the declared out-of-band delivery (${oob}); pass --secret-key/--connector for a drop target instead (DIVE-2411)"
+    fi
+  fi
+  if [[ -n "$oob" ]]; then
+    [[ "$type" == "secret" ]] \
+      || fail "$E_VALIDATION" "--out-of-band only applies to --type=secret (it declares how a CREDENTIAL will reach the box)"
+    [[ -z "$secret_key$connector" ]] \
+      || fail "$E_VALIDATION" "--out-of-band is mutually exclusive with --secret-key/--connector — a gate has ONE delivery path; the drop target already is one"
+    # Must NAME the channel: the whole point is that the human (and the reader of
+    # the answered row six months out) can see where the value was meant to land.
+    # A bare "yes" opt-in would restore the defect with a flag in front of it.
+    [[ ${#oob} -ge 12 ]] \
+      || fail "$E_VALIDATION" "--out-of-band must NAME where the value will land (e.g. --out-of-band=\"already in my .env on this box\") — it is shown to the human and is the only record of the delivery path"
+  elif [[ "$type" == "secret" && -z "$secret_key$connector" ]]; then
+    fail "$E_VALIDATION" "a secret gate must name a delivery path — pass --secret-key=<ENV_NAME> --connector=<stem> to mint a one-time drop link (DIVE-931), or --out-of-band=\"<where the value will land>\" to declare out-of-band delivery explicitly. With neither, the ask reads as complete while the value has nowhere to go, and the only answer left is pasting a live credential into chat (DIVE-2232)."
+  fi
   if [[ -n "$secret_key" || -n "$connector" ]]; then
     [[ "$type" == "secret" ]] || fail "$E_VALIDATION" "--secret-key/--connector only apply to --type=secret"
     [[ -n "$secret_key" && -n "$connector" ]] \
@@ -5405,6 +5458,7 @@ cmd_task_need() {
             recommend=$(sqlq_or_null "$recommend"),
             secret_key=$(sqlq_or_null "$secret_key"),
             connector=$(sqlq_or_null "$connector"),
+            secret_oob=$(sqlq_or_null "$oob"),
             ask_shape=$(sqlq_or_null "$ask_shape"),
             precedent_ref=${precedent_ref:-NULL},
             precedent_kind=$(sqlq_or_null "$precedent_kind"),
@@ -6817,6 +6871,38 @@ _task_mint_drop_link() {
 # Render the canonical tap keyboard for one gate. Kept separate from the alert
 # prose so heartbeat re-nags can combine N gates into one message without
 # drifting from the callback contract used by the initial task-need alert.
+# _task_secret_gate_cta <ident> <row_id> <secret_key> <connector> <drop> — DIVE-2411.
+# The "how do I clear this" instruction for a secret gate, extracted from the
+# notify body so the PROSE is testable. Four shapes, in order of how directly the
+# value can land: a minted burnable drop link, the on-box `secret write` (link
+# unavailable / tokenless box), an explicitly declared out-of-band channel, and —
+# for rows filed before this ticket — no delivery path at all, where the only
+# honest instruction is that the gate must be re-filed. That last branch used to
+# read "put the key where I expect it (my .env / our channel), then tap ✅
+# Provided", which on a gate that never named a target asks the human to do
+# something undefined and then attest to it; that attestation is what produced
+# the DIVE-2232 record — signed, nonced, human-attested, empty.
+_task_secret_gate_cta() {
+  local ident="$1" numid="$2" secret_key="$3" connector="$4" _drop="$5"
+  if [[ "$_drop" == "ONBOX" ]]; then
+    printf '%s' "🔑 [${ident}] needs the ${secret_key} credential. On the box, drop it straight in (never paste it here):"$'\n'"  echo -n \"\$SECRET\" | sudo 5dive secret write ${secret_key} --connector=${connector} --task=${ident}"$'\n'"That writes it and clears this gate. Or tap ✅ Provided once it is done."
+  elif [[ -n "$_drop" ]]; then
+    local _url="${_drop%%|*}" _ttl="${_drop##*|}"
+    printf '%s' "🔑 [${ident}] needs the ${secret_key} credential. Drop it securely (single-use, expires in ${_ttl}m):"$'\n'"${_url}"$'\n'"The value goes straight onto your box and is never shown in chat. Prefer the box? echo -n \"\$SECRET\" | sudo 5dive secret write ${secret_key} --connector=${connector} --task=${ident}"
+  elif [[ -n "$secret_key" && -n "$connector" ]]; then
+    # Target named, mint unavailable (api unreachable / tokenless): still name the
+    # target, because the box-side write is a real delivery path.
+    printf '%s' "🔑 [${ident}] needs the ${secret_key} credential. The drop link could not be minted right now, so put it in on the box (never paste it here):"$'\n'"  echo -n \"\$SECRET\" | sudo 5dive secret write ${secret_key} --connector=${connector} --task=${ident}"$'\n'"That writes it and clears this gate. Or tap ✅ Provided once it is done."
+  else
+    local _oob; _oob=$(db "SELECT COALESCE(secret_oob,'') FROM tasks WHERE id=${numid};" 2>/dev/null || echo "")
+    if [[ -n "$_oob" ]]; then
+      printf '%s' "🔑 [${ident}] needs a credential, delivered out-of-band: ${_oob}. Put it there, then tap ✅ Provided below — never paste it in this chat. Tap not working? On the box: sudo 5dive task answer ${ident}"
+    else
+      printf '%s' "⚠️ [${ident}] asks for a credential but names NO delivery path (no drop target, no declared out-of-band channel), so there is nowhere for the value to go and this gate cannot be cleared as it stands. Do NOT paste the credential here. It has to be re-filed with a delivery path: 5dive task need ${ident} --type=secret --secret-key=<ENV_NAME> --connector=<stem> --ask=\"…\" (DIVE-2411)."
+    fi
+  fi
+}
+
 _task_gate_reply_markup() { # <row_id> <type> <options> <recommend> <nonce> <channel_type> [label]
   local numid="$1" need_type="$2" options="$3" recommend="$4" human_nonce="$5" channel_type="$6" label="${7:-}"
   [[ -n "$label" ]] && label="[${label}] "
@@ -6862,7 +6948,32 @@ _task_gate_reply_markup() { # <row_id> <type> <options> <recommend> <nonce> <cha
         *)                reply_markup='{"inline_keyboard":[['"$appr"','"$deny"']]}' ;;
       esac
     elif [[ "$need_type" == "secret" ]]; then
-      reply_markup='{"inline_keyboard":[[{"text":"'"${label}"'✅ Provided","callback_data":"tna:'"${numid}"':provided'"${np}"'"}]]}'
+      # DIVE-2411: the ✅ Provided affordance is offered ONLY on a secret gate that
+      # names a delivery path — a drop target (secret_key+connector) or an explicit
+      # --out-of-band declaration. On a gate with neither, the button MEANS
+      # something the message never asked for: "I already put it where you said",
+      # on a gate that never said where. Measured on DIVE-2232 — a real human
+      # holding the raw nonce tapped it, and the row came back answered, signed,
+      # nonced and uid-stamped over an EMPTY payload. Nothing had landed anywhere.
+      #
+      # THE FIX IS HERE, at the mint/affordance layer, and that placement is the
+      # point: the tap that produced the false record landed on a BATCHED six-gate
+      # message, and the batcher has no idea what any of the six drops targeted. It
+      # could not have known to withhold the button, so it cannot be the layer that
+      # decides. This function is called by BOTH the single-gate notify and the
+      # batch re-send, and it reads the row, so both are covered without either
+      # caller changing.
+      #
+      # Read from the ROW, not from a parameter: the state that decides is the
+      # persisted gate, not what a caller happens to be holding (DIVE-2090).
+      local _sk_row _oob_row
+      _sk_row=$(db "SELECT COALESCE(secret_key,'')||COALESCE(connector,'') FROM tasks WHERE id=${numid};" 2>/dev/null || echo "")
+      _oob_row=$(db "SELECT COALESCE(secret_oob,'') FROM tasks WHERE id=${numid};" 2>/dev/null || echo "")
+      if [[ -n "$_sk_row" || -n "$_oob_row" ]]; then
+        reply_markup='{"inline_keyboard":[[{"text":"'"${label}"'✅ Provided","callback_data":"tna:'"${numid}"':provided'"${np}"'"}]]}'
+      else
+        reply_markup=""
+      fi
     elif [[ "$need_type" == "manual" ]]; then
       reply_markup='{"inline_keyboard":[[{"text":"'"${label}"'✅ Done","callback_data":"tna:'"${numid}"':done'"${np}"'"}]]}'
     fi
@@ -7246,14 +7357,14 @@ _task_need_notify_deliver() {
       if [[ -n "$secret_key" && -n "$connector" ]]; then
         _drop=$(_task_mint_drop_link "$ident" "$secret_key" "$connector")
       fi
-      if [[ "$_drop" == "ONBOX" ]]; then
-        text+=$'\n\n'"🔑 [${ident}] needs the ${secret_key} credential. On the box, drop it straight in (never paste it here):"$'\n'"  echo -n \"\$SECRET\" | sudo 5dive secret write ${secret_key} --connector=${connector} --task=${ident}"$'\n'"That writes it and clears this gate. Or tap ✅ Provided once it is done."
-      elif [[ -n "$_drop" ]]; then
-        local _url="${_drop%%|*}" _ttl="${_drop##*|}"
-        text+=$'\n\n'"🔑 [${ident}] needs the ${secret_key} credential. Drop it securely (single-use, expires in ${_ttl}m):"$'\n'"${_url}"$'\n'"The value goes straight onto your box and is never shown in chat. Prefer the box? echo -n \"\$SECRET\" | sudo 5dive secret write ${secret_key} --connector=${connector} --task=${ident}"
-      else
-        text+=$'\n\n'"🔑 Put the key where I expect it (my .env / our channel), then tap ✅ Provided below. Don't paste the key here. Tap not working? On the box: sudo 5dive task answer ${ident}"
-      fi
+      # DIVE-2411: the CTA text is a FUNCTION (_task_secret_gate_cta) rather than
+      # four inline branches, so the prose can be graded. The remedy half of a fix
+      # normally ships with the zero coverage that let the bug in — and here the
+      # prose IS half the fix: on a gate with no delivery path the old copy said
+      # "put the key where I expect it, then tap ✅ Provided", which is an
+      # instruction to do the impossible followed by the button that files the
+      # false record. See tests/secret_gate_delivery_path_unit.sh arms T8/T8b.
+      text+=$'\n\n'"$(_task_secret_gate_cta "$ident" "$numid" "$secret_key" "$connector" "$_drop")"
       ;;
     manual) text+=$'\n\n'"✋ Tap ✅ Done below once it is handled, which closes this out. Or on the box: sudo 5dive task answer ${ident} --value=done" ;;
     # DIVE-1243: an `access` gate normally clears via the org lead; it only reaches
@@ -7686,6 +7797,35 @@ cmd_task_answer() {
   local nt
   nt=$(db "SELECT CASE WHEN need_type IS NOT NULL AND need_answered_at IS NULL THEN need_type ELSE '' END FROM tasks WHERE id=${id};")
   [[ -n "$nt" ]] || fail "$E_CONFLICT" "$ident has no pending human gate (nothing to answer)"
+
+  # DIVE-2411: refuse to STAMP a secret gate that names no delivery path, before
+  # any write. This is the same defect as the filing refusal in cmd_task_need, one
+  # step later and strictly worse: the filing gap leaves a gate visibly stuck,
+  # while this one CLOSES the loop with full provenance over nothing.
+  #
+  # MEASURED on DIVE-2232: need_answered_at set, need_answered_by=human:main,
+  # uid 1004, need_answer_sig VALID, human_nonce_hash SET — a real human holding
+  # the raw nonce tapped ✅ Provided — and no connector file was written that day,
+  # no drop was ever minted, no value reached any channel. The record reads
+  # "credential provided, human-attested, signed, nonced" and no credential exists.
+  # Provenance and payload are INDEPENDENT and we only ever verified provenance.
+  #
+  # WHY THE AFFORDANCE FIX IS NOT ENOUGH ON ITS OWN. Withholding the button (see
+  # _task_gate_reply_markup) only changes messages sent FROM NOW ON. Telegram inline
+  # buttons on already-delivered messages never expire — the same fact DIVE-2228
+  # turns on — so every legacy secret gate already in someone's chat history keeps a
+  # live ✅ Provided button, and any of those taps still lands here. This is the
+  # durable half; the affordance removal is the half that stops NEW ones.
+  #
+  # The predicate is the ROW's shape only — no caller-supplied input can satisfy it,
+  # so there is nothing to forge. A gate that named a drop target still answers
+  # normally (that is the legitimate "I ran `5dive secret write` myself" case), and
+  # an explicitly out-of-band gate still answers, because its ask NAMED where the
+  # value goes. Only "asks for a credential, names nowhere" is refused.
+  if [[ "$nt" == "secret" ]]; then
+    local _paths; _paths=$(db "SELECT COALESCE(secret_key,'')||COALESCE(connector,'')||COALESCE(secret_oob,'') FROM tasks WHERE id=${id};")
+    [[ -n "$_paths" ]] || fail "$E_CONFLICT" "$ident is a secret gate that names NO delivery path (no --secret-key/--connector drop target, no --out-of-band declaration), so nothing can have landed and marking it provided would record a signed, human-attested answer over an empty payload (DIVE-2232). Re-file it with a delivery path: 5dive task need $ident --type=secret --secret-key=<ENV_NAME> --connector=<stem> --ask=\"…\" (DIVE-931), or --out-of-band=\"<where the value lands>\" if delivery really is out-of-band."
+  fi
 
   # DIVE-1117: resolve the gate's stored risk tier now — the human-only + evidence
   # blocks below key on need_type (approval/secret/manual), but tier 2 is the true

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -374,11 +374,18 @@ CREATE TABLE IF NOT EXISTS tasks (
   -- value should land — secret_key is the env-var name, connector the
   -- /etc/5dive/connectors/<connector>.env stem. When both are set, the gate
   -- notify mints a burnable drop link (api /drop/mint) instead of the legacy
-  -- "put it where I expect it" text. NULL on non-secret gates and on secret
-  -- gates filed without a target (legacy behavior preserved). The VALUE is never
-  -- stored here — only the destination coordinates.
+  -- "put it where I expect it" text. NULL on non-secret gates. The VALUE is
+  -- never stored here — only the destination coordinates.
   secret_key          TEXT,
   connector           TEXT,
+  -- DIVE-2411: the EXPLICIT out-of-band delivery declaration. A secret gate must
+  -- name a delivery path or it cannot be filed: either the drop target above, or
+  -- this — free text naming WHERE the human should put the value (".env on the
+  -- box", "our shared channel"). Before DIVE-2411 both-NULL was the DEFAULTED
+  -- legacy shape, which is how DIVE-2232 shipped a gate whose only answer path
+  -- was pasting a live token into chat. Now both-NULL is unfilable and
+  -- unanswerable; the legacy shape survives only when CHOSEN via --out-of-band.
+  secret_oob          TEXT,
   -- OSS-11 (DIVE-976) decision-memory precedent prefill. ask_shape is the
   -- normalized "shape key" of the ask (idents/nums/amounts/dates/hosts/names
   -- collapsed to typed placeholders) computed at gate-file time; precedent_ref
@@ -997,7 +1004,7 @@ _tasks_db_migrate() {
            'handoff_delivered_at TEXT' 'handoff_stale_pinged_at TEXT' \
            'tier INTEGER' 'need_asked_at TEXT' 'gate_pinged_at TEXT' 'wake_at TEXT' \
            'gate_filed_by TEXT' \
-           'secret_key TEXT' 'connector TEXT' 'human_nonce_hash TEXT' \
+           'secret_key TEXT' 'connector TEXT' 'secret_oob TEXT' 'human_nonce_hash TEXT' \
            'ask_shape TEXT' 'precedent_ref INTEGER' 'precedent_kind TEXT' \
            'needs_capability TEXT' \
            'shipped_flag_at TEXT' 'routed_reviewer TEXT' \

--- a/tests/gate_approval_routing_unit.sh
+++ b/tests/gate_approval_routing_unit.sh
@@ -110,7 +110,7 @@ cmd_task_need DIVE-206 --type=approval --ask="approve teardown of the prod datab
 
 # --- A7: SAFETY BACKSTOP (secret type) — a `secret` gate is always tier 2. ----------
 seed_task DIVE-207
-cmd_task_need DIVE-207 --type=secret --ask="drop the deploy key" >/dev/null 2>&1
+cmd_task_need DIVE-207 --type=secret --ask="drop the deploy key" --secret-key=DEPLOY_KEY --connector=fixture >/dev/null 2>&1
 [[ "$(tierof DIVE-207)" == "2" ]] \
   && ok_t "A7 secret type still tier 2 (unchanged)" \
   || bad_t "A7 secret type tier 2" "got tier '$(tierof DIVE-207)'"

--- a/tests/gate_class_over_tier_unit.sh
+++ b/tests/gate_class_over_tier_unit.sh
@@ -242,7 +242,10 @@ done
 seed_task DIVE-2320
 # $TMP, never a fixed /tmp path — see the ∅ note above. This one line is what
 # made the harness pass for its author and fail for main, root and claude.
-( cmd_task_need DIVE-2320 --type=secret --tier=0 --ask="drop the api key" ) >"$TMP/t0-secret.out" 2>&1
+# DIVE-2411: a secret gate must name a delivery path to file at all, so this one
+# carries a drop target. Unrelated to what the arm grades (the tier floor), but
+# without it cmd_task_need refuses and every assertion below grades the refusal.
+( cmd_task_need DIVE-2320 --type=secret --tier=0 --ask="drop the api key" --secret-key=API_KEY --connector=demo ) >"$TMP/t0-secret.out" 2>&1
 exists_t DIVE-2320 "T0: secret task row exists"
 eq_t "T0: secret gate was actually filed (cmd_task_need ran)" \
      "$(field DIVE-2320 need_type)" "secret"

--- a/tests/gate_nonce_unit.sh
+++ b/tests/gate_nonce_unit.sh
@@ -124,7 +124,10 @@ for ty in approval secret manual; do
   _t1n=$((_t1n+1)); ident="DIVE-$_t1n"
   seed_task "$ident"
   NOTIFY_NONCE=""
-  cmd_task_need "$ident" --type="$ty" --ask="need it" >/dev/null 2>&1
+  # DIVE-2411: a secret gate must name a delivery path to file at all. Without
+  # this the secret iteration is refused and its two arms grade the refusal.
+  _t1extra=(); [[ "$ty" == "secret" ]] && _t1extra=(--secret-key=FIXTURE_TOKEN --connector=fixture)
+  cmd_task_need "$ident" --type="$ty" --ask="need it" "${_t1extra[@]+"${_t1extra[@]}"}" >/dev/null 2>&1
   h=$(db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE ident='$ident';")
   if [[ "$h" =~ ^[0-9a-f]{64}$ ]]; then ok_t "T1 $ty gate mints human_nonce_hash"
   else bad_t "T1 $ty gate mints human_nonce_hash" "got: '$h'"; fi
@@ -187,7 +190,7 @@ out=$(SUDO_UID="$AGENT_UID" cmd_task_answer DIVE-400 --value=approved --human --
   || bad_t "T4 --proof dropped" "rc=$rc state=$(answered DIVE-400) out=$out"
 
 # --- T5: (c) non-agent SUDO_UID clears with NO proof (drop / human-on-box) ----
-seed_task DIVE-500; cmd_task_need DIVE-500 --type=secret --ask="drop key" >/dev/null 2>&1
+seed_task DIVE-500; cmd_task_need DIVE-500 --type=secret --ask="drop key" --secret-key=FIXTURE_TOKEN --connector=fixture >/dev/null 2>&1
 SUDO_UID=0 cmd_task_answer DIVE-500 --human --from=drop >/dev/null 2>&1
 [[ "$(answered DIVE-500)" == "closed" ]] && ok_t "T5 non-agent SUDO_UID (root) clears, no proof (drop path)" \
   || bad_t "T5 non-agent SUDO_UID clears" "still $(answered DIVE-500)"

--- a/tests/gate_precedent_unit.sh
+++ b/tests/gate_precedent_unit.sh
@@ -289,7 +289,7 @@ ASK_SEC="load the staging deploy key"; SHAPE_SEC="$(_gate_ask_shape "$ASK_SEC")"
 seed_prec_by DIVE-1250 secret 1 "$SHAPE_SEC" done "human:mark"
 seed_prec_by DIVE-1251 secret 1 "$SHAPE_SEC" done "human:mark"
 seed_task DIVE-1252
-cmd_task_need DIVE-1252 --type=secret --ask="$ASK_SEC" >/dev/null 2>&1
+cmd_task_need DIVE-1252 --type=secret --ask="$ASK_SEC" --secret-key=FIXTURE_TOKEN --connector=fixture >/dev/null 2>&1
 eq_t "autoclear A6: secret stays blocked"     "$(field DIVE-1252 status)"           "blocked"
 eq_t "autoclear A6: secret unanswered"        "$(field DIVE-1252 need_answered_at)" "∅"
 

--- a/tests/gate_ship_routing_unit.sh
+++ b/tests/gate_ship_routing_unit.sh
@@ -128,7 +128,7 @@ _rt=$(db "SELECT need_type FROM tasks WHERE ident='DIVE-4';")
 # would `exit` mid-harness — and the drop target is irrelevant to the routing
 # exclusion under test, so file it plain.
 seed DIVE-7; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-7 --type=secret --ask="paste the deploy key" --from=dev >/dev/null 2>&1
+cmd_task_need DIVE-7 --type=secret --ask="paste the deploy key" --secret-key=DEPLOY_KEY --connector=fixture --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "route on: secret stays human-directed (never routed)" || bad_t "secret → human" "HUMAN_PINGED=$HUMAN_PINGED"
 [[ -z "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-7';")" ]] && ok_t "secret leaves routed_reviewer NULL" || bad_t "secret routed_reviewer NULL" "got '$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-7';")'"
 

--- a/tests/gate_sudo_uid_forge_unit.sh
+++ b/tests/gate_sudo_uid_forge_unit.sh
@@ -103,7 +103,12 @@ _gate_passwd_stream() {
 
 seed_gate() {   # ident type
   db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"
-  cmd_task_need "$1" --type="$2" --ask="need it" >/dev/null 2>&1
+  # DIVE-2411: a secret gate must name a delivery path to file at all — and the
+  # arm that seeds one here is T-DROP, the DIVE-931 drop context, so a drop target
+  # is the right shape for it. Without this, `task need` refuses, `fail` exits this
+  # sourced harness mid-suite, and the arms below it grade nothing.
+  local _dp=(); [[ "$2" == "secret" ]] && _dp=(--secret-key=FIXTURE_TOKEN --connector=fixture)
+  cmd_task_need "$1" --type="$2" --ask="need it" "${_dp[@]+"${_dp[@]}"}" >/dev/null 2>&1
 }
 answered() { db "SELECT CASE WHEN need_answered_at IS NULL THEN 'open' ELSE 'closed' END FROM tasks WHERE ident='$1';"; }
 

--- a/tests/gate_withdraw_unit.sh
+++ b/tests/gate_withdraw_unit.sh
@@ -116,7 +116,7 @@ db "CREATE TABLE IF NOT EXISTS agents_org (name TEXT PRIMARY KEY, role TEXT, tit
 db "INSERT INTO agents_org (name, role, reports_to) VALUES ('main','coordinator',NULL);"
 db "INSERT INTO agents_org (name, role, reports_to) VALUES ('creative',NULL,'main');"
 db "INSERT INTO agents_org (name, role, reports_to) VALUES ('grok',NULL,NULL);"
-file_secret_gate() { seed_task "$1"; IS_ROOT=1 IDUN=root cmd_task_need "$1" --type=secret --ask="drop the fixture key" --from=creative >/dev/null 2>&1; }
+file_secret_gate() { seed_task "$1"; IS_ROOT=1 IDUN=root cmd_task_need "$1" --type=secret --ask="drop the fixture key" --secret-key=FIXTURE_TOKEN --connector=fixture --from=creative >/dev/null 2>&1; }
 
 # ── Root/sudo branch (agents commonly run `sudo 5dive ...`, EUID 0, SUDO_USER set) ──
 # T1: the FILER (real SUDO_USER=agent-creative) withdraws its own secret gate. Gate
@@ -230,7 +230,7 @@ out=$(wd DIVE-207 ROOT SU=agent-creative); rc=$?
 # the lead condition (in the org above, main is BOTH creative's lead AND the coordinator,
 # so T3 cannot tell the two conditions apart and grades neither of them alone).
 db "INSERT INTO agents_org (name, role, reports_to) VALUES ('pi',NULL,'grok');"
-file_pi_gate() { seed_task "$1"; IS_ROOT=1 IDUN=root cmd_task_need "$1" --type=secret --ask="drop the fixture key" --from=pi >/dev/null 2>&1; }
+file_pi_gate() { seed_task "$1"; IS_ROOT=1 IDUN=root cmd_task_need "$1" --type=secret --ask="drop the fixture key" --secret-key=FIXTURE_TOKEN --connector=fixture --from=pi >/dev/null 2>&1; }
 z_lead=$(_gate_route_reviewer pi); z_coord=$(_task_resolve_coordinator)
 [[ "$z_lead" == "grok" && "$z_coord" == "main" && "$z_lead" != "$z_coord" ]] \
   && ok_t "T-2382-DISTINCT pi's lead (grok) is NOT the coordinator (main) — the coordinator arm cannot pass through the lead condition" \

--- a/tests/secret_drop_unit.sh
+++ b/tests/secret_drop_unit.sh
@@ -56,12 +56,25 @@ got=$(db "SELECT need_type||'|'||COALESCE(secret_key,'')||'|'||COALESCE(connecto
 [[ "$got" == "secret|PYPI_TOKEN|pypi" ]] && ok_t "T1 secret gate stores secret_key+connector" \
   || bad_t "T1 secret gate stores secret_key+connector" "got: $got"
 
-# --- T2: a legacy secret gate (no target) leaves the columns NULL -------------
+# --- T2: DIVE-2411 — the no-target secret gate is no longer FILABLE -----------
+# This arm asserted the opposite until DIVE-2411 ("legacy secret gate keeps target
+# NULL"): both flags omitted was the DEFAULTED out-of-band shape. DIVE-2232 shipped
+# on that default and had no path for the value to reach the box at all. The shape
+# survives only when CHOSEN (--out-of-band, T2b). Full negative/positive/mutation
+# coverage lives in tests/secret_gate_delivery_path_unit.sh.
 seed_task DIVE-902
-cmd_task_need DIVE-902 --type=secret --ask="drop it somewhere" >/dev/null 2>&1
-got=$(db "SELECT COALESCE(secret_key,'null')||'|'||COALESCE(connector,'null') FROM tasks WHERE ident='DIVE-902';")
-[[ "$got" == "null|null" ]] && ok_t "T2 legacy secret gate keeps target NULL" \
-  || bad_t "T2 legacy secret gate keeps target NULL" "got: $got"
+out=$(cmd_task_need DIVE-902 --type=secret --ask="drop it somewhere" 2>&1); rc=$?
+got=$(db "SELECT COALESCE(need_type,'null') FROM tasks WHERE ident='DIVE-902';")
+[[ $rc -ne 0 && "$out" == *"must name a delivery path"* && "$got" == "null" ]] \
+  && ok_t "T2 secret gate with no delivery path is refused at filing (no row written)" \
+  || bad_t "T2 secret gate with no delivery path is refused at filing (no row written)" "rc=$rc need_type=$got out=$out"
+
+# --- T2b: the out-of-band shape stays reachable when explicitly chosen ---------
+seed_task DIVE-904
+cmd_task_need DIVE-904 --type=secret --ask="drop it somewhere" --out-of-band="already in my .env on this box" >/dev/null 2>&1
+got=$(db "SELECT need_type||'|'||COALESCE(secret_key,'null')||'|'||COALESCE(secret_oob,'') FROM tasks WHERE ident='DIVE-904';")
+[[ "$got" == "secret|null|already in my .env on this box" ]] && ok_t "T2b explicit --out-of-band files and records the declared channel" \
+  || bad_t "T2b explicit --out-of-band files and records the declared channel" "got: $got"
 
 # --- T3: validation rejections ------------------------------------------------
 seed_task DIVE-903

--- a/tests/secret_gate_delivery_path_mutation.sh
+++ b/tests/secret_gate_delivery_path_mutation.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# DIVE-2411 mutation grader for tests/secret_gate_delivery_path_unit.sh.
+#
+# WHY THIS FILE EXISTS. What DIVE-2411 ships is two REFUSALS and one WITHHELD
+# affordance, and "it must not accept a secret gate with nowhere to put the value"
+# is an absence-assertion: an arm that checks only a non-zero rc stays green when
+# the condition it is guarding is deleted, because some other refusal fires and
+# the rc is identical. The ticket asks for exactly this — force each bad path and
+# confirm the refusal is the one being claimed. Each mutant below deletes ONE
+# condition from a COPY of src/ and requires the NAMED arm to go red. A mutant
+# that leaves the suite green means that arm grades nothing.
+#
+# The ACCEPTANCE direction is graded too (P3), because a suite made of refusals
+# passes trivially on code that refuses everything — which here would brick
+# out-of-band delivery and the council's own escalation re-file.
+#
+# The REMEDY PROSE is graded too (T8). Half of this fix is a string: the old copy
+# on a no-path gate said "put the key where I expect it, then tap ✅ Provided",
+# which instructs the human to do something undefined and then attest to it. A
+# refusal whose message still invites the paste has fixed nothing the human sees,
+# and alarm text is exactly the half that ships with zero coverage.
+#
+# Every mutant asserts its own application (exactly one occurrence, or the run
+# fails loudly) — a mutation that silently no-ops after a refactor would
+# otherwise read as a passing grade.
+# Run: bash tests/secret_gate_delivery_path_mutation.sh   (no root, no network)
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# NOTE the absence of `2>/dev/null`: redirecting the source's stderr would also
+# swallow the helper's own stderr line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+TMP="$(mktemp -d /tmp/sgdp-mut.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# grade <name> <expected-red-arm-substring> <old> <new>
+# src is COPIED per mutant and the unit suite is pointed at the copy
+# (SGDP_SRC_DIR) — the working tree is never mutated, so a run killed halfway
+# cannot leave a deleted safety condition behind for the next thing to grade.
+grade() {
+  local name="$1" want="$2" old="$3" new="$4"
+  local dir="$TMP/$name"; rm -rf "$dir"; mkdir -p "$dir"
+  cp -r src "$dir/src"
+  if ! OLD="$old" NEW="$new" F="$dir/src/cmd_task.sh" python3 - <<'PY'
+import os, sys
+p, old, new = os.environ["F"], os.environ["OLD"], os.environ["NEW"]
+s = open(p).read()
+n = s.count(old)
+if n != 1:
+    sys.stderr.write("mutation did not apply cleanly: %d occurrences of %r\n" % (n, old[:90]))
+    sys.exit(1)
+open(p, "w").write(s.replace(old, new))
+PY
+  then
+    bad_t "$name — mutation applies to the current source" "the anchor is gone or duplicated; this mutant graded NOTHING"
+    return
+  fi
+  # A mutant that breaks the PARSE reddens every arm for the wrong reason, which
+  # would read as a kill while grading nothing.
+  if ! bash -n "$dir/src/cmd_task.sh" 2>/dev/null; then
+    bad_t "$name — mutated source still parses" "the substitution produced a syntax error; every arm would red for the wrong reason"
+    return
+  fi
+  local out rc
+  out=$(SGDP_SRC_DIR="$dir/src" bash tests/secret_gate_delivery_path_unit.sh 2>&1); rc=$?
+  if [[ $rc -eq 0 ]]; then
+    bad_t "$name — the suite must go RED" "suite stayed GREEN with the condition removed: the '$want' arm grades nothing"
+    return
+  fi
+  if grep -q "FAIL - .*${want}" <<<"$out"; then
+    ok_t "$name — kills the '$want' arm"
+  else
+    bad_t "$name — kills the '$want' arm" "suite failed, but NOT on that arm: $(grep '^FAIL' <<<"$out" | head -3)"
+  fi
+}
+
+# ── half 1: the FILING refusal ───────────────────────────────────────────────
+grade "M1-filing-refusal" "N1 filing with no delivery path is refused" \
+  '  elif [[ "$type" == "secret" && -z "$secret_key$connector" ]]; then' \
+  '  elif false; then'
+
+grade "M2-oob-secret-only" "N2 --out-of-band on a non-secret gate is refused" \
+  '    [[ "$type" == "secret" ]] \
+      || fail "$E_VALIDATION" "--out-of-band only applies' \
+  '    [[ 1 ]] \
+      || fail "$E_VALIDATION" "--out-of-band only applies'
+
+grade "M3-one-path-per-gate" "N3 --out-of-band + drop target is refused" \
+  '    [[ -z "$secret_key$connector" ]] \
+      || fail "$E_VALIDATION" "--out-of-band is mutually exclusive' \
+  '    [[ 1 ]] \
+      || fail "$E_VALIDATION" "--out-of-band is mutually exclusive'
+
+# The opt-in must NAME the channel. Without this, `--out-of-band=y` is a flag that
+# re-selects the defect — chosen, but still with nowhere for the value to go.
+grade "M4-oob-must-name-channel" "N4 a bare --out-of-band=yes is refused" \
+  '    [[ ${#oob} -ge 12 ]] \' \
+  '    [[ 1 ]] \'
+
+# ── half 2: the ANSWER refusal (the durable one) ─────────────────────────────
+# Withholding the button only changes messages sent from now on; Telegram never
+# expires the buttons already delivered, so this is the condition that stops the
+# false record on every legacy gate still in someone's chat history.
+grade "M5-answer-refusal" "N6 answering a no-path secret gate is refused" \
+  '    [[ -n "$_paths" ]] || fail "$E_CONFLICT"' \
+  '    [[ 1 ]] || fail "$E_CONFLICT"'
+
+# ── the affordance ───────────────────────────────────────────────────────────
+grade "M6-affordance-withheld" "N7 no ✅ Provided affordance" \
+  '      if [[ -n "$_sk_row" || -n "$_oob_row" ]]; then' \
+  '      if true; then'
+
+# ── the acceptance direction ─────────────────────────────────────────────────
+# A re-file carries the delivery path forward. src/council/engine.mjs re-files an
+# escalated gate as `task need <ident> --type=secret --tier=2 --ask=…` and passes
+# no delivery flags at all, so without inheritance the council escalation itself
+# manufactures the DIVE-2232 shape out of a properly-targeted gate.
+grade "M7-inheritance-dead" "P3 a re-file with no flags inherits the existing drop target" \
+  '  if [[ "$type" == "secret" && -z "$secret_key$connector$oob" ]]; then' \
+  '  if false; then'
+
+# ── the remedy prose ─────────────────────────────────────────────────────────
+grade "M8-old-paste-inviting-copy" "T8 the no-path alert names the missing path" \
+  'Do NOT paste the credential here.' \
+  'Put the key where I expect it, then tap ✅ Provided below.'
+
+printf '\nsecret_gate_delivery_path_mutation: %d mutants killed, %d ungraded\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/secret_gate_delivery_path_unit.sh
+++ b/tests/secret_gate_delivery_path_unit.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# DIVE-2411 isolated unit harness — a `secret` gate must NAME A DELIVERY PATH, at
+# filing time AND at answer time.
+#
+# WHY THIS EXISTS (measured, DIVE-2232, 2026-07-30):
+#   * FILING. `task need --type=secret` with neither --secret-key nor --connector
+#     was the DEFAULTED "legacy out-of-band" shape. The gate pinged correctly, the
+#     ask read as complete, and NO PATH existed for the value to reach the box —
+#     the only remaining answer was pasting a live credential into a persistent
+#     chat log. main nearly received one. A human staring at the ask cannot see
+#     that the drop is missing; nothing in the message is about the drop. Only the
+#     filer can, and only at filing time.
+#   * ANSWERING, which is worse. That gate WAS answered: need_answered_by=
+#     human:main, uid 1004, need_answer_sig VALID, human_nonce_hash SET — a real
+#     human holding the raw nonce tapped ✅ Provided — and need_answer EMPTY, no
+#     connector file written, no drop ever minted, no value anywhere. The record
+#     reads "credential provided, human-attested, signed, nonced" over nothing.
+#     Provenance and payload are independent and only provenance was ever checked.
+#   * THE AFFORDANCE. ✅ Provided is legitimate for "I already ran `5dive secret
+#     write` myself" — true on a gate with a drop target, meaningless on a gate
+#     that never named one. It was offered anyway, on a BATCHED six-gate message
+#     whose batcher cannot know what any of the six drops targeted, which is why
+#     the fix is at the affordance/mint layer (_task_gate_reply_markup reads the
+#     ROW) and not in the batcher's copy.
+#
+# WHAT IS PINNED HERE. Both halves are ABSENCE assertions ("must not accept"),
+# which pass on empty output, so every negative arm asserts a NONZERO rc AND that
+# the row did not move — never rc alone (feedback: a refusal graded by rc alone
+# passes the wrong refusal, so each also matches the refusal REASON). The positive
+# arms exist because the cheap version of this fix bricks out-of-band delivery and
+# the legitimate box-side write:
+#   N1  filing with no delivery path is refused, and NO gate is written
+#   N2  --out-of-band on a non-secret type is refused
+#   N3  --out-of-band together with a drop target is refused (one path per gate)
+#   N4  a bare/short --out-of-band is refused (it must NAME the channel)
+#   N5  a re-file with nothing to inherit is refused
+#   N6  answering a no-path secret gate is refused and the row does NOT transition
+#   N7  no ✅ Provided affordance on a no-path secret gate
+#   P1  drop target files and is stored
+#   P2  explicit --out-of-band files and is stored
+#   P3  a re-file inherits the drop target (the council-escalation shape)
+#   P4  a drop-target gate still ANSWERS (the legitimate `secret write` case)
+#   P5  an out-of-band gate still ANSWERS
+#   P6  drop-target gate still gets its ✅ Provided button
+#   P7  out-of-band gate still gets its ✅ Provided button
+#   T8  the no-path gate's alert text names the missing path and offers no tap
+# Isolation matches the sibling harnesses: source src/ libs, throwaway STATE_DIR —
+# the live shared tasks.db is NEVER touched.
+# Run: bash tests/secret_gate_delivery_path_unit.sh   (no root, no network)
+#
+# MUTATION GRADING lives in tests/secret_gate_delivery_path_mutation.sh, which
+# re-runs this suite once per safety condition with that condition deleted (in a
+# COPY of src/) and demands the named arm go red. An absence-assertion suite that
+# nobody mutation-grades is exactly the shape this ticket is about, and a mutation
+# mode that only runs when a human passes a flag is graded by nobody in CI.
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# NOTE the absence of `2>/dev/null` — see the sibling harnesses: redirecting the
+# source's stderr also swallows the helper's own line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC="${SGDP_SRC_DIR:-src}"
+TMP="$(mktemp -d /tmp/sgdp-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh cmd_task.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"; set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+tasks_db_init
+
+# Notify is a no-op in isolation (no channel resolves), but it is also how the raw
+# per-gate human nonce reaches us: cmd_task_need hands it to notify as $8, and the
+# answer path needs it as --human-proof (this harness runs as an agent account, so
+# the nonce is its only human-evidence form).
+NONCE=""
+task_need_notify() { NONCE="${8:-}"; return 0; }
+
+# The human-only block in cmd_task_answer refuses when the CALLER is an agent
+# account, and this suite runs as one, so P4/P5 would grade that refusal instead
+# of the delivery-path decision. Pin the DIVE-2330 seams to a non-agent uid — the
+# seam exists precisely so a harness can model a non-agent caller (its own comment
+# says so, after the EUID bypass made suite outcomes a function of whose uid ran
+# them). Every NEGATIVE arm below is unaffected: the delivery-path refusal lands
+# BEFORE this block, and N6 asserts its reason text, not just a nonzero rc.
+_PIN_UID=987654
+_gate_caller_uid() { printf '%s' "$_PIN_UID"; }
+_gate_passwd_stream() {
+  printf '%s:x:%s:%s::/nonexistent:/bin/false\n' "human-fixture" "$_PIN_UID" "$_PIN_UID"
+  printf '%s\n' "$(</etc/passwd)"
+}
+
+seed_task() { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
+field() { db "SELECT COALESCE($2,'∅') FROM tasks WHERE ident='$1';"; }
+
+# ============================ FILING ==========================================
+
+# --- N1: no delivery path -> refused, and NOTHING is written ------------------
+# Command substitution runs cmd_task_need in a subshell so its `fail` exit cannot
+# kill this harness (a fail-fast harness cannot grade per assertion).
+seed_task DIVE-2401
+out=$(cmd_task_need DIVE-2401 --type=secret --ask="drop the GH_BOT_TOKEN" 2>&1); rc=$?
+if [[ $rc -ne 0 ]] \
+   && [[ "$out" == *"must name a delivery path"* ]] \
+   && [[ "$out" == *"--secret-key"* && "$out" == *"--connector"* && "$out" == *"--out-of-band"* ]]; then
+  ok_t "N1 filing with no delivery path is refused, naming both flags and the opt-in"
+else
+  bad_t "N1 filing with no delivery path is refused, naming both flags and the opt-in" "rc=$rc out=$out"
+fi
+# The row must not have moved AT ALL — a refusal that leaves a half-filed gate is
+# the DIVE-2233 shape (refused the caller, created the state anyway).
+got="$(field DIVE-2401 need_type)|$(field DIVE-2401 ask)|$(field DIVE-2401 need_asked_at)|$(field DIVE-2401 human_nonce_hash)|$(field DIVE-2401 status)"
+[[ "$got" == "∅|∅|∅|∅|todo" ]] \
+  && ok_t "N1b the refused filing wrote no gate (type/ask/asked_at/nonce all NULL, status untouched)" \
+  || bad_t "N1b the refused filing wrote no gate (type/ask/asked_at/nonce all NULL, status untouched)" "got: $got"
+
+# --- N2: --out-of-band is secret-only ----------------------------------------
+seed_task DIVE-2402
+out=$(cmd_task_need DIVE-2402 --type=approval --ask="approve the deploy" --out-of-band="in my .env on this box" 2>&1); rc=$?
+[[ $rc -ne 0 && "$out" == *"only applies to --type=secret"* && "$(field DIVE-2402 need_type)" == "∅" ]] \
+  && ok_t "N2 --out-of-band on a non-secret gate is refused (no row written)" \
+  || bad_t "N2 --out-of-band on a non-secret gate is refused (no row written)" "rc=$rc need_type=$(field DIVE-2402 need_type) out=$out"
+
+# --- N3: one delivery path per gate ------------------------------------------
+seed_task DIVE-2403
+out=$(cmd_task_need DIVE-2403 --type=secret --ask="drop it" --secret-key=GH_BOT_TOKEN --connector=github-bot --out-of-band="in my .env on this box" 2>&1); rc=$?
+[[ $rc -ne 0 && "$out" == *"mutually exclusive"* && "$(field DIVE-2403 need_type)" == "∅" ]] \
+  && ok_t "N3 --out-of-band + drop target is refused (no row written)" \
+  || bad_t "N3 --out-of-band + drop target is refused (no row written)" "rc=$rc need_type=$(field DIVE-2403 need_type) out=$out"
+
+# --- N4: the opt-in must NAME the channel ------------------------------------
+# A bare "yes" opt-in would restore the defect with a flag in front of it.
+seed_task DIVE-2404
+out=$(cmd_task_need DIVE-2404 --type=secret --ask="drop it" --out-of-band="yes" 2>&1); rc=$?
+[[ $rc -ne 0 && "$out" == *"must NAME where the value will land"* && "$(field DIVE-2404 need_type)" == "∅" ]] \
+  && ok_t "N4 a bare --out-of-band=yes is refused (must name the channel)" \
+  || bad_t "N4 a bare --out-of-band=yes is refused (must name the channel)" "rc=$rc need_type=$(field DIVE-2404 need_type) out=$out"
+
+# --- P1: drop target files and is stored -------------------------------------
+seed_task DIVE-2405
+cmd_task_need DIVE-2405 --type=secret --ask="drop the GH_BOT_TOKEN" --secret-key=GH_BOT_TOKEN --connector=github-bot >/dev/null 2>&1
+got="$(field DIVE-2405 need_type)|$(field DIVE-2405 secret_key)|$(field DIVE-2405 connector)|$(field DIVE-2405 secret_oob)"
+[[ "$got" == "secret|GH_BOT_TOKEN|github-bot|∅" ]] \
+  && ok_t "P1 drop-target secret gate files and stores the target" \
+  || bad_t "P1 drop-target secret gate files and stores the target" "got: $got"
+
+# --- P2: the out-of-band shape stays reachable when CHOSEN --------------------
+seed_task DIVE-2406
+cmd_task_need DIVE-2406 --type=secret --ask="drop it" --out-of-band="already in my .env on this box" >/dev/null 2>&1
+got="$(field DIVE-2406 need_type)|$(field DIVE-2406 secret_key)|$(field DIVE-2406 secret_oob)"
+[[ "$got" == "secret|∅|already in my .env on this box" ]] \
+  && ok_t "P2 explicit --out-of-band files and records the declared channel" \
+  || bad_t "P2 explicit --out-of-band files and records the declared channel" "got: $got"
+
+# --- P3: a re-file INHERITS the delivery path (the council-escalation shape) --
+# src/council/engine.mjs re-files an escalated gate as
+# `task need <ident> --type=secret --tier=2 --ask=...` — type preserved, nothing
+# else. Without inheritance that re-file converts a properly-targeted gate into
+# the DIVE-2232 shape, i.e. the defect would have a generator.
+out=$(cmd_task_need DIVE-2405 --type=secret --tier=2 --ask="[council escalation] still needs the human" 2>&1); rc=$?
+got="$(field DIVE-2405 secret_key)|$(field DIVE-2405 connector)"
+[[ $rc -eq 0 && "$got" == "GH_BOT_TOKEN|github-bot" ]] \
+  && ok_t "P3 a re-file with no flags inherits the existing drop target" \
+  || bad_t "P3 a re-file with no flags inherits the existing drop target" "rc=$rc got=$got out=$out"
+out=$(cmd_task_need DIVE-2406 --type=secret --tier=2 --ask="[council escalation] still needs the human" 2>&1); rc=$?
+[[ $rc -eq 0 && "$(field DIVE-2406 secret_oob)" == "already in my .env on this box" ]] \
+  && ok_t "P3b a re-file with no flags inherits the declared out-of-band channel" \
+  || bad_t "P3b a re-file with no flags inherits the declared out-of-band channel" "rc=$rc oob=$(field DIVE-2406 secret_oob) out=$out"
+
+# --- N5: a re-file with NOTHING to inherit is still refused -------------------
+# Inheritance must not become a back door: a row whose gate columns are empty
+# (never targeted, or withdrawn — withdraw NULLs them) has nothing to carry.
+seed_task DIVE-2407
+db "UPDATE tasks SET need_type='decision', ask='pick one', status='blocked' WHERE ident='DIVE-2407';"
+out=$(cmd_task_need DIVE-2407 --type=secret --ask="drop it" 2>&1); rc=$?
+[[ $rc -ne 0 && "$out" == *"must name a delivery path"* && "$(field DIVE-2407 need_type)" == "decision" ]] \
+  && ok_t "N5 a re-file with no path to inherit is refused (prior gate untouched)" \
+  || bad_t "N5 a re-file with no path to inherit is refused (prior gate untouched)" "rc=$rc need_type=$(field DIVE-2407 need_type) out=$out"
+
+# ============================ ANSWERING =======================================
+
+# --- N6: the DIVE-2232 shape cannot be STAMPED -------------------------------
+# Built by direct SQL, deliberately: this row can no longer be produced by
+# `task need` (N1), and the exposure is exactly the rows that ALREADY exist —
+# plus every ✅ Provided button already sitting in someone's chat history, which
+# Telegram never expires. Fields mirror the measured DIVE-2232 row.
+seed_task DIVE-2408
+db "UPDATE tasks SET need_type='secret', ask='drop the GH_BOT_TOKEN', tier=2, status='blocked',
+      need_asked_at=datetime('now'), human_nonce_hash='$(printf 'a%.0s' {1..64})',
+      secret_key=NULL, connector=NULL, secret_oob=NULL WHERE ident='DIVE-2408';"
+out=$(cmd_task_answer DIVE-2408 --from=main --human 2>&1); rc=$?
+if [[ $rc -ne 0 ]] && [[ "$out" == *"names NO delivery path"* ]]; then
+  ok_t "N6 answering a no-path secret gate is refused, and the reason names the missing path"
+else
+  bad_t "N6 answering a no-path secret gate is refused, and the reason names the missing path" "rc=$rc out=$out"
+fi
+got="$(field DIVE-2408 need_answered_at)|$(field DIVE-2408 need_answered_by)|$(field DIVE-2408 need_answer_sig)|$(field DIVE-2408 status)"
+[[ "$got" == "∅|∅|∅|blocked" ]] \
+  && ok_t "N6b the refused answer left no provenance (answered_at/by/sig NULL, still blocked)" \
+  || bad_t "N6b the refused answer left no provenance (answered_at/by/sig NULL, still blocked)" "got: $got"
+
+# --- P4: a drop-target gate still ANSWERS (do not brick `secret write`) ------
+# This is the legitimate case the affordance exists for: "I already ran
+# `5dive secret write` on the box myself" — true on a gate that named a target.
+seed_task DIVE-2409
+NONCE=""
+cmd_task_need DIVE-2409 --type=secret --ask="drop the GH_BOT_TOKEN" --secret-key=GH_BOT_TOKEN --connector=github-bot >/dev/null 2>&1
+out=$(cmd_task_answer DIVE-2409 --from=main --human --human-proof="$NONCE" 2>&1); rc=$?
+[[ $rc -eq 0 && "$(field DIVE-2409 need_answered_at)" != "∅" ]] \
+  && ok_t "P4 a drop-target secret gate still accepts a human 'provided' answer" \
+  || bad_t "P4 a drop-target secret gate still accepts a human 'provided' answer" "rc=$rc answered_at=$(field DIVE-2409 need_answered_at) out=$out"
+
+# --- P5: an explicitly out-of-band gate still ANSWERS ------------------------
+# Its ask NAMED where the value goes, so "I put it there" is a coherent claim.
+seed_task DIVE-2410
+NONCE=""
+cmd_task_need DIVE-2410 --type=secret --ask="drop it" --out-of-band="already in my .env on this box" >/dev/null 2>&1
+out=$(cmd_task_answer DIVE-2410 --from=main --human --human-proof="$NONCE" 2>&1); rc=$?
+[[ $rc -eq 0 && "$(field DIVE-2410 need_answered_at)" != "∅" ]] \
+  && ok_t "P5 an out-of-band secret gate still accepts a human 'provided' answer" \
+  || bad_t "P5 an out-of-band secret gate still accepts a human 'provided' answer" "rc=$rc answered_at=$(field DIVE-2410 need_answered_at) out=$out"
+
+# ============================ THE AFFORDANCE ==================================
+# _task_gate_reply_markup reads the ROW (not a parameter), so the single-gate
+# notify and the batch re-send are both covered by the same decision.
+kb() { _task_gate_reply_markup "$(db "SELECT id FROM tasks WHERE ident='$1';")" secret "" "" "" claude 2>/dev/null; }
+
+# --- N7: no ✅ Provided button on a gate that named no path ------------------
+got=$(kb DIVE-2408)
+[[ "$got" != *"provided"* ]] \
+  && ok_t "N7 no ✅ Provided affordance is offered on a no-path secret gate" \
+  || bad_t "N7 no ✅ Provided affordance is offered on a no-path secret gate" "markup: $got"
+
+# --- P6/P7: the button survives where it MEANS something ---------------------
+got=$(kb DIVE-2405)
+[[ "$got" == *'"tna:'*':provided'* ]] \
+  && ok_t "P6 a drop-target secret gate still gets its ✅ Provided button" \
+  || bad_t "P6 a drop-target secret gate still gets its ✅ Provided button" "markup: $got"
+got=$(kb DIVE-2406)
+[[ "$got" == *'"tna:'*':provided'* ]] \
+  && ok_t "P7 an out-of-band secret gate still gets its ✅ Provided button" \
+  || bad_t "P7 an out-of-band secret gate still gets its ✅ Provided button" "markup: $got"
+
+# ============================ THE ALERT TEXT ==================================
+# The prose half ships with zero coverage unless it is graded too: a fix whose
+# remedy text tells the human to do the impossible is still a live defect. The
+# instruction on a no-path gate must NOT invite a tap or a paste — the tap is
+# withheld (N7) and `task answer` refuses (N6), so the only honest line is
+# "this gate names no delivery path and has to be re-filed".
+txt=$(_task_secret_gate_cta DIVE-2408 "$(db "SELECT id FROM tasks WHERE ident='DIVE-2408';")" "" "" "")
+if [[ "$txt" == *"NO delivery path"* && "$txt" == *"re-filed"* ]] \
+   && [[ "$txt" != *"tap ✅ Provided"* ]] && [[ "$txt" != *"task answer"* ]]; then
+  ok_t "T8 the no-path alert names the missing path and offers neither a tap nor a paste"
+else
+  bad_t "T8 the no-path alert names the missing path and offers neither a tap nor a paste" "text: $txt"
+fi
+txt=$(_task_secret_gate_cta DIVE-2406 "$(db "SELECT id FROM tasks WHERE ident='DIVE-2406';")" "" "" "")
+[[ "$txt" == *"already in my .env on this box"* && "$txt" == *"tap ✅ Provided"* ]] \
+  && ok_t "T8b the out-of-band alert names the declared channel and keeps the tap" \
+  || bad_t "T8b the out-of-band alert names the declared channel and keeps the tap" "text: $txt"
+
+printf '\nsecret-gate delivery-path unit: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## The defect, measured on DIVE-2232

`5dive task need --type=secret` with neither `--secret-key` nor `--connector` was the **defaulted** "legacy out-of-band" shape. The gate pinged correctly, the ask read as complete, and there was **no path for the value to reach the box** — the only remaining answer was pasting a live credential into a chat log that persists. main nearly received one.

A human staring at the ask cannot see that the drop is missing: nothing in the message is about the drop. Only the filer can see it, and only at filing time. That is why this is a filing-time refusal and not a doc fix.

## The worse half, one step later

That gate **was answered**. The row came back `need_answered_by=human:main`, uid stamped, `need_answer_sig` VALID, `human_nonce_hash` SET — a real human holding the raw nonce tapped ✅ Provided — and nothing had landed anywhere: no connector file written that day, no drop ever minted, no value on any channel.

So the record reads *credential provided, human-attested, signed, nonced* over an empty payload. Provenance and payload are independent, and only provenance was ever verified. This is strictly worse than the filing gap, which merely leaves a gate visibly stuck.

Nobody misbehaved. ✅ Provided exists for the legitimate case "I already ran `5dive secret write` on the box myself" — true on a gate with a drop target, meaningless on a gate that never named one. It was rendered by a **batcher carrying six gates**, which cannot know what any of the six drops targeted, so the fix has to sit at the affordance/mint layer rather than in the batcher's copy.

## What this changes

- **Filing** refuses when a secret gate names no delivery path; the error names both flags, DIVE-931, and the opt-in. The out-of-band shape survives only when **chosen**: `--out-of-band="<where the value lands>"`, which must NAME the channel — a bare opt-in would re-select the defect with a flag in front of it.
- **Answering** refuses on a no-path secret gate, before any write. **This is the durable half.** Withholding the button only changes messages sent from now on, and Telegram never expires buttons already delivered (the same fact DIVE-2228 turns on), so every legacy gate in someone's chat history keeps a live ✅ Provided. All three answer surfaces funnel through `cmd_task_answer` — verified, not assumed: the Telegram tap resolves `provided` to `5dive task answer <id>` (`plugins/telegram/tna.ts:59`), and the dashboard's "Mark provided" runs `task answer <ident> --human` through the exec tunnel (`needs-you.tsx:55`).
- **The affordance** is withheld on a no-path gate. `_task_gate_reply_markup` reads the ROW, so the single-gate notify and the batch re-send both inherit the decision without either caller changing.
- **A re-file inherits the delivery path it already had.** `src/council/engine.mjs` escalates a gate by re-filing it with the type preserved and nothing else, and a re-file resets the gate columns — so escalating a properly-targeted secret gate silently manufactured the DIVE-2232 shape. **The defect had a generator, not just an author.** Nobody had filed that.
- **The CTA prose is now a function** (`_task_secret_gate_cta`) so it can be graded. The old copy on a no-path gate — "put the key where I expect it, then tap ✅ Provided" — instructs the human to do something undefined and then attest to it. Half of this fix is that string.

## Verified by mutation, because both halves are absence-assertions

"Must not accept" passes on empty output, so no arm rests on a bare non-zero rc.

- `tests/secret_gate_delivery_path_unit.sh` — 19 arms. Seven negative, each asserting a non-zero rc **and** that the row did not move **and** the refusal reason (rc alone stays green when the condition is deleted, because another refusal fires with the same rc). Nine positive, so the fix cannot brick out-of-band delivery, the box-side `secret write`, or the council re-file. Three on the affordance and the prose. Green under **agent, root and non-agent** identities — the DIVE-2412 lesson that a suite can grade whose uid ran it.
- `tests/secret_gate_delivery_path_mutation.sh` — deletes each condition in a **copy** of `src/` and requires the named arm to go red: **8 of 8 killed**, including the acceptance direction (kill inheritance → the council-escalation arm reds) and the message text (restore the old paste-inviting copy → the prose arm reds). Each mutant asserts its own application (exactly one occurrence) and that the mutated source still parses, so a mutation that silently no-ops cannot read as a passing grade.

Eight sibling harnesses that filed fixture secret gates without a delivery path were updated; three of them were dying mid-suite on the new refusal, which is its own reminder that a `fail` inside a sourced harness takes the rest of the arms with it.

## Live board, and the residue

One pending row is affected: **DIVE-1817** (secret gate, no delivery path, unanswered) becomes unanswerable until re-filed with a path. That is the intended trade — visibly stuck beats falsely recorded — but it needs a re-file by its filer, and this PR deliberately does not touch someone else's gate.

Named rather than hidden: the **dashboard** still renders "Mark provided" with the old copy on a no-path gate (`app/.../needs-you.tsx`). Its outcome is now safe — the tap execs the CLI and gets the refusal, so no false record — but the button and its text are app-repo work, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
