### PR TITLE
fix(task): a re-close must PRESERVE done_at, not refresh it (DIVE-2477)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -2803,8 +2803,21 @@ _task_start_preflight() {
 }
 
 cmd_task_start()  { _task_status_cmd in_progress ", started_at=COALESCE(started_at, datetime('now'))" start "$@"; }
-cmd_task_done()   { _task_status_cmd done ", done_at=datetime('now')" done "$@"; }
-cmd_task_cancel() { _task_status_cmd cancelled ", done_at=datetime('now')" cancel "$@"; }
+# DIVE-2477: COALESCE, not a bare stamp — FIRST close wins. These wrote
+# done_at=datetime('now') unconditionally, so any second close silently moved the
+# original close timestamp forward: measured on a fixture, a row closed at T then
+# a BARE `task done` (no --result, the one shape DIVE-2464's result guard
+# correctly stays silent on) had done_at rewritten to 'now'. That matters because
+# DIVE-2464's own refusal quotes done_at as the evidence of who closed when
+# ("is ALREADY done (closed <done_at>; ...)") — a bare re-close in between made
+# the refusal cite a time that was not the close it was protecting.
+# `task start` next to them has always COALESCEd started_at; this is that rule
+# applied to the close clock. Correct only because the one verb that REOPENS a
+# closed row (`task reject`) now clears done_at — otherwise this would preserve a
+# stale value as the real close time. tests/task_close_preserves_done_at_unit.sh
+# grades both directions.
+cmd_task_done()   { _task_status_cmd done ", done_at=COALESCE(done_at, datetime('now'))" done "$@"; }
+cmd_task_cancel() { _task_status_cmd cancelled ", done_at=COALESCE(done_at, datetime('now'))" cancel "$@"; }
 
 # DIVE-1830: `task deliver` — the maker records the PR that delivers this task,
 # then hands off to the verifier for review. This is the OPT-IN half of the
@@ -3094,6 +3107,16 @@ cmd_task_reject() {
     _task_gate_retire_buttons "$ident" "superseded by auto:reject" || true
   fi
   # max_iterations reached -> stop bouncing, park it on a human to decide.
+  # DIVE-2477 considered clearing done_at here too, by symmetry with the
+  # bounce-back below, and MEASURED that it would be wrong: this branch does not
+  # reopen the row, it files a gate — and on a row that was CLOSED, `task need`
+  # refuses (rc=5, "is done — reopen it before gating on a human"), so the status
+  # stays 'done'. Clearing done_at would leave a done row with no close clock: a
+  # NEW contradiction, not a fix. That refusal also means a reject at
+  # max_iterations over a closed row cannot escalate at all (it writes the
+  # feedback, then fails) — a separate pre-existing defect, deliberately not
+  # ridden along here; graded as a documented control in
+  # tests/task_close_preserves_done_at_unit.sh (arm G).
   if (( maxi > 0 && iter >= maxi )); then
     db "UPDATE tasks SET result=$(sqlq "$fb_txt") WHERE id=${id};"
     warn "$ident hit max_iterations ($maxi) — escalating to human review"
@@ -3102,8 +3125,15 @@ cmd_task_reject() {
     return
   fi
   # Otherwise bounce back to the maker for another pass.
+  # DIVE-2477: clear done_at. `task reject` is the one verb that REOPENS a closed
+  # row (DIVE-2112 allows it for the recorded verifier withdrawing their own
+  # grade, and refuses everyone else), and it left the close timestamp in place —
+  # status='todo' on a row carrying a done_at, the same self-contradiction
+  # DIVE-2113 refuses `task start` for. Latent before; load-bearing now that the
+  # close verbs COALESCE, because a stale done_at would be PRESERVED as the real
+  # close time on the next pass instead of stamped fresh.
   db "UPDATE tasks SET status='todo', assignee=$(sqlq "$maker"), started_at=NULL, handoff_ack_at=NULL,
-        result=$(sqlq "$fb_txt") WHERE id=${id};"
+        done_at=NULL, result=$(sqlq "$fb_txt") WHERE id=${id};"
   ok "$ident rejected — bounced back to maker '$maker' (iteration $iter${maxi:+/$maxi})" \
      '{id:($i|tonumber), ident:$id, status:"todo", bouncedTo:$m, role:"maker", iteration:($n|tonumber)}' \
      --arg i "$id" --arg id "$ident" --arg m "$maker" --arg n "$iter"
@@ -3668,7 +3698,12 @@ cmd_task_verify() {
       _v_prev=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=${id};")
       [[ -n "$_v_prev" ]] && result_txt="${result_txt}"$'\n'"--- superseded result (DIVE-2067, preserved) ---"$'\n'"${_v_prev}"
     fi
-    db "UPDATE tasks SET status='done', done_at=datetime('now'), result=$(sqlq "$result_txt") WHERE id=${id};"
+    # DIVE-2477: the THIRD close writer. DIVE-2067 taught this lesson one column
+    # over — when you guard one verb, ask which OTHERS write the field. A
+    # verifier re-verifying their own already-done row (the case DIVE-2067's
+    # refusal deliberately allows) refreshed done_at here, same as the close
+    # verbs did. COALESCE for the same reason and by the same rule: first close wins.
+    db "UPDATE tasks SET status='done', done_at=COALESCE(done_at, datetime('now')), result=$(sqlq "$result_txt") WHERE id=${id};"
     flipped=1
     if (( self_verified_close )); then
       _task_store_audit_log "task.verify-self-close" "self-verified-close" 0 -- \

--- a/tests/task_close_preserves_done_at_unit.sh
+++ b/tests/task_close_preserves_done_at_unit.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# DIVE-2477 — a re-close must not REFRESH done_at.
+#
+# Every close writer passed ", done_at=datetime('now')" unconditionally, so any
+# second close on an already-closed row silently moved the original close
+# timestamp forward. Measured on a fixture: a row closed at T, then a BARE
+# `task done` (no --result, which is the one shape DIVE-2464's result guard
+# correctly stays silent on) => done_at became 'now'.
+#
+# Why it matters beyond tidiness: DIVE-2464's own refusal quotes done_at as the
+# evidence of who closed when ("is ALREADY done (closed <done_at>; assignee
+# ...)"). A bare re-close in between moves that timestamp, so the refusal cites
+# a time that is not the close it is protecting.
+#
+# FOUR writers, four arms — `task done`, `task cancel`, `task verify`'s
+# auto-close, and the REOPEN path. The reopen arm is not decoration: COALESCE is
+# only correct if a row that legitimately reopens has its done_at CLEARED,
+# otherwise `task reject` (the one verb that reopens a closed row — the verifier
+# withdrawing their own grade) leaves a stale done_at behind and the eventual
+# real close would preserve THAT instead of stamping fresh. So the fix cuts both
+# ways and both directions are graded here.
+#
+# Preserved-vs-refreshed is measured by BACKDATING done_at to a sentinel after
+# the first close rather than by sleeping: datetime('now') has 1-second
+# granularity, and a same-second re-stamp is indistinguishable from a preserve.
+# The sentinel makes refresh unmissable.
+# Run: bash tests/task_close_preserves_done_at_unit.sh
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades.
+# NOTE the absence of `2>/dev/null` — the helper's stderr line IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+cd "$(dirname "$0")/.."
+
+SRC=src
+TMP="$(mktemp -d /tmp/task-doneat-preserve-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1; mkdir -p "$TASKS_DIR"
+set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n       %s\n' "$1" "${2:-}"; }
+
+tasks_db_init
+as() { local who="$1"; shift; ( USER="agent-${who}"; SUDO_UID=""; SUDO_USER=""; "$@" ) 2>"$TMP"/err; }
+
+status_of() { db "SELECT status                 FROM tasks WHERE ident=$(sqlq "$1");"; }
+doneat_of() { db "SELECT COALESCE(done_at,'')   FROM tasks WHERE ident=$(sqlq "$1");"; }
+res_of()    { db "SELECT COALESCE(result,'')    FROM tasks WHERE ident=$(sqlq "$1");"; }
+
+SENTINEL='2020-01-01 00:00:00'
+backdate() { db "UPDATE tasks SET done_at=$(sqlq "$SENTINEL") WHERE ident=$(sqlq "$1");"; }
+
+add() { JSON_MODE=1 cmd_task_add "$@" 2>"$TMP"/err | jq -r '.data.ident // empty'; }
+
+# ── instrument: without impersonation the actor-scoped guards make cases vacuous
+actor_is() { ( USER="agent-$1"; SUDO_UID=""; SUDO_USER=""; task_actor ); }
+[[ "$(actor_is dev2)" == "dev2" ]] \
+  && ok_t "INSTRUMENT: harness impersonates an actor (task_actor -> dev2)" \
+  || bad_t "INSTRUMENT: actor impersonation broken" "got '$(actor_is dev2)' — cases are vacuous"
+
+# ── A: the FIRST close still stamps done_at (the still-works control) ─────────
+# Without this, a fix that simply never wrote done_at would pass every arm below.
+A=$(add "A first done stamps done_at" --assignee=dev)
+as dev cmd_task_done "$A" --result="first close" >/dev/null
+a_at=$(doneat_of "$A")
+[[ "$(status_of "$A")" == "done" && -n "$a_at" ]] \
+  && ok_t "A: first 'task done' stamps done_at ($a_at)" \
+  || bad_t "A: first close did not stamp done_at" "status=$(status_of "$A") done_at='$a_at'"
+
+D=$(add "D first cancel stamps done_at" --assignee=dev)
+as dev cmd_task_cancel "$D" --result="abandoned" >/dev/null
+d_at=$(doneat_of "$D")
+[[ "$(status_of "$D")" == "cancelled" && -n "$d_at" ]] \
+  && ok_t "D: first 'task cancel' stamps done_at ($d_at)" \
+  || bad_t "D: first cancel did not stamp done_at" "status=$(status_of "$D") done_at='$d_at'"
+
+# ── B: a BARE repeat `task done` PRESERVES the first close timestamp ──────────
+# Bare (no --result) on purpose: that is the shape DIVE-2464's result guard does
+# not refuse, so the write actually lands and this arm is not vacuous.
+B=$(add "B bare re-done preserves done_at" --assignee=dev)
+as dev cmd_task_done "$B" >/dev/null
+backdate "$B"
+as dev cmd_task_done "$B" >/dev/null; b_rc=$?
+b_at=$(doneat_of "$B")
+(( b_rc == 0 )) \
+  && ok_t "B/REACHABILITY: the bare re-close lands (rc=0, not refused) — the arm below is not vacuous" \
+  || bad_t "B/REACHABILITY: bare re-close did not land (rc=$b_rc)" "$(head -c 200 "$TMP"/err)"
+[[ "$b_at" == "$SENTINEL" ]] \
+  && ok_t "B: bare repeat 'task done' PRESERVES the original done_at" \
+  || bad_t "B: bare repeat 'task done' REFRESHED done_at" "expected '$SENTINEL', got '$b_at'"
+
+# ── C: `task cancel` after a done PRESERVES the first close timestamp ─────────
+C=$(add "C cancel-after-done preserves done_at" --assignee=dev)
+as dev cmd_task_done "$C" >/dev/null
+backdate "$C"
+as dev cmd_task_cancel "$C" >/dev/null; c_rc=$?
+c_at=$(doneat_of "$C")
+(( c_rc == 0 )) \
+  && ok_t "C/REACHABILITY: cancel-after-done lands (rc=0)" \
+  || bad_t "C/REACHABILITY: cancel-after-done did not land (rc=$c_rc)" "$(head -c 200 "$TMP"/err)"
+[[ "$c_at" == "$SENTINEL" ]] \
+  && ok_t "C: 'task cancel' over a done row PRESERVES the original done_at" \
+  || bad_t "C: 'task cancel' over a done row REFRESHED done_at" "expected '$SENTINEL', got '$c_at'"
+
+# ── E: `task verify`'s auto-close is a THIRD close writer ─────────────────────
+# DIVE-2067 taught this exact lesson one column over: when you guard one verb
+# against a clobber the question is "which other verbs write this column".
+# Reachable as the recorded verifier re-verifying their own already-done row
+# (DIVE-2067's refusal fires only for a DIFFERENT actor).
+E=$(add "E verify re-close preserves done_at" --assignee=main --verifier=main)
+as main cmd_task_done "$E" --result="closed by the verifier" >/dev/null
+backdate "$E"
+as main cmd_task_verify "$E" --cmd=true >/dev/null; e_rc=$?
+e_at=$(doneat_of "$E")
+(( e_rc == 0 )) \
+  && ok_t "E/REACHABILITY: the verifier's re-verify of their own done row lands (rc=0)" \
+  || bad_t "E/REACHABILITY: verify re-close did not land (rc=$e_rc)" "$(head -c 300 "$TMP"/err)"
+[[ "$e_at" == "$SENTINEL" ]] \
+  && ok_t "E: 'task verify' auto-close over a done row PRESERVES done_at" \
+  || bad_t "E: 'task verify' auto-close REFRESHED done_at" "expected '$SENTINEL', got '$e_at'"
+# DIVE-2067's preserve-by-appending must still hold — this arm must not have
+# bought a timestamp by dropping the record it sits next to.
+[[ "$(res_of "$E")" == *"superseded result"* ]] \
+  && ok_t "E: DIVE-2067's preserve-by-appending still holds on that same write" \
+  || bad_t "E: DIVE-2067 result preservation regressed" "result='$(head -c 120 <<<"$(res_of "$E")")'"
+
+# ── F: the REOPEN path must CLEAR done_at, or COALESCE preserves a STALE one ──
+# `task reject` is the one verb that reopens a CLOSED row: the recorded verifier
+# withdrawing their own grade (DIVE-2112 refuses everyone else). Before this
+# change it left done_at set — a row with status='todo' AND a close timestamp,
+# the same self-contradiction DIVE-2113 refuses `task start` for. With COALESCE
+# in place that stale value would then be PRESERVED as the real close time.
+F=$(add "F reject clears done_at" --assignee=dev --verifier=main)
+as dev  cmd_task_done "$F" --result="maker delivery" >/dev/null   # routes to verifier
+as main cmd_task_done "$F" --result="verifier ACK" >/dev/null     # real close
+backdate "$F"
+as main cmd_task_reject "$F" --feedback="withdrawing my own grade" >/dev/null; f_rc=$?
+f_reopened=$(status_of "$F"); f_at=$(doneat_of "$F")
+(( f_rc == 0 )) && [[ "$f_reopened" == "todo" ]] \
+  && ok_t "F/REACHABILITY: the verifier's reject reopens their own closed row (rc=0, status=todo)" \
+  || bad_t "F/REACHABILITY: reject did not reopen the closed row (rc=$f_rc status=$f_reopened)" "$(head -c 300 "$TMP"/err)"
+[[ -z "$f_at" ]] \
+  && ok_t "F1: the reopen CLEARS done_at (no open row carrying a close timestamp)" \
+  || bad_t "F1: reopened row still carries a done_at" "got '$f_at' on status=$f_reopened"
+# ...and the eventual real close stamps FRESH, not the stale pre-reject value.
+# TWO closes, not one: after the bounce the row is assigned to the MAKER again, so
+# the maker's `task done` re-DELIVERS (routes to the verifier) and only the
+# verifier's own close writes done_at. A single `as main cmd_task_done` here would
+# route rather than close — and would then pass on the unfixed tree too, i.e. be
+# vacuous. Asserted rather than assumed below.
+as dev  cmd_task_done "$F" --result="maker delivery, second pass" >/dev/null
+as main cmd_task_done "$F" --result="verifier ACK, second pass" >/dev/null
+f2_at=$(doneat_of "$F")
+[[ "$(status_of "$F")" == "done" ]] \
+  && ok_t "F2/REACHABILITY: the second pass really CLOSES the row (status=done, not re-routed)" \
+  || bad_t "F2/REACHABILITY: second pass did not close" "status=$(status_of "$F") — the arm below is vacuous"
+[[ -n "$f2_at" && "$f2_at" != "$SENTINEL" ]] \
+  && ok_t "F2: the close AFTER a reopen stamps a FRESH done_at ($f2_at), not the stale one" \
+  || bad_t "F2: close after reopen did not stamp fresh" "expected != '$SENTINEL', got '$f2_at'"
+
+# ── G: reject's OTHER exit — max_iterations — is a CONTROL, not a fix ──────────
+# Same verb, different branch: it does not bounce, it files a gate. Symmetry says
+# "clear done_at here too"; measurement says otherwise, and this arm is why the
+# source does not. On a row that was CLOSED, `task need` REFUSES (rc=5, "is done —
+# reopen it before gating on a human"), so the status stays 'done' — clearing
+# done_at would leave a done row with no close clock, a new contradiction rather
+# than a fix. So the invariant graded here is PRESERVED, same as B/C/E.
+#
+# It also records a SEPARATE pre-existing defect this ticket does not fix: that
+# refusal means a reject at max_iterations over a closed row cannot escalate at
+# all — it writes the feedback text and then fails rc!=0. Filed on its own row.
+# max_iterations is set by SQL because the point is the branch, not the flag that
+# reaches it.
+G=$(add "G reject at max_iterations clears done_at" --assignee=dev --verifier=main)
+as dev  cmd_task_done "$G" --result="maker delivery" >/dev/null
+as main cmd_task_done "$G" --result="verifier ACK" >/dev/null
+backdate "$G"
+db "UPDATE tasks SET max_iterations=1, iteration=1 WHERE ident=$(sqlq "$G");"
+as main cmd_task_reject "$G" --feedback="stuck, escalating" >/dev/null; g_rc=$?
+g_st=$(status_of "$G"); g_at=$(doneat_of "$G")
+# Reachability is the FEEDBACK WRITE, not rc: this branch is known to fail rc=5 on
+# a closed row (that is the separate defect above). Keying reachability on rc would
+# make the arm unrunnable; keying it on the write this branch uniquely performs
+# does not.
+[[ "$(res_of "$G")" == *"stuck, escalating"* ]] \
+  && ok_t "G/REACHABILITY: the max_iterations branch ran (its feedback write landed; rc=$g_rc status=$g_st)" \
+  || bad_t "G/REACHABILITY: max_iterations branch not reached (rc=$g_rc status=$g_st)" "$(head -c 300 "$TMP"/err)"
+[[ "$g_at" == "$SENTINEL" && "$g_st" == "done" ]] \
+  && ok_t "G: reject-at-max_iterations PRESERVES done_at — it does not reopen, so the close clock stands" \
+  || bad_t "G: reject-at-max_iterations moved or cleared done_at" "got '$g_at' (want '$SENTINEL') on status=$g_st"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+(( FAIL == 0 ))


### PR DESCRIPTION
## What

Every close writer passed `done_at=datetime('now')` **unconditionally**, so a second close on an already-closed row silently moved the original close timestamp. Measured on a fixture: a row closed at T, then a **bare** `task done` (no `--result` — the one shape DIVE-2464's result guard correctly stays silent on) had `done_at` rewritten to `'now'`.

Why it matters beyond tidiness: DIVE-2464's own refusal quotes `done_at` as the evidence of who closed when (`is ALREADY done (closed <done_at>; assignee ...)`). A bare re-close in between moved that timestamp, so the refusal cited a time that was **not the close it was protecting**.

## Three close writers, not two

The ticket named `task done` and `task cancel`. `task verify`'s auto-close is a third, reachable as the verifier re-verifying their own already-done row — the case DIVE-2067's refusal deliberately allows. Guarding one verb and then asking *which others write this field* is the DIVE-2067 lesson one column over.

## The fourth part, which is what makes COALESCE correct

`task reject` is the only verb that **reopens** a closed row (DIVE-2112 permits it for the recorded verifier withdrawing their own grade, refuses everyone else) and it left `done_at` set — `status='todo'` on a row carrying a close timestamp, the same self-contradiction DIVE-2113 refuses `task start` for. Latent before; **load-bearing now**, because COALESCE would otherwise preserve that stale value as the real close time. It now clears it.

## Deliberately NOT changed, and measured rather than assumed

The `max_iterations` branch of the same verb. Symmetry says clear `done_at` there too — measurement says no: it does not reopen the row, it files a gate, and `task need` **refuses on a closed row** (rc=5, "is done — reopen it before gating on a human"), so status stays `done`. Clearing would leave a `done` row with **no close clock**: a new contradiction, not a fix. Graded as a documented control (arm G) rather than left unmentioned.

That refusal also means **a reject at max_iterations over a closed row cannot escalate at all** — it writes the feedback text, then fails. Separate pre-existing defect, filed on its own row, not ridden along here.

The remaining `done_at` writers (loop advance, manual-gate close, gate-step close) already carry a `status NOT IN ('done','cancelled')` predicate and cannot reach a closed row — enumerated, not assumed.

## Evidence

`tests/task_close_preserves_done_at_unit.sh` — **16 arms, 16 pass**. Reproduced 5 failures on `origin/main` before the fix.

- First close still stamps, for `done` **and** `cancel` (without this, a fix that never wrote `done_at` would pass everything else)
- Bare re-done / cancel-after-done / verify-re-close all **preserve**
- The reopen **clears**, and the next real close stamps **fresh**
- A reachability control on every arm — a refusal and a defended row are the same observation at the row level and opposite facts
- DIVE-2067's result-append re-asserted on the write it shares with arm E, so the timestamp was not bought by dropping the record next to it

Preserve-vs-refresh is measured by **backdating `done_at` to a sentinel**, not by sleeping: `datetime('now')` is 1-second granular, so a same-second re-stamp is indistinguishable from a preserve.

**Mutation-checked per part** (4 parts -> 4 mutations, so "both needed" can be told from "one subsumes the other"):

| mutation | arms that fail |
|---|---|
| `done` verb -> unconditional | B only |
| `cancel` verb -> unconditional | C only |
| `verify` close -> unconditional | E only |
| `reject` keeps stale `done_at` | F1 + F2 only |

No part is subsumed by another.

Maker: olivia. Verifier: main (same rail as DIVE-2464 / #357).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
