### PR TITLE
fix(task): extend the already-closed-result guard to `task deliver` (DIVE-2476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Unreleased — fix(task): `task deliver --result=` destroyed a closed row's result too (DIVE-2476)
+
+DIVE-2464 guarded `task done|cancel`. It did not guard the verb next door. `cmd_task_deliver` ended
+in an unconditional `UPDATE tasks SET result=` with no status check anywhere in the function, so
+`5dive task deliver <id> --pr=... --result=<text>` on an already done or cancelled row replaced the
+recorded result the same silent way, exit 0 — and stamped `delivery_ref`/`delivered_at` over that
+closed row on the line above. Found by main while reviewing DIVE-2464's PR and measured on both
+trees (origin/main `e935d82` and that PR's tip), so it was pre-existing rather than a regression.
+
+The reason it is a real second hole and not a tidy-up: what makes the clobber unrecoverable is that
+the ledger keeps a sha256 of the result and not the text, and that property belongs to the *column*,
+not to the verb that writes it. Guarding one writer leaves the value exactly as destroyable through
+the others.
+
+So the fix is one guard, not a second variant of it: the DIVE-2464 block is now the shared
+`_task_guard_result_over_closed`, and `task deliver` consults it — same refusal text, same
+`--append-result` ordering (prior text verbatim and first), same audited `--force-result` escape,
+which `deliver` now accepts as well. A reader who learns the rule from one verb is not surprised by
+another. It is consulted *before* the delivery stamp, so a refused delivery leaves no
+`delivery_ref` behind, and it sits above the routed/unrouted fork, so it also covers the shape that
+hands off through `_task_route_to_verifier` — which additionally sets `status='todo'` and would have
+resurrected the closed row on top of destroying its record.
+
+Still open on `deliver`, named in the source rather than implied to be covered: a *bare* `task
+deliver` with no `--result=` re-stamps `delivery_ref`/`delivered_at` on a closed row, and on a
+closed row with a distinct verifier it still routes. Both are the no-result population this guard
+cannot see.
+
 ## Unreleased — fix(digest): a completion was credited to whoever OWNED the row at close, which on a graded row is the verifier (DIVE-2556)
 
 On a maker/verifier loop the row's `assignee` moves to the verifier at delivery,

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -77,7 +77,7 @@ _task_usage() {
   5dive task done|cancel ... [--keep-worktree]       # DIVE-1967: a close RECLAIMS node_modules from that task's worktrees (gitignored,
                                                      # 'npm ci'-regenerable -> structurally data-loss-free). --keep-worktree opts out.
                                                      # The worktree DIRECTORY is never deleted — it may hold unpushed commits.
-  5dive task done|cancel|deliver ... [--append-result]  # DIVE-2464/DIVE-2476: a close, or a `deliver --result=`, on an ALREADY-closed row that carries a result is REFUSED —
+  5dive task done|cancel|deliver ... [--append-result]  # DIVE-2464/DIVE-2476: a close, or a 'deliver --result=', on an ALREADY-closed row that carries a result is REFUSED —
                      [--force-result]                # it used to silently REPLACE it, and the ledger stores only a sha256, so the prior
                                                      # text was unrecoverable. --append-result keeps theirs verbatim and adds yours under
                                                      # it (the common case: two closers, one task). --force-result replaces (audited).

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -77,7 +77,7 @@ _task_usage() {
   5dive task done|cancel ... [--keep-worktree]       # DIVE-1967: a close RECLAIMS node_modules from that task's worktrees (gitignored,
                                                      # 'npm ci'-regenerable -> structurally data-loss-free). --keep-worktree opts out.
                                                      # The worktree DIRECTORY is never deleted — it may hold unpushed commits.
-  5dive task done|cancel ... [--append-result]       # DIVE-2464: a close on an ALREADY-closed row that carries a result is REFUSED —
+  5dive task done|cancel|deliver ... [--append-result]  # DIVE-2464/DIVE-2476: a close, or a `deliver --result=`, on an ALREADY-closed row that carries a result is REFUSED —
                      [--force-result]                # it used to silently REPLACE it, and the ledger stores only a sha256, so the prior
                                                      # text was unrecoverable. --append-result keeps theirs verbatim and adds yours under
                                                      # it (the common case: two closers, one task). --force-result replaces (audited).
@@ -2048,6 +2048,58 @@ _gate_branch_ident_on_main() {
   printf 'bound:%s' "$walked"
 }
 
+# DIVE-2464 / DIVE-2476: the one guard standing between a `--result=` write and an
+# ALREADY-CLOSED row's recorded result. Extracted from `_task_status_cmd` so the
+# refusal text, the --append-result ordering and the --force-result audit row are
+# LITERALLY the same across every verb that writes the column, rather than a second
+# variant that drifts apart from it. DIVE-2476 is why it is a function: the rule
+# belongs to the COLUMN — whose ledger copy is a sha256, so a silent replace is
+# unrecoverable — and not to the verb, and `task deliver --result=` was destroying
+# the same value through the door next to the guarded one. Measured on origin/main
+# e935d82 AND on #357's tip, so pre-existing rather than a #357 regression.
+#
+# Callers decide WHEN to consult it (which verbs, and only when a result was
+# actually passed); it decides what happens. It is NOT safe to call inside a command
+# substitution: the refusal path ends in `fail`, which exits, and a subshell would
+# turn the refusal into a shrug the caller then writes straight past. So the
+# (possibly appended) text it wants written comes back in a global, not on stdout.
+#
+# args: <id> <ident> <verb> <result> [append_result] [force_result] [policy-slug]
+# out:  _TASK_GUARDED_RESULT — the text the caller must write from here on.
+_task_guard_result_over_closed() {
+  local id="$1" ident="$2" verb="$3" result="$4"
+  local append_result="${5:-0}" force_result="${6:-0}" policy="${7:-done-over-closed-result}"
+  _TASK_GUARDED_RESULT="$result"
+  local _cl_st _cl_prev
+  _cl_st=$(db "SELECT COALESCE(status,'') FROM tasks WHERE id=${id};")
+  if [[ "$_cl_st" == "done" || "$_cl_st" == "cancelled" ]]; then
+    _cl_prev=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=${id};")
+    if [[ -n "$_cl_prev" && "$_cl_prev" != "$result" ]]; then
+      if (( append_result )); then
+        # Prior text FIRST and untouched: the existing record is the one that
+        # must survive verbatim, and the addition is what is new.
+        result="${_cl_prev}"$'\n\n'"--- appended by a later close (DIVE-2464) ---"$'\n'"${result}"
+      elif (( force_result )); then
+        # The only lossy path, so it is the only one that leaves a row behind.
+        # The overwritten text goes in the audit args, not just its hash — the
+        # whole point of this ticket is that a hash is not a backup.
+        _task_store_audit_log "task.force-result-over-closed" ok 0 -- \
+          "$ident" "closed_status=$_cl_st" "overwritten_result=$_cl_prev"
+        warn "$ident: --force-result REPLACED the result recorded at close. The overwritten text is in the audit log (task.force-result-over-closed); the board copy is gone (DIVE-2464)."
+      else
+        local _cl_at _cl_asg _cl_vf _cl_mk
+        _cl_at=$(db  "SELECT COALESCE(done_at,'unknown')     FROM tasks WHERE id=${id};")
+        _cl_asg=$(db "SELECT COALESCE(assignee,'unassigned') FROM tasks WHERE id=${id};")
+        _cl_vf=$(db  "SELECT COALESCE(verifier,'')           FROM tasks WHERE id=${id};")
+        _cl_mk=$(db  "SELECT COALESCE(maker_agent,'')        FROM tasks WHERE id=${id};")
+        policy_refuse "$E_CONFLICT" "$policy" DIVE-2464 "$ident" \
+          "$ident is ALREADY ${_cl_st} (closed ${_cl_at}; assignee '${_cl_asg}'${_cl_vf:+, verifier '${_cl_vf}'}${_cl_mk:+, maker '${_cl_mk}'}) and carries a result — a bare '5dive task ${verb} --result=' here would REPLACE that record with no warning, and the ledger keeps only a sha256 of it, so it could not be restored (DIVE-2464). Run '5dive trace $ident' to see who wrote it. If you are ADDING your half of the work, say so: '5dive task ${verb} $ident --append-result --result=<your text>' (keeps theirs verbatim, adds yours under it). Only if the recorded text is genuinely WRONG: '--force-result' (replaces it, audited with the overwritten text)."
+      fi
+    fi
+  fi
+  _TASK_GUARDED_RESULT="$result"
+}
+
 _task_status_cmd() {
   local newstatus="$1" extra="$2" verb="$3"; shift 3
   tasks_db_init
@@ -2290,8 +2342,14 @@ _task_status_cmd() {
   # block correctly stays silent. Ordering alone does not reach it.
   #
   # NOT FIXED HERE, named so none of it is mistaken for covered:
-  #   * `task deliver --result=` clobbers a closed row the same way (main's probe
-  #     P4, filed as DIVE-2476);
+  #   * (CLOSED by DIVE-2476: `task deliver --result=` clobbered a closed row the
+  #     same way — main's probe P4. It now consults the SAME guard, extracted above,
+  #     and consults it BEFORE it stamps delivery_ref. Still open on that verb, and
+  #     measured: a BARE `task deliver` with no --result= re-stamps delivery_ref and
+  #     delivered_at on a closed row, and on a closed row carrying a distinct
+  #     verifier it still ROUTES — resurrecting it to 'todo' — the shape DIVE-2464
+  #     iter 2 excluded on the `task done` rail only. Both live in the no-result
+  #     population this guard is blind to by construction, so neither is covered.)
   #   * `_task_route_to_verifier` still writes unconditionally over an OPEN row's
   #     existing result — a different population than this ticket measured;
   #   * a BARE re-close still REFRESHES done_at (both close verbs pass
@@ -2316,33 +2374,8 @@ _task_status_cmd() {
   # actor lives in the audit trail, so the message sends the reader to `5dive
   # trace` for it rather than implying the row knows.
   if [[ "$verb" == "done" || "$verb" == "cancel" ]] && (( want_result )); then
-    local _cl_st _cl_prev
-    _cl_st=$(db "SELECT COALESCE(status,'') FROM tasks WHERE id=${id};")
-    if [[ "$_cl_st" == "done" || "$_cl_st" == "cancelled" ]]; then
-      _cl_prev=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=${id};")
-      if [[ -n "$_cl_prev" && "$_cl_prev" != "$result" ]]; then
-        if (( append_result )); then
-          # Prior text FIRST and untouched: the existing record is the one that
-          # must survive verbatim, and the addition is what is new.
-          result="${_cl_prev}"$'\n\n'"--- appended by a later close (DIVE-2464) ---"$'\n'"${result}"
-        elif (( force_result )); then
-          # The only lossy path, so it is the only one that leaves a row behind.
-          # The overwritten text goes in the audit args, not just its hash — the
-          # whole point of this ticket is that a hash is not a backup.
-          _task_store_audit_log "task.force-result-over-closed" ok 0 -- \
-            "$ident" "closed_status=$_cl_st" "overwritten_result=$_cl_prev"
-          warn "$ident: --force-result REPLACED the result recorded at close. The overwritten text is in the audit log (task.force-result-over-closed); the board copy is gone (DIVE-2464)."
-        else
-          local _cl_at _cl_asg _cl_vf _cl_mk
-          _cl_at=$(db  "SELECT COALESCE(done_at,'unknown')     FROM tasks WHERE id=${id};")
-          _cl_asg=$(db "SELECT COALESCE(assignee,'unassigned') FROM tasks WHERE id=${id};")
-          _cl_vf=$(db  "SELECT COALESCE(verifier,'')           FROM tasks WHERE id=${id};")
-          _cl_mk=$(db  "SELECT COALESCE(maker_agent,'')        FROM tasks WHERE id=${id};")
-          policy_refuse "$E_CONFLICT" done-over-closed-result DIVE-2464 "$ident" \
-            "$ident is ALREADY ${_cl_st} (closed ${_cl_at}; assignee '${_cl_asg}'${_cl_vf:+, verifier '${_cl_vf}'}${_cl_mk:+, maker '${_cl_mk}'}) and carries a result — a bare '5dive task ${verb} --result=' here would REPLACE that record with no warning, and the ledger keeps only a sha256 of it, so it could not be restored (DIVE-2464). Run '5dive trace $ident' to see who wrote it. If you are ADDING your half of the work, say so: '5dive task ${verb} $ident --append-result --result=<your text>' (keeps theirs verbatim, adds yours under it). Only if the recorded text is genuinely WRONG: '--force-result' (replaces it, audited with the overwritten text)."
-        fi
-      fi
-    fi
+    _task_guard_result_over_closed "$id" "$ident" "$verb" "$result" "$append_result" "$force_result"
+    result="$_TASK_GUARDED_RESULT"
   fi
   # DIVE-477: maker→verifier routing. A `task done` on a task that carries a
   # `verifier` distinct from its current assignee is NOT a close — it's a handoff.
@@ -3135,22 +3168,37 @@ cmd_task_cancel() { _task_status_cmd cancelled ", done_at=COALESCE(done_at, date
 cmd_task_deliver() {
   tasks_db_init
   local task="" pr="" result="" want_result=0
+  local append_result=0 force_result=0   # DIVE-2476: the two sanctioned answers to the
+                                         # already-closed-row refusal, spelled exactly
+                                         # as `task done|cancel` spells them.
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --pr=*)      pr="${1#*=}" ;;
-      --result=*)  result="${1#*=}"; want_result=1 ;;
-      -*)          fail "$E_USAGE" "unknown flag: $1" ;;
-      *)           [[ -z "$task" ]] && task="$1" || fail "$E_USAGE" "unexpected arg: $1" ;;
+      --pr=*)          pr="${1#*=}" ;;
+      --result=*)      result="${1#*=}"; want_result=1 ;;
+      --append-result) append_result=1 ;;
+      --force-result)  force_result=1 ;;
+      -*)              fail "$E_USAGE" "unknown flag: $1" ;;
+      *)               [[ -z "$task" ]] && task="$1" || fail "$E_USAGE" "unexpected arg: $1" ;;
     esac
     shift
   done
-  [[ -n "$task" ]] || fail "$E_USAGE" "usage: 5dive task deliver <id|DIVE-N> --pr=<url> [--result=<text>]"
+  [[ -n "$task" ]] || fail "$E_USAGE" "usage: 5dive task deliver <id|DIVE-N> --pr=<url> [--result=<text>] [--append-result|--force-result]"
   [[ -n "$pr" ]]   || fail "$E_USAGE" "task deliver requires --pr=<url> (the PR that delivers this task; done stays blocked until it is MERGED — DIVE-1830)"
   # Basic sanity: a delivery ref must look like a PR URL, not a bare word.
   if [[ "$pr" != http*://* && "$pr" != *github.com* ]]; then
     fail "$E_VALIDATION" "--pr must be a URL (e.g. https://github.com/<org>/<repo>/pull/<n>) — got '$pr'"
   fi
   resolve_task_id "$task"; local id="$RESOLVED_TASK_ID" ident="$RESOLVED_TASK_IDENT"
+  # DIVE-2476: consult the shared already-closed-row guard BEFORE anything is
+  # written. The ordering IS the fix and not a detail — the delivery stamp on the
+  # next line lands on a closed row too, so a refusal that fired after it would
+  # leave delivery_ref/delivered_at rewritten on the very row it just declined to
+  # touch. It sits above the routed/not-routed fork, so both deliver rails reach it.
+  if (( want_result )); then
+    _task_guard_result_over_closed "$id" "$ident" deliver "$result" \
+      "$append_result" "$force_result" deliver-over-closed-result
+    result="$_TASK_GUARDED_RESULT"
+  fi
   # Record the delivery ref + timestamp before the handoff, so the merge-gate can
   # see it regardless of where the task lands next.
   db "UPDATE tasks SET delivery_ref=$(sqlq "$pr"), delivered_at=datetime('now') WHERE id=${id};"

--- a/tests/task_deliver_over_closed_result_unit.sh
+++ b/tests/task_deliver_over_closed_result_unit.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# DIVE-2211 / DIVE-2286: name the tree this harness grades. Sourced BEFORE any cd so
+# ${BASH_SOURCE[0]} still resolves relative to tests/. Three-state on purpose: if the
+# helper is unreachable the log says NO TREE WAS NAMED rather than falling silent.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+# DIVE-2476 isolated unit harness for the `task deliver --result=` over-a-CLOSED-ROW
+# guard — the sibling verb of the one DIVE-2464 guarded.
+#
+# The bug: `cmd_task_deliver` ended in an unconditional `UPDATE tasks SET result=`
+# with no status check anywhere in the function, so `task deliver --pr=… --result=`
+# on an already done/cancelled row REPLACED the recorded result exactly the way
+# `task done` did before DIVE-2464 — no warning, no refusal, exit 0. It also stamped
+# delivery_ref/delivered_at over that closed row on the line above. Measured by
+# main's probe arm P4 against origin/main e935d82 AND #357's tip, so it is
+# pre-existing and not a #357 regression.
+#
+# WHY IT IS A SEPARATE HARNESS AND NOT A DIVE-2464 ARM: the property that makes the
+# clobber unrecoverable (the ledger keeps a sha256 of the result, not the text)
+# belongs to the COLUMN, not to the verb. Guarding one writer leaves the value just
+# as destroyable through the next one. So the thing this harness has to prove is not
+# only "deliver refuses" but "deliver refuses IDENTICALLY" — same refusal text, same
+# --append-result ordering, same audited --force-result escape — because a reader who
+# learns the rule from one verb must not be surprised by another.
+#
+# TWO SHAPES ARE GRADED, and the D2 arm is why. `cmd_task_deliver` forks on
+# `verifier != assignee`: the routed rail hands off through
+# `_task_route_to_verifier` (its own unconditional result write) and the unrouted
+# rail writes the column directly. main's P4 only ever measured the unrouted one.
+# Excluding the routed shape because "the DIVE-477 rail handles it" is precisely the
+# reasoning DIVE-2464's own review demolished, so both rails are measured here.
+#
+# Same isolation contract as the sibling task harnesses: sources src/ libs directly
+# with STATE_DIR on a throwaway temp dir, so it NEVER touches the live shared
+# tasks.db.
+# Run: bash tests/task_deliver_over_closed_result_unit.sh
+set -uo pipefail
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/task-deliver-over-closed-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"
+TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"
+set +e
+
+P=0; F=0
+ok(){ P=$((P+1)); echo "ok   - $1"; }
+no(){ F=$((F+1)); echo "FAIL - $1"; [ -n "${2:-}" ] && echo "   ${2:0:260}"; }
+
+seed() { # $1=status $2=result -> echoes the row id (verifier NULL: the unrouted rail)
+  seedv "$1" "$2" olivia ""
+}
+seedv() { # $1=status $2=result $3=assignee $4=verifier -> echoes the row id
+  tasks_db_init >/dev/null 2>&1
+  db "INSERT INTO tasks (title,status,assignee,verifier,result,kind,priority,created_by,done_at)
+      VALUES ('t','$1','$3',$(sqlq "$4"),$(sqlq "$2"),'standard','medium','main',
+              CASE WHEN '$1' IN ('done','cancelled') THEN '2026-07-30 21:08:59' ELSE NULL END);" >/dev/null 2>&1
+  db "SELECT id FROM tasks ORDER BY id DESC LIMIT 1;"
+}
+dref() { db "SELECT COALESCE(delivery_ref,'') FROM tasks WHERE id=$1;"; }
+dat()  { db "SELECT COALESCE(delivered_at,'') FROM tasks WHERE id=$1;"; }
+res()  { db "SELECT COALESCE(result,'')       FROM tasks WHERE id=$1;"; }
+st()   { db "SELECT COALESCE(status,'')       FROM tasks WHERE id=$1;"; }
+
+PR=https://github.com/5dive-ai/5dive/pull/999
+THEIRS="main2: verifier ACK — release cut 0.9.14 confirmed green, two caveats recorded."
+MINE="olivia: delivering the follow-up."
+
+# --- D1. the defect, unrouted rail (main's probe P4) --------------------------
+id=$(seed done "$THEIRS")
+out=$( cmd_task_deliver "$id" --pr="$PR" --result="$MINE" 2>&1 ); rc=$?
+[ "$rc" -ne 0 ] && ok "D1a 'task deliver --result=' on a done row is REFUSED (rc=$rc)" || no "D1a deliver over closed is REFUSED" "rc=$rc $out"
+[ "$(res "$id")" = "$THEIRS" ] && ok "D1b the prior closer's result is INTACT" || no "D1b prior result INTACT" "$(res "$id")"
+grep -q 'DIVE-2464' <<<"$out" && ok "D1c the refusal cites DIVE-2464 (same rule, same citation as the close verbs)" || no "D1c refusal cites DIVE-2464" "$out"
+grep -q "5dive task deliver .* --append-result" <<<"$out" && ok "D1d the refusal names the non-destructive route for THIS verb" || no "D1d refusal names deliver --append-result" "$out"
+grep -q '2026-07-30 21:08:59' <<<"$out" && ok "D1e the refusal names the close TIMESTAMP" || no "D1e refusal names the timestamp" "$out"
+# ORDERING, which is half the fix: the stamp on the line after the guard must not
+# have run. A refusal that rewrote delivery_ref/delivered_at on a row it declined to
+# touch would leave the board asserting a delivery that was refused.
+[ -z "$(dref "$id")" ] && ok "D1f delivery_ref was NOT stamped on the refused row" || no "D1f delivery_ref not stamped" "$(dref "$id")"
+[ -z "$(dat  "$id")" ] && ok "D1g delivered_at was NOT stamped on the refused row" || no "D1g delivered_at not stamped" "$(dat "$id")"
+
+# --- D2. the defect, ROUTED rail (verifier != assignee) -----------------------
+# The shape P4 never measured. Here the write happens inside
+# `_task_route_to_verifier` after an early return, so a guard placed below the fork
+# would miss it entirely — and that rail ALSO sets status='todo', which would
+# resurrect a closed row on top of destroying its result.
+id=$(seedv done "$THEIRS" olivia main)
+out=$( cmd_task_deliver "$id" --pr="$PR" --result="$MINE" 2>&1 ); rc=$?
+[ "$rc" -ne 0 ] && ok "D2a deliver over a closed row is REFUSED on the ROUTED rail too (rc=$rc)" || no "D2a routed rail REFUSED" "rc=$rc $out"
+[ "$(res "$id")" = "$THEIRS" ] && ok "D2b prior result INTACT on the routed rail" || no "D2b routed prior result intact" "$(res "$id")"
+[ "$(st "$id")" = "done" ] && ok "D2c the closed row was not RESURRECTED to 'todo' by the refused delivery" || no "D2c row not resurrected" "$(st "$id")"
+[ -z "$(dref "$id")" ] && ok "D2d delivery_ref not stamped on the refused routed row" || no "D2d routed delivery_ref not stamped" "$(dref "$id")"
+
+# --- D3. the legitimate second half: --append-result --------------------------
+id=$(seed done "$THEIRS")
+out=$( cmd_task_deliver "$id" --pr="$PR" --append-result --result="$MINE" 2>&1 ); rc=$?
+r=$(res "$id")
+[ "$rc" -eq 0 ] && ok "D3a deliver --append-result is ACCEPTED (rc=0)" || no "D3a append accepted" "rc=$rc $out"
+grep -qF "$THEIRS" <<<"$r" && ok "D3b the prior result survives VERBATIM" || no "D3b prior result verbatim" "$r"
+grep -qF "$MINE"   <<<"$r" && ok "D3c the new text is present too" || no "D3c new text present" "$r"
+[ "${r:0:20}" = "${THEIRS:0:20}" ] && ok "D3d the prior result comes FIRST (same ordering as the close verbs)" || no "D3d prior result first" "$r"
+[ "$(dref "$id")" = "$PR" ] && ok "D3e an ACCEPTED delivery does stamp delivery_ref" || no "D3e accepted delivery stamps" "$(dref "$id")"
+
+# --- D4. --force-result replaces, but never silently -------------------------
+id=$(seed done "$THEIRS")
+out=$( cmd_task_deliver "$id" --pr="$PR" --force-result --result="$MINE" 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] && ok "D4a deliver --force-result is ACCEPTED (rc=0)" || no "D4a force accepted" "rc=$rc $out"
+[ "$(res "$id")" = "$MINE" ] && ok "D4b --force-result REPLACES the result (that is its job)" || no "D4b force replaces" "$(res "$id")"
+grep -q 'REPLACED the result' <<<"$out" && ok "D4c the replace is announced on stderr, not silent" || no "D4c replace announced" "$out"
+
+# --- D5..D8. the guard must stay NARROW --------------------------------------
+# Every shape below was working before this change and must keep working; a guard
+# that starts refusing them trades one broken verb for another.
+id=$(seed in_progress "")
+out=$( cmd_task_deliver "$id" --pr="$PR" --result="$MINE" 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] && [ "$(res "$id")" = "$MINE" ] && ok "D5 an OPEN row still records the delivery result (no new refusal)" || no "D5 open row unaffected" "rc=$rc $(res "$id")"
+
+id=$(seed done "$THEIRS")
+out=$( cmd_task_deliver "$id" --pr="$PR" --result="$THEIRS" 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] && [ "$(res "$id")" = "$THEIRS" ] && ok "D6 an IDENTICAL result is not refused (nothing is being destroyed)" || no "D6 identical result idempotent" "rc=$rc $out"
+
+id=$(seed done "")
+out=$( cmd_task_deliver "$id" --pr="$PR" --result="$MINE" 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] && [ "$(res "$id")" = "$MINE" ] && ok "D7 an EMPTY stored result is not refused (there is no record to lose)" || no "D7 empty stored result" "rc=$rc $out"
+
+id=$(seed done "$THEIRS")
+out=$( cmd_task_deliver "$id" --pr="$PR" 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] && [ "$(res "$id")" = "$THEIRS" ] && ok "D8 a BARE deliver (no --result=) is not refused and leaves the result alone" || no "D8 bare deliver untouched" "rc=$rc $(res "$id")"
+# Recorded, NOT asserted as correct: that bare deliver DID re-stamp delivery_ref and
+# delivered_at on a closed row. It is the no-result population this guard cannot see
+# (there is no result to protect), it is named in the source comment, and it is
+# unfixed here rather than quietly claimed.
+echo "     note: bare deliver re-stamped delivery_ref='$(dref "$id")' on the closed row — known, out of scope, named in cmd_task.sh"
+
+echo
+echo "=== DIVE-2476 deliver-over-closed unit: $P passed, $F failed ==="
+[ "$F" -eq 0 ] || exit 1

--- a/tests/task_deliver_over_closed_result_unit.sh
+++ b/tests/task_deliver_over_closed_result_unit.sh
@@ -44,7 +44,8 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
+         lib/disk.sh lib/tasks_db.sh lib/broker.sh \
+         cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done


### PR DESCRIPTION
## What

DIVE-2464 guarded `task done|cancel` against replacing an already-closed row's result. It did not guard the verb next door. `cmd_task_deliver` ended in an unconditional `UPDATE tasks SET result=` with **no status check anywhere in the function**, so

```
5dive task deliver <id> --pr=<url> --result=<text>
```

on an already `done`/`cancelled` row replaced the recorded result the same silent way — no warning, no refusal, exit 0 — and stamped `delivery_ref`/`delivered_at` over that closed row on the line above.

Found by main while reviewing DIVE-2464 / #357, measured (probe arm P4) on **both** `origin/main e935d82` and #357's tip: pre-existing, **not** a #357 regression.

## Why it is a real second hole

What makes the clobber unrecoverable is that the ledger keeps a **sha256 of the result, not the text**. That property belongs to the **column**, not to the verb that writes it — so guarding one writer leaves the value exactly as destroyable through the next.

## How

One guard, not a second variant of it. The DIVE-2464 block is extracted as `_task_guard_result_over_closed` and `task deliver` consults it:

- identical refusal text (same `DIVE-2464` citation, the row's holders, the close timestamp, the pointer to `5dive trace`), with the verb substituted;
- identical `--append-result` semantics — prior text verbatim and **first**, addition beneath;
- identical audited `--force-result` escape. Both flags are now accepted by `deliver`.
- consulted **before** the delivery stamp, so a refused delivery leaves no `delivery_ref` behind;
- placed **above** the routed/unrouted fork, so it also covers the `_task_route_to_verifier` shape — which sets `status='todo'` and would have *resurrected* the closed row on top of destroying its record. main's P4 only measured the unrouted rail.

A reader who learns the rule from one verb is not surprised by another, which is what the ticket asked for.

## Evidence

`tests/task_deliver_over_closed_result_unit.sh` — 23 assertions, isolated temp DB, both rails: **23/23**. Includes the four narrowness arms that must keep working (open row, identical result, empty stored result, bare `deliver`).

DIVE-2464's own harness through the extracted helper: **29/29**.

**Mutation-graded, one arm per part of the fix:**

| mutation | expected | measured |
|---|---|---|
| delete the guard call in `cmd_task_deliver` | deliver arms die, 2464 rail unaffected | 8 deliver arms FAIL; 2464 harness still 29/29 (separate call site) |
| move the call *below* the delivery stamp | only the ordering assertions die | exactly `D1f`/`D1g`/`D2d` FAIL, other 20 pass |
| neuter the shared helper (`return 0`) | **both** verbs lose their guard | deliver arms FAIL **and** 2464's harness FAILs 14 — proves the extraction is the live guard for `done|cancel`, not a copy |

Tree restored to the pristine commit after each arm (sha256-verified).

## Named, not fixed

In the source comment and the CHANGELOG, so none of it reads as covered: a **bare** `task deliver` with no `--result=` still re-stamps `delivery_ref`/`delivered_at` on a closed row, and on a closed row with a distinct verifier it still **routes** (the shape DIVE-2464 iter 2 excluded on the `task done` rail only). Both are the no-result population this guard is blind to by construction — worth their own row if they matter.

Refs DIVE-2476. Sibling of DIVE-2464 (#357).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
