### PR TITLE
test(merge-gate): the token-resolver arm must construct its caller, not inherit it (DIVE-2484)

### DIFF
--- a/tests/task_merge_gate_result_pr_unit.sh
+++ b/tests/task_merge_gate_result_pr_unit.sh
@@ -85,6 +85,27 @@ exit 1
 SUDOSTUB
 chmod +x "$TMP/bin/sudo"
 : >"$TMP/sudo.calls"
+
+# --- stub id: DIVE-2484. The token resolver's last branch is guarded on
+# `id -un != claude` (it must not borrow a credential from the account it is
+# already running as). This harness stubbed `gh` and `sudo` but NOT `id`, so that
+# arm inherited the HOST's identity and graded the running user rather than the
+# code: red as `claude`, green as anyone else. Since this repo's own convention is
+# to run local tests via `sudo -u claude`, the conventional local run was the red
+# one, while CI — where no `claude` account exists — was permanently green. Same
+# tree, two verdicts, and neither was about the tree. Opt-in override so a test
+# CONSTRUCTS the identity its scenario needs; everything else passes through to
+# the real binary, which keeps the other arms reading the true host.
+REAL_ID=$(command -v id)
+cat >"$TMP/bin/id" <<IDSTUB
+#!/usr/bin/env bash
+if [[ -n "\${ID_STUB_UN:-}" && "\$*" == "-un" ]]; then
+  printf '%s\n' "\$ID_STUB_UN"; exit 0
+fi
+exec $REAL_ID "\$@"
+IDSTUB
+chmod +x "$TMP/bin/id"
+
 export PATH="$TMP/bin:$PATH"
 export GH_ARGS_LOG="$TMP/gh.args"; : >"$GH_ARGS_LOG"
 
@@ -260,13 +281,48 @@ fi
 # --- 8. the token resolver reaches `claude` for a NON-root caller -------------
 # The whole gate was inert for the agent fleet because this fallback was gated on
 # `id -un == root`; every agent-* closes tasks as itself, unauthed.
+#
+# DIVE-2484: the two arms below are a DIFFERENTIAL PAIR. They hold every variable
+# equal and change only the caller's identity, because the identity is the whole
+# subject: the fallback must fire for an agent-* caller and must NOT fire for
+# `claude` itself. `ID_STUB_UN` is what makes each one construct its own
+# precondition — before it existed this arm read the host's identity and its
+# verdict tracked whoever ran it.
 : >"$TMP/sudo.calls"
-got=$(GH_TOKEN="" GITHUB_TOKEN="" SUDO_USER="" GH_STUB_AUTH_TOKEN="" \
+got=$(ID_STUB_UN="agent-fixture" GH_TOKEN="" GITHUB_TOKEN="" SUDO_USER="" GH_STUB_AUTH_TOKEN="" \
       SUDO_STUB_TOKEN="claude-token" _gate_gh_token)
 if [[ "$got" == "claude-token" ]] && grep -q -- "-u claude gh auth token" "$TMP/sudo.calls"; then
-  ok_t "non-root caller resolves the gh token via claude (gate is live for agents)"
+  ok_t "a non-root NON-claude caller resolves the gh token via claude (gate is live for agents)"
 else
   bad_t "non-root token resolution via claude" "got=[$got] sudo=$(cat "$TMP/sudo.calls")"
+fi
+
+# The negative half, and the case this suite never covered at all: when the caller
+# IS `claude`, the fallback must not borrow from the account it is already running
+# as. Empty resolution is the CORRECT answer here — `claude`'s own credential is
+# the arm above this one's business (`gh auth token`, line ~1257), not this branch.
+# Liveness for the negative: the arm directly above differs from this one ONLY in
+# ID_STUB_UN and DOES record a sudo call, so a silent sudo.calls here is a real
+# absence and not a dead stub.
+: >"$TMP/sudo.calls"
+got=$(ID_STUB_UN="claude" GH_TOKEN="" GITHUB_TOKEN="" SUDO_USER="" GH_STUB_AUTH_TOKEN="" \
+      SUDO_STUB_TOKEN="claude-token" _gate_gh_token)
+if [[ -z "$got" ]] && ! grep -q -- "-u claude gh auth token" "$TMP/sudo.calls"; then
+  ok_t "a caller who IS claude never borrows a token from itself"
+else
+  bad_t "claude caller must not self-borrow" "got=[$got] sudo=$(cat "$TMP/sudo.calls")"
+fi
+
+# ...and that refusal to self-borrow costs `claude` nothing, because its OWN login
+# resolves one branch earlier. This is the arm that proves the empty result above
+# is a scoped no-op rather than a broken resolver for the claude account.
+: >"$TMP/sudo.calls"
+got=$(ID_STUB_UN="claude" GH_TOKEN="" GITHUB_TOKEN="" SUDO_USER="" GH_STUB_AUTH_TOKEN="own-login-tok" \
+      SUDO_STUB_TOKEN="claude-token" _gate_gh_token)
+if [[ "$got" == "own-login-tok" ]] && ! grep -q -- "-u claude gh auth token" "$TMP/sudo.calls"; then
+  ok_t "claude resolves via its OWN gh login, not the borrow branch"
+else
+  bad_t "claude own-login resolution" "got=[$got] sudo=$(cat "$TMP/sudo.calls")"
 fi
 # an explicit env token still wins, and a real SUDO_USER is still tried first.
 got=$(GH_TOKEN="env-tok" SUDO_STUB_TOKEN="claude-token" _gate_gh_token)


### PR DESCRIPTION
`tests/task_merge_gate_result_pr_unit.sh` graded the **running user**, not the code.

`_gate_gh_token`'s last branch is guarded on `id -un != claude` — it must not borrow a credential from the account it is already running as — and this harness stubbed `gh` and `sudo` but **not** `id`. So the arm named *"non-root token resolution via claude"* inherited the host's identity:

| caller | verdict at 97c8a69 **and** at current main |
|---|---|
| `claude` | 28 passed, **1 failed** |
| `agent-dev` | 29 passed, 0 failed |
| `root` | 29 passed, 0 failed |

Same tree, two verdicts, neither about the tree. The test file is byte-identical between the sha DIVE-2484 cites and current main — nothing fixed it and nothing broke it.

**Why the red was never visible as a check-run.** This repo's convention is to run local tests via `sudo -u claude`, so the conventional local run was the red one. CI has no `claude` account, so `test` was permanently green. That resolves the contradiction olivia flagged on the row: the arm was genuinely red locally *and* the check-run surface at that sha was genuinely all green. It also settles her open question — this harness **is** CI-wired (`unit-tests.yml` globs `tests/*.sh`), so "local-only" was not the explanation.

## What changed

An opt-in `id` stub (`ID_STUB_UN`, passthrough to the real binary otherwise so the other arms still read the true host), and the arm now **constructs** the identity its name claims. The two identity arms are a differential pair holding everything else equal.

It also closes the hole the false red was hiding: nothing asserted the `claude`-caller case at all. Two new arms — `claude` must not self-borrow, and its own `gh` login still resolves one branch earlier, so that refusal costs it nothing.

## Grading

31/0 as `claude`, as `agent-dev` and as `root`. Mutations, each against the committed work:

| mutation | expected | result |
|---|---|---|
| delete the `!= claude` guard | self-borrow arm red | ✅ red |
| invert guard to `== claude` | both identity arms red | ✅ both red |
| neuter the `id` stub, run as `claude` | reproduces the original DIVE-2484 symptom | ✅ red, same arm |
| neuter the `id` stub, run as `agent-dev` | mirror image | ✅ self-borrow arm red |

The last two are the load-bearing pair: without the `id` stub this suite **cannot** be green for any single user, so the new negative arm would itself have been an unfixable false failure had it been added without the stub.

## What this does not claim

The resolver's behaviour was correct throughout — this is a harness fix, not a code fix. So DIVE-2466's failing acceptance criterion still has an unfound cause; this arm was never the publish-path blocker the row's consequence clause described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Why a PATH-shimmed `id` is not the DIVE-2281 defect here

Fair challenge, since `community/wiki/a-harness-that-simulates-the-attack-certifies-the-vulnerability.md` (DIVE-2281, caught on review) records the opposite verdict on this exact mechanism: a harness stubbing `id` through a PATH shim was *certifying* the vulnerability, because the code derived a **trust decision** from `id -un` and a PATH shim is how you forge one.

That rule stands, and this is a consequence of it rather than an exception. DIVE-2330 already moved **every authorization check in `cmd_task.sh` off `id -un`** for exactly that forgeability reason — `:581` retracts the comment that had claimed `id -un` unspoofable, `:8386` records the migration — onto `$EUID` via the `_gate_caller_uid` seam. `$EUID` is a bash builtin reflecting the kernel's view of the process; **a PATH shim cannot reach it.**

What survives at `:1266` is advisory: it decides only whether to *attempt* a borrow, and the real authority is `sudo -n` (kernel + sudoers). Forging the name grants nothing — it makes the process ask a question it will be refused.

Two properties keep that concrete rather than asserted:

- **The stub is opt-in.** `ID_STUB_UN` unset ⇒ `exec` the real binary. The other 28 arms — several of which read `id -un` for caller labels — still see the true host. Blanket replacement is what made the DIVE-2281 case unrecoverable.
- **The mutations drive the guard in `src/`, not the fixture.** The arms go red when the behaviour changes, not when the stub does.

Short form: stub an identity source only when authorization does not read it. If the downstream decision is *"may I"*, attack it; if it is *"is it worth asking"*, construct it.
