### PR TITLE
fix(gate): read the SUBJECT's state, never the row's commit stream (DIVE-2414)

### DIFF
--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -1846,10 +1846,57 @@ _hb_gate_shipped_sweep() {
   # Normalize the repo allow-list: commas or spaces both separate.
   local repos; repos="${_HB_GATE_SHIPPED_REPOS//,/ }"
   [[ -n "${repos// }" ]] || return 0
+  # DIVE-2414: resolve the read-only gh credential ONCE for the whole sweep, not
+  # per gate — _gate_gh_token can shell out to sudo and the sweep runs every tick.
+  # Empty is a first-class answer: the subject reader returns UNKNOWN, never a
+  # silent accept.
+  local _gs_tok=""
+  command -v gh >/dev/null 2>&1 && _gs_tok=$(_gate_gh_token)
   while IFS= read -r grow; do
     [[ -n "$grow" ]] || continue
     IFS=$'\x1f' read -r gid gident gtype gowner <<<"$grow"
     [[ -n "$gid" && -n "$gident" ]] || continue
+    # DIVE-2414: READ WHAT THE GATE IS ABOUT BEFORE READING THE ROW.
+    # The commit-stream lookup below is row-level evidence: it answers "did
+    # something naming this ROW land", which on a multi-item row is routinely a
+    # different item than the one the ask is about (DIVE-2382 — flagged "likely
+    # shipped, verify+close" while its live approval asked about something else).
+    # So when the ASK names a pull request, that PR's MEASURED state is
+    # authoritative and the row's commits are not consulted at all:
+    #   OPEN     -> withhold the flag even if the row has commits. The ask is live.
+    #   UNKNOWN  -> withhold. A state that could not be read is not a negative
+    #               (DIVE-2318). No stamp, so a later tick retries.
+    #   MERGED   -> flag, with the SUBJECT as the named evidence.
+    # A gate that names NO subject falls through to the row-level path, which
+    # keeps its DIVE-1140 behaviour and now SAYS which evidence class it used.
+    # Fetched per row rather than in the sweep query on purpose: an ask is
+    # multi-line and would break the x'1f' line-per-row read above.
+    local _ask _sbody _sslug _sv _svd
+    _ask=$(db "SELECT COALESCE(ask,'') FROM tasks WHERE id=${gid};")
+    _sbody=$(db "SELECT COALESCE(body,'') FROM tasks WHERE id=${gid};")
+    _sslug=$(_gate_task_repo_slug "" "$_sbody")
+    _sv=$(_gate_subject_verdict "$_ask" "$_gs_tok" "$gident" "$_sslug")
+    _svd="${_sv#*|}"
+    case "${_sv%%|*}" in
+      OPEN)
+        _hb_log "[gate-shipped] ${gident} — the PR its ASK names is still OPEN (${_svd}); NOT flagging, and the row's own commits are NOT evidence about this gate (DIVE-2414). Gate stays eligible."
+        _task_store_audit_log "gate shipped-flag" "skip" 0 -- "task=$gident" "reason=subject-open" "subject=$_svd" || true
+        continue ;;
+      UNKNOWN)
+        _hb_log "[gate-shipped] ${gident} — its ASK names a PR whose state could NOT be read (${_svd}); NOT flagging (a non-verdict is not a negative), no stamp, will retry (DIVE-2414)."
+        _task_store_audit_log "gate shipped-flag" "skip" 0 -- "task=$gident" "reason=subject-unreadable" "subject=$_svd" || true
+        continue ;;
+      MERGED)
+        db "UPDATE tasks SET shipped_flag_at=datetime('now') WHERE id=${gid};"
+        _task_store_audit_log "gate shipped-flag" "ok" 0 -- "task=$gident" "type=$gtype" "evidence=subject-pr" "subject=$_svd" || true
+        _hb_log "[gate-shipped] ${gident} — the PR its ASK names is MERGED (${_svd}) -> flagged on SUBJECT state, not on the row's commits (DIVE-2414)"
+        if [[ -n "$gowner" ]] && _task_agent_channel "$gowner"; then
+          ( cmd_send "$gowner" --message="🚢 ${gident} — the pull request this open ${gtype} gate ASKS ABOUT is now merged (${_svd}). Likely settled: verify and close with \`5dive task show ${gident}\`. Auto-flag only — a merge is not a sign-off (DIVE-555), so it stays open until you clear it." ) >/dev/null 2>&1 || true
+        fi
+        continue ;;
+    esac
+    # NO-SUBJECT from here down: the ask names no pull request, so nothing can
+    # retire it automatically and the row-level nudge has to say what it is.
     hit=""
     for repo in $repos; do
       hit=$(_hb_repo_grep_ident "$repo" "$gident") && [[ -n "$hit" ]] && break
@@ -1896,10 +1943,14 @@ _hb_gate_shipped_sweep() {
     fi
     db "UPDATE tasks SET shipped_flag_at=datetime('now') WHERE id=${gid};"
     # DIVE-2054: same reasoning as the two branches above — fenced.
-    _task_store_audit_log "gate shipped-flag" "ok" 0 -- "task=$gident" "type=$gtype" "commit=$hit" || true
-    _hb_log "[gate-shipped] ${gident} — commit on ${_HB_GATE_SHIPPED_REF} references it: ${hit} -> flagged"
+    _task_store_audit_log "gate shipped-flag" "ok" 0 -- "task=$gident" "type=$gtype" "evidence=row-commit" "commit=$hit" || true
+    _hb_log "[gate-shipped] ${gident} — its ask names NO PR subject; falling back to ROW-level evidence: commit on ${_HB_GATE_SHIPPED_REF} references the row: ${hit} -> flagged"
     if [[ -n "$gowner" ]] && _task_agent_channel "$gowner"; then
-      ( cmd_send "$gowner" --message="🚢 ${gident} — a commit referencing this open ${gtype} gate landed on ${_HB_GATE_SHIPPED_REF} (${hit}). Likely shipped: verify and close with \`5dive task show ${gident}\`. Auto-flag only — a merge is not a sign-off, so it stays open until you clear it." ) >/dev/null 2>&1 || true
+      # DIVE-2414: name the EVIDENCE CLASS in the nudge. This flag says a commit
+      # named the ROW, and the ask names no PR to check instead — so on a row
+      # carrying several items it may well be about a different one (DIVE-2382).
+      # The old wording asserted "likely shipped" with no way to tell the two apart.
+      ( cmd_send "$gowner" --message="🚢 ${gident} — a commit referencing this open ${gtype} gate's ROW landed on ${_HB_GATE_SHIPPED_REF} (${hit}). This ask names no pull request, so the evidence is ROW-level: if the row carries several items, the commit may be about a different one — check before you clear. Verify with \`5dive task show ${gident}\`. Auto-flag only — a merge is not a sign-off, so it stays open until you clear it." ) >/dev/null 2>&1 || true
     fi
   done < <(db "SELECT id||x'1f'||COALESCE(ident,'DIVE-'||id)||x'1f'||need_type||x'1f'||COALESCE(assignee,'')
                FROM tasks

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -1528,6 +1528,18 @@ _gate_text_names_a_ref() {
 # as the subject retires a live human question, reading the subject as a citation
 # costs ONE nudge. Line-scoped, negations rejected, `tolower` for matching only so
 # offsets still index the original line (a URL keeps its owner/repo case).
+#
+# THE VERB LIST IS A CLOSED VOCABULARY, AND THAT IS THE DESIGN, not an oversight
+# left for the next person to finish (Marcus, verifying DIVE-2414). An ask phrased
+# outside it — "can you OK PR #123" — yields NO subject, and a gate with no subject
+# withholds the flag. That is the fail-closed direction and it costs a nudge.
+# Widening the vocabulary is how the pinned negatives come back: E3 (DIVE-2382's
+# "already in review as PR #335"), E4 (a bare mention) and E8 ("shipped as PR #N")
+# in tests/gate_subject_state_unit.sh each pass only because some phrasing is
+# OUTSIDE the set. If you add a verb, add it with the arm that proves the
+# citations still miss — and note that the two halves are pinned by mutations the
+# other survives: subject:=any-mention reds E3/E4/E5/E8, subject:=nothing reds
+# E1/E2/E6/E7, a clean 4/4 partition with no overlap. Keep that property.
 _gate_subject_refs_from_text() {
   printf '%s' "$1" | awk '
     BEGIN {

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -1488,6 +1488,189 @@ _gate_text_names_a_ref() {
 # announces itself at the exact moment it matters, to the person it is failing. That is
 # the property to preserve if this list is ever edited; adding a repo without it just
 # moves the blind spot.
+# ---------------------------------------------------------------------------
+# DIVE-2414 — THE SUBJECT-STATE READER. ONE reader, pointed TWO directions.
+#
+# THE DEFECT IT REPLACES. "A gate whose task looks shipped retires with it" reads
+# the ROW's own commit stream (`git log --grep=<ident>`, _hb_repo_grep_ident) and
+# calls that evidence about the GATE. It is not. A row carrying a six-item program
+# gets one commit for item #5 and reads as complete: DIVE-2382 was flagged
+# "likely shipped, verify+close" while its live human gate asked about a
+# completely different item. On a ticket that lands in pieces that nudge points
+# the right way for the wrong reason and arrives with the authority of an
+# automatic check. So the rule this file now enforces:
+#
+#   THE READER RESOLVES WHAT THE GATE IS ABOUT — the pull request it NAMES — and
+#   NEVER inherits the row's commit stream as evidence. A gate that names NO
+#   subject does not auto-retire; it stays open and SAYS so.
+#
+# TWO DIRECTIONS, ONE READER (olivia's scope, and it is a correctness argument,
+# not just anti-duplication — built as two rows it repeats DIVE-2382's own defect):
+#   (a) retire/flag a gate when the PR its ASK names has merged   — _gate_subject_verdict
+#   (b) the DIVE-1830 merge-gate's cited-not-delivered gap, where a PR named in
+#       prose is never read for its state AT ALL                 — _gate_cited_state_note
+# Same blindness, opposite directions: one asks "is my subject resolved?", the
+# other "what state is the thing you are citing actually in?".
+#
+# _gate_subject_refs_from_text <text> — of the refs this text names, which ones is
+# it ASKING ABOUT? Emits the qualified `<slug>|<n>` subset, same shape as
+# _gate_delivery_refs_from_text (DIVE-1965), and for the same reason: the subject
+# must come from a STRUCTURED, INTENTIONAL signal, never from "a number appeared in
+# the text". DIVE-2382's own ask is the pinned negative — it says "fix #5 is
+# already in review as PR #335", a PR it is NOT about, and a mention-predicate
+# would have retired a live approval on the strength of it.
+#   Accepted: a `Subject:` / `Gate-subject:` / `Blocked-on:` line, or an
+# ACTION-REQUEST verb adjacent to the ref (approve / merge / land / sign off) —
+# the ask wants something DONE to that PR. Report verbs (review, shipped, cited)
+# are deliberately NOT in the set: "in review as PR #335" is the exact shape that
+# must miss, and "shipped as PR #N" describes a PR rather than asking about it.
+# The asymmetry is deliberate and is the whole safety argument: reading a citation
+# as the subject retires a live human question, reading the subject as a citation
+# costs ONE nudge. Line-scoped, negations rejected, `tolower` for matching only so
+# offsets still index the original line (a URL keeps its owner/repo case).
+_gate_subject_refs_from_text() {
+  printf '%s' "$1" | awk '
+    BEGIN {
+      RE   = "(https://github\\.com/[a-z0-9._-]+/[a-z0-9._-]+/pull/[0-9]+[a-z0-9]*)|((^|[^a-z0-9])(prs?|pull request)[[:space:]]*#?[[:space:]]*[0-9]+[a-z0-9]*)"
+      VERB = "(approve|approves|approved|approval|merge|merges|merging|land|lands|landing|sign[- ]?off|signs[- ]?off|signed[- ]?off)"
+      CONN = "([[:space:]]+(as|in|on|of|to|into|via|by|the|this|that|is|was|it))*"
+      PRE  = "(^|[^a-z0-9])" VERB CONN "[^[:alnum:]]*$"
+      NEG  = "(^|[^a-z0-9])(not|never|no|un|cannot|can[[:space:]]not|dont|do[[:space:]]not)[- ]?" VERB CONN "[^[:alnum:]]*$"
+      POST = "^[[:space:]]*(is|was|needs|need)[[:space:]]+(your[[:space:]]+|a[[:space:]]+)?(approval|approving|sign[- ]?off|merging|merged|landing)"
+    }
+    function refkey(m,   n, k, p) {
+      n = m; sub(/^.*[^0-9]/, "", n)
+      if (n !~ /^[0-9]{1,6}$/) return ""
+      if (tolower(m) ~ /https:\/\/github\.com\//) {
+        k = m; sub(/^.*https:\/\/github\.com\//, "", k)
+        split(k, p, "/"); return p[1] "/" p[2] "|" n
+      }
+      return "|" n
+    }
+    {
+      line = $0; low = tolower(line)
+      sline = (low ~ /^[[:space:]]*(subject|gate-subject|gate subject|blocked-on|blocked on)[[:space:]]*:/)
+      pos = 1
+      while (match(substr(low, pos), RE)) {
+        st = pos + RSTART - 1; ln = RLENGTH
+        key = refkey(substr(line, st, ln))
+        if (key != "") {
+          pre = tolower(substr(line, 1, st - 1)); post = tolower(substr(line, st + ln))
+          if (sline || (pre ~ PRE && pre !~ NEG) || post ~ POST)
+            if (!seen[key]++) print key
+        }
+        pos = st + ln
+      }
+    }'
+}
+
+# _gate_ref_states <tok> <ident> <task_slug> — THE READER. Qualified refs on
+# STDIN, one MEASURED state line per ref on stdout:
+#
+#   <number>|<STATE>|<where>     STATE ∈ MERGED | MERGED-RED | OPEN | CLOSED
+#                                        | AMBIGUOUS | UNRESOLVED
+#
+# Every state comes from `gh pr view` on the ref ITSELF, through the DIVE-1955
+# qualified resolver (a bare `#N` is looked up in the declared repo, or bound by
+# ident evidence, or reported AMBIGUOUS — never guessed against a default slug).
+# There is deliberately NO git call anywhere in this path: the moment this reader
+# can reach the row's commit stream, the defect it exists to delete is back.
+# MERGED-RED is kept DISTINCT from MERGED because "merged" is not the same claim
+# as "landed and green" (DIVE-1935), and a caller retiring a human ask must not
+# collapse them.
+_gate_ref_states() {
+  local tok="$1" ident="$2" task_slug="$3" qref st rslug
+  while IFS= read -r qref; do
+    [[ -n "$qref" ]] || continue
+    st=$(_gate_resolve_qualified "$qref" "$tok" "$ident" "$task_slug")
+    rslug="${st%%|*}"; st="${st#*|}"
+    case "$rslug|$st" in
+      AMBIGUOUS\|*)          printf '%s|AMBIGUOUS|%s\n' "${qref#*|}" "$st" ;;
+      \|)                    printf '%s|UNRESOLVED|%s\n' "${qref#*|}" "$(_gate_search_scope "$qref" "$task_slug")" ;;
+      *\|MERGED\|*\|FAILURE) printf '%s|MERGED-RED|%s\n' "${qref#*|}" "$rslug" ;;
+      *\|MERGED\|*)          printf '%s|MERGED|%s\n' "${qref#*|}" "$rslug" ;;
+      *\|OPEN\|*)            printf '%s|OPEN|%s\n' "${qref#*|}" "$rslug" ;;
+      *)                     printf '%s|%s|%s\n' "${qref#*|}" "${st%%|*}" "$rslug" ;;
+    esac
+  done
+}
+_GATE_SUBJECT_CAP=5
+
+# _gate_subject_verdict <ask-text> <tok> <ident> <task_slug> — DIRECTION (a).
+# One line: `NO-SUBJECT` | `UNKNOWN|<why>` | `OPEN|<detail>` | `MERGED|<detail>`.
+#
+# Feed it the gate's own ASK and nothing else. NOT the row body: the body carries
+# the whole program and every PR it cites, which is exactly how a row-level signal
+# gets read as a gate-level one — the DIVE-2382 misread, one input earlier.
+#
+# Precedence, strictest first, because these are answers to "may this ask be
+# retired without a human":
+#   OPEN     — a subject is still open. Nothing else matters; the ask is live.
+#   UNKNOWN  — a subject exists and its state could not be READ (no gh, no token,
+#              dead parser, unresolvable, ambiguous, merged-but-red). A non-verdict
+#              is not a negative (DIVE-2318) and must never read as "resolved".
+#   MERGED   — every subject named resolved, and all of them merged green.
+#   NO-SUBJECT — the ask names no pull request AT ALL. Not a failure: most gates
+#              ask for a decision, not for a merge. Nothing can retire them
+#              automatically and the caller has to say that out loud.
+_gate_subject_verdict() {
+  local text="$1" tok="$2" ident="$3" task_slug="$4"
+  local refs n
+  refs=$(_gate_subject_refs_from_text "$text")
+  refs=$(printf '%s\n' "$refs" | grep . || true)
+  [[ -n "$refs" ]] || { printf 'NO-SUBJECT'; return 0; }
+  # A ref was named, so from here on silence is never an accept. An unrunnable
+  # parser or a missing credential is UNKNOWN — the same distinction DIVE-1955
+  # drew between "I looked and could not tell" and "there was nothing to look at".
+  _gate_pr_refs_engine_ok || { printf 'UNKNOWN|ref-parser-broken'; return 0; }
+  command -v gh >/dev/null 2>&1 || { printf 'UNKNOWN|gh-absent'; return 0; }
+  [[ -n "$tok" ]] || { printf 'UNKNOWN|no-gh-token'; return 0; }
+  n=$(printf '%s\n' "$refs" | grep -c .)
+  local states open="" merged="" unk=""
+  states=$(printf '%s\n' "$refs" | head -n "$_GATE_SUBJECT_CAP" | _gate_ref_states "$tok" "$ident" "$task_slug")
+  local num st where
+  while IFS='|' read -r num st where; do
+    [[ -n "$num" ]] || continue
+    case "$st" in
+      OPEN)   open="${open:+$open, }#${num} in ${where}" ;;
+      MERGED) merged="${merged:+$merged, }#${num} in ${where}" ;;
+      *)      unk="${unk:+$unk; }#${num} ${st} (${where})" ;;
+    esac
+  done <<<"$states"
+  (( n > _GATE_SUBJECT_CAP )) && unk="${unk:+$unk; }only the first ${_GATE_SUBJECT_CAP} of ${n} named refs were checked"
+  [[ -n "$open" ]] && { printf 'OPEN|%s' "$open"; return 0; }
+  [[ -n "$unk"  ]] && { printf 'UNKNOWN|%s' "$unk"; return 0; }
+  [[ -n "$merged" ]] && { printf 'MERGED|%s' "$merged"; return 0; }
+  printf 'UNKNOWN|no state read for any named subject'
+}
+
+# _gate_cited_state_note <qualified-refs> <tok> <ident> <task_slug> — DIRECTION (b).
+# The DIVE-1830 merge-gate sets CITED refs aside and, until now, did not read them
+# at all: "nothing binds them to this task, so their merge state was NOT checked".
+# The set-aside is right — a cited PR is another task's delivery and must never
+# gate this close (DIVE-1965 deleted that fleet-wide blocker on purpose). Reading
+# it is a different act from judging it. DIVE-2382's own close cited PR #337 while
+# it was OPEN and nothing said so; the same open PR then outlived the row that was
+# its only tracker. This returns the MEASURED state as a note. It never refuses,
+# never stamps UNVERIFIED, and never changes a verdict — it is disclosure only.
+# Bounded to 3 (a close that cites ten PRs must not pay ten round-trips) and the
+# cap is named in the note, because a silent cap reads as "all of them checked".
+_gate_cited_state_note() {
+  local qrefs="$1" tok="$2" ident="$3" task_slug="$4"
+  local refs n out="" num st where
+  refs=$(printf '%s\n' "$qrefs" | grep . || true)
+  [[ -n "$refs" ]] || { printf 'no cited reference resolved to read'; return 0; }
+  [[ -n "$tok" ]] || { printf 'state NOT read (no gh credential resolved)'; return 0; }
+  n=$(printf '%s\n' "$refs" | grep -c .)
+  while IFS='|' read -r num st where; do
+    [[ -n "$num" ]] || continue
+    out="${out:+$out; }#${num} ${st} in ${where}"
+  done < <(printf '%s\n' "$refs" | head -n 3 | _gate_ref_states "$tok" "$ident" "$task_slug")
+  [[ -n "$out" ]] || out="state NOT read"
+  (( n > 3 )) && out="$out (first 3 of $n cited refs read)"
+  printf '%s' "$out"
+}
+
 _gate_repo_slugs() {
   local raw="${FIVE_GATE_REPOS:-}"
   if [[ -z "$raw" ]]; then
@@ -2581,6 +2764,11 @@ _task_status_cmd() {
     # make a task unclosable, per DIVE-1835), and an unresolvable ref is a loud note
     # rather than a block, so a non-PR "#12" and an offline box both stay closable.
     local _txt_open="" _txt_open_slug="" _txt_red="" _txt_unres="" _txt_amb="" _txt_cited=""
+    # DIVE-2414: the cited set kept QUALIFIED as well as by number. `_txt_cited`
+    # is the number-only list the warning and the audit row have always printed;
+    # the subject-state reader needs the slug that travelled with the ref, or a
+    # bare "#6" gets read against whichever repo answers first (DIVE-1955).
+    local _txt_cited_q=""
     # DIVE-1955 (review, Marcus): decide "was a PR mentioned at all" UNCONDITIONALLY,
     # before the token/parser checks below, because those are exactly the paths that
     # cannot answer it later. Without this, a no-token close cannot distinguish a
@@ -2621,6 +2809,7 @@ $_body"
         # Skipped BEFORE the cap so five cited PRs cannot crowd out the real one.
         if ! printf '%s\n' "$_deliv" | grep -qxF -e "$_qref" -e "|${_qref#*|}"; then
           _txt_cited="${_txt_cited:+$_txt_cited,}${_qref#*|}"
+          _txt_cited_q="${_txt_cited_q:+$_txt_cited_q$'\n'}${_qref}"
           continue
         fi
         # Bounded: 5 refs max per close, and the drop is announced — a silent cap
@@ -2659,9 +2848,16 @@ $_body"
       # also the guard on this ticket's one coverage cost: if the maker's own
       # delivery landed in here, this line is where they see it.
       if [[ -n "$_txt_cited" ]]; then
-        warn "$ident: merge-gate treated PR reference(s) #${_txt_cited//,/, #} as CITED, not delivered — nothing binds them to this task, so their merge state was NOT checked (DIVE-1965). If one of them IS this task's delivery, bind it (\`task deliver $ident --pr=<url>\`) or say so (\"merged as PR #N\", or a \`Delivered: <url>\` line)."
+        # DIVE-2414: SET ASIDE IS NOT THE SAME ACT AS NOT LOOKED AT. These refs
+        # still do not gate this close — restoring that would re-create the
+        # fleet-wide blocker DIVE-1965 deleted — but their state is now READ and
+        # DISCLOSED through the same subject-state reader the gate sweep uses.
+        # DIVE-2382 closed while citing its own PR #337 as OPEN and nothing said
+        # so; that open PR then outlived the only row pointing at it.
+        local _cited_note; _cited_note=$(_gate_cited_state_note "$_txt_cited_q" "$_ghtok2" "$ident" "$_task_slug")
+        warn "$ident: merge-gate treated PR reference(s) #${_txt_cited//,/, #} as CITED, not delivered — nothing binds them to this task, so they do NOT gate this close (DIVE-1965). Their state, MEASURED anyway and reported only (DIVE-2414): ${_cited_note}. If one of them IS this task's delivery, bind it (\`task deliver $ident --pr=<url>\`) or say so (\"merged as PR #N\", or a \`Delivered: <url>\` line)."
         # DIVE-2054 (judgment call): same merge-gate family as -ambiguous above — fenced.
-        _task_store_audit_log "task.merge-gate-reported-on" ok 0 -- "$ident" "refs=$_txt_cited"
+        _task_store_audit_log "task.merge-gate-reported-on" ok 0 -- "$ident" "refs=$_txt_cited" "states=$_cited_note"
       fi
     fi
     if [[ -n "$_txt_open" && $force_merge_gate -eq 0 ]]; then

--- a/tests/gate_subject_state_unit.sh
+++ b/tests/gate_subject_state_unit.sh
@@ -88,6 +88,22 @@ gh() {
   printf '%s|%s|%s\n' "$st" "$merged" "$roll"
 }
 timeout() { shift; "$@"; }   # strip the timeout wrapper, run the stub
+# CREDENTIAL STUB (DIVE-2530). The gh COMMAND above is stubbed; the CREDENTIAL was
+# not, and that is a different thing. `_gate_subject_verdict` takes the token as a
+# PARAMETER, so the V arms below are deterministic — they pass `tok` or `''` by hand.
+# The H arms do not: they go through `_hb_gate_shipped_sweep`, which resolves the
+# token itself via `_gate_gh_token`. That made them read whatever credential the
+# HOST happened to have.
+# MEASURED 2026-07-31 (CI job 91163957248): identical commit, identical command,
+# 34/0 on the control-plane host and 30/4 on the pristine runner, every failure
+# carrying `subject=no-gh-token`. cmd_task.sh short-circuits on an empty token
+# BEFORE gh is called, so the stub above was never reached and the H2 family could
+# not arrive at the state it asserts. A harness that reads an ambient credential is
+# measuring the environment, not the subject (DIVE-1919).
+# Non-empty on purpose, and the same literal the V arms pass, so both halves of the
+# file agree about what "has a token" means. The no-token path keeps its own
+# coverage at V5, where the empty value is passed EXPLICITLY rather than inherited.
+_gate_gh_token() { printf 'tok'; }
 command() { builtin command "$@"; }
 export -f 2>/dev/null || true
 

--- a/tests/gate_subject_state_unit.sh
+++ b/tests/gate_subject_state_unit.sh
@@ -183,7 +183,20 @@ _hb_repo_grep_ident() { printf '5dive-cli abc1234 %s subject naming %s\n' "$(dat
 g1=$(mkgate DIVE-9001 'Approve PR #102 before we merge?')   # subject OPEN
 _hb_gate_shipped_sweep >/dev/null 2>&1
 is "H1 open subject VETOES the row-commit flag" "$(flagged DIVE-9001)" "no"
+# H1a (DIVE-2530): the OUTCOME above is reachable by two paths — vetoed-because-OPEN
+# and withheld-because-UNREADABLE both leave flagged=no. On the tokenless runner H1
+# went green while the state it exists to prove was never reached. Assert the REASON,
+# so the arm can only pass on the path it names.
+has "H1a and the veto names the OPEN subject, not an unreadable one" "$(cat "$HB_LOG")" "#102"
+hasnt "H1a2 and it is NOT the unreadable path" "$(cat "$HB_LOG")" "no-gh-token"
 has "H1b and says the row's commits are not evidence" "$(cat "$HB_LOG")" "NOT evidence about this gate"
+# H1c is an ABSENCE assertion and absence assertions pass on EMPTY output (olivia,
+# DIVE-2530): it cannot fail even if the sweep produced nothing at all, which makes it
+# strictly weaker than H1 — H1 needs a wrong-but-present value, H1c needs nothing.
+# The positive companion is what stops it staying green through a future breakage that
+# SILENCES the sweep rather than mis-answering it.
+is "H1c0 the sweep actually ran (positive companion for the absence arm)" \
+   "$([[ -s "$HB_LOG" ]] && echo produced || echo empty)" "produced"
 hasnt "H1c owner NOT nudged" "$(cat "$SEND_LOG")" "DIVE-9001"
 
 : >"$HB_LOG"; : >"$SEND_LOG"

--- a/tests/gate_subject_state_unit.sh
+++ b/tests/gate_subject_state_unit.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# DIVE-2414 — the subject-state reader, and the two directions it is pointed.
+#
+# WHAT THIS GRADES, and why the arms are shaped this way. The defect is not a
+# missing feature, it is WRONG EVIDENCE: a gate was flagged "likely shipped,
+# verify+close" because a commit naming its ROW landed, while its live human ask
+# was about a different item (DIVE-2382). So the arms that matter are the ones
+# that were ALREADY PASSING before the change — the withholds. An arm that only
+# proves "a merged subject flags" signs off on a wider nudge, not a narrower one.
+#
+#   E1-E8  the subject EXTRACTOR: intentional signal accepted, mention rejected.
+#          E3 is DIVE-2382's own ask, verbatim in shape: it cites a PR it is not
+#          about, and a mention-predicate retires a live approval on it.
+#   R1-R6  the READER: every gh state mapped, and NO git call on any path.
+#   V1-V5  the verdict roll-up precedence (OPEN > UNKNOWN > MERGED).
+#   H1-H4  direction (a), the heartbeat gate sweep: open subject VETOES a
+#          row-commit flag; merged subject flags on subject evidence; a
+#          no-subject gate keeps DIVE-1140 behaviour and names its evidence class.
+#   C1-C3  direction (b), the cited-not-delivered gap: state READ and reported,
+#          never refused, cap announced.
+#
+# Fixtures use reserved fakes only (CLAUDE.md): fake idents DIVE-9001/9002, fake
+# slug example/repo. Runs on a throwaway tasks.db, stubs gh/git/send. No network.
+# Run: bash tests/gate_subject_state_unit.sh   (no root, no network)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/gate-subject.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_agent.sh cmd_heartbeat.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"
+TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"
+export FIVEDIVE_PROD_TASKS_DB="$TASKS_DB"
+set +e
+tasks_db_init
+
+PASS=0; FAIL=0
+ok_()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad_()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+is()    { [[ "$2" == "$3" ]] && ok_ "$1" || bad_ "$1" "want [$3] got [$2]"; }
+has()   { [[ "$2" == *"$3"* ]] && ok_ "$1" || bad_ "$1" "want substring [$3] in [$2]"; }
+hasnt() { [[ "$2" != *"$3"* ]] && ok_ "$1" || bad_ "$1" "did NOT want [$3] in [$2]"; }
+
+# --- stubs -------------------------------------------------------------------
+# GIT TRIPWIRE. The whole point of the reader is that it reads the SUBJECT, never
+# the row's commit stream — so `git` is not merely unused here, it is an ERROR to
+# call. Any invocation lands in this file and the arms assert it is empty.
+GIT_CALLS="$TMP/git-calls"; : >"$GIT_CALLS"
+git() { printf 'git %s\n' "$*" >>"$GIT_CALLS"; return 1; }
+
+# gh stub: state comes from a per-PR table the arms write. `gh pr view --json ...`
+# is called through _gate_pr_state, which asks for state,mergedAt,rollup joined
+# by "|" — we answer in that shape.
+GH_TABLE="$TMP/gh-table"; : >"$GH_TABLE"        # lines: <slug>|<n>|<state>|<rollup>
+gh_set() { printf '%s|%s|%s|%s\n' "$1" "$2" "$3" "${4:-SUCCESS}" >>"$GH_TABLE"; }
+GH_CALLS="$TMP/gh-calls"; : >"$GH_CALLS"
+gh() {
+  printf 'gh %s\n' "$*" >>"$GH_CALLS"
+  local n="" slug="" want_view=0 a
+  for a in "$@"; do
+    case "$a" in
+      view) want_view=1 ;;
+      --repo) slug="NEXT" ;;
+      *) if [[ "$slug" == "NEXT" ]]; then slug="$a"
+         elif [[ "$want_view" == 1 && -z "$n" && "$a" =~ ^[0-9]+$ ]]; then n="$a"; fi ;;
+    esac
+  done
+  local row; row=$(grep -F "${slug}|${n}|" "$GH_TABLE" | head -1)
+  [[ -n "$row" ]] || return 1
+  local st="${row#*|*|}"; st="${st%%|*}"
+  local roll="${row##*|}"
+  local merged="null"; [[ "$st" == "MERGED" ]] && merged="2026-07-30T00:00:00Z"
+  printf '%s|%s|%s\n' "$st" "$merged" "$roll"
+}
+timeout() { shift; "$@"; }   # strip the timeout wrapper, run the stub
+command() { builtin command "$@"; }
+export -f 2>/dev/null || true
+
+SEND_LOG="$TMP/sent"; : >"$SEND_LOG"
+cmd_send()            { printf '%s\n' "$*" >>"$SEND_LOG"; }
+_task_agent_channel() { return 0; }
+HB_LOG="$TMP/hblog"; : >"$HB_LOG"
+_hb_log()             { printf '%s\n' "$*" >>"$HB_LOG"; }
+AUD="$TMP/audit"; : >"$AUD"
+_task_store_audit_log() { printf '%s\n' "$*" >>"$AUD"; return 0; }
+# Single known repo, so a bare "#N" has one place to resolve.
+_gate_repo_slugs()    { printf 'example/repo\n'; }
+
+echo "== E: the subject extractor (intentional signal, not a mention) =="
+is "E1 approve+bare ref is a subject" \
+   "$(_gate_subject_refs_from_text 'Approve PR #12 so this can land?')" "|12"
+is "E2 Subject: line is a subject" \
+   "$(_gate_subject_refs_from_text 'Subject: https://github.com/example/repo/pull/12')" "example/repo|12"
+# DIVE-2382's own ask: it cites a PR it is NOT about. A mention-predicate here
+# retires a live approval. This arm is the reason the extractor exists at all.
+is "E3 DIVE-2382 shape — 'already in review as PR #335' is NOT a subject" \
+   "$(_gate_subject_refs_from_text 'Approve loosening the tier-2 human floor so a decision you state in prose clears a gate? The other five items are ours, and fix #5 is already in review as PR #335.')" ""
+is "E4 bare mention is not a subject" \
+   "$(_gate_subject_refs_from_text 'Context: PR #12 exists.')" ""
+is "E5 negation rejected" \
+   "$(_gate_subject_refs_from_text 'This is not merged — PR #12 still pending.')" ""
+is "E6 post-cue 'needs your approval'" \
+   "$(_gate_subject_refs_from_text 'PR #12 needs your approval before Friday.')" "|12"
+is "E7 sign-off cue with connector" \
+   "$(_gate_subject_refs_from_text 'Please sign off on PR #12.')" "|12"
+is "E8 report verb 'shipped as' is not a subject" \
+   "$(_gate_subject_refs_from_text 'Shipped as PR #12.')" ""
+
+echo "== R: the reader (states mapped; git never called) =="
+gh_set example/repo 101 MERGED SUCCESS
+gh_set example/repo 102 OPEN SUCCESS
+gh_set example/repo 103 MERGED FAILURE
+gh_set example/repo 104 CLOSED SUCCESS
+is "R1 merged+green -> MERGED" \
+   "$(printf 'example/repo|101\n' | _gate_ref_states tok DIVE-9001 example/repo)" "101|MERGED|example/repo"
+is "R2 open -> OPEN" \
+   "$(printf 'example/repo|102\n' | _gate_ref_states tok DIVE-9001 example/repo)" "102|OPEN|example/repo"
+is "R3 merged+red stays DISTINCT from merged" \
+   "$(printf 'example/repo|103\n' | _gate_ref_states tok DIVE-9001 example/repo)" "103|MERGED-RED|example/repo"
+is "R4 closed-unmerged -> CLOSED" \
+   "$(printf 'example/repo|104\n' | _gate_ref_states tok DIVE-9001 example/repo)" "104|CLOSED|example/repo"
+has "R5 no such PR -> UNRESOLVED, naming the scope searched" \
+   "$(printf '|999\n' | _gate_ref_states tok DIVE-9001 '')" "999|UNRESOLVED|"
+is "R6 the reader made NO git call" "$(cat "$GIT_CALLS")" ""
+
+echo "== V: verdict precedence =="
+is "V1 no ref named -> NO-SUBJECT" \
+   "$(_gate_subject_verdict 'Which of A or B should we pick?' tok DIVE-9001 example/repo)" "NO-SUBJECT"
+has "V2 merged subject -> MERGED" \
+    "$(_gate_subject_verdict 'Approve PR #101 to land?' tok DIVE-9001 example/repo)" "MERGED|#101 in example/repo"
+has "V3 open subject -> OPEN" \
+    "$(_gate_subject_verdict 'Approve PR #102 to land?' tok DIVE-9001 example/repo)" "OPEN|#102 in example/repo"
+has "V4 OPEN wins over a merged sibling" \
+    "$(_gate_subject_verdict 'Approve PR #101 and merge PR #102?' tok DIVE-9001 example/repo)" "OPEN|"
+has "V5 no credential is UNKNOWN, never an accept" \
+    "$(_gate_subject_verdict 'Approve PR #101?' '' DIVE-9001 example/repo)" "UNKNOWN|no-gh-token"
+has "V6 merged-but-RED is UNKNOWN, not retirable" \
+    "$(_gate_subject_verdict 'Approve PR #103?' tok DIVE-9001 example/repo)" "UNKNOWN|"
+
+echo "== H: direction (a) — the heartbeat gate sweep =="
+_HB_GATE_SHIPPED_REPOS="5dive-cli"
+mkgate() {  # <ident> <ask> ; returns the row id
+  db "INSERT INTO tasks (ident,title,status,assignee,created_by,need_type,ask,need_asked_at,tier)
+      VALUES ($(sqlq "$1"),'t','blocked','dev','dev','approval',$(sqlq "$2"),datetime('now'),2);"
+  db "SELECT id FROM tasks WHERE ident=$(sqlq "$1");"
+}
+flagged() { db "SELECT CASE WHEN shipped_flag_at IS NULL THEN 'no' ELSE 'yes' END FROM tasks WHERE ident=$(sqlq "$1");"; }
+# The row-level evidence is present in EVERY H arm: a commit naming the row landed.
+# That is what makes H1 a veto arm rather than a coverage arm.
+_hb_repo_grep_ident() { printf '5dive-cli abc1234 %s subject naming %s\n' "$(date -u +%s)" "$2"; }
+
+g1=$(mkgate DIVE-9001 'Approve PR #102 before we merge?')   # subject OPEN
+_hb_gate_shipped_sweep >/dev/null 2>&1
+is "H1 open subject VETOES the row-commit flag" "$(flagged DIVE-9001)" "no"
+has "H1b and says the row's commits are not evidence" "$(cat "$HB_LOG")" "NOT evidence about this gate"
+hasnt "H1c owner NOT nudged" "$(cat "$SEND_LOG")" "DIVE-9001"
+
+: >"$HB_LOG"; : >"$SEND_LOG"
+g2=$(mkgate DIVE-9002 'Approve PR #101 before we merge?')   # subject MERGED
+_hb_gate_shipped_sweep >/dev/null 2>&1
+is "H2 merged subject flags" "$(flagged DIVE-9002)" "yes"
+has "H2b flag names SUBJECT evidence, not the row's commits" "$(cat "$AUD")" "evidence=subject-pr"
+has "H2c owner nudge names the subject PR" "$(cat "$SEND_LOG")" "ASKS ABOUT is now merged"
+
+: >"$HB_LOG"; : >"$SEND_LOG"
+g3=$(mkgate DIVE-9003 'Which plan do you want, A or B?')    # NO subject
+_hb_gate_shipped_sweep >/dev/null 2>&1
+is "H3 no-subject gate keeps DIVE-1140 row-level flagging" "$(flagged DIVE-9003)" "yes"
+has "H3b nudge names the evidence class as ROW-level" "$(cat "$SEND_LOG")" "evidence is ROW-level"
+has "H3c audit records the evidence class" "$(cat "$AUD")" "evidence=row-commit"
+
+: >"$HB_LOG"; : >"$SEND_LOG"
+g4=$(mkgate DIVE-9004 'Approve PR #777 before we merge?')   # subject unreadable
+_hb_gate_shipped_sweep >/dev/null 2>&1
+is "H4 unreadable subject withholds the flag (no stamp, retries)" "$(flagged DIVE-9004)" "no"
+has "H4b and says a non-verdict is not a negative" "$(cat "$HB_LOG")" "could NOT be read"
+
+echo "== C: direction (b) — cited-not-delivered now READ, never judged =="
+has "C1 cited open PR's state is reported" \
+    "$(_gate_cited_state_note 'example/repo|102' tok DIVE-9001 example/repo)" "#102 OPEN in example/repo"
+has "C2 no credential says so instead of implying clean" \
+    "$(_gate_cited_state_note 'example/repo|102' '' DIVE-9001 example/repo)" "state NOT read"
+has "C3 cap is announced, never silent" \
+    "$(_gate_cited_state_note "$(printf 'example/repo|101\nexample/repo|102\nexample/repo|103\nexample/repo|104\n')" tok DIVE-9001 example/repo)" \
+    "first 3 of 4 cited refs read"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## DIVE-2414 — one subject-state reader, two call sites

**The defect.** "A gate whose task looks shipped retires with it" reads the **row's own commit
stream** and calls that evidence about the **gate**. It is not. DIVE-2382 was auto-flagged
"likely shipped, verify+close" because one commit naming that row landed, while its live human
gate asked about a completely different item — a row carrying a six-item program gets one commit
for item #5 and reads as complete. On a ticket that lands in pieces the nudge points the right
way for the wrong reason and arrives with the authority of an automatic check.

**The rule.** The reader resolves what the **gate** is about — the pull request it names — and
never inherits the row's commit stream as evidence. A gate that names **no** subject does not
auto-retire; it stays open and says so.

### One reader (`src/cmd_task.sh`)

| function | what it answers |
|---|---|
| `_gate_subject_refs_from_text` | which refs does this text **ask about** (structured `Subject:`/`Blocked-on:` line, or `approve`/`merge`/`land`/`sign off` adjacent to the ref) |
| `_gate_ref_states` | **measured** state per ref via `gh`, through the DIVE-1955 qualified resolver. `MERGED` / `MERGED-RED` / `OPEN` / `CLOSED` / `AMBIGUOUS` / `UNRESOLVED` |
| `_gate_subject_verdict` | `NO-SUBJECT` \| `UNKNOWN` \| `OPEN` \| `MERGED`, strictest first |

The subject must come from a **structured, intentional signal**, never "a number appeared in the
text" — the same rule DIVE-1965 set for delivery. Report verbs are excluded on purpose:
DIVE-2382's own ask says *"fix #5 is already in review as PR #335"* about a PR it is **not**
about, and a mention-predicate retires a live approval on the strength of it. The asymmetry is
the safety argument: reading a citation as the subject retires a live human question, reading a
subject as a citation costs one nudge.

There is **no git call anywhere in the reader**. The moment it can reach the row's commit stream,
the defect is back — so the test asserts it with a tripwire, not a comment.

### Two directions

**(a) the heartbeat gate sweep.** When the ask names a PR, that PR's state is authoritative and
the row's commits are not consulted at all. `OPEN` or `UNKNOWN` **withholds** the flag (no stamp,
so a later tick retries — a non-verdict is not a negative, DIVE-2318); `MERGED` flags with the
subject as the named evidence. A **no-subject** gate keeps its DIVE-1140 row-level flag, and the
nudge now says the evidence is row-level and may be about a different item on the same row.

**(b) the DIVE-1830 cited-not-delivered gap.** Cited refs were set aside *and never read*. The
set-aside is right — DIVE-1965 deleted that fleet-wide close blocker on purpose — but **reading
is a different act from judging**. Their state is now measured and disclosed: never refused,
never stamped UNVERIFIED, never changes a verdict. DIVE-2382 closed while citing its own PR #337
as OPEN and nothing said so; that PR then outlived the only row pointing at it.

Built as one reader because building it as two rows repeats the defect DIVE-2382 was filed about
(olivia's scope, and it is a correctness argument, not anti-duplication).

### Flag-only is unchanged

Nothing here auto-answers or auto-closes a human gate (lodar 2026-07-12, DIVE-555). Whether a
**merged subject may retire a gate without a human** is a policy call and is filed as a decision
gate on DIVE-2414 rather than decided in this diff.

### Grading — 34 arms, mutation-graded, `tests/gate_subject_state_unit.sh`

The load-bearing arms are the **withholds**, not the flags: an arm proving "a merged subject
flags" signs off on a *wider* nudge, not a narrower one.

| mutation | signature | reds |
|---|---|---|
| baseline | 34/0 | — |
| delete the open-subject veto | 31/3 | H1 H1b H1c |
| subject := any PR mention | 30/4 | E3 E4 E5 E8 |
| collapse MERGED-RED into MERGED | 32/2 | R3 V6 |
| cited refs not read | 31/3 | C1 C2 C3 |
| UNKNOWN treated as retirable | 32/2 | H4 H4b |
| revert the row-level evidence wording | 33/1 | H3b |

Each mutation shown applied (non-empty diff) before its run, so none of these is a VOID
measurement. Existing suites unchanged and green against this tree:
`heartbeat_gate_shipped_unit` 19/0 · `task_merge_gate_result_pr_unit` 29/0 ·
`task_merge_gate_delivered_vs_cited_unit` 31/0 · `task_deliver_merge_gate_unit` 11/0 ·
`task_merge_gate_autodetect_unit` 14/0 · `task_merge_gate_ancestry_unit` 35/0.

**Verifier must be someone other than me.** Not CI-cleared: graded locally by mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
