### PR TITLE
fix(task): refuse a close that would REPLACE an already-closed row's result (DIVE-2464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,30 @@ stderr, and writes the overwritten text (not its hash) to the audit log.
 The guard is deliberately narrow, so nothing idempotent changed: it fires only when `--result=`
 was actually passed, the stored result is non-empty, and the new text differs. A bare re-close, a
 replay with identical text, an empty prior result, and any first close of an open row all behave
-exactly as before. `tests/task_done_over_closed_result_unit.sh` grades both halves, and its arms
-were checked against the pristine tree — the defect (prior result destroyed) reproduces there,
-and the four idempotence arms pass on both trees, which is what makes them regression guards
-rather than evidence for the fix.
+exactly as before.
+
+A second change was needed, and review is what found it: the DIVE-477 verifier-routing branch
+`return`s early and does its own unconditional result write, so on a row where `verifier` is set
+and differs from `assignee` the guard was never reached at all and the clobber survived — plus
+`_task_route_to_verifier` sets `status='todo'`, so a closed row was also **resurrected** and
+re-delivered. A closed row is now stopped from routing in the first place, which is right on its
+own merits, and the guard sits above that branch.
+
+Their division of labour was measured by mutating each independently rather than assumed, and the
+answer is not the intuitive one: removing the routing exclusion reds only the resurrection arms,
+while reverting the guard's position reds **nothing** — the exclusion subsumes the ordering for
+the result clobber. So no test arm pins the block's position; it is kept as defence-in-depth and
+said so in the source rather than presented as coverage. The resurrection is a separate harm, not
+a second symptom: it fires on a bare re-close where there is no result to protect.
+
+Two adjacent clobbers on the same column are **not** fixed here and are named rather than left to
+be discovered: `task deliver --result=` over a closed row (DIVE-2476), and
+`_task_route_to_verifier` writing over an **open** row's existing result.
+
+`tests/task_done_over_closed_result_unit.sh` — 29 arms. Checked against the pristine tree: the
+defect (prior result destroyed) reproduces there, and the idempotence and DIVE-477-still-routes
+arms pass on both trees, which is what makes them regression guards rather than evidence for the
+fix.
 
 ## Unreleased — fix(release-cut): move the nightly off the contended top-of-hour and poll for CI to settle (DIVE-2466)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased — fix(task): refuse a close that would REPLACE an already-closed row's result (DIVE-2464)
+
+`5dive task done <id> --result=...` on a row that was already done overwrote the result column and
+said nothing about it — no warning, no refusal, no merge, exit 0. It happened on DIVE-2451: one
+agent closed at 21:08:59, another closed again at 21:11:43, and the first record was gone from the
+board. The ledger does not cover this. `5dive trace` shows both `task.done` events with an
+authority envelope and an `out:` field, but that field is a sha256 *of* the result, not the text —
+it proves the record changed and cannot restore it. An integrity hash is not a backup. What
+actually recovered the text was a `/var/lib/5dive/tasks-backups/` snapshot that happened to fall
+between the two writes; a 3-minute window landing inside a 5-minute cron is luck, not a path.
+
+The check has to live in the verb. "Read the status first" was already being done — the
+overwriting invocation printed the row's status in the same call as the write, so the read could
+not gate anything. DIVE-2067 had fixed exactly this clobber in `task verify`; `task done` was left
+unguarded, and the DIVE-2007 guard above it deliberately falls through for closed rows because "a
+repeat done stays idempotent" — true of the status write, false of the result write.
+
+A close (`done` or `cancel`) that lands on an already-closed row carrying a result is now refused,
+naming the close timestamp and the row's recorded holders, and pointing at `5dive trace` for the
+actor the row itself does not store. Two flags answer it. `--append-result` is the common
+legitimate case — a maker closes, then the owner of the other half adds theirs — and keeps the
+prior text verbatim and first, with the addition beneath it. `--force-result` replaces, warns on
+stderr, and writes the overwritten text (not its hash) to the audit log.
+
+The guard is deliberately narrow, so nothing idempotent changed: it fires only when `--result=`
+was actually passed, the stored result is non-empty, and the new text differs. A bare re-close, a
+replay with identical text, an empty prior result, and any first close of an open row all behave
+exactly as before. `tests/task_done_over_closed_result_unit.sh` grades both halves, and its arms
+were checked against the pristine tree — the defect (prior result destroyed) reproduces there,
+and the four idempotence arms pass on both trees, which is what makes them regression guards
+rather than evidence for the fix.
+
 ## Unreleased — fix(release-cut): move the nightly off the contended top-of-hour and poll for CI to settle (DIVE-2466)
 
 The nightly cut has never once run on time. `- cron: '0 3 * * *'` was byte-identical across all six

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -1933,6 +1933,124 @@ _task_status_cmd() {
       extra+=", handoff_ack_at=COALESCE(handoff_ack_at, datetime('now'))"
     fi
   fi
+  # DIVE-2464: a close landing on an ALREADY-CLOSED row silently REPLACED its
+  # result. Hit live 2026-07-30 21:11 on DIVE-2451 — main2 closed at 21:08:59,
+  # main ran `task done --result=...` at 21:11:43, and the verb accepted it,
+  # overwrote the result column, printed nothing, exited 0. The prior record was
+  # gone from the board.
+  #
+  # WHY THE LEDGER DOES NOT COVER THIS: `5dive trace` shows both task.done events
+  # with an authority envelope and an `out:` field — but that field is a sha256 OF
+  # the result, not the text. It proves the record changed and cannot restore it.
+  # An integrity hash is not a backup. What actually recovered DIVE-2451 was a
+  # /var/lib/5dive/tasks-backups/ snapshot that happened to fall between the two
+  # writes (5-minute cadence, 3-minute window) — luck about a cron, not a path.
+  #
+  # WHY THE CHECK HAS TO LIVE IN THE VERB: "read the status first" does not work.
+  # The overwriting invocation PRINTED the row's status in the same call as the
+  # write, so the read could not gate anything. A check that cannot stop the
+  # action is decoration.
+  #
+  # This is DIVE-2067 rec 1, ported to the verb that was left unguarded. DIVE-2067
+  # fixed the same clobber in `task verify` (verify-over-closed refusal + the
+  # preserve-by-appending fallback further down that function); `task done` kept
+  # the destructive behaviour, and the DIVE-2007 guard above explicitly falls
+  # THROUGH for closed rows ("a repeat done stays idempotent") — true of the
+  # status write, false of the result write.
+  #
+  # SCOPE, deliberately narrow so nothing idempotent regresses:
+  #   * only a close verb (done/cancel) landing on status done|cancelled;
+  #   * only when --result= was actually PASSED (a bare re-close writes no result);
+  #   * only when the stored result is NON-EMPTY (nothing to destroy otherwise);
+  #   * only when the new text DIFFERS (a replay with identical text is a no-op).
+  # Everything else keeps working exactly as before.
+  #
+  # PLACEMENT IS PART OF THE FIX, and the first version of this change got it
+  # wrong in a way worth recording. This block originally sat BELOW the DIVE-477
+  # verifier-routing branch, which `return`s early — so on any row where
+  # `verifier` is set and differs from `assignee` the guard was never reached,
+  # `_task_route_to_verifier` performed its own unconditional
+  # `(( want_result )) && set_result=`, and the clobber survived untouched on that
+  # shape. The scope list above then read as sufficient while an unstated fourth
+  # condition ("...and the row does not route to a distinct verifier") was doing
+  # real work. Caught in review by main, measured on a clean detached worktree
+  # rather than argued.
+  #
+  # TWO CHANGES ANSWER IT, and their division of labour was MEASURED by mutating
+  # each independently rather than inferred — the result is not what either of us
+  # expected:
+  #   * this block moved ABOVE the routing branch;
+  #   * a closed row additionally stopped from routing at all (note there).
+  # Mutation A (exclusion removed, placement kept): the routed-shape arms stay
+  # GREEN, the resurrection arms RED. Mutation B (placement reverted, exclusion
+  # kept): EVERYTHING stays green. So the exclusion SUBSUMES the ordering for the
+  # result clobber and the ordering is redundant given it — no test arm pins this
+  # block's position, and a future refactor could move it back down with no red.
+  # Kept anyway as defence-in-depth: it is the only thing left standing if the
+  # exclusion is relaxed, and a closed row not routing is right on its own merits.
+  # Written down rather than sold as belt-and-braces coverage, because the first
+  # version of this change asserted coverage it had not measured and that is the
+  # entire reason it came back.
+  #
+  # The resurrection is a genuinely SEPARATE harm, not a second symptom of this
+  # one: it fires on a BARE re-close where there is no result to protect and this
+  # block correctly stays silent. Ordering alone does not reach it.
+  #
+  # NOT FIXED HERE, named so none of it is mistaken for covered:
+  #   * `task deliver --result=` clobbers a closed row the same way (main's probe
+  #     P4, filed as DIVE-2476);
+  #   * `_task_route_to_verifier` still writes unconditionally over an OPEN row's
+  #     existing result — a different population than this ticket measured;
+  #   * a BARE re-close still REFRESHES done_at (both close verbs pass
+  #     `done_at=datetime('now')` unconditionally), measured: 2026-07-30 21:08:59
+  #     -> now. Pre-existing on the non-routed shape and unchanged by this ticket;
+  #     NEW on the routed shape only because the exclusion above now lets it fall
+  #     through here instead of resurrecting the row, which is strictly the better
+  #     of the two. It matters slightly more than it looks, because the refusal
+  #     message quotes done_at as evidence of who closed when — so the honest fix
+  #     is `COALESCE(done_at, datetime('now'))` at the two call sites, which is a
+  #     change to EVERY close and therefore its own row (DIVE-2477), not a rider
+  #     on this one.
+  #
+  # The general lesson, since it is this ticket's own defect wearing a different
+  # hat: a guard's scope is bounded by every early `return` above it, and "the
+  # other rail handles that shape" is a claim about a GUARD when the thing above
+  # you may be a different WRITE PATH. Enumerate the writers, do not reason from
+  # the neighbouring comment.
+  #
+  # The refusal names the row's recorded holders and the close timestamp, not the
+  # invoking actor of the earlier write — the tasks row does not store that. The
+  # actor lives in the audit trail, so the message sends the reader to `5dive
+  # trace` for it rather than implying the row knows.
+  if [[ "$verb" == "done" || "$verb" == "cancel" ]] && (( want_result )); then
+    local _cl_st _cl_prev
+    _cl_st=$(db "SELECT COALESCE(status,'') FROM tasks WHERE id=${id};")
+    if [[ "$_cl_st" == "done" || "$_cl_st" == "cancelled" ]]; then
+      _cl_prev=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=${id};")
+      if [[ -n "$_cl_prev" && "$_cl_prev" != "$result" ]]; then
+        if (( append_result )); then
+          # Prior text FIRST and untouched: the existing record is the one that
+          # must survive verbatim, and the addition is what is new.
+          result="${_cl_prev}"$'\n\n'"--- appended by a later close (DIVE-2464) ---"$'\n'"${result}"
+        elif (( force_result )); then
+          # The only lossy path, so it is the only one that leaves a row behind.
+          # The overwritten text goes in the audit args, not just its hash — the
+          # whole point of this ticket is that a hash is not a backup.
+          _task_store_audit_log "task.force-result-over-closed" ok 0 -- \
+            "$ident" "closed_status=$_cl_st" "overwritten_result=$_cl_prev"
+          warn "$ident: --force-result REPLACED the result recorded at close. The overwritten text is in the audit log (task.force-result-over-closed); the board copy is gone (DIVE-2464)."
+        else
+          local _cl_at _cl_asg _cl_vf _cl_mk
+          _cl_at=$(db  "SELECT COALESCE(done_at,'unknown')     FROM tasks WHERE id=${id};")
+          _cl_asg=$(db "SELECT COALESCE(assignee,'unassigned') FROM tasks WHERE id=${id};")
+          _cl_vf=$(db  "SELECT COALESCE(verifier,'')           FROM tasks WHERE id=${id};")
+          _cl_mk=$(db  "SELECT COALESCE(maker_agent,'')        FROM tasks WHERE id=${id};")
+          policy_refuse "$E_CONFLICT" done-over-closed-result DIVE-2464 "$ident" \
+            "$ident is ALREADY ${_cl_st} (closed ${_cl_at}; assignee '${_cl_asg}'${_cl_vf:+, verifier '${_cl_vf}'}${_cl_mk:+, maker '${_cl_mk}'}) and carries a result — a bare '5dive task ${verb} --result=' here would REPLACE that record with no warning, and the ledger keeps only a sha256 of it, so it could not be restored (DIVE-2464). Run '5dive trace $ident' to see who wrote it. If you are ADDING your half of the work, say so: '5dive task ${verb} $ident --append-result --result=<your text>' (keeps theirs verbatim, adds yours under it). Only if the recorded text is genuinely WRONG: '--force-result' (replaces it, audited with the overwritten text)."
+        fi
+      fi
+    fi
+  fi
   # DIVE-477: maker→verifier routing. A `task done` on a task that carries a
   # `verifier` distinct from its current assignee is NOT a close — it's a handoff.
   # The maker is claiming the work is ready; the verifier must grade it before the
@@ -1942,10 +2060,30 @@ _task_status_cmd() {
   # rejects it (`task reject` → bounce back to the maker). Opt-in: ordinary tasks
   # (verifier NULL) and the verifier's own close are untouched.
   if [[ "$verb" == "done" ]]; then
-    local _vfier _asignee
+    local _vfier _asignee _route_st
     _vfier=$(db "SELECT COALESCE(verifier,'')  FROM tasks WHERE id=${id};")
     _asignee=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=${id};")
-    if [[ -n "$_vfier" && "$_vfier" != "$_asignee" ]]; then
+    # DIVE-2464 (review, main): a row that is ALREADY CLOSED must not route. The
+    # routing predicate is purely positional (`verifier != assignee`) and never
+    # read status, so a second `task done` on a closed handoff row was routed
+    # again — and `_task_route_to_verifier` sets status='todo', so the close was
+    # RESURRECTED and re-delivered. Measured on a closed row with verifier='main',
+    # assignee='olivia': status done -> todo, rc=0, and (before the guard above
+    # moved ahead of this branch) the result destroyed on the way through.
+    #
+    # This is the SECOND harm on the path and it is not the result clobber: it
+    # fires on a BARE re-close too, where there is no result to protect and the
+    # DIVE-2464 guard above correctly stays silent. So ordering alone does not
+    # cover it and this condition is doing separate work — stated because the
+    # first version of this change asserted coverage it did not have, which is
+    # what the review caught.
+    #
+    # Falling through (rather than refusing) is deliberate: the normal close path
+    # below is idempotent on an already-closed row, so a bare repeat `task done`
+    # keeps its long-standing rc=0 no-op behaviour instead of newly erroring.
+    _route_st=$(db "SELECT COALESCE(status,'') FROM tasks WHERE id=${id};")
+    if [[ -n "$_vfier" && "$_vfier" != "$_asignee" \
+          && "$_route_st" != "done" && "$_route_st" != "cancelled" ]]; then
       _task_route_to_verifier "$id" "$_vfier" "$_asignee" "$result" "$want_result"
       return
     fi
@@ -1986,71 +2124,6 @@ _task_status_cmd() {
             && "$_st" != "done" && "$_st" != "cancelled" ]]; then
         policy_refuse "$E_CONFLICT" done-over-delivered-loop DIVE-2007 "$ident" \
           "$ident is DELIVERED to verifier '${_vfier}' (iteration ${_iter}, maker '${_maker}') and has NOT been graded — a 'task done' from '${_actor}' would close it ungraded, which is the maker grading its own work (writer != grader, DIVE-477). Only '${_vfier}' can close it. To CORRECT the result text do NOT re-run done: send the correction to '${_vfier}' (5dive agent send ${_vfier} \"...\") and let them fold it in. Real exits: '5dive task reject $ident --feedback=...' (verifier bounces it back), '5dive task verify $ident --cmd=\"<acceptance test>\"' (evidence-backed close), or '5dive task cancel $ident --result=...' (abandon)."
-      fi
-    fi
-  fi
-  # DIVE-2464: a close landing on an ALREADY-CLOSED row silently REPLACED its
-  # result. Hit live 2026-07-30 21:11 on DIVE-2451 — main2 closed at 21:08:59,
-  # main ran `task done --result=...` at 21:11:43, and the verb accepted it,
-  # overwrote the result column, printed nothing, exited 0. The prior record was
-  # gone from the board.
-  #
-  # WHY THE LEDGER DOES NOT COVER THIS: `5dive trace` shows both task.done events
-  # with an authority envelope and an `out:` field — but that field is a sha256 OF
-  # the result, not the text. It proves the record changed and cannot restore it.
-  # An integrity hash is not a backup. What actually recovered DIVE-2451 was a
-  # /var/lib/5dive/tasks-backups/ snapshot that happened to fall between the two
-  # writes (5-minute cadence, 3-minute window) — luck about a cron, not a path.
-  #
-  # WHY THE CHECK HAS TO LIVE IN THE VERB: "read the status first" does not work.
-  # The overwriting invocation PRINTED the row's status in the same call as the
-  # write, so the read could not gate anything. A check that cannot stop the
-  # action is decoration.
-  #
-  # This is DIVE-2067 rec 1, ported to the verb that was left unguarded. DIVE-2067
-  # fixed the same clobber in `task verify` (verify-over-closed refusal + the
-  # preserve-by-appending fallback further down that function); `task done` kept
-  # the destructive behaviour, and the DIVE-2007 guard above explicitly falls
-  # THROUGH for closed rows ("a repeat done stays idempotent") — true of the
-  # status write, false of the result write.
-  #
-  # SCOPE, deliberately narrow so nothing idempotent regresses:
-  #   * only a close verb (done/cancel) landing on status done|cancelled;
-  #   * only when --result= was actually PASSED (a bare re-close writes no result);
-  #   * only when the stored result is NON-EMPTY (nothing to destroy otherwise);
-  #   * only when the new text DIFFERS (a replay with identical text is a no-op).
-  # Everything else keeps working exactly as before.
-  #
-  # The refusal names the row's recorded holders and the close timestamp, not the
-  # invoking actor of the earlier write — the tasks row does not store that. The
-  # actor lives in the audit trail, so the message sends the reader to `5dive
-  # trace` for it rather than implying the row knows.
-  if [[ "$verb" == "done" || "$verb" == "cancel" ]] && (( want_result )); then
-    local _cl_st _cl_prev
-    _cl_st=$(db "SELECT COALESCE(status,'') FROM tasks WHERE id=${id};")
-    if [[ "$_cl_st" == "done" || "$_cl_st" == "cancelled" ]]; then
-      _cl_prev=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=${id};")
-      if [[ -n "$_cl_prev" && "$_cl_prev" != "$result" ]]; then
-        if (( append_result )); then
-          # Prior text FIRST and untouched: the existing record is the one that
-          # must survive verbatim, and the addition is what is new.
-          result="${_cl_prev}"$'\n\n'"--- appended by a later close (DIVE-2464) ---"$'\n'"${result}"
-        elif (( force_result )); then
-          # The only lossy path, so it is the only one that leaves a row behind.
-          # The overwritten text goes in the audit args, not just its hash — the
-          # whole point of this ticket is that a hash is not a backup.
-          _task_store_audit_log "task.force-result-over-closed" ok 0 -- \
-            "$ident" "closed_status=$_cl_st" "overwritten_result=$_cl_prev"
-          warn "$ident: --force-result REPLACED the result recorded at close. The overwritten text is in the audit log (task.force-result-over-closed); the board copy is gone (DIVE-2464)."
-        else
-          local _cl_at _cl_asg _cl_vf _cl_mk
-          _cl_at=$(db  "SELECT COALESCE(done_at,'unknown')     FROM tasks WHERE id=${id};")
-          _cl_asg=$(db "SELECT COALESCE(assignee,'unassigned') FROM tasks WHERE id=${id};")
-          _cl_vf=$(db  "SELECT COALESCE(verifier,'')           FROM tasks WHERE id=${id};")
-          _cl_mk=$(db  "SELECT COALESCE(maker_agent,'')        FROM tasks WHERE id=${id};")
-          policy_refuse "$E_CONFLICT" done-over-closed-result DIVE-2464 "$ident" \
-            "$ident is ALREADY ${_cl_st} (closed ${_cl_at}; assignee '${_cl_asg}'${_cl_vf:+, verifier '${_cl_vf}'}${_cl_mk:+, maker '${_cl_mk}'}) and carries a result — a bare '5dive task ${verb} --result=' here would REPLACE that record with no warning, and the ledger keeps only a sha256 of it, so it could not be restored (DIVE-2464). Run '5dive trace $ident' to see who wrote it. If you are ADDING your half of the work, say so: '5dive task ${verb} $ident --append-result --result=<your text>' (keeps theirs verbatim, adds yours under it). Only if the recorded text is genuinely WRONG: '--force-result' (replaces it, audited with the overwritten text)."
-        fi
       fi
     fi
   fi

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -75,6 +75,10 @@ _task_usage() {
   5dive task done|cancel ... [--keep-worktree]       # DIVE-1967: a close RECLAIMS node_modules from that task's worktrees (gitignored,
                                                      # 'npm ci'-regenerable -> structurally data-loss-free). --keep-worktree opts out.
                                                      # The worktree DIRECTORY is never deleted — it may hold unpushed commits.
+  5dive task done|cancel ... [--append-result]       # DIVE-2464: a close on an ALREADY-closed row that carries a result is REFUSED —
+                     [--force-result]                # it used to silently REPLACE it, and the ledger stores only a sha256, so the prior
+                                                     # text was unrecoverable. --append-result keeps theirs verbatim and adds yours under
+                                                     # it (the common case: two closers, one task). --force-result replaces (audited).
   5dive task reclaim <id|DIVE-N>|--all [--dry-run]   # reclaim node_modules from closed tasks' worktrees. --all sweeps every worktree whose
                                                      # task is done/cancelled/absent and SKIPS in_progress/blocked. Also REPORTS which
                                                      # worktree dirs look prunable (nothing unpushed) — pruning itself stays a human call.
@@ -1826,6 +1830,7 @@ _task_status_cmd() {
   local newstatus="$1" extra="$2" verb="$3"; shift 3
   tasks_db_init
   local result="" want_result=0 notify=0 no_preflight=0 force_merge_gate=0 keep_wt=0
+  local append_result=0 force_result=0   # DIVE-2464
   # DIVE-1955 (review, Marcus): every reason the merge-gate could NOT reach an answer,
   # accumulated so the close can be stamped UNVERIFIED in the DURABLE RECORD. A stderr
   # warn and an audit row are necessary and not sufficient: the task row is what a
@@ -1847,6 +1852,12 @@ _task_status_cmd() {
       # DIVE-1967: opt OUT of the node_modules reclaim a close performs (you are
       # about to reuse the worktree and do not want to pay for another npm ci).
       --keep-worktree) keep_wt=1 ;;
+      # DIVE-2464: the two sanctioned answers to the already-closed-row refusal
+      # below. --append-result is the COMMON legitimate case (a second closer
+      # adds their half); --force-result is the rare "the prior text was wrong"
+      # replace, and it is audited because it is the only lossy one.
+      --append-result) append_result=1 ;;
+      --force-result)  force_result=1 ;;
       --)         shift; positional+=("$@"); break ;;
       -*)         fail "$E_USAGE" "unknown flag: $1" ;;
       *)          positional+=("$1") ;;
@@ -1975,6 +1986,71 @@ _task_status_cmd() {
             && "$_st" != "done" && "$_st" != "cancelled" ]]; then
         policy_refuse "$E_CONFLICT" done-over-delivered-loop DIVE-2007 "$ident" \
           "$ident is DELIVERED to verifier '${_vfier}' (iteration ${_iter}, maker '${_maker}') and has NOT been graded — a 'task done' from '${_actor}' would close it ungraded, which is the maker grading its own work (writer != grader, DIVE-477). Only '${_vfier}' can close it. To CORRECT the result text do NOT re-run done: send the correction to '${_vfier}' (5dive agent send ${_vfier} \"...\") and let them fold it in. Real exits: '5dive task reject $ident --feedback=...' (verifier bounces it back), '5dive task verify $ident --cmd=\"<acceptance test>\"' (evidence-backed close), or '5dive task cancel $ident --result=...' (abandon)."
+      fi
+    fi
+  fi
+  # DIVE-2464: a close landing on an ALREADY-CLOSED row silently REPLACED its
+  # result. Hit live 2026-07-30 21:11 on DIVE-2451 — main2 closed at 21:08:59,
+  # main ran `task done --result=...` at 21:11:43, and the verb accepted it,
+  # overwrote the result column, printed nothing, exited 0. The prior record was
+  # gone from the board.
+  #
+  # WHY THE LEDGER DOES NOT COVER THIS: `5dive trace` shows both task.done events
+  # with an authority envelope and an `out:` field — but that field is a sha256 OF
+  # the result, not the text. It proves the record changed and cannot restore it.
+  # An integrity hash is not a backup. What actually recovered DIVE-2451 was a
+  # /var/lib/5dive/tasks-backups/ snapshot that happened to fall between the two
+  # writes (5-minute cadence, 3-minute window) — luck about a cron, not a path.
+  #
+  # WHY THE CHECK HAS TO LIVE IN THE VERB: "read the status first" does not work.
+  # The overwriting invocation PRINTED the row's status in the same call as the
+  # write, so the read could not gate anything. A check that cannot stop the
+  # action is decoration.
+  #
+  # This is DIVE-2067 rec 1, ported to the verb that was left unguarded. DIVE-2067
+  # fixed the same clobber in `task verify` (verify-over-closed refusal + the
+  # preserve-by-appending fallback further down that function); `task done` kept
+  # the destructive behaviour, and the DIVE-2007 guard above explicitly falls
+  # THROUGH for closed rows ("a repeat done stays idempotent") — true of the
+  # status write, false of the result write.
+  #
+  # SCOPE, deliberately narrow so nothing idempotent regresses:
+  #   * only a close verb (done/cancel) landing on status done|cancelled;
+  #   * only when --result= was actually PASSED (a bare re-close writes no result);
+  #   * only when the stored result is NON-EMPTY (nothing to destroy otherwise);
+  #   * only when the new text DIFFERS (a replay with identical text is a no-op).
+  # Everything else keeps working exactly as before.
+  #
+  # The refusal names the row's recorded holders and the close timestamp, not the
+  # invoking actor of the earlier write — the tasks row does not store that. The
+  # actor lives in the audit trail, so the message sends the reader to `5dive
+  # trace` for it rather than implying the row knows.
+  if [[ "$verb" == "done" || "$verb" == "cancel" ]] && (( want_result )); then
+    local _cl_st _cl_prev
+    _cl_st=$(db "SELECT COALESCE(status,'') FROM tasks WHERE id=${id};")
+    if [[ "$_cl_st" == "done" || "$_cl_st" == "cancelled" ]]; then
+      _cl_prev=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=${id};")
+      if [[ -n "$_cl_prev" && "$_cl_prev" != "$result" ]]; then
+        if (( append_result )); then
+          # Prior text FIRST and untouched: the existing record is the one that
+          # must survive verbatim, and the addition is what is new.
+          result="${_cl_prev}"$'\n\n'"--- appended by a later close (DIVE-2464) ---"$'\n'"${result}"
+        elif (( force_result )); then
+          # The only lossy path, so it is the only one that leaves a row behind.
+          # The overwritten text goes in the audit args, not just its hash — the
+          # whole point of this ticket is that a hash is not a backup.
+          _task_store_audit_log "task.force-result-over-closed" ok 0 -- \
+            "$ident" "closed_status=$_cl_st" "overwritten_result=$_cl_prev"
+          warn "$ident: --force-result REPLACED the result recorded at close. The overwritten text is in the audit log (task.force-result-over-closed); the board copy is gone (DIVE-2464)."
+        else
+          local _cl_at _cl_asg _cl_vf _cl_mk
+          _cl_at=$(db  "SELECT COALESCE(done_at,'unknown')     FROM tasks WHERE id=${id};")
+          _cl_asg=$(db "SELECT COALESCE(assignee,'unassigned') FROM tasks WHERE id=${id};")
+          _cl_vf=$(db  "SELECT COALESCE(verifier,'')           FROM tasks WHERE id=${id};")
+          _cl_mk=$(db  "SELECT COALESCE(maker_agent,'')        FROM tasks WHERE id=${id};")
+          policy_refuse "$E_CONFLICT" done-over-closed-result DIVE-2464 "$ident" \
+            "$ident is ALREADY ${_cl_st} (closed ${_cl_at}; assignee '${_cl_asg}'${_cl_vf:+, verifier '${_cl_vf}'}${_cl_mk:+, maker '${_cl_mk}'}) and carries a result — a bare '5dive task ${verb} --result=' here would REPLACE that record with no warning, and the ledger keeps only a sha256 of it, so it could not be restored (DIVE-2464). Run '5dive trace $ident' to see who wrote it. If you are ADDING your half of the work, say so: '5dive task ${verb} $ident --append-result --result=<your text>' (keeps theirs verbatim, adds yours under it). Only if the recorded text is genuinely WRONG: '--force-result' (replaces it, audited with the overwritten text)."
+        fi
       fi
     fi
   fi

--- a/tests/task_done_over_closed_result_unit.sh
+++ b/tests/task_done_over_closed_result_unit.sh
@@ -58,13 +58,27 @@ P=0; F=0
 ok(){ P=$((P+1)); echo "ok   - $1"; }
 no(){ F=$((F+1)); echo "FAIL - $1"; [ -n "${2:-}" ] && echo "   ${2:0:260}"; }
 
-# verifier and maker_agent are left NULL on purpose: a row carrying a live
-# maker/verifier pair is the DIVE-2007 / DIVE-477 rail's business, and seeding one
-# here would let THAT guard produce the refusal and fake a green for this one.
-seed() { # $1=status $2=result -> echoes the row id
+# seed() leaves verifier NULL; seedv() sets it. BOTH shapes are graded, and the F
+# arms below are why.
+#
+# The first version of this harness had only seed(), justified in a comment saying a
+# row carrying a live maker/verifier pair "is the DIVE-2007 / DIVE-477 rail's
+# business". That reasoning was WRONG and main's review caught it by probe. DIVE-477
+# is not a guard, it is a different WRITE PATH — it `return`s early and does its own
+# unconditional result write — and the DIVE-2007 guard says in its own comment that
+# already-closed rows pass through. So the excluded shape was the one shape where
+# NOTHING caught the clobber, excluded on the grounds that something else did.
+#
+# That is this ticket's own defect wearing a different hat, so it is recorded here
+# rather than quietly fixed: a harness that omits a shape because another rail
+# "handles" it is asserting coverage it never measured.
+seed() { # $1=status $2=result -> echoes the row id (verifier NULL)
+  seedv "$1" "$2" olivia ""
+}
+seedv() { # $1=status $2=result $3=assignee $4=verifier -> echoes the row id
   tasks_db_init >/dev/null 2>&1
-  db "INSERT INTO tasks (title,status,assignee,result,kind,priority,created_by,done_at)
-      VALUES ('t','$1','olivia',$(sqlq "$2"),'standard','medium','main',
+  db "INSERT INTO tasks (title,status,assignee,verifier,result,kind,priority,created_by,done_at)
+      VALUES ('t','$1','$3',$(sqlq "$4"),$(sqlq "$2"),'standard','medium','main',
               CASE WHEN '$1' IN ('done','cancelled') THEN '2026-07-30 21:08:59' ELSE NULL END);" >/dev/null 2>&1
   db "SELECT id FROM tasks ORDER BY id DESC LIMIT 1;"
 }
@@ -132,6 +146,60 @@ out=$( cmd_task_cancel "$id" --result="abandoning" 2>&1 ); rc=$?
 res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
 [ "$rc" -ne 0 ] && ok "E1 'task cancel --result=' over a closed row is REFUSED too" || no "E1 cancel over closed refused" "rc=$rc $out"
 [ "$res" = "$THEIRS" ] && ok "E2 the prior result is INTACT after the cancel refusal" || no "E2 prior result intact after cancel" "$res"
+
+# --- F. the shape the first version MISSED: verifier != assignee --------------
+# The DIVE-477 routing branch `return`s early and writes the result itself, so a
+# guard placed BELOW it was unreachable on this shape and the clobber survived.
+#
+# THESE ARMS DO NOT PIN THE PLACEMENT, and the first draft of this comment claimed
+# they did. Measured: with the block moved back BELOW the routing branch, all 29
+# arms stay green — because the closed-row exclusion added to that branch means a
+# closed row never reaches it, so the block catches the clobber from either
+# position. The exclusion SUBSUMES the ordering for this shape. Stated plainly
+# because an unpinned property described as pinned is precisely the defect under
+# review here, and it would have shipped a second time.
+# What these arms do pin: that SOMETHING refuses the clobber on the routed shape.
+# The mutation that reds them is removing the exclusion AND moving the block down.
+id=$(seedv done "$THEIRS" olivia main)
+out=$( cmd_task_done "$id" --result="$MINE" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+st=$(db  "SELECT status FROM tasks WHERE id=$id;")
+[ "$rc" -ne 0 ] && ok "F1 a closed row with verifier != assignee is REFUSED, not routed" || no "F1 closed+routed row refused" "rc=$rc $out"
+[ "$res" = "$THEIRS" ] && ok "F2 its prior result is INTACT (guard is reached before routing)" || no "F2 prior result intact on routed shape" "$res"
+[ "$st" = "done" ] && ok "F3 it is STILL done — not resurrected to todo" || no "F3 still done" "status=$st"
+
+id=$(seedv cancelled "$THEIRS" olivia main)
+out=$( cmd_task_done "$id" --result="$MINE" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+st=$(db  "SELECT status FROM tasks WHERE id=$id;")
+[ "$res" = "$THEIRS" ] && ok "F4 same on a CANCELLED row: prior result INTACT" || no "F4 cancelled prior result intact" "$res"
+[ "$st" = "cancelled" ] && ok "F5 the cancelled row is not resurrected either" || no "F5 cancelled not resurrected" "status=$st"
+
+# --- G. the SECOND harm: status resurrection on a BARE re-close ----------------
+# Ordering alone does not cover this. With no --result there is nothing for the
+# DIVE-2464 guard to protect, so it stays silent (correctly) and the routing branch
+# would still have fired and set status='todo'. The closed-row exclusion added to
+# that branch is what these arms grade, and they are separate on purpose: the first
+# version of this change claimed the move fixed the resurrection too.
+id=$(seedv done "$THEIRS" olivia main)
+out=$( cmd_task_done "$id" 2>&1 ); rc=$?
+st=$(db  "SELECT status FROM tasks WHERE id=$id;")
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+asg=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=$id;")
+[ "$st" = "done" ] && ok "G1 a BARE re-close of a closed+routed row does NOT resurrect it to todo" || no "G1 bare re-close resurrection" "status=$st $out"
+[ "$res" = "$THEIRS" ] && ok "G2 and its result is untouched" || no "G2 bare re-close result untouched" "$res"
+[ "$rc" -eq 0 ] && ok "G3 and it stays a rc=0 no-op (no NEW error introduced)" || no "G3 bare re-close still rc=0" "rc=$rc $out"
+[ "$asg" = "olivia" ] && ok "G4 and it is not re-delivered to the verifier" || no "G4 not re-delivered" "assignee=$asg"
+
+# --- H. routing on an OPEN row is untouched (the DIVE-477 rail still works) ----
+# The regression arm for the exclusion above. If this reds, the closed-row check is
+# too broad and the maker->verifier handoff is broken.
+id=$(seedv in_progress "" dev2 main)
+out=$( cmd_task_done "$id" --result="delivering" 2>&1 ); rc=$?
+st=$(db  "SELECT status FROM tasks WHERE id=$id;")
+asg=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=$id;")
+[ "$asg" = "main" ] && ok "H1 an OPEN row still ROUTES to its verifier (DIVE-477 intact)" || no "H1 open row still routes" "assignee=$asg st=$st rc=$rc $out"
+[ "$st" != "done" ] && ok "H2 and routing did not close it" || no "H2 routing did not close it" "status=$st"
 
 echo; echo "DIVE-2464 done-over-closed-result guard: passed: $P  failed: $F"
 [ "$F" -eq 0 ]

--- a/tests/task_done_over_closed_result_unit.sh
+++ b/tests/task_done_over_closed_result_unit.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# DIVE-2211 / DIVE-2286: name the tree this harness grades. Sourced BEFORE any cd so
+# ${BASH_SOURCE[0]} still resolves relative to tests/. Three-state on purpose: if the
+# helper is unreachable the log says NO TREE WAS NAMED rather than falling silent.
+# Deliberately NO `2>/dev/null` — redirecting it also swallows the helper's own stderr
+# line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+# DIVE-2464 isolated unit harness for the `task done|cancel` over-a-CLOSED-ROW guard.
+#
+# The bug: `task done --result=` on a row that was ALREADY done REPLACED the result
+# column — no warning, no refusal, no merge, exit 0. Hit live 2026-07-30 21:11 on
+# DIVE-2451: main2 closed at 21:08:59, main closed again at 21:11:43, and main2's
+# record was gone from the board. `5dive trace` shows both task.done events but its
+# `out:` field is a sha256 OF the result, not the text — it proves the record changed
+# and cannot restore it. Recovery came from a tasks-backups snapshot that happened to
+# fall between the two writes; a 3-minute window inside a 5-minute cadence is luck,
+# not a designed path.
+#
+# DIVE-2067 fixed exactly this clobber in `task verify` (see
+# tests/task_verify_over_closed_unit.sh). `task done` was left unguarded, and the
+# DIVE-2007 guard above it falls THROUGH for closed rows on the stated grounds that
+# "a repeat done stays idempotent" — true of the status write, false of the result.
+#
+# WHAT THIS HARNESS MUST ALSO PROVE, not just the refusal: the guard is narrow. The
+# legitimate second close (a maker closes, then the owner of the other half adds
+# theirs) is COMMON here, so --append-result has to keep the prior text VERBATIM,
+# and none of the idempotent shapes (no --result at all, identical --result, an empty
+# stored result, an OPEN row) may start refusing.
+#
+# Same isolation contract as the sibling task harnesses: sources src/ libs directly
+# with STATE_DIR on a throwaway temp dir, so it NEVER touches the live shared
+# tasks.db.
+# Run: bash tests/task_done_over_closed_result_unit.sh
+set -uo pipefail
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/task-done-over-closed-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"
+TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"
+set +e
+
+P=0; F=0
+ok(){ P=$((P+1)); echo "ok   - $1"; }
+no(){ F=$((F+1)); echo "FAIL - $1"; [ -n "${2:-}" ] && echo "   ${2:0:260}"; }
+
+# verifier and maker_agent are left NULL on purpose: a row carrying a live
+# maker/verifier pair is the DIVE-2007 / DIVE-477 rail's business, and seeding one
+# here would let THAT guard produce the refusal and fake a green for this one.
+seed() { # $1=status $2=result -> echoes the row id
+  tasks_db_init >/dev/null 2>&1
+  db "INSERT INTO tasks (title,status,assignee,result,kind,priority,created_by,done_at)
+      VALUES ('t','$1','olivia',$(sqlq "$2"),'standard','medium','main',
+              CASE WHEN '$1' IN ('done','cancelled') THEN '2026-07-30 21:08:59' ELSE NULL END);" >/dev/null 2>&1
+  db "SELECT id FROM tasks ORDER BY id DESC LIMIT 1;"
+}
+
+THEIRS="main2: verifier ACK — release cut 0.9.14 confirmed green, two caveats recorded."
+MINE="main: closing after the follow-up landed."
+
+# --- A. the defect: a second close with a DIFFERENT result is REFUSED ----------
+id=$(seed done "$THEIRS")
+out=$( cmd_task_done "$id" --result="$MINE" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -ne 0 ] && ok "A1 a second 'task done --result=' on a done row is REFUSED (rc=$rc)" || no "A1 second done is REFUSED" "rc=$rc $out"
+grep -q 'DIVE-2464' <<<"$out" && ok "A2 the refusal cites DIVE-2464" || no "A2 the refusal cites DIVE-2464" "$out"
+[ "$res" = "$THEIRS" ] && ok "A3 the prior closer's result is INTACT after the refusal" || no "A3 prior result intact" "$res"
+grep -q '2026-07-30 21:08:59' <<<"$out" && ok "A4 the refusal names the close TIMESTAMP" || no "A4 refusal names the timestamp" "$out"
+grep -q "olivia" <<<"$out" && ok "A5 the refusal names the recorded holder" || no "A5 refusal names the holder" "$out"
+
+# --- B. the legitimate case: --append-result keeps BOTH ------------------------
+# This is the arm that matters most. The refusal is worthless if the common
+# second-closer case has no non-destructive route, because then everyone reaches
+# for the lossy flag.
+id=$(seed done "$THEIRS")
+out=$( cmd_task_done "$id" --append-result --result="$MINE" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -eq 0 ] && ok "B1 --append-result is ACCEPTED (rc=0)" || no "B1 --append-result accepted" "rc=$rc $out"
+grep -qF "$THEIRS" <<<"$res" && ok "B2 the prior result survives VERBATIM" || no "B2 prior result verbatim" "$res"
+grep -qF "$MINE" <<<"$res" && ok "B3 the new text is present too" || no "B3 new text present" "$res"
+# Order is load-bearing: the record that already existed must read first, so the
+# board shows the original close and the addition beneath it.
+[ "${res:0:20}" = "${THEIRS:0:20}" ] && ok "B4 the prior result comes FIRST" || no "B4 prior result first" "$res"
+
+# --- C. --force-result replaces, but never silently ---------------------------
+id=$(seed done "$THEIRS")
+out=$( cmd_task_done "$id" --force-result --result="$MINE" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -eq 0 ] && ok "C1 --force-result is ACCEPTED (rc=0)" || no "C1 --force-result accepted" "rc=$rc $out"
+[ "$res" = "$MINE" ] && ok "C2 --force-result REPLACES the result (that is its job)" || no "C2 force replaces" "$res"
+grep -q 'REPLACED the result' <<<"$out" && ok "C3 the replace is announced on stderr, not silent" || no "C3 replace announced" "$out"
+
+# --- D. nothing idempotent regressed ------------------------------------------
+# Each of these was legal before the guard and must stay legal. A guard that
+# starts refusing a replay would break the heartbeat and half the corpus.
+id=$(seed done "$THEIRS")
+out=$( cmd_task_done "$id" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -eq 0 ] && [ "$res" = "$THEIRS" ] && ok "D1 a bare re-close (no --result) still succeeds and touches nothing" || no "D1 bare re-close" "rc=$rc res=$res $out"
+
+id=$(seed done "$THEIRS")
+out=$( cmd_task_done "$id" --result="$THEIRS" 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] && ok "D2 a replay with the IDENTICAL result is a no-op, not a refusal" || no "D2 identical result replay" "rc=$rc $out"
+
+id=$(seed done "")
+out=$( cmd_task_done "$id" --result="$MINE" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -eq 0 ] && [ "$res" = "$MINE" ] && ok "D3 a done row with an EMPTY result accepts one (nothing to destroy)" || no "D3 empty prior result" "rc=$rc res=$res $out"
+
+id=$(seed in_progress "notes so far")
+out=$( cmd_task_done "$id" --result="$MINE" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -eq 0 ] && [ "$res" = "$MINE" ] && ok "D4 a FIRST close of an open row is untouched by the guard" || no "D4 first close of open row" "rc=$rc res=$res $out"
+
+# --- E. cancel writes the same column, so it is guarded the same --------------
+id=$(seed done "$THEIRS")
+out=$( cmd_task_cancel "$id" --result="abandoning" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -ne 0 ] && ok "E1 'task cancel --result=' over a closed row is REFUSED too" || no "E1 cancel over closed refused" "rc=$rc $out"
+[ "$res" = "$THEIRS" ] && ok "E2 the prior result is INTACT after the cancel refusal" || no "E2 prior result intact after cancel" "$res"
+
+echo; echo "DIVE-2464 done-over-closed-result guard: passed: $P  failed: $F"
+[ "$F" -eq 0 ]


### PR DESCRIPTION
## The defect

`5dive task done <id> --result=...` on a row that was **already done** overwrote the result column and said nothing about it — no warning, no refusal, no merge, exit 0.

Hit live on **DIVE-2451**: one agent closed at 21:08:59, another closed again at 21:11:43, and the first agent's record was gone from the board.

**The ledger does not cover this.** `5dive trace` shows both `task.done` events with an authority envelope and an `out:` field — but that field is a **sha256 *of* the result**, not the text. It proves the record changed and cannot restore it. An integrity hash is not a backup, and the trace output reads like a full audit trail right up until you need the bytes.

What actually recovered the text was a `/var/lib/5dive/tasks-backups/` snapshot that happened to fall between the two writes. A 3-minute window landing inside a 5-minute cron is luck about a cadence, not a designed path.

## Why the check has to live in the verb

"Read the status first" does not work, and this was tested rather than assumed: the overwriting invocation **printed the row's status in the same call as the write**, so the read could not gate anything. A check that cannot stop the action is decoration.

This is DIVE-2067 rec 1, ported to the verb that was left unguarded. DIVE-2067 fixed the identical clobber in `task verify` (`verify-over-closed` + the preserve-by-appending fallback). `task done` kept the destructive behaviour, and the DIVE-2007 guard directly above it falls **through** for closed rows on the stated grounds that "a repeat done stays idempotent" — true of the status write, **false of the result write**.

## The change

A close (`done` or `cancel`) landing on an already-closed row that carries a result is now **refused**, naming the close timestamp and the row's recorded holders, and pointing at `5dive trace` for the actor — the tasks row does not store who wrote the earlier result, so the message says so rather than implying the row knows.

Two flags answer it, because the legitimate second close is **common** here (a maker closes, then the owner of the other half adds theirs) and a refusal with no non-destructive route just pushes everyone to the lossy flag:

- **`--append-result`** — keeps the prior text **verbatim and first**, adds yours beneath it. Order is load-bearing: the record that already existed reads first.
- **`--force-result`** — replaces (its job), warns on stderr, and writes the **overwritten text** to the audit log, not just its hash. It is the only lossy path, so it is the only one that leaves a row behind.

## Scope — nothing idempotent regressed

Deliberately narrow. The guard fires **only** when all four hold: a close verb, on status `done|cancelled`, with `--result=` actually passed, a **non-empty** stored result, and text that **differs**. So all of these behave exactly as before:

| shape | behaviour |
|---|---|
| bare re-close (no `--result`) | unchanged, rc=0, touches nothing |
| replay with **identical** result | no-op, not a refusal |
| done row with an **empty** result | accepts one (nothing to destroy) |
| **first** close of an open row | untouched |

## Verification

`tests/task_done_over_closed_result_unit.sh` — 18 arms, all green. Isolated harness (own `STATE_DIR`, never touches the shared `tasks.db`), auto-discovered by `unit-tests.yml`'s `for t in tests/*.sh`.

**Mutation-checked against the pristine tree** rather than trusted because it was green: with the guard reverted, 12 arms red and — the one that matters — `A3 prior result intact` **fails**, i.e. the mutation reproduces the actual data destruction, not just the absence of a message. The four idempotence arms (D1–D4) pass on **both** trees, which is what makes them regression guards rather than evidence for the fix.

Also verified **end-to-end on the built binary** against a throwaway store, not only via sourced functions: refusal exits **rc=5** (`E_CONFLICT`), `--append-result` exits 0 with both texts stored in the right order. Exit code was measured explicitly — a refusal that exited 0 would be the same silent-success class this ticket is about.

No regressions in the harnesses that close the same id twice with a result: `task_done_delivered_guard_unit`, `worktree_reclaim_unit`, `task_reject_actor_and_closed_unit`, `verifier_gate_ack_unit`, plus 15 `task_*` harnesses swept — all rc=0. `pii-scan` clean on the diff and on `CHANGELOG.md`.

## Known limitation, stated rather than left to be found

The refusal keys on **row state**, not on an authenticated actor — so it stops the measured accident (a second closer overwriting a teammate) and is not an anti-forgery control. Same tradeoff DIVE-2389 recorded on the DIVE-2067 guard, and for the same reason: keying on the authenticated actor breaks every harness that models a closer by setting `USER`.

Closes DIVE-2464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
