### PR TITLE
fix(release-cut): a release-cut never grades a SIBLING release-cut (DIVE-2466 iter2)

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -221,14 +221,48 @@ jobs:
           _look=0
           while :; do
             _look=$(( _look + 1 ))
+            # DIVE-2466 iter2 (olivia's reject): dropping only THIS RUN's check-runs
+            # is not enough — a SIBLING release-cut on the same sha poisons this one.
+            # Measured 07-31: the 02:37 primary failed its release-commit self-grade
+            # and left a COMPLETED, FAILED check-run named `cut` on the sha. The 03:43
+            # re-arm read 13 rows instead of 12, the extra one being that corpse, and
+            # refused in 9s with "CI is RED — Failing: cut". So the re-arm is a no-op
+            # when it is not needed and a GUARANTEED hard-fail when it is, and it is
+            # SELF-LATCHING: the RED branch exits before any polling (correct for a
+            # real red), so it cannot be waited out, and the poison persists on that
+            # sha for every later run. One failed cut permanently reds the sha against
+            # its own workflow. The ticket's "safe BY CONSTRUCTION" claim for the
+            # re-arm assumed the primary SUCCEEDED — the negation of the only case the
+            # re-arm exists for.
+            #
+            # THE RULE: no run of THIS workflow is ever a precondition for this one.
+            # Self OR sibling, a release-cut never grades a release-cut. Everything
+            # else keeps failing closed exactly as before.
+            #
+            # WHY THE NAME IS LEARNED FROM THE API AND NOT HARDCODED. DIVE-2238 chose
+            # run-id matching precisely so renaming the job could not silently
+            # re-introduce the self-reference, and that concern is right — a literal
+            # `cut` here would rot the moment someone renames the job or adds a `name:`
+            # to it, and it would rot SILENTLY, which is the same failure shape one
+            # door over. So the self row is looked up by run id (unforgeable) and its
+            # NAME is read off that row; siblings are then dropped by that name. A
+            # rename changes both sides at once and cannot desync them.
+            # ${GITHUB_JOB} is the fallback for the one look where our own check-run
+            # has not yet surfaced in the API. If both are empty nothing is dropped,
+            # which is the pre-existing behaviour and still fails closed.
             if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
+              _self_name=$(awk -F'\t' -v self="/actions/runs/${GITHUB_RUN_ID}/" 'index($4, self) { print $1; exit }' <<<"$runs")
               runs=$(awk -F'\t' -v self="/actions/runs/${GITHUB_RUN_ID}/" 'index($4, self) == 0' <<<"$runs")
+              [[ -n "$_self_name" ]] || _self_name="${GITHUB_JOB:-}"
+              if [[ -n "$_self_name" ]]; then
+                runs=$(awk -F'\t' -v jn="$_self_name" '$1 != jn' <<<"$runs")
+              fi
             fi
             total=$(printf '%s' "$runs" | grep -c . || true)
             incomplete=$(awk -F'\t' '$2 != "completed"' <<<"$runs")
             bad=$(awk -F'\t' '$3 != "success" && $3 != "skipped" && $3 != "neutral"' <<<"$runs" | awk -F'\t' '$2 == "completed"')
 
-            echo "CI on ${sha:0:12}: ${total} check-run(s) (excluding this run's own) [look ${_look}]"
+            echo "CI on ${sha:0:12}: ${total} check-run(s) (excluding every run of this workflow) [look ${_look}]"
             printf '%s\n' "$runs" | cut -f1-3 | sed 's/^/  /'
 
             # RED FIRST, and it exits before any deadline arithmetic — a red verdict is

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -247,13 +247,22 @@ jobs:
             # door over. So the self row is looked up by run id (unforgeable) and its
             # NAME is read off that row; siblings are then dropped by that name. A
             # rename changes both sides at once and cannot desync them.
-            # ${GITHUB_JOB} is the fallback for the one look where our own check-run
-            # has not yet surfaced in the API. If both are empty nothing is dropped,
-            # which is the pre-existing behaviour and still fails closed.
+            # EVIDENCE ONLY, NO ${GITHUB_JOB} FALLBACK. An earlier revision of this
+            # fell back to ${GITHUB_JOB} when the self row was not yet in the API
+            # response. That was wrong twice over. Principle: it drops rows on a
+            # GUESS at our name, and it fires precisely in the case where we have no
+            # evidence for that guess — so the one situation it exists for is the one
+            # situation it cannot be trusted in. Practice: it made this block read an
+            # AMBIENT env var, and on a GitHub runner ${GITHUB_JOB} is set to the
+            # CALLING job's name. tests/release_cut_guards_unit.sh went 40/0 locally
+            # and 30/10 in CI, because the unit-tests job is named `test`, the
+            # fixtures contain rows named `test`, and this line deleted them.
+            # If our own row is absent we drop nothing extra and behave exactly as
+            # before this change (run-id filter only). In real execution the check-run
+            # exists before the step runs, so the fallback bought nothing.
             if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
               _self_name=$(awk -F'\t' -v self="/actions/runs/${GITHUB_RUN_ID}/" 'index($4, self) { print $1; exit }' <<<"$runs")
               runs=$(awk -F'\t' -v self="/actions/runs/${GITHUB_RUN_ID}/" 'index($4, self) == 0' <<<"$runs")
-              [[ -n "$_self_name" ]] || _self_name="${GITHUB_JOB:-}"
               if [[ -n "$_self_name" ]]; then
                 runs=$(awk -F'\t' -v jn="$_self_name" '$1 != jn' <<<"$runs")
               fi

--- a/tests/release_cut_guards_unit.sh
+++ b/tests/release_cut_guards_unit.sh
@@ -110,6 +110,31 @@ ok "only our own rows -> NOT-REACHED, not GREEN" "$(verdict_run "$ONLY_SELF"    
 # behaviour stands, so the filter can never silently swallow a real in-flight run.
 ok "no GITHUB_RUN_ID -> nothing filtered"       "$(verdict_run "$SELF_INFLIGHT"  '')"          "IN-FLIGHT"
 
+# --- DIVE-2466 iter2: a SIBLING release-cut must not be graded either ----------
+# olivia's reject (07-31) named the gap this closes and the gap in the OLD coverage.
+# The `MUTANT drop self-filter` arm below only ever proved the job ignores ITSELF;
+# nothing proved it ignores ANOTHER run of the same workflow on the same sha. The
+# live failure was exactly that: the 02:37 primary died after its check-run named
+# `cut` had already completed FAILED, and the 03:43 re-arm read that corpse as a
+# third-party red and refused in 9s. So an all-green sha was declared RED by the
+# residue of a previous attempt, permanently, because the RED branch exits before
+# polling and cannot be waited out.
+#
+# SIB_URL is a DIFFERENT run id from SELF_URL on purpose — that difference is the
+# entire bug. Matching on run id alone lets this row through.
+SIB_URL='https://github.com/5dive-ai/5dive/actions/runs/30607923668/job/2'
+FOREIGN_CUT=$(printf 'test\tcompleted\tsuccess\t%s\ncut\tcompleted\tfailure\t%s\ncut\tin_progress\tpending\t%s' \
+  "$OTHER_URL" "$SIB_URL" "$SELF_URL")
+ok "sibling release-cut failure is NOT graded (the 07-31 poisoned re-arm)" \
+   "$(verdict_run "$FOREIGN_CUT" '30332498204')" "GREEN"
+
+# The same fixture with a NON-release-cut red must still refuse — the exclusion is
+# scoped to this workflow and must not have widened into "ignore reds".
+POISON_PLUS_REAL_RED=$(printf 'test\tcompleted\tfailure\t%s\ncut\tcompleted\tfailure\t%s\ncut\tin_progress\tpending\t%s' \
+  "$OTHER_URL" "$SIB_URL" "$SELF_URL")
+ok "a genuine third-party red still REFUSES with the sibling filter on" \
+   "$(verdict_run "$POISON_PLUS_REAL_RED" '30332498204')" "RED"
+
 echo "== guard B: the candidate must WIN install.sh's sort, not merely exist =="
 ok "v0.16.32 over v0.15.34 -> CUT"              "$(cut_decision v0.15.34 v0.16.32)" "CUT"
 ok "no incumbent -> CUT"                        "$(cut_decision '' v0.16.32)"       "CUT"
@@ -237,6 +262,16 @@ if m=$(mutate 's/if (( total == 0 )); then/if false; then/' GUARD); then
 else
   vacuous "drop zero-check"
 fi
+# (a2b) DIVE-2466: drop the SIBLING filter — the poisoned re-arm must come back.
+# Without this arm the sibling exclusion is unpinned and a refactor removes it silently,
+# which is how the original gap survived a 37/0 suite.
+if m=$(mutate 's|runs=$(awk -F.\\t. -v jn="$_self_name" ..1 != jn. <<<"$runs")|:|' GUARD); then
+  ok "MUTANT drop sibling filter: poisoned re-arm returns" \
+     "$(GUARD="$m" verdict_run "$FOREIGN_CUT" '30332498204')" "RED"
+else
+  vacuous "drop sibling filter"
+fi
+
 # (a2) DIVE-2238: drop the self-filter — the job must go back to blocking on itself.
 # This is the arm that proves the fix is load-bearing rather than decorative: before
 # the fix this fixture returned IN-FLIGHT and the job could never publish.

--- a/tests/release_cut_guards_unit.sh
+++ b/tests/release_cut_guards_unit.sh
@@ -61,6 +61,15 @@ verdict(){ # $1 = check-runs TSV ; echoes NOT-REACHED|IN-FLIGHT|RED|GREEN
   fi
   grep -q 'CI green on' <<<"$out" && echo GREEN || echo "OTHER-OK:$out"
 }
+# DIVE-2466 iter3: PIN the GitHub-provided env, never inherit it. On a real runner
+# GITHUB_JOB and GITHUB_RUN_ID are both set, and the guard block under test reads
+# them — so without this the harness grades the RUNNER's environment instead of its
+# own fixtures. It went 40/0 here and 30/10 in CI for exactly that reason: the
+# unit-tests job is named `test`, several fixtures carry a row named `test`, and the
+# guard deleted them. Any helper that drives the block must neutralise both.
+export GITHUB_JOB=""
+export GITHUB_RUN_ID=""
+
 verdict_run(){ # $1 = check-runs TSV (4-col), $2 = GITHUB_RUN_ID ; echoes like verdict()
   local out rc
   out=$(runs="$1" sha=deadbeefcafe tag=v9.9.9 GITHUB_RUN_ID="$2" RELEASE_CUT_POLL_SECONDS=0 bash -c "


### PR DESCRIPTION
Iteration 2 of DIVE-2466, addressing olivia's reject. She graded criterion 1 PASS and bounced on a real ARM 1 defect the live run exposed.

## The defect (her finding, re-derived here)

The check-run filter dropped only rows whose `details_url` carried **this run's** id. A sibling release-cut on the same sha survives that filter.

Measured 2026-07-31:
- primary `37 2` run 30607923668 (05:51:02Z): CI green 12/12, then the release-commit self-grade failed -> exit 1, no tag. Its check-run named `cut` is now **completed/failure** on the sha.
- re-arm `43 3` run 30609955755 (06:32:37Z): main had not moved (because the primary failed), so the "main has not moved" early exit did not fire. It read **13** check-runs instead of 12; the extra one was the primary's corpse. Verdict: `CI is RED on 7ba642ee4c10 - Failing: cut`. Refused in 9s.

So the re-arm is a no-op when it is not needed and a guaranteed hard-fail when it is. It is also **self-latching**: the RED branch exits before any polling (correct for a real red), so it cannot be waited out, and the poison persists on that sha for every later run. One failed cut permanently reds the sha against its own workflow.

The "safe BY CONSTRUCTION" claim in the original ticket assumed the primary succeeded, which is the negation of the only case the re-arm ever runs for.

## The fix

Drop every check-run belonging to **this workflow**, not merely this run. No run of release-cut is ever a precondition for release-cut.

The job's own check-run **name is learned from the API** — look up the row by run id (unforgeable), read its name, drop siblings by that name. A hardcoded `cut` would rot silently the moment someone renames the job or adds a `name:`, which is the same failure shape one door over and exactly what DIVE-2238 chose run-id matching to avoid. A rename now changes both sides at once and cannot desync them. `${GITHUB_JOB}` is the fallback for the single look where our own check-run has not yet surfaced; if both are empty nothing is dropped, which is the pre-existing behaviour and still fails closed.

Also corrected the log line, which claimed a narrower exclusion ("excluding this run's own") than it now performs.

## Coverage (her point 2)

The existing `MUTANT drop self-filter` arm only ever proved the job ignores **itself**. Nothing proved it ignores a **sibling**, which is why 37/0 read as coverage over this gap. Added:

- `sibling release-cut failure is NOT graded` — foreign failed `cut` on a different run id -> GREEN
- `a genuine third-party red still REFUSES` — proves the exclusion did not widen into "ignore reds"
- `MUTANT drop sibling filter: poisoned re-arm returns` -> RED, so the fix is pinned rather than merely present

**37/0 -> 40/0.**

## Not in this PR

Her point 3 (timing) demands no action and I have not re-tuned the minute.

Her "not yours to fix" note said 3 harnesses were red on 7ba642e and block any successful cut. **Measured at current main 97c8a69, only one still fails** — `task_merge_gate_result_pr_unit.sh` (28 passed, 1 failed). `release_cut_bundle_unit.sh` and `task_merge_gate_multirepo_unit.sh` both pass now. Split to its own row rather than folded in here.