### PR TITLE
feat(broker): generalize the capability broker and fold in delegated deploy (INST-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased — feat(broker): generalize the capability broker and fold in delegated deploy (INST-5)
+
+`5dive push` was our only brokered capability: a dangerous action an agent can take without ever
+holding a credential, gated on a cleared human/lead decision and executed atomically as root.
+INST-5 asked to extend that template to the next surfaces — email, deploy, DNS, payments, secrets,
+data-export. This lands the primitive and the first new surface.
+
+The counterintuitive part is which half of delegated push generalizes. Its headline security
+property is a repo-SCOPED, SHORT-LIVED token minted per use, and that half does NOT port: it
+exists only because GitHub Apps expose a mint-on-demand API we can drive from the control plane.
+Measured against our own Vercel credential, `POST /v3/user/tokens` returns HTTP 403 — there is no
+equivalent to drive. Defining the broker as "it mints scoped short-lived credentials" would put
+five of six surfaces out of scope by definition. The portable contract is the part that reads as
+plumbing: a policy predicate plus a target binding, feeding a root-only single-action executor
+that takes its parameters on stdin, feeding an audit record and a capability row.
+
+`src/lib/broker.sh` holds that, surface-agnostic, plus the one surface table the sudoers policy,
+the capability registry and every refusal string now derive from. `_push_gate_check` and
+`_push_bind_branch` become one-line bindings of it, and the move is proven inert rather than
+asserted to be: `tests/broker_surface_unit.sh` runs both the new and the pre-refactor
+implementations over the same 13 fixture states and compares refusal text and exit status byte for
+byte.
+
+`5dive deploy <task>` is the first new executor. It deploys only the `Deploy: <project>@<ref>` the
+task itself declares, only after that task's gate clears, with `VERCEL_TOKEN` read root-only and
+never handed to the agent. It also gets a bound push does not have: the git repo is not a
+parameter — it is read from the Vercel project's own link, so a granted agent cannot point one of
+our projects at a repo it chose. The capability is a separate axis from `--can-push`
+(`agent create --can-deploy`), because shipping a branch for review and shipping to production are
+different authorities.
+
 ## Unreleased — fix(task): refuse a close that would REPLACE an already-closed row's result (DIVE-2464)
 
 `5dive task done <id> --result=...` on a row that was already done overwrote the result column and

--- a/build.sh
+++ b/build.sh
@@ -32,6 +32,7 @@ cat \
   src/lib/state.sh \
   src/lib/env_overrides.sh \
   src/lib/capability.sh \
+  src/lib/broker.sh \
   src/lib/disk.sh \
   src/lib/audit.sh \
   src/lib/registry.sh \
@@ -73,6 +74,7 @@ cat \
   src/cmd_proof.sh \
   src/cmd_selfcheck.sh \
   src/cmd_push.sh \
+  src/cmd_deploy.sh \
   src/cmd_gh.sh \
   src/cmd_memory.sh \
   src/cmd_pack.sh \

--- a/src/cmd_agent_create.sh
+++ b/src/cmd_agent_create.sh
@@ -3,6 +3,7 @@ create_agent_user() {
   # tier (cmd_create resolves standard-by-default + bootstrap-admin). The
   # fallback here is 'standard', never 'admin', so no path silently grants root.
   local name="$1" isolation="${2:-standard}" can_push="${3:-0}"
+  local can_deploy="${4:-0}"     # INST-5: the broker's delegated-deploy surface
   local user="agent-${name}"
   if ! id -u "$user" &>/dev/null; then
     adduser --disabled-password --gecos "" "$user" >/dev/null
@@ -33,7 +34,7 @@ create_agent_user() {
   if [[ "$isolation" == "admin" ]]; then
     write_admin_sudoers "$user"
   elif [[ "$isolation" == "standard" ]]; then
-    write_standard_sudoers "$user" "$can_push"
+    write_standard_sudoers "$user" "$can_push" "$can_deploy"
   else
     rm -f "/etc/sudoers.d/${user}"
   fi
@@ -513,6 +514,8 @@ agent_sudo_grant() {
 # visudo-validates + installs it.
 render_standard_sudoers() {
   local user="$1" can_push="${2:-0}"
+  # INST-5: delegated deploy, the broker's second surface, on its own axis.
+  local can_deploy="${3:-0}"
   cat <<SUDOERS
 # Managed by 5dive (DIVE-1065/1074). Scoped inter-agent a2a grants for standard agent ${user}.
 # Do not edit by hand; regenerated on agent create/provision.
@@ -544,12 +547,30 @@ ${user} ALL=(root) NOPASSWD: /usr/local/bin/5dive _push_do
 ${user} ALL=(root) NOPASSWD: /usr/local/bin/5dive _gh_do
 SUDOERS
   fi
+  if [[ "$can_deploy" == "1" ]]; then
+    cat <<SUDOERS
+# INST-5: delegated-deploy capability, the capability broker's SECOND surface.
+# Same template as the push grant: exact command path, params over stdin (no arg
+# wildcard, so it holds identically under classic sudo and sudo-rs), gate
+# re-verified authoritatively inside _deploy_do under signature, and the target
+# bound to the Deploy line the task itself declares.
+# Deliberately a SEPARATE axis from can_push: shipping a branch for review and
+# shipping to PRODUCTION are different authorities, and the capability registry
+# records them under different names.
+# NOTE FOR THE NEXT EDITOR: this heredoc is UNQUOTED (it interpolates the user),
+# so a backtick or a dollar sign in a COMMENT is executed and its output lands
+# in the sudoers file. Keep this block free of both.
+${user} ALL=(root) NOPASSWD: /usr/local/bin/5dive _deploy_do
+SUDOERS
+  fi
 }
 
 write_standard_sudoers() {
-  local user="$1" can_push="${2:-0}" f="/etc/sudoers.d/${user}" tmp
+  local user="$1" can_push="${2:-0}"
+  local can_deploy="${3:-0}"
+  local f="/etc/sudoers.d/${user}" tmp
   tmp=$(mktemp)
-  render_standard_sudoers "$user" "$can_push" > "$tmp"
+  render_standard_sudoers "$user" "$can_push" "$can_deploy" > "$tmp"
   chmod 440 "$tmp"
   if visudo -cf "$tmp" >/dev/null 2>&1; then
     chown root:root "$tmp"
@@ -562,7 +583,7 @@ write_standard_sudoers() {
     # copies minted at different moments IS the drift shape. This is the record
     # OF the authoritative write, taken at the instant it succeeds.
     # Best-effort: it never fails the install (see capability_declare_standard).
-    capability_declare_standard "$user" "$can_push" provisioned
+    capability_declare_standard "$user" "$can_push" provisioned "$can_deploy"
   else
     rm -f "$tmp"
     fail "$E_GENERIC" "generated sudoers for ${user} failed visudo validation; aborting (no partial install)"
@@ -724,6 +745,11 @@ write_agent_env() {
   if [[ -z "$can_push" && -r "$env_file" ]]; then
     can_push=$(sed -n 's/^AGENT_CAN_PUSH=//p' "$env_file" | head -1)
   fi
+  # INST-5: same PRESERVE-unless-overridden discipline for delegated deploy.
+  local can_deploy="${_CAN_DEPLOY_OVERRIDE:-}"
+  if [[ -z "$can_deploy" && -r "$env_file" ]]; then
+    can_deploy=$(sed -n 's/^AGENT_CAN_DEPLOY=//p' "$env_file" | head -1)
+  fi
   {
     printf 'AGENT_NAME=%s\n' "$name"
     printf 'AGENT_TYPE=%s\n' "$type"
@@ -733,6 +759,7 @@ write_agent_env() {
     printf 'AGENT_ISOLATION=%s\n' "$isolation"
     [[ -n "$autonomy" && "$autonomy" != "standard" ]] && printf 'AGENT_AUTONOMY=%s\n' "$autonomy"
     [[ "$can_push" == "1" ]] && printf 'AGENT_CAN_PUSH=1\n'
+    [[ "$can_deploy" == "1" ]] && printf 'AGENT_CAN_DEPLOY=1\n'
     # New telegram agents flow through our 5dive-plugins fork (bundled
     # hooks, richer slash commands). 5dive-agent-start reads this var to
     # build the runtime --channels arg, defaulting to claude-plugins-official
@@ -1164,6 +1191,7 @@ cmd_create() {
   local isolation="" isolation_explicit=0 no_team_bot=0
   local autonomy="standard"   # DIVE-499
   local can_push=0            # DIVE-1462/STEER-4: delegated-push (builder) capability
+  local can_deploy=0          # INST-5: delegated-deploy (production ship) capability
   local inherit_memory=""     # DIVE-990 memory-as-onboarding
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -1189,12 +1217,13 @@ cmd_create() {
       --isolation=*)               isolation="${1#--isolation=}"; isolation_explicit=1 ;;
       --inherit-memory=*)          inherit_memory="${1#--inherit-memory=}" ;;
       --can-push)                  can_push=1 ;;
+      --can-deploy)                can_deploy=1 ;;
       -*)                          fail "$E_USAGE" "unknown flag: $1" ;;
       *)                           [[ -z "$name" ]] && name="$1" || fail "$E_USAGE" "extra arg: $1" ;;
     esac
     shift
   done
-  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent create <name> --type=<type> [--channels=none|telegram|discord|dashboard[,ch...]] [--telegram-token=<token|->] [--telegram-cos=<child-username>] [--telegram-cos-avatar=<png>] [--telegram-home-channel=<id>] [--telegram-allowed-users=<csv>] [--discord-token=<token|->] [--workdir=<path>] [--auth-profile=<name>] [--provider=<id> --api-key=<key|->] [--model=<slug>] [--with-skills=<spec>[,...]] [--no-skills] [--no-team-bot] [--defer-auth] [--isolation=admin|standard|sandboxed] [--can-push] [--inherit-memory=wiki|all|team|<agent>[,...]]"
+  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent create <name> --type=<type> [--channels=none|telegram|discord|dashboard[,ch...]] [--telegram-token=<token|->] [--telegram-cos=<child-username>] [--telegram-cos-avatar=<png>] [--telegram-home-channel=<id>] [--telegram-allowed-users=<csv>] [--discord-token=<token|->] [--workdir=<path>] [--auth-profile=<name>] [--provider=<id> --api-key=<key|->] [--model=<slug>] [--with-skills=<spec>[,...]] [--no-skills] [--no-team-bot] [--defer-auth] [--isolation=admin|standard|sandboxed] [--can-push] [--can-deploy] [--inherit-memory=wiki|all|team|<agent>[,...]]"
   [[ -n "$type" ]] || fail "$E_USAGE" "--type is required"
   valid_name "$name" || fail "$E_VALIDATION" "invalid name (lowercase letters/digits/hyphens, start letter, <=16 chars)"
   is_known_type "$type" || fail "$E_NOT_FOUND" "unknown type: $type (known: ${!TYPE_BIN[*]})"
@@ -1252,6 +1281,13 @@ cmd_create() {
     case "$isolation" in
       sandboxed) fail "$E_VALIDATION" "--can-push is incompatible with --isolation=sandboxed (a sandboxed agent gets no sudoers, so it cannot be granted delegated push)." ;;
       admin)     can_push=0; warn "--can-push is redundant for an admin agent (admin sudo already permits '5dive _push_do'); ignoring." ;;
+    esac
+  fi
+  # INST-5: --can-deploy, identical posture to --can-push above.
+  if (( can_deploy )); then
+    case "$isolation" in
+      sandboxed) fail "$E_VALIDATION" "--can-deploy is incompatible with --isolation=sandboxed (a sandboxed agent gets no sudoers, so it cannot be granted delegated deploy)." ;;
+      admin)     can_deploy=0; warn "--can-deploy is redundant for an admin agent (admin sudo already permits '5dive _deploy_do'); ignoring." ;;
     esac
   fi
   # DIVE-990: validate every inherit-memory scope token (wiki|all|team|<agent-name>).
@@ -1603,7 +1639,7 @@ cmd_create() {
   fi
 
   step "Creating user agent-${name}"
-  create_agent_user "$name" "$isolation" "$can_push"
+  create_agent_user "$name" "$isolation" "$can_push" "$can_deploy"
 
   if [[ "$isolation" == "sandboxed" ]]; then
     step "Applying sandbox resource limits for agent-${name}"
@@ -1766,7 +1802,7 @@ cmd_create() {
   step "Writing agent env"
   # DIVE-499: stamp the autonomy mode into the env file (yolo/son-of-anton add the
   # approved directive at launch; standard = nothing).
-  _AUTONOMY_OVERRIDE="$autonomy" _CAN_PUSH_OVERRIDE="$can_push" \
+  _AUTONOMY_OVERRIDE="$autonomy" _CAN_PUSH_OVERRIDE="$can_push" _CAN_DEPLOY_OVERRIDE="$can_deploy" \
     write_agent_env "$name" "$type" "$channels" "$workdir" "$profile" "$isolation"
   link_agent_profile "$name" "$profile"
 

--- a/src/cmd_deploy.sh
+++ b/src/cmd_deploy.sh
@@ -1,0 +1,221 @@
+# cmd_deploy — INST-5: the SECOND brokered capability. Delegated production
+# deploy, behind the same gate → bind → root-only-executor template as
+# `5dive push`, built on lib/broker.sh.
+#
+# WHY DEPLOY IS FIRST OF THE FIVE REMAINING SURFACES, and it is not a
+# preference. INST-5 names six surfaces (email, deploy, DNS, payments, secrets,
+# data-export). Reading the control plane on 2026-07-29 and again 2026-08-01,
+# /etc/5dive/connectors/ holds vercel.env, npm.env and expo.env and NOTHING
+# matching mail/smtp/resend/sendgrid/dns/cloudflare/namecheap/route53/stripe/
+# paypal/export. Deploy is therefore the ONLY surface whose first commit is not
+# blocked on a human dropping a credential. (Payments is additionally blocked on
+# a spend decision.)
+#
+# WHAT DOES NOT PORT FROM PUSH, MEASURED RATHER THAN ASSUMED. Delegated push's
+# headline property is a repo-scoped, short-lived installation token minted per
+# use (set A: A1 scoped mint, A2 short-lived). It has no analogue here:
+#
+#   probe, 2026-08-01, with the on-box VERCEL_TOKEN:
+#     POST https://api.vercel.com/v3/user/tokens  ->  HTTP 403
+#     {"error":{"code":"forbidden","message":"To create a token you must be
+#      authenticated to scope \"lodar\""}}
+#
+# So there is no mint-on-demand API we can drive from the control plane, and the
+# wiki row's "none we drive" is now a measurement instead of a claim about our
+# own code. The blast-radius bound must come entirely from set B — the executor,
+# not the credential — which is exactly the inversion lib/broker.sh documents.
+#
+# Concretely, the bound here is:
+#   B1  VERCEL_TOKEN read root-only from /etc/5dive/connectors/vercel.env, never
+#       handed to the agent (broker_connector_read, which also flags a connector
+#       whose mode already leaks it).
+#   B2  gate re-verify + project resolve + deploy happen atomically inside the
+#       one root helper `_deploy_do`; the agent process never holds the token.
+#   B3  params over STDIN, never argv, so the NOPASSWD grant is an EXACT command
+#       path with no trailing `*` — identical under classic sudo and sudo-rs.
+#   B4  broker_gate_check with require-signature=1 inside root.
+#   B5  the target is bound to the `Deploy: <project>@<ref>` line the TASK
+#       declares, read fresh from the DB.
+#   B6  audited via the main.sh dispatch wrapper + a `delegated_deploy`
+#       capability row minted by the same path that installs the sudoers grant.
+#
+# And one bound this surface gets that push does not: THE REPO IS NOT A
+# PARAMETER. The git repo deployed is read from the Vercel project's own link
+# (GET /v9/projects/<project> -> .link), so a granted agent cannot point one of
+# our projects at a repo it chose. The only things it supplies are which
+# already-linked project, and which ref of that project's own repo.
+
+readonly _DEPLOY_ENV_DEFAULT="/etc/5dive/connectors/vercel.env"
+readonly _DEPLOY_API="https://api.vercel.com"
+
+# _deploy_split_target <project@ref> — echo "<project> <ref>". Empty on a value
+# that is not exactly one '@'-separated pair.
+_deploy_split_target() {
+  local v="$1"
+  [[ "$v" == *@* ]] || return 0
+  local proj="${v%@*}" ref="${v##*@}"
+  [[ -n "$proj" && -n "$ref" && "$proj" != *@* ]] || return 0
+  printf '%s %s' "$proj" "$ref"
+}
+
+# _deploy_validate_target <project> <ref> <env> — treat all three as hostile.
+# They reach a URL path and a JSON body, and `ref` additionally names what runs
+# in production, so "looks fine" is not the bar.
+_deploy_validate_target() {
+  local proj="$1" ref="$2" env="$3"
+  [[ "$proj" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$ ]] \
+    || fail "$E_VALIDATION" "unsafe project name '${proj}' (allowed: letters, digits, . _ -; no leading punctuation; max 100)."
+  [[ "$ref" =~ ^[A-Za-z0-9._/][A-Za-z0-9._/-]*$ ]] \
+    || fail "$E_VALIDATION" "unsafe git ref '${ref}' (allowed: letters, digits, . _ / -; no leading '-')."
+  [[ "$ref" == *..* ]] \
+    && fail "$E_VALIDATION" "ref may not contain '..'."
+  case "$env" in
+    production|preview) ;;
+    *) fail "$E_VALIDATION" "--env must be production or preview (got '${env}')." ;;
+  esac
+  return 0
+}
+
+# cmd_deploy <task-id> [--target=<project@ref>] [--env=production|preview] [--dry-run]
+# Agent-context front door: resolve the task, take the target from the task's own
+# `Deploy:` line, run the same guards as a friendly pre-flight (so --dry-run
+# needs no privilege and the errors are readable), then hand the actual gated
+# deploy to the root-only `_deploy_do`. The agent never receives a token.
+cmd_deploy() {
+  tasks_db_init
+  local target="" env="production" dry=0
+  local -a positional=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --target=*) target="${1#*=}" ;;
+      --env=*)    env="${1#*=}" ;;
+      --dry-run)  dry=1 ;;
+      --) shift; positional+=("$@"); break ;;
+      -*) fail "$E_USAGE" "unknown flag: $1" ;;
+      *)  positional+=("$1") ;;
+    esac
+    shift
+  done
+  [[ ${#positional[@]} -gt 0 ]] || fail "$E_USAGE" \
+    "usage: 5dive deploy <id|DIVE-N> [--target=<project@ref>] [--env=production|preview] [--dry-run]"
+
+  resolve_task_id "${positional[0]}"
+  local id="$RESOLVED_TASK_ID" ident="$RESOLVED_TASK_IDENT"
+
+  # Target: --target wins, else the task's own `Deploy: <project>@<ref>` line.
+  # Either way broker_bind_target below re-derives it from the DB and refuses a
+  # flag that disagrees, so the flag is a convenience, never an override.
+  [[ -n "$target" ]] || target=$(broker_task_target deploy "$id")
+  [[ -n "$target" ]] || fail "$E_USAGE" \
+    "no deploy target for ${ident}: add a 'Deploy: <project>@<ref>' line to the task body (deploy refuses to guess)."
+
+  local pair; pair=$(_deploy_split_target "$target")
+  [[ -n "$pair" ]] || fail "$E_VALIDATION" \
+    "deploy target must be exactly '<project>@<ref>' — got '${target}'."
+  local proj="${pair%% *}" ref="${pair##* }"
+  _deploy_validate_target "$proj" "$ref" "$env"
+
+  # --- GATE pre-flight (re-verified authoritatively, signature-bound, in root).
+  broker_gate_check deploy "$id" "$ident"
+  # --- TARGET BINDING pre-flight (re-verified authoritatively in root).
+  broker_bind_target deploy "$id" "$ident" "$target"
+
+  if (( dry )); then
+    ok "dry-run: would deploy ${proj}@${ref} to ${env} (gate cleared, target bound to ${ident})" \
+       "$(jq -n --arg t "$ident" --arg p "$proj" --arg r "$ref" --arg e "$env" \
+             '{task:$t,project:$p,ref:$r,env:$e,dryRun:true,gate:"cleared"}')"
+    return 0
+  fi
+
+  # --- Hand off to the root helper: it re-verifies the gate under signature,
+  # resolves the project's OWN linked repo, reads the token root-only and fires
+  # the one deployment. Parameters go over STDIN (never argv) so the NOPASSWD
+  # grant stays an exact command path.
+  local rc=0
+  printf '%s\n' "$ident" "$proj" "$ref" "$env" \
+    | sudo -n /usr/local/bin/5dive _deploy_do || rc=$?
+  if [[ $rc -ne 0 ]]; then
+    fail "$E_GENERIC" \
+      "delegated deploy failed — the task gate is not cleared, the Vercel credential is not provisioned (${_DEPLOY_ENV_DEFAULT}), the NOPASSWD grant for '_deploy_do' is missing (agent create --can-deploy), or the deploy itself failed (see above). See INST-5."
+  fi
+}
+
+# cmd_deploy_do — ROOT-ONLY, the atomic gated deploy. Reads four lines on STDIN:
+# <ident> <project> <ref> <env>. Re-verifies the gate AUTHORITATIVELY under
+# signature (never trusts the caller), re-binds the target to the task's own
+# declared value, resolves the project's linked repo from Vercel itself, reads
+# the token root-only and fires ONE deployment. Prints only the result — never
+# the token. Invoked over NOPASSWD sudo by cmd_deploy; parameters on stdin keep
+# the grant exact-path (sudo-rs safe). Not advertised; not itself audited (the
+# parent `deploy` verb is).
+cmd_deploy_do() {
+  [[ "$(id -u)" -eq 0 ]] || fail "$E_PERMISSION" "_deploy_do is root-only"
+  local ident proj ref env
+  IFS= read -r ident || true
+  IFS= read -r proj  || true
+  IFS= read -r ref   || true
+  IFS= read -r env   || true
+  [[ -n "$ident" && -n "$proj" && -n "$ref" && -n "$env" ]] \
+    || fail "$E_USAGE" "_deploy_do expects <ident> <project> <ref> <env> on stdin (INST-5)."
+
+  # Input hardening BEFORE any of these strings reaches a URL or a JSON body.
+  _deploy_validate_target "$proj" "$ref" "$env"
+
+  # Authoritative gate re-verify — read FRESH from the DB by task id, never
+  # trusting a verdict passed over stdin. require-signature=1 so a raw DB edit
+  # cannot forge the clearance.
+  tasks_db_init
+  resolve_task_id "$ident"
+  local id="$RESOLVED_TASK_ID"; ident="$RESOLVED_TASK_IDENT"
+  broker_gate_check deploy "$id" "$ident" 1
+
+  # Authoritative target binding — the caller-supplied project@ref must be the
+  # one the cited task itself declares, so a granted agent cannot reuse one
+  # task's cleared gate to ship a different project or a different ref.
+  broker_bind_target deploy "$id" "$ident" "${proj}@${ref}"
+
+  # --- credential (B1): root-only read, never exported to the agent.
+  broker_connector_read "${VERCEL_ENV_FILE:-$_DEPLOY_ENV_DEFAULT}" "the Vercel"
+  local tok="${VERCEL_TOKEN:-}"
+  [[ -n "$tok" ]] || fail "$E_GENERIC" "vercel.env is missing VERCEL_TOKEN"
+  local team="${VERCEL_TEAM_ID:-}" q=""
+  [[ -n "$team" ]] && q="?teamId=${team}"
+
+  # --- resolve the project's OWN linked repo. The repo is deliberately NOT a
+  # parameter: whatever the agent named, the code deployed comes from the repo
+  # this Vercel project is already linked to.
+  local pj
+  pj=$(curl -fsS --max-time 20 -H "Authorization: Bearer ${tok}" \
+        "${_DEPLOY_API}/v9/projects/${proj}${q}") \
+    || fail "$E_GENERIC" "Vercel project '${proj}' not found or the token cannot read it."
+  local link_type link_org link_repo repo_id
+  link_type=$(jq -r '.link.type // empty'   <<<"$pj")
+  link_org=$( jq -r '.link.org  // empty'   <<<"$pj")
+  link_repo=$(jq -r '.link.repo // empty'   <<<"$pj")
+  repo_id=$(  jq -r '.link.repoId // empty' <<<"$pj")
+  [[ "$link_type" == "github" && -n "$link_org" && -n "$link_repo" ]] \
+    || fail "$E_GENERIC" "Vercel project '${proj}' has no linked GitHub repo (link.type='${link_type:-none}') — delegated deploy refuses to supply a repo the project did not already choose."
+
+  # --- the ONE action.
+  local body out rc=0
+  body=$(jq -cn --arg n "$proj" --arg t "$env" --arg o "$link_org" --arg r "$link_repo" \
+                --arg ref "$ref" --arg rid "$repo_id" \
+        '{name:$n, target:$t,
+          gitSource: ({type:"github", org:$o, repo:$r, ref:$ref}
+                      + (if $rid == "" then {} else {repoId:($rid|tonumber? // $rid)} end))}')
+  out=$(curl -fsS --max-time 60 -X POST \
+        -H "Authorization: Bearer ${tok}" \
+        -H "Content-Type: application/json" \
+        -d "$body" "${_DEPLOY_API}/v13/deployments${q}") || rc=$?
+  tok=""   # discard
+  [[ $rc -eq 0 ]] || fail "$E_GENERIC" "Vercel deployment request failed for ${proj}@${ref} (${env})."
+
+  local did durl
+  did=$( jq -r '.id  // empty' <<<"$out")
+  durl=$(jq -r '.url // empty' <<<"$out")
+  [[ -n "$did" ]] || fail "$E_GENERIC" "Vercel accepted the request but returned no deployment id."
+  ok "deployed ${proj}@${ref} → ${env} (${did}${durl:+, https://$durl}) — delegated, gate cleared, repo ${link_org}/${link_repo} from the project's own link" \
+     "$(jq -n --arg t "$ident" --arg p "$proj" --arg r "$ref" --arg e "$env" \
+              --arg d "$did" --arg u "$durl" --arg repo "${link_org}/${link_repo}" \
+           '{task:$t,project:$p,ref:$r,env:$e,deploymentId:$d,url:$u,repo:$repo,deployed:true,scoped:false,boundBy:"executor"}')"
+}

--- a/src/cmd_deploy.sh
+++ b/src/cmd_deploy.sh
@@ -82,6 +82,7 @@ _deploy_validate_target() {
 # needs no privilege and the errors are readable), then hand the actual gated
 # deploy to the root-only `_deploy_do`. The agent never receives a token.
 cmd_deploy() {
+  require_loaded deploy broker_gate_check broker_bind_target broker_task_target broker_connector_read
   tasks_db_init
   local target="" env="production" dry=0
   local -a positional=()
@@ -150,6 +151,7 @@ cmd_deploy() {
 # parent `deploy` verb is).
 cmd_deploy_do() {
   [[ "$(id -u)" -eq 0 ]] || fail "$E_PERMISSION" "_deploy_do is root-only"
+  require_loaded deploy broker_gate_check broker_bind_target broker_task_target broker_connector_read
   local ident proj ref env
   IFS= read -r ident || true
   IFS= read -r proj  || true

--- a/src/cmd_push.sh
+++ b/src/cmd_push.sh
@@ -279,6 +279,7 @@ _push_touches_workflows() { # <repopath> <repourl> <branch>
 }
 
 cmd_push() {
+  require_loaded push broker_gate_check broker_bind_target broker_task_target
   tasks_db_init
   local branch="" repo="" dry=0 yes=0
   local -a positional=()
@@ -465,6 +466,7 @@ _push_record_ship_ledger() {
 }
 
 cmd_push_do() {
+  require_loaded push broker_gate_check broker_bind_target broker_task_target
   [[ "$(id -u)" -eq 0 ]] || fail "$E_PERMISSION" "_push_do is root-only"
   local ident repopath branch repourl
   IFS= read -r ident    || true

--- a/src/cmd_push.sh
+++ b/src/cmd_push.sh
@@ -61,115 +61,32 @@ _push_repo_name() {
   local n="${1##*/}"; printf '%s' "${n%.git}"
 }
 
-# _push_gate_check <id> <ident> [require-signature] — the ONE cleared-gate
-# predicate (DIVE-1376/1460/1496). The task must carry an answered, non-rejected
-# gate cleared by either a proven human OR the gate's designated routed reviewer.
-# A bare agent answer and every auto-clear provenance are deliberately excluded:
-# neither authorizes a git write. The friendly agent-side preflight checks the
-# persisted provenance; root `_push_do` passes require-signature=1 and also
-# verifies the root-HMAC closure, so raw DB edits cannot forge authorization.
+# _push_gate_check <id> <ident> [require-signature] — push's binding of the
+# broker's ONE cleared-gate predicate. INST-5 moved the logic VERBATIM to
+# broker_gate_check (src/lib/broker.sh) so a second surface could not fork it;
+# the `push` surface row supplies exactly the nouns this function used to
+# hardcode, so every refusal string is byte-identical to the pre-INST-5 copy
+# (asserted against origin/main's text in tests/broker_surface_unit.sh).
 _push_gate_check() {
-  local id="$1" ident="$2" require_sig="${3:-0}"
-  local gtype ganswer gansweredat gby guid gsig reviewer authorized=0
-  gtype=$(db "SELECT COALESCE(need_type,'')          FROM tasks WHERE id=${id};")
-  gansweredat=$(db "SELECT COALESCE(need_answered_at,'') FROM tasks WHERE id=${id};")
-  ganswer=$(db "SELECT COALESCE(need_answer,'')       FROM tasks WHERE id=${id};")
-  gby=$(db "SELECT COALESCE(need_answered_by,'')      FROM tasks WHERE id=${id};")
-  guid=$(db "SELECT COALESCE(need_answered_uid,'')    FROM tasks WHERE id=${id};")
-  gsig=$(db "SELECT COALESCE(need_answer_sig,'')      FROM tasks WHERE id=${id};")
-  reviewer=$(db "SELECT COALESCE(routed_reviewer,'')  FROM tasks WHERE id=${id};")
-  if [[ -z "$gtype" ]]; then
-    fail "$E_VALIDATION" "no gate on ${ident}: file a push-for-review gate first (5dive task need ${ident} --type=approval --ask='approve delegated push for review of branch <b>') — a push-for-review ask files as a lead-routed tier-1 gate the org lead can clear (not a human-only tier-2 in the human's DM), and push runs once a human OR that lead clears it."
-  fi
-  if [[ -z "$gansweredat" ]]; then
-    fail "$E_VALIDATION" "gate on ${ident} is OPEN (unanswered ${gtype}) — push refused until it clears (5dive task answer ${ident} ...)."
-  fi
-  if printf '%s' "$ganswer" | grep -qiE '^\s*(no|reject|deny|denied|block)'; then
-    fail "$E_VALIDATION" "gate on ${ident} was REJECTED ('${ganswer}') — push refused."
-  fi
-  [[ "$gby" == human:* ]] && authorized=1
-  # DIVE-1555: accept ANY lead-clear provenance (`lead:*`), not only one whose
-  # routed_reviewer STILL equals the clearer. `lead:X` is stamped ONLY by the
-  # sanctioned lead-clear path in `task answer` (cmd_task.sh), which fires only
-  # when the caller was `agent-X` AND X was the gate's routed_reviewer at clear
-  # time — so the value after `lead:` IS the designated reviewer who cleared it.
-  # DIVE-2099 adds a SECOND minting path under the same `lead:` prefix:
-  # `lead:standing:X` records the org lead clearing an ENGINEERING approval under
-  # their standing authority, with no routing involved (so `reviewer` is legitimately
-  # empty there). It is authorized by the generic `lead:*` arm below on purpose —
-  # push-for-review on our own repos is in-scope item #1 of that grant — and it is
-  # equally signature-bound, since `need_answered_by` is inside the signed closure.
-  # Read `lead:standing:X` as "the org lead X, standing authority"; `lead:X` stays
-  # "the designated reviewer X".
-  # Requiring routed_reviewer to still match at push time was the bug: routing
-  # can be mutated after the clear (a re-route, or the DIVE-1437 T2-escalation
-  # NULLs routed_reviewer), stranding a correctly lead-cleared push with an empty
-  # `reviewer` and a valid `lead:X` provenance. This is not a weakening: `_push_do`
-  # passes require_sig=1, and `need_answered_by` is part of the signed closure
-  # (see _gate_closure_verify below), so a raw DB edit forging `lead:X` fails the
-  # signature check. (The exact-match line is kept as belt-and-braces.)
-  [[ "$gby" == lead:* ]] && authorized=1
-  [[ -n "$reviewer" && "$gby" == "lead:${reviewer}" ]] && authorized=1
-  # DIVE-2004: a `decision` gate cleared by its own designated reviewer could never
-  # authorize a push, because `lead:` is minted ONLY for approval|manual|access —
-  # so the refusal accused the reviewer who had in fact cleared it. The predicate
-  # push actually needs is "was this authorized by the party it was routed to";
-  # the stamp is one way to prove that, not the only one. The claim `gby ==
-  # reviewer` is NOT sufficient on its own (`task answer --from=<reviewer>` writes
-  # it verbatim), so it must be corroborated by the stored `need_answered_uid`,
-  # which DIVE-756 stamps from the real pre-sudo invoker and no flag can set.
-  local uid_agent=""
-  if (( ! authorized )) && [[ "$gtype" == "decision" && -n "$reviewer" && "$gby" == "$reviewer" ]]; then
-    uid_agent=$(_gate_agent_for_uid "$guid")
-    [[ -n "$uid_agent" && "$uid_agent" == "$reviewer" ]] && authorized=1
-  fi
-  if (( ! authorized )); then
-    # Name the stamp REQUIRED and the one FOUND. A refusal that says "unauthorized
-    # provenance" while the designated reviewer is exactly who cleared it sends the
-    # reader off to audit the reviewer instead of the gate type (DIVE-1970/2000).
-    local detail=""
-    if [[ "$gtype" == "decision" && -n "$reviewer" && "$gby" == "$reviewer" ]]; then
-      detail=" — '${gby}' IS this gate's routed reviewer, but the recorded invoker uid ${guid:-<none>} maps to '${uid_agent:-no agent}', so the answer cannot be attributed to them. If that is unexpected, the answer was recorded with a --from that did not match who ran it."
-    elif [[ -n "$reviewer" ]]; then
-      detail=" — required 'human:*', 'lead:${reviewer}', or a decision answered by '${reviewer}' with a matching invoker uid; found '${gby:-unknown}'. A ${gtype:-gate} answered by the lead is only stamped 'lead:' for approval/manual/access."
-    else
-      detail=" — required 'human:*' or 'lead:*'; found '${gby:-unknown}', and this gate has no routed reviewer to attribute a decision answer to."
-    fi
-    fail "$E_VALIDATION" "gate on ${ident} was not cleared by an authority delegated push accepts${detail}"
-  fi
-  if [[ "$require_sig" == "1" ]] \
-      && ! _gate_closure_verify "$id" "$gtype" "$ganswer" "$gby" "$gansweredat" "$guid" "$gsig"; then
-    fail "$E_VALIDATION" "gate on ${ident} has no valid signed closure — delegated push refused (the authoritative gate record may be unsigned or tampered)."
-  fi
+  broker_gate_check push "$@"
 }
 
 # _push_task_branch <id> — the branch a task AUTHORITATIVELY declares via a
 # "Branch: <name>" line in its body. Empty if the task names none. This is the
 # server-side value a cleared gate binds to (DIVE-1462), read fresh from the DB.
+# INST-5: now the broker's generic body-key read; `Branch` is push's surface key.
 _push_task_branch() {
-  local id="$1" body
-  body=$(db "SELECT COALESCE(body,'') FROM tasks WHERE id=${id};")
-  _push_branch_from_body "$body"
+  broker_task_target push "$1"
 }
 
-# _push_bind_branch <id> <ident> <branch> — DIVE-1462 (STEER-4). Bind the cleared
-# gate to a SPECIFIC branch. A cleared gate authorizes shipping exactly the task
-# it sits on, and that task declares its branch (a "Branch: <name>" line in its
-# body). Without this, a granted agent could cite ANY cleared-gate task's ident
-# but push an arbitrary feature branch — the gate would clear while an unrelated
-# branch shipped. So the branch actually being pushed MUST equal the branch the
-# task itself declares; anything else is refused. Called by BOTH the cmd_push
-# pre-flight (friendly) AND the root-only `_push_do` (authoritative), the same
-# belt-and-braces posture as _push_gate_check.
+# _push_bind_branch <id> <ident> <branch> — DIVE-1462 (STEER-4), now push's
+# binding of the broker's generic target binding (INST-5). A cleared gate
+# authorizes shipping exactly the task it sits on, and that task declares its
+# branch, so the branch actually being pushed MUST equal the branch the task
+# itself declares. Same belt-and-braces posture as before: called by BOTH the
+# cmd_push pre-flight (friendly) AND the root-only `_push_do` (authoritative).
 _push_bind_branch() {
-  local id="$1" ident="$2" branch="$3" task_branch
-  task_branch=$(_push_task_branch "$id")
-  if [[ -z "$task_branch" ]]; then
-    fail "$E_VALIDATION" "task ${ident} declares no branch — add a 'Branch: <name>' line to its body so the cleared gate binds to a specific branch (delegated push refuses an unbound branch)."
-  fi
-  if [[ "$branch" != "$task_branch" ]]; then
-    fail "$E_VALIDATION" "branch '${branch}' is not the branch bound to ${ident}'s cleared gate ('${task_branch}') — a cleared gate authorizes only its task's own declared branch. Push refused (DIVE-1462)."
-  fi
+  broker_bind_target push "$1" "$2" "$3"
 }
 
 # _push_repo_from_worktree <repo-path> — DIVE-1970: the GitHub repo THIS WORK TREE

--- a/src/header.sh
+++ b/src/header.sh
@@ -771,3 +771,22 @@ declare -A TYPE_PROBE=(
   # File-presence via the TYPE_AUTH sentinel.
   [devin]=''
 )
+
+# require_loaded <context> <fn>... — INST-5: fail-closed dependency assertion.
+#
+# The broker refactor moved push's security predicates out of cmd_push.sh and
+# into src/lib/broker.sh. That introduced a failure mode the inline code could
+# not have had: if the lib is not loaded, `broker_gate_check ...` is just
+# "command not found" (rc 127), and as a BARE STATEMENT execution simply
+# continues — push then reports "gate cleared" for a task carrying no gate at
+# all. Extracting a predicate turns "cannot fail" into "fails open", so each
+# brokered surface asserts its predicates are really loaded before it acts.
+# Lives in header.sh deliberately: a guard against a missing file cannot itself
+# live in the file that might be missing.
+require_loaded() {
+  local ctx="$1" fn; shift
+  for fn in "$@"; do
+    declare -F "$fn" >/dev/null && continue
+    fail "$E_GENERIC" "${ctx}: required predicate '${fn}' is not loaded (src/lib/broker.sh missing from this build) — refusing rather than proceeding unchecked."
+  done
+}

--- a/src/lib/broker.sh
+++ b/src/lib/broker.sh
@@ -1,0 +1,231 @@
+# lib/broker.sh — INST-5: the capability broker, generalized off delegated push.
+#
+# Delegated push (DIVE-1376/1460/1461/1462/1496) was our first brokered
+# capability. INST-5 asks to fold the remaining dangerous surfaces in behind the
+# same template — email, deploy, DNS, payments, secrets, data-export — one at a
+# time. The design pass that preceded this file measured which half of the push
+# template actually ports, and the answer is counterintuitive enough to belong
+# next to the code rather than only in the wiki
+# ([[which-half-of-the-delegated-push-template-generalizes]]):
+#
+#   The HEADLINE security property of delegated push — a repo-SCOPED,
+#   SHORT-LIVED installation token minted per use — is the half that does NOT
+#   generalize. It exists only because GitHub Apps expose a mint-on-demand API
+#   we can drive from the control plane. No other surface we hold a credential
+#   for does (for deploy this is MEASURED, not assumed — see cmd_deploy.sh).
+#   Defining the broker as "it mints scoped short-lived credentials" would put
+#   five of six surfaces out of scope BY DEFINITION and stall the project.
+#
+# So the portable contract is the part that reads as plumbing:
+#
+#   (policy predicate + target binding)
+#     -> (root-only single-action executor, params on STDIN)
+#       -> (audit + capability row)
+#
+# This file holds the first stage, surface-agnostic. `_push_gate_check` and
+# `_push_bind_branch` were already surface-agnostic in everything but their
+# names and the body key they read; what follows is those two functions with the
+# body key, the target noun and the action noun lifted into a table. Push passes
+# exactly the values it used to hardcode, so its behaviour AND its refusal
+# strings are byte-identical — tests/broker_surface_unit.sh proves that
+# inertness against origin/main's copies before deploy is allowed to rely on it.
+#
+# Adding surface N+1 is then: one row in the table below, one root-only
+# executor, one name in _capability_names_for_standard, one sudoers block. The
+# security model is not rewritten per surface, which was the whole point.
+
+# broker_surfaces — every surface folded into the broker, one per line. The
+# capability registry drift test enumerates THIS, so a surface that gains a
+# sudoers grant without a registry name (or the reverse) fails a test rather
+# than becoming a silently unrecorded authority.
+broker_surfaces() {
+  printf '%s\n' push deploy
+}
+
+# broker_surface <surface> <field> — the per-surface constants the predicates
+# below need. ONE table, so the capability registry, the sudoers policy and the
+# refusal strings cannot each carry a private copy of "what deploy is".
+#
+# fields:
+#   noun    the action, lowercase, as it appears in a refusal    (push / deploy)
+#   Noun    the same word, sentence-initial
+#   cap     the capability-registry name                       (delegated_push)
+#   verb    the root-only executor subcommand                        (_push_do)
+#   key     the task-body key a cleared gate binds to                  (Branch)
+#   target  the bound thing, lowercase, as it appears in a refusal     (branch)
+#   ask     the example --ask the no-gate refusal suggests
+#   ticket  the ticket that introduced the binding, cited in the refusal
+#
+# Unknown surface/field is a HARD failure, not an empty string: a refusal
+# rendered with an empty noun still refuses, so it would ship as "works".
+broker_surface() {
+  local s="$1"
+  local f="$2"
+  case "${s}.${f}" in
+    push.noun)     printf 'push' ;;
+    push.Noun)     printf 'Push' ;;
+    push.cap)      printf 'delegated_push' ;;
+    push.verb)     printf '_push_do' ;;
+    push.key)      printf 'Branch' ;;
+    push.target)   printf 'branch' ;;
+    push.ask)      printf 'approve delegated push for review of branch <b>' ;;
+    push.ticket)   printf 'DIVE-1462' ;;
+    deploy.noun)   printf 'deploy' ;;
+    deploy.Noun)   printf 'Deploy' ;;
+    deploy.cap)    printf 'delegated_deploy' ;;
+    deploy.verb)   printf '_deploy_do' ;;
+    deploy.key)    printf 'Deploy' ;;
+    deploy.target) printf 'deploy target' ;;
+    deploy.ask)    printf 'approve production deploy of <project>@<ref>' ;;
+    deploy.ticket) printf 'INST-5' ;;
+    *) fail "$E_GENERIC" "broker: unknown surface/field '${s}.${f}' (add it to broker_surface in src/lib/broker.sh)" ;;
+  esac
+}
+
+# broker_gate_check <surface> <id> <ident> [require-signature] — the ONE
+# cleared-gate predicate, formerly _push_gate_check (DIVE-1376/1460/1496). The
+# task must carry an answered, non-rejected gate cleared by either a proven
+# human OR the gate's designated routed reviewer. A bare agent answer and every
+# auto-clear provenance are deliberately excluded: neither authorizes a
+# privileged write. The friendly agent-side preflight checks the persisted
+# provenance; the root-only executor passes require-signature=1 and also
+# verifies the root-HMAC closure, so raw DB edits cannot forge authorization.
+broker_gate_check() {
+  local surface="$1" id="$2" ident="$3" require_sig="${4:-0}"
+  local noun; noun=$(broker_surface "$surface" noun)
+  local ask;  ask=$(broker_surface "$surface" ask)
+  local gtype ganswer gansweredat gby guid gsig reviewer authorized=0
+  gtype=$(db "SELECT COALESCE(need_type,'')          FROM tasks WHERE id=${id};")
+  gansweredat=$(db "SELECT COALESCE(need_answered_at,'') FROM tasks WHERE id=${id};")
+  ganswer=$(db "SELECT COALESCE(need_answer,'')       FROM tasks WHERE id=${id};")
+  gby=$(db "SELECT COALESCE(need_answered_by,'')      FROM tasks WHERE id=${id};")
+  guid=$(db "SELECT COALESCE(need_answered_uid,'')    FROM tasks WHERE id=${id};")
+  gsig=$(db "SELECT COALESCE(need_answer_sig,'')      FROM tasks WHERE id=${id};")
+  reviewer=$(db "SELECT COALESCE(routed_reviewer,'')  FROM tasks WHERE id=${id};")
+  if [[ -z "$gtype" ]]; then
+    fail "$E_VALIDATION" "no gate on ${ident}: file a ${noun}-for-review gate first (5dive task need ${ident} --type=approval --ask='${ask}') — a ${noun}-for-review ask files as a lead-routed tier-1 gate the org lead can clear (not a human-only tier-2 in the human's DM), and ${noun} runs once a human OR that lead clears it."
+  fi
+  if [[ -z "$gansweredat" ]]; then
+    fail "$E_VALIDATION" "gate on ${ident} is OPEN (unanswered ${gtype}) — ${noun} refused until it clears (5dive task answer ${ident} ...)."
+  fi
+  if printf '%s' "$ganswer" | grep -qiE '^\s*(no|reject|deny|denied|block)'; then
+    fail "$E_VALIDATION" "gate on ${ident} was REJECTED ('${ganswer}') — ${noun} refused."
+  fi
+  [[ "$gby" == human:* ]] && authorized=1
+  # DIVE-1555: accept ANY lead-clear provenance (`lead:*`), not only one whose
+  # routed_reviewer STILL equals the clearer. `lead:X` is stamped ONLY by the
+  # sanctioned lead-clear path in `task answer` (cmd_task.sh), which fires only
+  # when the caller was `agent-X` AND X was the gate's routed_reviewer at clear
+  # time — so the value after `lead:` IS the designated reviewer who cleared it.
+  # DIVE-2099 adds a SECOND minting path under the same `lead:` prefix:
+  # `lead:standing:X` records the org lead clearing an ENGINEERING approval under
+  # their standing authority, with no routing involved (so `reviewer` is legitimately
+  # empty there). It is authorized by the generic `lead:*` arm below on purpose —
+  # push-for-review on our own repos is in-scope item #1 of that grant — and it is
+  # equally signature-bound, since `need_answered_by` is inside the signed closure.
+  # Read `lead:standing:X` as "the org lead X, standing authority"; `lead:X` stays
+  # "the designated reviewer X".
+  # Requiring routed_reviewer to still match at act time was the bug: routing
+  # can be mutated after the clear (a re-route, or the DIVE-1437 T2-escalation
+  # NULLs routed_reviewer), stranding a correctly lead-cleared action with an empty
+  # `reviewer` and a valid `lead:X` provenance. This is not a weakening: the root
+  # executor passes require_sig=1, and `need_answered_by` is part of the signed
+  # closure (see _gate_closure_verify), so a raw DB edit forging `lead:X` fails the
+  # signature check. (The exact-match line is kept as belt-and-braces.)
+  [[ "$gby" == lead:* ]] && authorized=1
+  [[ -n "$reviewer" && "$gby" == "lead:${reviewer}" ]] && authorized=1
+  # DIVE-2004: a `decision` gate cleared by its own designated reviewer could never
+  # authorize an action, because `lead:` is minted ONLY for approval|manual|access —
+  # so the refusal accused the reviewer who had in fact cleared it. The predicate
+  # we actually need is "was this authorized by the party it was routed to";
+  # the stamp is one way to prove that, not the only one. The claim `gby ==
+  # reviewer` is NOT sufficient on its own (`task answer --from=<reviewer>` writes
+  # it verbatim), so it must be corroborated by the stored `need_answered_uid`,
+  # which DIVE-756 stamps from the real pre-sudo invoker and no flag can set.
+  local uid_agent=""
+  if (( ! authorized )) && [[ "$gtype" == "decision" && -n "$reviewer" && "$gby" == "$reviewer" ]]; then
+    uid_agent=$(_gate_agent_for_uid "$guid")
+    [[ -n "$uid_agent" && "$uid_agent" == "$reviewer" ]] && authorized=1
+  fi
+  if (( ! authorized )); then
+    # Name the stamp REQUIRED and the one FOUND. A refusal that says "unauthorized
+    # provenance" while the designated reviewer is exactly who cleared it sends the
+    # reader off to audit the reviewer instead of the gate type (DIVE-1970/2000).
+    local detail=""
+    if [[ "$gtype" == "decision" && -n "$reviewer" && "$gby" == "$reviewer" ]]; then
+      detail=" — '${gby}' IS this gate's routed reviewer, but the recorded invoker uid ${guid:-<none>} maps to '${uid_agent:-no agent}', so the answer cannot be attributed to them. If that is unexpected, the answer was recorded with a --from that did not match who ran it."
+    elif [[ -n "$reviewer" ]]; then
+      detail=" — required 'human:*', 'lead:${reviewer}', or a decision answered by '${reviewer}' with a matching invoker uid; found '${gby:-unknown}'. A ${gtype:-gate} answered by the lead is only stamped 'lead:' for approval/manual/access."
+    else
+      detail=" — required 'human:*' or 'lead:*'; found '${gby:-unknown}', and this gate has no routed reviewer to attribute a decision answer to."
+    fi
+    fail "$E_VALIDATION" "gate on ${ident} was not cleared by an authority delegated ${noun} accepts${detail}"
+  fi
+  if [[ "$require_sig" == "1" ]] \
+      && ! _gate_closure_verify "$id" "$gtype" "$ganswer" "$gby" "$gansweredat" "$guid" "$gsig"; then
+    fail "$E_VALIDATION" "gate on ${ident} has no valid signed closure — delegated ${noun} refused (the authoritative gate record may be unsigned or tampered)."
+  fi
+}
+
+# broker_task_target <surface> <id> — the target a task AUTHORITATIVELY declares
+# via a "<Key>: <value>" line in its body. Empty if the task names none. This is
+# the server-side value a cleared gate binds to, read fresh from the DB.
+broker_task_target() {
+  local surface="$1" id="$2"
+  local key; key=$(broker_surface "$surface" key)
+  local body; body=$(db "SELECT COALESCE(body,'') FROM tasks WHERE id=${id};")
+  # `|| true` so a no-match grep can't trip `set -euo pipefail` when this runs
+  # inside a command substitution.
+  printf '%s\n' "$body" | grep -ioP "^\s*${key}:\s*\K\S+" | head -1 || true
+}
+
+# broker_bind_target <surface> <id> <ident> <value> — DIVE-1462 (STEER-4),
+# generalized. Bind the cleared gate to a SPECIFIC target. A cleared gate
+# authorizes acting on exactly the task it sits on, and that task declares its
+# target (a "<Key>: <value>" line in its body). Without this, a granted agent
+# could cite ANY cleared-gate task's ident but act on an arbitrary target — the
+# gate would clear while something unrelated shipped. So the target actually
+# being acted on MUST equal the target the task itself declares; anything else
+# is refused. Called by BOTH the friendly pre-flight AND the root-only executor,
+# the same belt-and-braces posture as broker_gate_check.
+broker_bind_target() {
+  local surface="$1" id="$2" ident="$3" value="$4"
+  local noun;   noun=$(broker_surface "$surface" noun)
+  local Noun;   Noun=$(broker_surface "$surface" Noun)
+  local key;    key=$(broker_surface "$surface" key)
+  local target; target=$(broker_surface "$surface" target)
+  local ticket; ticket=$(broker_surface "$surface" ticket)
+  local task_value; task_value=$(broker_task_target "$surface" "$id")
+  if [[ -z "$task_value" ]]; then
+    fail "$E_VALIDATION" "task ${ident} declares no ${target} — add a '${key}: <name>' line to its body so the cleared gate binds to a specific ${target} (delegated ${noun} refuses an unbound ${target})."
+  fi
+  if [[ "$value" != "$task_value" ]]; then
+    fail "$E_VALIDATION" "${target} '${value}' is not the ${target} bound to ${ident}'s cleared gate ('${task_value}') — a cleared gate authorizes only its task's own declared ${target}. ${Noun} refused (${ticket})."
+  fi
+}
+
+# broker_connector_read <path> <what> — B1, the control-plane-only credential.
+# Source a root-600 connector env file as root and NOTHING else. Two properties
+# it enforces that a bare `. "$f"` does not:
+#
+#   1. root-only caller. The whole B1 invariant is that the agent process never
+#      holds the credential; sourcing it under any other euid defeats that.
+#   2. a LOUD warning when the file is group- or world-readable. Several
+#      connectors on our own box predate the invariant and are 0644 — which
+#      means every account on the host can already read them, and a broker
+#      built on top would be recording an authority the filesystem already
+#      hands out. Warn rather than refuse: refusing would make the executor
+#      unusable on exactly the boxes that need it, and the operator fix
+#      (chmod 600) is one command that this message names.
+broker_connector_read() {
+  local f="$1" what="${2:-connector}"
+  [[ "$(id -u)" -eq 0 ]] || fail "$E_PERMISSION" "broker_connector_read is root-only (B1: the agent process must never hold ${what})"
+  [[ -r "$f" ]] || fail "$E_GENERIC" "missing ${what} credential: ${f}"
+  local mode; mode=$(stat -c '%a' "$f" 2>/dev/null || echo "")
+  case "$mode" in
+    600|400|"") ;;
+    *) warn "connector ${f} is mode ${mode} — group/world readable, so the ${what} credential is NOT control-plane-only (B1 violated). Fix with: sudo chmod 600 ${f}" ;;
+  esac
+  # shellcheck disable=SC1090
+  set -a; . "$f"; set +a
+}

--- a/src/lib/capability.sh
+++ b/src/lib/capability.sh
@@ -149,8 +149,13 @@ capability_forget_agent() {
 # it, and the unit test asserts they agree.
 _capability_names_for_standard() {
   local can_push="${1:-0}"
+  # INST-5: the broker's second surface. Its own axis, not a rider on can_push —
+  # shipping a branch for review and shipping to PRODUCTION are different
+  # authorities, so they are different rows a router can ask about separately.
+  local can_deploy="${2:-0}"
   printf '%s\n' a2a_deliver a2a_capture audit_append self_restart
   [[ "$can_push" == "1" ]] && printf '%s\n' delegated_push
+  [[ "$can_deploy" == "1" ]] && printf '%s\n' delegated_deploy
   return 0
 }
 
@@ -199,8 +204,9 @@ _capability_reconcile_locked() {
 # record. A failure warns and returns 0, because failing the install would turn
 # a bookkeeping error into a provisioning outage. Absent reads as undeclared.
 capability_declare_standard() {
-  local user="$1" can_push="${2:-0}" source="${3:-provisioned}" caps
-  caps=$(_capability_names_for_standard "$can_push")
+  local user="$1" can_push="${2:-0}" source="${3:-provisioned}"
+  local can_deploy="${4:-0}" caps
+  caps=$(_capability_names_for_standard "$can_push" "$can_deploy")
   _capability_lock _capability_reconcile_locked "$user" root "$source" "$caps" \
     || warn "capability registry: could not record capabilities for ${user} (the sudoers grant IS installed; the rows are absent, which reads as undeclared)"
   return 0
@@ -218,7 +224,9 @@ capability_declare_standard() {
 # and would convert an expired-and-therefore-safe row into a confidently wrong
 # one. If the file is gone, the grant is gone, so the rows go too.
 capability_reverify_from_sudoers() {
-  local user="$1" can_push=0 f
+  local user="$1" can_push=0
+  local can_deploy=0
+  local f
   [[ -n "$user" ]] || return 2
   # NOT one `local` line. `local a="$1" b="...${a}"` expands every word before it
   # assigns any, so ${a} resolves to whatever `a` meant in the CALLER's scope
@@ -238,8 +246,9 @@ capability_reverify_from_sudoers() {
     return 0
   fi
   grep -q '5dive _push_do' "$f" && can_push=1
+  grep -q '5dive _deploy_do' "$f" && can_deploy=1
   # Only a STANDARD policy is modelled here; an admin policy is a different
   # shape and claiming standard capabilities from it would be a false record.
   grep -q '5dive agent _deliver' "$f" || { capability_forget_agent "$user"; return 0; }
-  capability_declare_standard "$user" "$can_push" reverified
+  capability_declare_standard "$user" "$can_push" reverified "$can_deploy"
 }

--- a/src/main.sh
+++ b/src/main.sh
@@ -258,6 +258,8 @@ Zero-human proof (publish your own badge — OSS-17):
 
 Delegated push (bring your own GitHub App — DIVE-1376):
   5dive push <id|DIVE-N> [--branch=<b>] [--dry-run]  # push ONLY the task's branch, ONLY after its gate clears; author enforced
+  5dive deploy <id|DIVE-N> [--target=<project@ref>] [--env=production|preview] [--dry-run]
+                                                     # INST-5: deploy ONLY the project@ref the task declares, ONLY after its gate clears
   5dive push setup                                   # scaffold + check the GitHub App credential (bring-your-own; root)
   # Branch comes from --branch or a 'Branch: <name>' line in the task body. The credential is YOUR GitHub App
   # (contents:write, installed on your ship repos), held root-side in /etc/5dive/connectors — never a human token.

--- a/src/main.sh
+++ b/src/main.sh
@@ -393,6 +393,17 @@ main() {
       # audited itself (the parent `gh` verb is) and never advertised.
       cmd_gh_do "$@"
       exit $? ;;
+    _deploy_do)
+      # INST-5: hidden, privileged, ATOMIC delegated deploy — the capability
+      # broker's SECOND surface, same template as _push_do. Reachable ONLY via
+      # NOPASSWD sudo. Reads <ident> <project> <ref> <env> on STDIN (never argv,
+      # so the grant stays exact-path / sudo-rs safe), re-verifies the cleared
+      # gate under signature, re-binds the target to the task's own Deploy line,
+      # reads VERCEL_TOKEN root-only and fires ONE deployment of the repo the
+      # project is ALREADY linked to. The agent process never holds the token.
+      # Not audited itself (the parent `deploy` verb is) and never advertised.
+      cmd_deploy_do "$@"
+      exit $? ;;
     _push_do)
       # DIVE-1376/1460: hidden, privileged, ATOMIC delegated push. Reachable ONLY
       # via NOPASSWD sudo. Reads <ident> <repo-path> <branch> <repo-url> on STDIN
@@ -783,6 +794,15 @@ main() {
         AUDIT_CMD="push"; AUDIT_ARGS=("$@")
         cmd_push "$@"
       fi ;;
+    deploy)
+      # INST-5: delegated PRODUCTION deploy — the capability broker generalized
+      # off delegated push. Deploys ONLY the project@ref the task declares, ONLY
+      # after that task's gate clears, and only into the repo the Vercel project
+      # is already linked to. The privileged gate+bind+credential+deploy runs
+      # atomically in the root-only _deploy_do helper; the agent never holds the
+      # token. Mutating + credential-bearing -> audited.
+      AUDIT_CMD="deploy"; AUDIT_ARGS=("$@")
+      cmd_deploy "$@" ;;
     proof)
       # OSS-17: publish this box's zero-human proof (badge.json/zero-human.json/
       # history.jsonl) to a git status branch, computed verbatim from `digest`.

--- a/tests/broker_surface_unit.sh
+++ b/tests/broker_surface_unit.sh
@@ -20,6 +20,16 @@
 #    "push" — and the case set must produce distinct messages, or the harness is
 #    grading one sentence six times.
 set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source.
+# NOTE the absence of `2>/dev/null`. Redirecting the source's stderr would also
+# swallow the helper's own stderr line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PASS=0; FAIL=0
 want() { local n="$1"; shift; if eval "$@"; then echo "  ok   $n"; PASS=$((PASS+1)); else echo "  FAIL $n"; FAIL=$((FAIL+1)); fi; }

--- a/tests/broker_surface_unit.sh
+++ b/tests/broker_surface_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: core — 2.4s measured (DIVE-2525): fits the 300s PR core; stated, not defaulted.
 # tests/broker_surface_unit.sh — INST-5.
 #
 # Two questions, and the first is the one that decides whether this refactor was

--- a/tests/broker_surface_unit.sh
+++ b/tests/broker_surface_unit.sh
@@ -190,6 +190,28 @@ want "unknown surface fails loudly" '[[ "$u" == *"unknown surface/field"* ]]'
 want "every surface in broker_surfaces resolves every field" \
      '( for s in $(broker_surfaces); do for f in noun Noun cap verb key target ask ticket; do [[ -n "$(broker_surface "$s" "$f")" ]] || exit 1; done; done )'
 
+# == 6. every consumer of the broker asserts the broker is LOADED (INST-5).
+# The consumer list is DERIVED from the tree, never hand-written: a seventh
+# surface folded in later gets swept automatically, which is the whole point —
+# a hand list would go stale exactly when a new surface is added. A consumer
+# that calls a broker predicate without require_loaded is the fail-open shape
+# CI caught on this branch (push reporting "gate cleared" on an unread gate).
+echo "== 6. brokered surfaces fail closed when lib/broker.sh is absent"
+_consumers=$(grep -rlE '(^|[^_[:alnum:]])broker_(gate_check|bind_target|task_target)\b' \
+               "$ROOT/src" --include='cmd_*.sh' | sort)
+want "the derived consumer sweep is non-vacuous (found at least push + deploy)" \
+     '[[ "$(printf "%s\n" "$_consumers" | grep -c .)" -ge 2 ]]'
+for _c in $_consumers; do
+  want "$(basename "$_c") guards its broker calls with require_loaded" \
+       'grep -q "require_loaded" "$_c"'
+done
+# And the guard itself must live OUTSIDE lib/broker.sh — a check for a missing
+# file cannot be defined in the file that might be missing.
+want "require_loaded is not defined in lib/broker.sh" \
+     '! grep -q "^require_loaded()" "$ROOT/src/lib/broker.sh"'
+want "require_loaded is defined in header.sh (always first in the bundle)" \
+     'grep -q "^require_loaded()" "$ROOT/src/header.sh"'
+
 echo
 echo "broker surface unit: ${PASS} passed, ${FAIL} failed"
 [[ $FAIL -eq 0 ]]

--- a/tests/broker_surface_unit.sh
+++ b/tests/broker_surface_unit.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# tests/broker_surface_unit.sh — INST-5.
+#
+# Two questions, and the first is the one that decides whether this refactor was
+# safe to make at all.
+#
+# 1. IS THE PUSH PATH INERT? `_push_gate_check` and `_push_bind_branch` are the
+#    predicates that stand between a granted agent and a git write. INST-5 moved
+#    their bodies into lib/broker.sh and left one-line wrappers behind. "I only
+#    parameterized the nouns" is exactly the claim that is cheap to assert and
+#    expensive to be wrong about, so this file does not assert it — it MEASURES
+#    it, differentially, against origin/main's own copies of those functions,
+#    driving BOTH implementations through the same fixture states and comparing
+#    the refusal text and the exit status byte for byte.
+#
+# 2. IS THE PARAMETERIZATION ACTUALLY LIVE? A differential test that passes
+#    because both sides are equally dead is the standard way this shape lies. So
+#    every string arm is paired with a liveness arm: the SAME predicate, on the
+#    SAME state, under the `deploy` surface must say "deploy" where push says
+#    "push" — and the case set must produce distinct messages, or the harness is
+#    grading one sentence six times.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0; FAIL=0
+want() { local n="$1"; shift; if eval "$@"; then echo "  ok   $n"; PASS=$((PASS+1)); else echo "  FAIL $n"; FAIL=$((FAIL+1)); fi; }
+same() { # <name> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then echo "  ok   $1"; PASS=$((PASS+1));
+  else echo "  FAIL $1"; echo "    old: $2"; echo "    new: $3"; FAIL=$((FAIL+1)); fi
+}
+
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+# ---------------------------------------------------------------- the baseline
+# origin/main's copies, renamed so both live in one shell. If the baseline ref
+# is unreachable the arms would silently become "compare new against nothing",
+# which is the vacuous pass this file exists to avoid — so refuse instead.
+BASE="${BROKER_BASELINE_REF:-origin/main}"
+if ! git -C "$ROOT" cat-file -e "${BASE}:src/cmd_push.sh" 2>/dev/null; then
+  echo "REFUSING: baseline ${BASE}:src/cmd_push.sh is unreachable — the differential arms cannot run."
+  echo "  (fetch origin, or set BROKER_BASELINE_REF to a ref that predates INST-5)"
+  exit 1
+fi
+git -C "$ROOT" show "${BASE}:src/cmd_push.sh" > "$TMP/base_push.sh"
+# Guard the extraction itself: the baseline must actually still CONTAIN the
+# pre-refactor bodies. If someone re-runs this after INST-5 has landed on the
+# baseline ref, the "old" side becomes a wrapper too and every arm passes for
+# the wrong reason.
+grep -q 'gansweredat=\$(db' "$TMP/base_push.sh" \
+  || { echo "REFUSING: ${BASE} already carries the refactored wrapper — nothing to differ against."; exit 1; }
+
+extract() { awk -v f="$1" '$0 ~ "^"f"\\(\\) \\{" {p=1} p{print} p&&/^\}$/{exit}' "$TMP/base_push.sh"; }
+{
+  for fn in _push_gate_check _push_task_branch _push_bind_branch _push_branch_from_body; do
+    extract "$fn"
+  done
+} | sed -E 's/(^|[^A-Za-z0-9_])_push_(gate_check|task_branch|bind_branch|branch_from_body)\b/\1old_push_\2/g' \
+  > "$TMP/old.sh"
+for fn in old_push_gate_check old_push_task_branch old_push_bind_branch old_push_branch_from_body; do
+  grep -q "^${fn}() {" "$TMP/old.sh" || { echo "REFUSING: could not extract ${fn} from ${BASE}"; exit 1; }
+done
+
+# ------------------------------------------------------------------- the stubs
+E_VALIDATION=2; E_USAGE=1; E_GENERIC=1; E_PERMISSION=3
+warn() { printf 'warn: %s\n' "$*" >&2; }
+fail() { printf '%s\n' "$2"; exit 9; }
+# One fixture row, addressed by column name pulled out of the SQL. Both
+# implementations issue the identical SELECTs, so one stub serves both.
+declare -A ROW=()
+db() {
+  local col; col=$(sed -nE 's/.*COALESCE\(([a-z_]+),.*/\1/p' <<<"$1")
+  printf '%s' "${ROW[$col]:-}"
+}
+_gate_closure_verify() { return "${CLOSURE_RC:-0}"; }
+_gate_agent_for_uid()  { printf '%s' "${UID_AGENT:-}"; }
+
+# shellcheck source=../src/lib/broker.sh
+. "$ROOT/src/lib/broker.sh"
+# shellcheck source=/dev/null
+. "$TMP/old.sh"
+# The new wrappers, taken from the real file rather than retyped here.
+eval "$(awk '/^_push_gate_check\(\) \{/,/^\}$/' "$ROOT/src/cmd_push.sh")"
+eval "$(awk '/^_push_bind_branch\(\) \{/,/^\}$/' "$ROOT/src/cmd_push.sh")"
+eval "$(awk '/^_push_task_branch\(\) \{/,/^\}$/' "$ROOT/src/cmd_push.sh")"
+
+run() { ( "$@" ) 2>/dev/null; printf 'rc=%s' "$?"; }
+
+reset_row() { ROW=( [need_type]="" [need_answered_at]="" [need_answer]="" \
+                    [need_answered_by]="" [need_answered_uid]="" [need_answer_sig]="" \
+                    [routed_reviewer]="" [body]="" ); CLOSURE_RC=0; UID_AGENT=""; }
+
+echo "== 1. the push path is INERT: new wrappers == origin/main, string for string"
+declare -a SEEN=()
+case_gate() { # <name> then the caller has already set ROW
+  local n="$1" old new
+  old=$(run old_push_gate_check 7 DIVE-7 "${2:-0}")
+  new=$(run _push_gate_check     7 DIVE-7 "${2:-0}")
+  same "gate/${n}" "$old" "$new"
+  SEEN+=("$new")
+}
+
+reset_row;                                              case_gate "no gate at all"
+reset_row; ROW[need_type]=approval;                     case_gate "gate OPEN (unanswered)"
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t; ROW[need_answer]="no, not yet"
+                                                        case_gate "gate REJECTED"
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t; ROW[need_answer]=yes
+           ROW[need_answered_by]=agent-dev; ROW[routed_reviewer]=main
+                                                        case_gate "unauthorized, reviewer named"
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t; ROW[need_answer]=yes
+           ROW[need_answered_by]=agent-dev;              case_gate "unauthorized, no reviewer"
+reset_row; ROW[need_type]=decision; ROW[need_answered_at]=t; ROW[need_answer]=yes
+           ROW[need_answered_by]=main; ROW[routed_reviewer]=main
+           ROW[need_answered_uid]=1234567890; UID_AGENT=dev
+                                                        case_gate "decision by reviewer, uid mismatch"
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t; ROW[need_answer]=yes
+           ROW[need_answered_by]="human:lodar";          case_gate "AUTHORIZED (human)"
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t; ROW[need_answer]=yes
+           ROW[need_answered_by]="lead:main";            case_gate "AUTHORIZED (lead)"
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t; ROW[need_answer]=yes
+           ROW[need_answered_by]="human:lodar"; CLOSURE_RC=1
+                                                        case_gate "signed-closure failure" 1
+
+case_bind() { # <name> <branch-arg>
+  local n="$1" b="$2" old new
+  old=$(run old_push_bind_branch 7 DIVE-7 "$b")
+  new=$(run _push_bind_branch     7 DIVE-7 "$b")
+  same "bind/${n}" "$old" "$new"
+  SEEN+=("$new")
+}
+reset_row;                                       case_bind "task declares no branch" feat/x
+reset_row; ROW[body]=$'Branch: feat/a\n';        case_bind "branch mismatch"          feat/b
+reset_row; ROW[body]=$'Branch: feat/a\n';        case_bind "branch matches"           feat/a
+reset_row; ROW[body]=$'branch:   feat/a  \n';    case_bind "case+space insensitive"   feat/a
+
+echo "-- non-vacuity: the arms above must not all be one sentence"
+uniq_n=$(printf '%s\n' "${SEEN[@]}" | sort -u | wc -l)
+want "the ${#SEEN[@]} differential arms produced >=8 distinct outcomes (got ${uniq_n})" "[[ $uniq_n -ge 8 ]]"
+want "at least one arm SUCCEEDED (rc=0), so the harness can reach the pass path" \
+     'printf "%s\n" "${SEEN[@]}" | grep -qx "rc=0"'
+want "at least one arm REFUSED (rc=9), so the harness can reach the fail path" \
+     'printf "%s\n" "${SEEN[@]}" | grep -q "^gate on\|^no gate on\|^task DIVE-7 declares"'
+
+echo
+echo "== 2. the parameterization is LIVE, not dead: deploy says deploy"
+reset_row
+d_nogate=$(run broker_gate_check deploy 7 DIVE-7)
+p_nogate=$(run broker_gate_check push   7 DIVE-7)
+want "deploy's no-gate refusal names deploy"  '[[ "$d_nogate" == *"deploy-for-review gate"* ]]'
+want "push's no-gate refusal still names push" '[[ "$p_nogate" == *"push-for-review gate"* ]]'
+want "the two differ (the surface argument is load-bearing)" '[[ "$d_nogate" != "$p_nogate" ]]'
+want "deploy suggests its own --ask, not push's" \
+     '[[ "$d_nogate" == *"approve production deploy of <project>@<ref>"* ]]'
+
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t; ROW[need_answer]=yes; ROW[need_answered_by]=agent-dev
+d_unauth=$(run broker_gate_check deploy 7 DIVE-7)
+want "deploy's unauthorized refusal says 'delegated deploy'" '[[ "$d_unauth" == *"delegated deploy accepts"* ]]'
+
+echo
+echo "== 3. deploy binds to ITS OWN body key, and a push task cannot satisfy it"
+reset_row; ROW[body]=$'Branch: feat/a\nDeploy: app@feat/a\n'
+want "deploy reads the Deploy: line"  '[[ "$(broker_task_target deploy 7)" == "app@feat/a" ]]'
+want "push still reads the Branch: line" '[[ "$(broker_task_target push 7)" == "feat/a" ]]'
+b_ok=$(run broker_bind_target deploy 7 DIVE-7 "app@feat/a")
+b_no=$(run broker_bind_target deploy 7 DIVE-7 "other@feat/a")
+want "the declared deploy target binds"  '[[ "$b_ok" == "rc=0" ]]'
+want "a DIFFERENT project is refused"    '[[ "$b_no" == *"is not the deploy target bound to DIVE-7"* ]]'
+want "…and the refusal cites the declared value, not the requested one" \
+     '[[ "$b_no" == *"(&#39;app@feat/a&#39;)"* || "$b_no" == *"('"'"'app@feat/a'"'"')"* ]]'
+reset_row; ROW[body]=$'Branch: feat/a\n'
+b_unb=$(run broker_bind_target deploy 7 DIVE-7 "app@feat/a")
+want "a task with ONLY a Branch: line cannot authorize a deploy" \
+     '[[ "$b_unb" == *"declares no deploy target"* ]]'
+
+echo
+echo "== 4. an unknown surface is a hard failure, never an empty noun"
+u=$(run broker_surface bananas noun)
+want "unknown surface fails loudly" '[[ "$u" == *"unknown surface/field"* ]]'
+# Subshell parens deliberate: `want` evals in THIS shell, so a bare `exit` here
+# would end the harness with status 0 and skip the tally (see the same note in
+# tests/capability_registry_unit.sh — it cost a vacuous mutation pass there).
+want "every surface in broker_surfaces resolves every field" \
+     '( for s in $(broker_surfaces); do for f in noun Noun cap verb key target ask ticket; do [[ -n "$(broker_surface "$s" "$f")" ]] || exit 1; done; done )'
+
+echo
+echo "broker surface unit: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]]

--- a/tests/broker_surface_unit.sh
+++ b/tests/broker_surface_unit.sh
@@ -212,6 +212,29 @@ want "require_loaded is not defined in lib/broker.sh" \
 want "require_loaded is defined in header.sh (always first in the bundle)" \
      'grep -q "^require_loaded()" "$ROOT/src/header.sh"'
 
+# == 7. no harness loads a broker CONSUMER without lib/broker.sh (INST-5).
+# This is how the branch broke: tests/ harnesses hand-maintain a source list
+# mirroring build.sh, and a new lib is invisible to every one of them. push_unit
+# and gate_lead_standing failed loudly because they CALL cmd_push; 18 others
+# sourced cmd_push.sh and stayed green only because they never called it —
+# latent, and the next arm added to any of them would have graded through a
+# missing predicate. Derived from the tree, so it also covers surface N+1.
+echo "== 7. every harness sourcing a broker consumer also sources lib/broker.sh"
+_bad=""
+for _t in "$ROOT"/tests/*.sh; do
+  awk '/for f in/,/; do/' "$_t" | grep -qE 'cmd_push\.sh|cmd_deploy\.sh' || continue
+  grep -q 'lib/broker.sh' "$_t" || _bad="$_bad $(basename "$_t")"
+done
+want "no harness sources a broker consumer without lib/broker.sh" '[[ -z "$_bad" ]]'
+[[ -n "$_bad" ]] && echo "    missing:$_bad"
+# Non-vacuity: the sweep must actually be finding harnesses to check, or it
+# passes by inspecting nothing — the exact way this check could rot silently.
+_seen=$(for _t in "$ROOT"/tests/*.sh; do
+          awk '/for f in/,/; do/' "$_t" | grep -qE 'cmd_push\.sh|cmd_deploy\.sh' && echo x
+        done | grep -c x)
+want "non-vacuity: the harness sweep inspected at least 15 harnesses (saw $_seen)" \
+     '[[ "$_seen" -ge 15 ]]'
+
 echo
 echo "broker surface unit: ${PASS} passed, ${FAIL} failed"
 [[ $FAIL -eq 0 ]]

--- a/tests/capability_registry_unit.sh
+++ b/tests/capability_registry_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: core — 1.4s measured (DIVE-2525): fits the 300s PR core; stated, not defaulted.
 # DIVE-2102 — the capability registry answers "confirmed holder" and nothing else.
 #
 # The assertions that matter are the NEGATIVE-SPACE ones: absence, staleness and

--- a/tests/capability_registry_unit.sh
+++ b/tests/capability_registry_unit.sh
@@ -211,6 +211,22 @@ want "C: confirmed BEFORE"          'capability_confirmed_holder a2a_deliver rvC
 capability_reverify_from_sudoers rvC
 want "C: ALL rows gone after"       '! capability_confirmed_holder a2a_deliver rvC && ! capability_confirmed_holder delegated_push rvC'
 
+# INST-5 / E. the SECOND brokered surface must reverify from the artifact too.
+# Iteration-1 coverage stopped at push, so a deploy grant could have been
+# installed and never recorded — an authority the sudoers file gives out and
+# the registry answers "not confirmed" about. Both directions, because the
+# dangerous one is the DROP: a pulled deploy grant that stays confirmed hands a
+# revoked production-ship capability to a router as a live fact.
+reset_rv rvE; capability_forget_agent rvE
+render_standard_sudoers rvE 0 1 > "$sudoers_dir/rvE"
+capability_reverify_from_sudoers rvE
+want "E: deploy confirmed from a deploy-only policy" 'capability_confirmed_holder delegated_deploy rvE'
+want "E: …and push is NOT claimed from it"           '! capability_confirmed_holder delegated_push rvE'
+render_standard_sudoers rvE 1 0 > "$sudoers_dir/rvE"
+capability_reverify_from_sudoers rvE
+want "E: policy loses deploy -> row DROPPED"         '! capability_confirmed_holder delegated_deploy rvE'
+want "E: …and push is picked up in the same pass"    'capability_confirmed_holder delegated_push rvE'
+
 # D. a policy that is NOT a standard policy -> decline, do not claim standard caps
 reset_rv rvD
 printf 'rvD ALL=(ALL) NOPASSWD: ALL\n' > "$sudoers_dir/rvD"

--- a/tests/capability_registry_unit.sh
+++ b/tests/capability_registry_unit.sh
@@ -87,19 +87,51 @@ echo "-- the declared set matches what the sudoers policy actually grants"
 # The registry claiming a grant the policy does not emit is the drift this
 # ticket exists to prevent, so assert against render_standard_sudoers itself
 # rather than against a second hand-written list.
+#
+# INST-5 widened this from "does the push grant agree" to "does EVERY brokered
+# surface agree", enumerated from broker_surfaces() rather than from a list
+# written here. That matters for the surface AFTER deploy: folding in email or
+# DNS means adding a sudoers block and a registry name, and the way that goes
+# wrong is landing one without the other — a granted authority nobody records,
+# or a recorded authority nobody granted. Enumerating the table means the next
+# surface is covered by this loop on the day its row is added, with no second
+# edit here to forget.
 # shellcheck source=../src/cmd_agent_create.sh
 fail() { printf 'fail: %s\n' "$*" >&2; return 1; }
+E_GENERIC=1
+# shellcheck source=../src/lib/broker.sh
+source "$ROOT/src/lib/broker.sh"
 eval "$(awk '/^render_standard_sudoers\(\) \{/,/^\}/' "$ROOT/src/cmd_agent_create.sh")"
 for cp in 0 1; do
-  policy=$(render_standard_sudoers testuser "$cp")
-  emits_push=0; grep -q '5dive _push_do' <<<"$policy" && emits_push=1
-  declares_push=0
-  _capability_names_for_standard "$cp" | grep -qx delegated_push && declares_push=1
-  want "can_push=$cp: policy emits push ($emits_push) == registry declares it ($declares_push)" \
-       "[[ $emits_push -eq $declares_push ]]"
+ for cd in 0 1; do
+  policy=$(render_standard_sudoers testuser "$cp" "$cd")
+  for surface in $(broker_surfaces); do
+    verb=$(broker_surface "$surface" verb)
+    cap=$(broker_surface "$surface" cap)
+    emits=0;    grep -qE "5dive ${verb}\$" <<<"$policy" && emits=1
+    declares=0; _capability_names_for_standard "$cp" "$cd" | grep -qx "$cap" && declares=1
+    want "can_push=$cp can_deploy=$cd / ${surface}: policy emits ($emits) == registry declares ($declares)" \
+         "[[ $emits -eq $declares ]]"
+  done
+ done
 done
+# NON-VACUITY. Every arm above is an equality, and 0==0 satisfies it — a
+# render_ that emitted nothing and a registry that declared nothing would pass
+# the whole loop. So assert the loop actually reached the granting corner.
+#
+# NOTE THE SUBSHELL PARENS, they are not style. `want` runs its argument through
+# `eval` in the HARNESS shell, so a bare `exit` inside the expression exits the
+# HARNESS — silently, with status 0, skipping every remaining arm and the final
+# tally. Written without them, this pair passed while the mutation that deletes
+# the delegated_deploy declaration stayed green, because the run ended here.
+want "the fully-granted corner really emits every brokered verb" \
+     '( p=$(render_standard_sudoers testuser 1 1); for s in $(broker_surfaces); do grep -qE "5dive $(broker_surface "$s" verb)\$" <<<"$p" || exit 1; done )'
+want "the ungranted corner emits NONE of them" \
+     '( p=$(render_standard_sudoers testuser 0 0); for s in $(broker_surfaces); do grep -qE "5dive $(broker_surface "$s" verb)\$" <<<"$p" && exit 1; done; exit 0 )'
 want "unconditional grants are always declared" \
      '[[ "$(_capability_names_for_standard 0 | wc -l)" -eq 4 ]]'
+want "an omitted can_deploy arg defaults to NOT granted (every pre-INST-5 caller)" \
+     '[[ "$(render_standard_sudoers testuser 1)" == "$(render_standard_sudoers testuser 1 0)" ]] && ! grep -q "_deploy_do" <<<"$(render_standard_sudoers testuser 1)"'
 
 echo "-- the store must be READABLE BY AGENTS, not just written by root"
 # olivia, DIVE-2102 iteration 1: the writer shipped chmod and dropped chown, so

--- a/tests/deploy_unit.sh
+++ b/tests/deploy_unit.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# deploy_unit — INST-5: the delegated-deploy EXECUTOR (src/cmd_deploy.sh).
+#
+# tests/broker_surface_unit.sh grades the POLICY stage under the deploy surface
+# (lib/broker.sh parameterized by `deploy`). Nothing sourced cmd_deploy.sh
+# itself, so the 221-line executor — the thing INST-5 was actually filed to land
+# — shipped its first iteration with no harness that loaded it. This is that
+# harness. Same isolation posture as push_unit.sh: source the src/ libs, point
+# STATE_DIR at a throwaway temp dir, seed the tasks store directly.
+#
+# Covers every NON-CREDENTIAL path. The real deploy needs root, the on-box
+# Vercel token and the network, so everything here stops at --dry-run or at the
+# root-only refusal; no token is read and no deployment is ever fired.
+#   - usage: no task id -> refuse
+#   - no deploy target (no --target, no `Deploy:` body line) -> refuse, and the
+#     refusal names the body line to add rather than guessing a target
+#   - a target that is not exactly <project>@<ref> -> refuse
+#   - hostile project/ref/env are rejected BEFORE anything reaches a URL or a
+#     JSON body (traversal, injection, leading '-', '..', unknown --env)
+#   - gate states: no gate / open / rejected -> refuse; cleared -> dry-run ok
+#   - B5 target binding: a --target disagreeing with the task's own `Deploy:`
+#     line is refused, and a task carrying only a `Branch:` line cannot
+#     authorize a deploy at all (a push gate is not a deploy gate)
+#   - _deploy_do is root-only, graded against a STUBBED uid so the arm tests the
+#     code rather than whichever user the runner happens to be
+#   - INST-5 fail-closed: a missing broker predicate refuses instead of
+#     proceeding (the shape CI caught on this branch)
+# Run: bash tests/deploy_unit.sh  (no root, no network, no credential)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/deploy-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh \
+         lib/registry.sh lib/tasks_db.sh cmd_task.sh cmd_deploy.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"
+TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DB="$TASKS_DIR/tasks.db"
+GATE_PROOF_KEY="$STATE_DIR/gate-proof.key"
+GATE_PROOF_ENFORCE="$STATE_DIR/gate-proof.enforce"
+JSON_MODE=0
+# Hermetic: point the connector at an absent path so nothing here can read the
+# box's real /etc/5dive/connectors/vercel.env. Every arm stops before the
+# credential anyway; this makes that a property of the harness, not a hope.
+export VERCEL_ENV_FILE="$TMP/no-vercel-env"
+mkdir -p "$TASKS_DIR"
+printf '%064d\n' 1496 > "$GATE_PROOF_KEY"
+set +e
+
+tasks_db_init
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# seed_task <ident> <body> <need_type> <need_answered_at> <need_answer>
+#           [answered_by] [routed_reviewer] [sign=1]
+seed_task() {
+  local answered_by="${6:-human:test}" reviewer="${7:-}" sign="${8:-1}" id sig
+  db "INSERT INTO tasks(ident,project_key,title,status,assignee,kind,body,
+         need_type,need_answered_at,need_answer,need_answered_by,
+         need_answered_uid,routed_reviewer)
+      VALUES($(sqlq "$1"),'dive',$(sqlq "t-$1"),'in_progress','dev','standard',
+             $(sqlq "$2"),$(sqlq_or_null "$3"),$(sqlq_or_null "$4"),
+             $(sqlq_or_null "$5"),$(sqlq_or_null "$answered_by"),1000,
+             $(sqlq_or_null "$reviewer"));"
+  if [[ -n "$4" && "$sign" == "1" ]]; then
+    id=$(db "SELECT id FROM tasks WHERE ident=$(sqlq "$1");")
+    sig=$(_gate_closure_sign "$id" "$3" "$5" "$answered_by" "$4" 1000)
+    db "UPDATE tasks SET need_answer_sig=$(sqlq "$sig") WHERE id=${id};"
+  fi
+}
+
+run_deploy() { ( cmd_deploy "$@" ) 2>&1; }
+
+CLEARED="2026-08-01 00:00:00"
+
+# --- 1) usage -------------------------------------------------------------
+out=$(run_deploy); rc=$?
+{ [[ $rc -ne 0 ]] && grep -qi "usage: 5dive deploy" <<<"$out"; } \
+  && ok_t "no task id -> usage refusal" || bad_t "no task id -> usage refusal" "rc=$rc :: $out"
+
+# --- 2) no declared target ------------------------------------------------
+# The executor must refuse to GUESS. A task with no `Deploy:` line and no
+# --target names nothing deployable, and "deploy something reasonable" is
+# exactly the inference a broker exists to delete.
+seed_task DIVE-801 "no target here" approval "$CLEARED" "yes ship it"
+out=$(run_deploy DIVE-801 --dry-run); rc=$?
+{ [[ $rc -ne 0 ]] && grep -q "Deploy: <project>@<ref>" <<<"$out"; } \
+  && ok_t "no deploy target -> refuse, naming the body line to add" \
+  || bad_t "no deploy target -> refuse, naming the body line to add" "rc=$rc :: $out"
+
+# A task carrying ONLY a `Branch:` line is a PUSH task. Its cleared gate must not
+# authorize a deploy — the two surfaces read different body keys on purpose.
+seed_task DIVE-802 "Branch: feature-ok" approval "$CLEARED" "yes ship it"
+out=$(run_deploy DIVE-802 --dry-run); rc=$?
+{ [[ $rc -ne 0 ]] && ! grep -qi "would deploy" <<<"$out"; } \
+  && ok_t "a Branch:-only (push) task cannot authorize a deploy" \
+  || bad_t "a Branch:-only (push) task cannot authorize a deploy" "rc=$rc :: $out"
+
+# --- 3) target SHAPE ------------------------------------------------------
+seed_task DIVE-803 "Deploy: notapair" approval "$CLEARED" "yes ship it"
+out=$(run_deploy DIVE-803 --dry-run); rc=$?
+{ [[ $rc -ne 0 ]] && grep -q "must be exactly" <<<"$out"; } \
+  && ok_t "a target that is not <project>@<ref> -> refuse" \
+  || bad_t "a target that is not <project>@<ref> -> refuse" "rc=$rc :: $out"
+
+# Two '@' is ambiguous, not "close enough" — _deploy_split_target returns empty.
+[[ -z "$(_deploy_split_target 'a@b@c')" ]] \
+  && ok_t "a two-'@' target is ambiguous -> empty split" \
+  || bad_t "a two-'@' target is ambiguous -> empty split" "got '$(_deploy_split_target 'a@b@c')'"
+[[ "$(_deploy_split_target 'app@feat/x')" == "app feat/x" ]] \
+  && ok_t "non-vacuity: a well-formed target still splits" \
+  || bad_t "non-vacuity: a well-formed target still splits" "got '$(_deploy_split_target 'app@feat/x')'"
+
+# --- 4) hostile inputs, rejected BEFORE they reach a URL or a JSON body ----
+# project, ref and env are all attacker-controlled in the threat model this
+# broker exists for: a granted agent supplies them. Each is graded on its own so
+# a single over-broad regex cannot make the others vacuous.
+for bad in '../etc/passwd' '-rf' 'a b' 'x;rm -rf /' '.leading' '$(id)'; do
+  ( _deploy_validate_target "$bad" main production ) >/dev/null 2>&1
+  [[ $? -ne 0 ]] && ok_t "hostile project '$bad' -> refused" \
+                 || bad_t "hostile project '$bad' -> refused" "accepted"
+done
+for bad in '-delete' 'a..b' 'x;y' 'a b' '$(id)'; do
+  ( _deploy_validate_target app "$bad" production ) >/dev/null 2>&1
+  [[ $? -ne 0 ]] && ok_t "hostile ref '$bad' -> refused" \
+                 || bad_t "hostile ref '$bad' -> refused" "accepted"
+done
+( _deploy_validate_target app main staging ) >/dev/null 2>&1
+[[ $? -ne 0 ]] && ok_t "an unknown --env -> refused (production|preview only)" \
+               || bad_t "an unknown --env -> refused" "accepted 'staging'"
+# Non-vacuity: the validator is not simply refusing everything.
+( _deploy_validate_target my-app feat/a-1 production ) >/dev/null 2>&1
+[[ $? -eq 0 ]] && ok_t "non-vacuity: a legitimate project/ref/env passes" \
+               || bad_t "non-vacuity: a legitimate project/ref/env passes" "refused a valid triple"
+( _deploy_validate_target app main preview ) >/dev/null 2>&1
+[[ $? -eq 0 ]] && ok_t "non-vacuity: --env=preview is accepted" \
+               || bad_t "non-vacuity: --env=preview is accepted" "refused preview"
+
+# --- 5) gate states -------------------------------------------------------
+seed_task DIVE-804 "Deploy: app@feat/a" "" "" ""
+out=$(run_deploy DIVE-804 --dry-run); rc=$?
+{ [[ $rc -ne 0 ]] && ! grep -qi "would deploy" <<<"$out"; } \
+  && ok_t "no gate -> refuse" || bad_t "no gate -> refuse" "rc=$rc :: $out"
+
+seed_task DIVE-805 "Deploy: app@feat/a" approval "" ""
+out=$(run_deploy DIVE-805 --dry-run); rc=$?
+{ [[ $rc -ne 0 ]] && ! grep -qi "would deploy" <<<"$out"; } \
+  && ok_t "open (unanswered) gate -> refuse" || bad_t "open (unanswered) gate -> refuse" "rc=$rc :: $out"
+
+seed_task DIVE-806 "Deploy: app@feat/a" approval "$CLEARED" "no, do not ship"
+out=$(run_deploy DIVE-806 --dry-run); rc=$?
+{ [[ $rc -ne 0 ]] && ! grep -qi "would deploy" <<<"$out"; } \
+  && ok_t "rejected gate -> refuse" || bad_t "rejected gate -> refuse" "rc=$rc :: $out"
+
+# --- 6) happy dry-run (the liveness anchor for every negative above) -------
+seed_task DIVE-807 "Deploy: app@feat/a" approval "$CLEARED" "yes ship it"
+out=$(run_deploy DIVE-807 --dry-run); rc=$?
+{ [[ $rc -eq 0 ]] && grep -qi "would deploy app@feat/a" <<<"$out"; } \
+  && ok_t "cleared gate + declared target -> dry-run ok" \
+  || bad_t "cleared gate + declared target -> dry-run ok" "rc=$rc :: $out"
+grep -q "production" <<<"$out" \
+  && ok_t "…and it defaults to the production env" \
+  || bad_t "…and it defaults to the production env" "$out"
+
+# --- 7) B5 target binding -------------------------------------------------
+# The cleared gate authorizes exactly the target the TASK declares, read fresh
+# from the DB. A --target that disagrees is refused, so a granted agent cannot
+# cite one task's cleared gate to ship a different project or a different ref.
+out=$(run_deploy DIVE-807 --target=other@feat/a --dry-run); rc=$?
+{ [[ $rc -ne 0 ]] && ! grep -qi "would deploy" <<<"$out"; } \
+  && ok_t "a --target naming a DIFFERENT project -> refuse" \
+  || bad_t "a --target naming a DIFFERENT project -> refuse" "rc=$rc :: $out"
+out=$(run_deploy DIVE-807 --target=app@other-ref --dry-run); rc=$?
+{ [[ $rc -ne 0 ]] && ! grep -qi "would deploy" <<<"$out"; } \
+  && ok_t "a --target naming a DIFFERENT ref -> refuse" \
+  || bad_t "a --target naming a DIFFERENT ref -> refuse" "rc=$rc :: $out"
+# Non-vacuity: --target is not simply always refused.
+out=$(run_deploy DIVE-807 --target=app@feat/a --dry-run); rc=$?
+[[ $rc -eq 0 ]] \
+  && ok_t "non-vacuity: a --target AGREEING with the task passes" \
+  || bad_t "non-vacuity: a --target AGREEING with the task passes" "rc=$rc :: $out"
+
+# --- 8) _deploy_do is root-only -------------------------------------------
+# STUB the uid the code READS. An unstubbed `id -u` grades the RUNNER, not the
+# code: red under our `sudo -u claude` convention and green in a root container,
+# so both readings would be "true" and neither would be about cmd_deploy.sh.
+id() { if [[ "${1:-}" == "-u" ]]; then printf '%s' "$FAKE_UID"; else command id "$@"; fi; }
+FAKE_UID=1000
+out=$( printf 'DIVE-807\napp\nfeat/a\nproduction\n' | cmd_deploy_do 2>&1 ); rc=$?
+{ [[ $rc -ne 0 ]] && grep -q "root-only" <<<"$out"; } \
+  && ok_t "_deploy_do as non-root -> refuse (stubbed uid 1000)" \
+  || bad_t "_deploy_do as non-root -> refuse" "rc=$rc :: $out"
+# Differential: as uid 0 the SAME call gets past the root check. It must not
+# succeed — there is no credential here — but it must fail for a LATER reason,
+# which is what proves the arm above graded the root check and not some
+# unrelated refusal that would fire either way.
+FAKE_UID=0
+out=$( printf 'DIVE-807\napp\nfeat/a\nproduction\n' | cmd_deploy_do 2>&1 ); rc=$?
+{ [[ $rc -ne 0 ]] && ! grep -q "root-only" <<<"$out"; } \
+  && ok_t "…and as uid 0 it passes the root check and fails LATER (arm is differential)" \
+  || bad_t "…and as uid 0 it passes the root check and fails later" "rc=$rc :: $out"
+# The credential is absent, so the failure must be the connector — never a
+# silent success, and never a token read from the real box.
+grep -qiE "vercel|connector" <<<"$out" \
+  && ok_t "…and the later failure is the absent Vercel connector, not a silent pass" \
+  || bad_t "…and the later failure is the absent Vercel connector" "$out"
+FAKE_UID=1000
+unset -f id
+
+# --- 9) INST-5 fail-closed on a missing predicate -------------------------
+# The shape CI caught on this branch: an extracted predicate that is not loaded
+# is merely "command not found", and a bare call site reads that as success. The
+# control is arm 6 above — same fixture, same command, one predicate removed.
+for _pred in broker_gate_check broker_bind_target; do
+  out=$( unset -f "$_pred"; cmd_deploy DIVE-807 --dry-run 2>&1 ); rc=$?
+  { [[ $rc -ne 0 ]] && ! grep -qi "would deploy" <<<"$out"; } \
+    && ok_t "missing $_pred -> refuses, and no deploy is reported" \
+    || bad_t "missing $_pred -> refuses, and no deploy is reported" "rc=$rc :: $out"
+done
+unset _pred
+
+echo "-----"
+printf 'deploy_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/deploy_unit.sh
+++ b/tests/deploy_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: core — 5.0s measured (DIVE-2525): fits the 300s PR core; stated, not defaulted.
 # deploy_unit — INST-5: the delegated-deploy EXECUTOR (src/cmd_deploy.sh).
 #
 # tests/broker_surface_unit.sh grades the POLICY stage under the deploy surface

--- a/tests/deploy_unit.sh
+++ b/tests/deploy_unit.sh
@@ -197,19 +197,32 @@ out=$(run_deploy DIVE-807 --target=app@feat/a --dry-run); rc=$?
 # STUB the uid the code READS. An unstubbed `id -u` grades the RUNNER, not the
 # code: red under our `sudo -u claude` convention and green in a root container,
 # so both readings would be "true" and neither would be about cmd_deploy.sh.
+#
+# ASSERT THE EXACT MESSAGE, not the substring "root-only". This is a guard
+# behind a guard: delete cmd_deploy_do's own uid check and the call still
+# refuses, because broker_connector_read (B1) is independently root-only and
+# says so in the same words. Graded on the substring, this arm stayed GREEN with
+# the check deleted — it was reading the second layer. Only the exact string
+# "_deploy_do is root-only" isolates the layer this arm claims to be about.
 id() { if [[ "${1:-}" == "-u" ]]; then printf '%s' "$FAKE_UID"; else command id "$@"; fi; }
 FAKE_UID=1000
 out=$( printf 'DIVE-807\napp\nfeat/a\nproduction\n' | cmd_deploy_do 2>&1 ); rc=$?
-{ [[ $rc -ne 0 ]] && grep -q "root-only" <<<"$out"; } \
+{ [[ $rc -ne 0 ]] && grep -q "_deploy_do is root-only" <<<"$out"; } \
   && ok_t "_deploy_do as non-root -> refuse (stubbed uid 1000)" \
   || bad_t "_deploy_do as non-root -> refuse" "rc=$rc :: $out"
+# The second layer, named as its own property rather than left to be mistaken
+# for the first: even reached directly, the credential read refuses non-root.
+out=$( broker_connector_read "$VERCEL_ENV_FILE" "the Vercel" 2>&1 ); rc=$?
+{ [[ $rc -ne 0 ]] && grep -q "broker_connector_read is root-only" <<<"$out"; } \
+  && ok_t "B1 defence in depth: the credential read is independently root-only" \
+  || bad_t "B1 defence in depth: the credential read is independently root-only" "rc=$rc :: $out"
 # Differential: as uid 0 the SAME call gets past the root check. It must not
 # succeed — there is no credential here — but it must fail for a LATER reason,
 # which is what proves the arm above graded the root check and not some
 # unrelated refusal that would fire either way.
 FAKE_UID=0
 out=$( printf 'DIVE-807\napp\nfeat/a\nproduction\n' | cmd_deploy_do 2>&1 ); rc=$?
-{ [[ $rc -ne 0 ]] && ! grep -q "root-only" <<<"$out"; } \
+{ [[ $rc -ne 0 ]] && ! grep -q "_deploy_do is root-only" <<<"$out"; } \
   && ok_t "…and as uid 0 it passes the root check and fails LATER (arm is differential)" \
   || bad_t "…and as uid 0 it passes the root check and fails later" "rc=$rc :: $out"
 # The credential is absent, so the failure must be the connector — never a

--- a/tests/gate_delivery_actor_unit.sh
+++ b/tests/gate_delivery_actor_unit.sh
@@ -65,7 +65,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/tasks_db.sh cmd_push.sh cmd_agent_pairing.sh cmd_task.sh; do
   source "$SRC/$f"
 done

--- a/tests/gate_lead_standing_unit.sh
+++ b/tests/gate_lead_standing_unit.sh
@@ -41,8 +41,8 @@ trap 'rm -rf "$TMP"' EXIT
 STATE_DIR="$TMP"
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_council.sh; do
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh \
+         lib/registry.sh lib/tasks_db.sh cmd_task.sh cmd_council.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_telemetry_fence_unit.sh
+++ b/tests/gate_telemetry_fence_unit.sh
@@ -48,7 +48,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/tasks_db.sh cmd_push.sh cmd_agent_pairing.sh cmd_task.sh; do
   source "$SRC/$f"
 done

--- a/tests/push_unit.sh
+++ b/tests/push_unit.sh
@@ -37,8 +37,9 @@ trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_agent_create.sh; do
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh \
+         lib/registry.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh \
+         cmd_agent_create.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done
@@ -165,6 +166,26 @@ seed_task DIVE-907 "Branch: feature-ok" approval "2026-07-18 00:00:00" "yes ship
 out=$(run_push DIVE-907 --dry-run); rc=$?
 { [[ $rc -eq 0 ]] && grep -qi "dry-run: would push" <<<"$out"; } \
   && ok_t "happy dry-run -> ok" || bad_t "happy dry-run -> ok" "rc=$rc :: $out"
+
+# 7b) INST-5 FAIL-CLOSED ON A MISSING PREDICATE. Extracting push's gate check into
+# lib/broker.sh created a failure mode the inline code could not have: if the lib
+# is not loaded the call is merely "command not found" (rc 127) and, as a bare
+# statement, execution CONTINUES — CI caught exactly this, with push printing
+# "would push ... (gate cleared)" for a task whose gate it never read. The control
+# is arm 7 directly above: the SAME fixture, the SAME command, one predicate
+# removed. If this pair ever stops differing, the guard has gone vacuous.
+for _pred in broker_gate_check broker_bind_target; do
+  out=$( cd "$REPO"; unset -f "$_pred"; cmd_push DIVE-907 --repo="file://$REPO" --dry-run 2>&1 ); rc=$?
+  # The ACTION must not have happened — an rc alone would also pass on the wrong refusal.
+  { [[ $rc -ne 0 ]] && ! grep -qi "would push" <<<"$out"; } \
+    && ok_t "missing $_pred -> refuses, and no push is reported" \
+    || bad_t "missing $_pred -> refuses, and no push is reported" "rc=$rc :: $out"
+  # …and the refusal NAMES the absent predicate, so the operator is not left guessing.
+  grep -q "$_pred" <<<"$out" \
+    && ok_t "…and the refusal names '$_pred' as the missing predicate" \
+    || bad_t "…and the refusal names '$_pred' as the missing predicate" "$out"
+done
+unset _pred
 
 # 8) DIVE-1462 branch binding: a --branch that DISAGREES with the task's declared
 # branch is refused — the cleared gate binds to the task's own branch, so an agent

--- a/tests/task_answer_closed_row_unit.sh
+++ b/tests/task_answer_closed_row_unit.sh
@@ -51,7 +51,7 @@ TMP="$(mktemp -d /tmp/task-answer-closed-unit.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"

--- a/tests/task_close_preserves_done_at_unit.sh
+++ b/tests/task_close_preserves_done_at_unit.sh
@@ -44,8 +44,9 @@ TMP="$(mktemp -d /tmp/task-doneat-preserve-unit.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/disk.sh lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
+         lib/disk.sh lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_push.sh cmd_org.sh \
+         cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/task_deliver_merge_gate_unit.sh
+++ b/tests/task_deliver_merge_gate_unit.sh
@@ -103,7 +103,7 @@ export PATH="$TMP/bin:$PATH"
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/tasks_db.sh cmd_push.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"

--- a/tests/task_done_delivered_guard_unit.sh
+++ b/tests/task_done_delivered_guard_unit.sh
@@ -31,7 +31,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"

--- a/tests/task_done_over_closed_result_unit.sh
+++ b/tests/task_done_over_closed_result_unit.sh
@@ -41,7 +41,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"

--- a/tests/task_merge_gate_ancestry_unit.sh
+++ b/tests/task_merge_gate_ancestry_unit.sh
@@ -139,7 +139,7 @@ export GH_ARGS_LOG="$TMP/gh.args"; : >"$GH_ARGS_LOG"
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/tasks_db.sh cmd_push.sh cmd_task.sh; do
   source "$SRC/$f"
 done

--- a/tests/task_merge_gate_autodetect_unit.sh
+++ b/tests/task_merge_gate_autodetect_unit.sh
@@ -54,7 +54,7 @@ export GH_ARGS_LOG="$TMP/gh.args"; : >"$GH_ARGS_LOG"
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/tasks_db.sh cmd_push.sh cmd_task.sh; do
   source "$SRC/$f"
 done

--- a/tests/task_merge_gate_delivered_vs_cited_unit.sh
+++ b/tests/task_merge_gate_delivered_vs_cited_unit.sh
@@ -88,7 +88,7 @@ export GH_ARGS_LOG="$TMP/gh.args"; : >"$GH_ARGS_LOG"
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/tasks_db.sh cmd_push.sh cmd_task.sh; do
   source "$SRC/$f"
 done

--- a/tests/task_merge_gate_diagnostic_unit.sh
+++ b/tests/task_merge_gate_diagnostic_unit.sh
@@ -116,7 +116,7 @@ export GH_ARGS_LOG="$TMP/gh.args"; : >"$GH_ARGS_LOG"
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/tasks_db.sh cmd_push.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"

--- a/tests/task_merge_gate_gh_resolve_unit.sh
+++ b/tests/task_merge_gate_gh_resolve_unit.sh
@@ -65,7 +65,7 @@ export GH_ARGS_LOG="$TMP/gh.args"; : >"$GH_ARGS_LOG"
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/tasks_db.sh cmd_push.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"

--- a/tests/task_merge_gate_inferred_repo_unit.sh
+++ b/tests/task_merge_gate_inferred_repo_unit.sh
@@ -90,7 +90,7 @@ export GH_ARGS_LOG="$TMP/gh.args"; : >"$GH_ARGS_LOG"
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/tasks_db.sh cmd_push.sh cmd_task.sh; do
   source "$SRC/$f"
 done

--- a/tests/task_merge_gate_multirepo_unit.sh
+++ b/tests/task_merge_gate_multirepo_unit.sh
@@ -97,7 +97,7 @@ export GH_ARGS_LOG="$TMP/gh.args"; : >"$GH_ARGS_LOG"
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/tasks_db.sh cmd_push.sh cmd_task.sh; do
   source "$SRC/$f"
 done

--- a/tests/task_merge_gate_result_pr_unit.sh
+++ b/tests/task_merge_gate_result_pr_unit.sh
@@ -111,7 +111,7 @@ export GH_ARGS_LOG="$TMP/gh.args"; : >"$GH_ARGS_LOG"
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/tasks_db.sh cmd_push.sh cmd_task.sh; do
   source "$SRC/$f"
 done

--- a/tests/task_reject_actor_and_closed_unit.sh
+++ b/tests/task_reject_actor_and_closed_unit.sh
@@ -33,7 +33,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"

--- a/tests/task_set_branch_unit.sh
+++ b/tests/task_set_branch_unit.sh
@@ -24,7 +24,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_push.sh; do
   source "$SRC/$f"
 done

--- a/tests/task_verify_over_closed_unit.sh
+++ b/tests/task_verify_over_closed_unit.sh
@@ -37,7 +37,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"

--- a/tests/verifier_gate_ack_unit.sh
+++ b/tests/verifier_gate_ack_unit.sh
@@ -44,7 +44,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
          lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh \
          cmd_project.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null

--- a/tests/verifier_gate_ack_unit.sh
+++ b/tests/verifier_gate_ack_unit.sh
@@ -51,8 +51,7 @@ trap 'rm -rf "$TMP"' EXIT
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh \
          lib/registry.sh lib/disk.sh lib/tasks_db.sh lib/actor.sh cmd_task.sh \
-         cmd_push.sh cmd_org.sh; do
-         cmd_project.sh cmd_heartbeat.sh; do
+         cmd_push.sh cmd_org.sh cmd_project.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done


### PR DESCRIPTION
## What

`5dive push` was our only **brokered capability**: a dangerous action an agent can take without ever holding a credential, gated on a cleared human/lead decision and executed atomically as root. INST-5 asks to extend that template to the next surfaces — email, deploy, DNS, payments, secrets, data-export, one at a time. This PR lands the reusable primitive and the first new surface.

## Which half of delegated push actually generalizes (the counterintuitive part)

Delegated push's headline security property is a repo-**scoped**, **short-lived** installation token minted per use. That half does **not** port. It exists only because GitHub Apps expose a mint-on-demand API we can drive from the control plane. Measured against our own Vercel credential, before writing a line of the executor:

```
POST https://api.vercel.com/v3/user/tokens   ->  HTTP 403
{"error":{"code":"forbidden","message":"To create a token you must be authenticated to scope \"lodar\""}}
```

So defining the broker as "it mints scoped short-lived credentials" would put five of six surfaces out of scope **by definition**. The portable contract is the part that reads as plumbing:

```
(policy predicate + target binding) -> (root-only single-action executor, params on STDIN) -> (audit + capability row)
```

## Changes

- **`src/lib/broker.sh`** (new) — that contract, surface-agnostic: `broker_gate_check`, `broker_task_target`, `broker_bind_target`, `broker_connector_read`, plus **one surface table** (`broker_surface` / `broker_surfaces`) that the sudoers policy, the capability registry and every refusal string derive from.
- **`src/cmd_push.sh`** — `_push_gate_check`, `_push_task_branch` and `_push_bind_branch` become one-line bindings of the broker. −115 lines, no behaviour change (see below).
- **`src/cmd_deploy.sh`** (new) — `5dive deploy <task>` plus the root-only `_deploy_do`. Deploys only the `Deploy: <project>@<ref>` the task declares, only after that task's gate clears, with `VERCEL_TOKEN` read root-only and never handed to the agent.
- **`delegated_deploy`** as its own capability axis — `agent create --can-deploy`, its own sudoers block, registry name and reverify. Deliberately not a rider on `--can-push`: shipping a branch for review and shipping to production are different authorities.

One bound this surface gets that push does not: **the git repo is not a parameter.** `_deploy_do` reads it from the Vercel project's own `link`, so a granted agent supplies only *which already-linked project* and *which ref* — it cannot point one of our projects at a repo it chose.

## How it was checked

**The refactor is proven inert, not asserted to be.** `_push_gate_check` and `_push_bind_branch` stand between a granted agent and a git write, and "I only parameterized the nouns" is cheap to say. `tests/broker_surface_unit.sh` extracts `origin/main`'s own pre-refactor copies of those functions, runs them and the new wrappers over the same 13 fixture states, and compares refusal text and exit status **byte for byte**. 29/0. It refuses to run at all if the baseline ref is unreachable or already carries the refactored wrapper, so it cannot pass vacuously.

**Mutation-graded, every arm:**

| mutation | result |
|---|---|
| push's gate check re-pointed at the `deploy` surface | RED |
| push's target binding re-pointed at the `deploy` surface | RED |
| registry stops declaring `delegated_deploy` | RED |
| sudoers stops emitting the `_deploy_do` grant | RED |
| reverify stops grepping `_deploy_do` | RED |
| a table row added with no matching grant | RED |

`tests/capability_registry_unit.sh` (54 assertions) now enumerates `broker_surfaces()` instead of naming push, over all four `can_push` × `can_deploy` corners, with explicit non-vacuity arms on both the fully-granted and fully-ungranted corners — so the surface *after* this one is covered by that loop the day its table row lands, with nothing to remember to edit here.

**Live rail smoke** against the real DB (not the stubs): no-gate refusal, malformed-target refusal, bad-`--env` refusal, and `_deploy_do` refusing a non-root caller all fire correctly. The rendered sudoers policy `visudo -c` parses OK, and `render_standard_sudoers <user> 1` (the arity every pre-existing caller uses) is byte-identical to before, so no existing provisioning path changes.

## Known gaps, disclosed rather than implied

1. **VM smoke not run.** This touches the agent-create path, so our convention owes it. `test-vm.sh smoke` runs `update.sh refresh` and takes no branch/ref, so it grades the *released* bundle — it cannot grade this branch. The offline substitutes above establish "unchanged for existing callers", not "the new path provisions". **Merge is gated on this.**
2. **`/etc/5dive/connectors/vercel.env` is mode 0644** on our box, so `VERCEL_TOKEN` is readable by every account today. B1 (control-plane-only credential) is a precondition this design depends on and does not yet have — a broker gating who may deploy, guarding a token anyone can read and use directly, is theatre. `broker_connector_read` warns loudly and names the fix; the chmod itself wants its own row with the readers enumerated first, not a blind change. **Merge is gated on this.**
3. **The executor has never fired against Vercel.** Doing so requires a cleared gate on a task naming a real project, i.e. a live production deploy — not something to spend proving a test point.
4. **npm and Expo remain unprobed** for mint-on-demand. Neither is on the critical path until a surface needs them. Note also that the Vercel 403 is a fact about *our token's authority*, not proof the vendor could never mint a scoped token for a differently-scoped principal.

Design write-up: `community/wiki/which-half-of-the-delegated-push-template-generalizes.md` (updated with the probe result and what landed).



---

**Precondition update (2026-08-02) — disclosure 2 above is resolved, its merge gate is cleared.** The `0644 root:root` reading on `/etc/5dive/connectors/vercel.env` was accurate when this body was written. It stopped being true at `ctime 2026-08-01 17:48:24 +0000` (chmod moves ctime, not mtime), when olivia delivered **DIVE-2509** — a row filed 17:37:10 the same day because this PR surfaced the exposure — recording `chmod 0600 /etc/5dive/connectors/vercel.env (was 0644 root:root)`. Re-measured today the file is `600 root:root` and `sudo -u agent-dev cat` is denied, so **B1 holds on the deploy surface because of that fix**, not because the original measurement was wrong.

Still open, out of scope for this PR and independently flagged by olivia as the DIVE-2509 follow-up: 15 of the 25 entries under `/etc/5dive/connectors/` are `640 root:claude` while every `agent-*` account on this box is a member of group `claude` (verified by reading `anthropic.env` as `agent-dev`).



---

**Base update (2026-08-03) — this branch was CONFLICTING and is now MERGEABLE; `pull_request` CI has graded it for the first time.**

A conflicting PR gets zero `pull_request` workflow runs, so the previous 13-pass/1-skip green was pinned to a base 17 commits stale and nothing would ever regrade it. That was the evidence gap. `origin/main` is now merged in (merge-base was `5b576e8`; head of main at merge `cd29fa5`), 21 files conflicted — `CHANGELOG.md` (both entries kept) and 20 harness source lists where main added `lib/actor.sh` (DIVE-2517) and this branch added `lib/broker.sh`. Resolved as the union in every case.

**A merge, not a rebase, and the reason is this PR's own subject.** `src/cmd_push.sh` runs `git push <url> refs/heads/B:refs/heads/B` — no `+` refspec, no `--force`, no flag to request one. So a rewritten branch is rejected `non-fast-forward` and **the delegated-push broker cannot execute the standard remediation for a stale base at all**. Measured, not inferred: the rebase was done first, `5dive push` refused it. The two ways past that are force-pushing outside the broker (the exact bypass this ticket exists to remove, and it leaves no capability row) or bolting a destructive capability onto the broker as a side effect of a review comment. The merge is the third way: **its tree hash is byte-identical to the rebase's**, the old head is an ancestor of the new one so the push is a fast-forward, `5dive push` accepted it unchanged, and squash-merge flattens the merge commit at land time. Recorded as an INST-5 finding in the wiki page, not fixed here — whether the broker should ever hold force-push, and under what predicate, is a separate capability axis and a policy call.

**The merge earned its keep.** `broker_surface_unit` went 35/1 on the merged tree: `tests/task_close_preserves_done_at_unit.sh` sources `cmd_push.sh` without `lib/broker.sh`. It landed on main in `6ffb695` (DIVE-2525) *after* this branch was cut, so it inherited the exact latent break the 18-harness commit had just closed, and nothing on the stale base could see it. Fixed; back to 36/0. The sweep found it unaided because it derives its consumer list from the tree rather than naming files — that property is the point, and this is its first live catch.

**Tier stated, not defaulted (DIVE-2525).** The three new/changed harnesses now carry explicit `# TIER: core` markers with the measurement behind them: `deploy_unit` 4.1s, `broker_surface_unit` 2.4s, `capability_registry_unit` 1.3s — 7.8s against a 300s core budget, so core is defensible and no demotion is warranted. `push_unit`, which this branch also touches, keeps main's `nightly` marker at 11.9s.

Disclosure 1 (VM smoke at release-cut) above stands unchanged.
