### PR TITLE
fix(task): refuse `task start` over a live DELIVERED maker→verifier loop (DIVE-2510)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -1909,6 +1909,77 @@ _task_status_cmd() {
       _cd=$(db "SELECT COALESCE(done_at,'unknown') FROM tasks WHERE id=${id};")
       policy_refuse "$E_CONFLICT" start-on-closed-task DIVE-2113 "$ident" "$ident is CLOSED (status='${_cs}', closed ${_cd}) — 'task start' would silently reopen it to in_progress while LEAVING done_at set, so the row contradicts itself and any recorded grade would describe a task the board shows as open. If it genuinely must be reopened, that is a deliberate decision and belongs on the record; no alternative verb is named here on purpose, because a refusal that lists exits publishes a route around itself (DIVE-2067)."
     fi
+    # DIVE-2510: `task start` was the LAST status writer with no delivered-loop
+    # guard. `task done` refuses a non-verifier over a live delivery (DIVE-2007),
+    # `task reject` refuses the maker (DIVE-2112), `task start` refuses a closed
+    # row (DIVE-2113) — but a delivered row could still be re-claimed by its own
+    # maker, and the /goal prompt instructs exactly that ("claim it with
+    # `task start`"). So the documented workflow walks a maker into it: any
+    # delivered row a goal is re-issued over gets silently taken back out of the
+    # delivered shape by an agent following instructions correctly.
+    #
+    # THE HARM IS A MISREPRESENTED STATE. Measured on an isolated fixture, not
+    # inferred, and scoped narrowly on purpose because the exact scope is what
+    # the reader needs:
+    #   * status flips todo -> in_progress, and started_at (which the handoff set
+    #     to NULL) is re-stamped with the re-claim time. That is the whole write.
+    #   * `task show` keeps printing `handoff: delivered (awaiting verifier ACK)`
+    #     throughout — the render keys on `assignee=verifier AND status NOT IN
+    #     ('done','cancelled')`, and in_progress passes that. `task reject` is
+    #     what moves assignee back to the maker and (correctly) drops the line.
+    # So the board shows in_progress on a row nobody is working — it is sitting
+    # in the verifier's queue — and `status='todo' AND assignee=verifier`, the
+    # predicate the delivered state is documented as, stops matching. A false
+    # record either way, which is reason enough to refuse.
+    #
+    # DO NOT go looking for cleared delivery columns; there are none, and a
+    # reading of this rail that expects them is wrong at the schema level.
+    # `delivered_at` and `delivery_ref` have exactly ONE writer — cmd_task_deliver,
+    # the `task deliver --pr=` flow — so on a loop delivered by `task done` they
+    # are NULL and always were. `handoff_ack_at` is set to NULL by
+    # _task_route_to_verifier as PART of delivering. All three are therefore NULL
+    # *while the row is legitimately delivered*, which is why observing them NULL
+    # after a stray `task start` says nothing about that start. T6 of the harness
+    # measures the columns a loop delivery actually populates
+    # (handoff_delivered_at, maker_agent, iteration, result) and pins that they
+    # are untouched, rather than restating survival of columns that were never
+    # set — a "survives" claim over a NULL column is vacuously true and misleads.
+    #
+    # Keyed on the ACTOR, exactly like DIVE-2007, not on who the row is assigned
+    # to: delivery flips assignee TO the verifier, so an assignee test would read
+    # the maker's re-claim as a stranger's. The verifier's own start is the
+    # DIVE-1378 ACK further down and is excluded HERE by the actor comparison —
+    # the SQL only yields a verifier name when that verifier is not the caller.
+    # `cli` is task_actor's "could not attribute this invocation" sentinel
+    # (non-agent user, root cron, CI) and is EXEMPT for the same reason DIVE-2007
+    # exempts it — the threat model is a resolvable agent re-claiming its own
+    # delivery, and CI is where an over-broad version of that guard breaks
+    # unrelated harnesses.
+    #
+    # NOT an iteration fix, and it was proposed as one — measured instead of
+    # assumed, see T7. A maker's re-claim cannot inflate `iteration`: the only
+    # writer is _task_route_to_verifier, reached only by a `task done` that was
+    # NOT refused, and DIVE-2007 refuses the maker's done whatever status a stray
+    # start left behind. A climbing iteration on a delivered row means real
+    # reject/re-deliver cycles (or the exempt `cli`/verifier actor), not this bug.
+    #
+    # Placed BEFORE _task_start_preflight, alongside the DIVE-2059 and DIVE-2113
+    # refusals, so a start that is going to be refused does not first print three
+    # advisory heads-up warnings about work it will not be allowed to do.
+    local _sd_actor; _sd_actor=$(task_actor)
+    local _sd_vfier _sd_maker _sd_iter
+    IFS='|' read -r _sd_vfier _sd_maker _sd_iter <<<"$(db "SELECT
+            CASE WHEN maker_agent IS NOT NULL AND verifier IS NOT NULL
+                      AND assignee=verifier AND verifier IS NOT $(sqlq "$_sd_actor")
+                      AND handoff_ack_at IS NULL
+                      AND status NOT IN ('done','cancelled')
+                 THEN verifier ELSE '' END
+            ||'|'||COALESCE(maker_agent,'')||'|'||COALESCE(iteration,0)
+          FROM tasks WHERE id=${id};")"
+    if [[ -n "$_sd_vfier" && "$_sd_actor" != "cli" ]]; then
+        policy_refuse "$E_CONFLICT" start-over-delivered-loop DIVE-2510 "$ident" \
+          "$ident is DELIVERED to verifier '${_sd_vfier}' (iteration ${_sd_iter}, maker '${_sd_maker}') and has NOT been graded — a 'task start' from '${_sd_actor}' would flip it to in_progress, so the board would show someone working a row that is actually sitting in '${_sd_vfier}''s review queue, and the delivered predicate (status='todo' AND assignee=verifier) would stop matching it. Nothing is yours to claim here until it comes back: '${_sd_vfier}' either closes it or bounces it with '5dive task reject $ident --feedback=...' — that bounce reassigns it to you and 'task start' works again. If you have a CORRECTION to the delivery, send it to '${_sd_vfier}' (5dive agent send ${_sd_vfier} \"...\") rather than taking the row back."
+    fi
   fi
   # DIVE-1375: fail-loud preflight — surface identity/auth/repo gaps at `start`
   # BEFORE the agent burns a turn discovering them mid-task. Advisory only

--- a/tests/task_start_delivered_guard_unit.sh
+++ b/tests/task_start_delivered_guard_unit.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# DIVE-2510 unit harness — `task start` over a LIVE DELIVERED maker→verifier loop.
+#
+# THE DEFECT: `task start` was the last status writer with no delivered-loop
+# guard. `task done` refuses a non-verifier over a live delivery (DIVE-2007),
+# `task reject` refuses the maker (DIVE-2112), `task start` refuses a CLOSED row
+# (DIVE-2113) — but a DELIVERED row could still be re-claimed by its own maker,
+# and the /goal nudge the heartbeat writes literally instructs it ("claim it with
+# '5dive task start <id>'"). So the documented workflow walks a maker into it.
+#
+# THE HARM IS A MISREPRESENTED STATE, and this harness is where the scope is
+# pinned. T6 measures the un-guarded write on the exempt `cli` path: the columns
+# a loop delivery actually populates (handoff_delivered_at, maker_agent,
+# iteration, result) are untouched, and `task show` keeps printing the handoff
+# line at status=in_progress. What moves is status (todo -> in_progress) and
+# started_at.
+#
+# T6 deliberately does NOT assert survival of delivered_at/delivery_ref/
+# handoff_ack_at. Those are NULL on a `task done` delivery by construction —
+# delivered_at/delivery_ref have exactly one writer (cmd_task_deliver, the
+# `task deliver --pr=` flow) and handoff_ack_at is nulled by
+# _task_route_to_verifier as part of delivering. T6d pins that directly. An arm
+# asserting a NULL column "survived" a write would pass no matter what the code
+# did, and stating it in prose invites a reader to hunt a data-loss bug that the
+# schema makes impossible.
+#
+# Arms:
+#   T1 liveness — an ordinary (non-delivered) start still works. Without this the
+#      whole file passes on a CLI that refuses everything.
+#   T2 the fix — the MAKER is refused, and (per the standing rule that rc alone
+#      grades the wrong refusal) the ACTION never ran: status/started_at unmoved,
+#      and the reason names the verifier and the delivered condition.
+#   T3 a THIRD party is refused too (the guard is about the delivered shape, not
+#      about the maker specifically).
+#   T4 DIVE-1378 must not regress — the VERIFIER's own start is the ACK and works.
+#   T5 the REMEDY the refusal promises is real: after `task reject` bounces the
+#      row back, the maker's `task start` works again.
+#   T6 the `cli` sentinel (unattributable caller: CI, root cron) stays EXEMPT —
+#      same carve-out as DIVE-2007, and the arm that measures what the un-guarded
+#      write does (and, in T6d, which columns are NULL by construction).
+#   T7 SCOPE: this guard is NOT an iteration fix, and it was proposed as one.
+#      A maker's re-claim cannot inflate `iteration` — measured, not assumed.
+#
+# Same isolation contract as tests/task_verifier_rail_unit.sh: source src/
+# directly and point STATE_DIR at a throwaway temp dir so the live shared
+# tasks.db is NEVER touched. Run: bash tests/task_start_delivered_guard_unit.sh
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades. NOTE the absence of 2>/dev/null —
+# redirecting the source's stderr also swallows the helper's own stderr line,
+# which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/task-start-delivered-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"
+TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DB="$TASKS_DIR/tasks.db"
+mkdir -p "$TASKS_DIR"
+set +e   # header.sh enabled `set -e`; tests expect non-zero exits
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+# The guard reads the ACTOR, so every arm has to SAY who is calling. task_actor()
+# falls back to $USER when there is no sudo mapping and no --from.
+run_as() { local who="$1" verb="$2"; shift 2
+           ( USER="agent-${who}"; SUDO_UID=""; SUDO_USER=""; JSON_MODE=1; "cmd_task_$verb" "$@" ) 2>"$TMP"/err; }
+rc_of()  { local who="$1" verb="$2"; shift 2
+           ( USER="agent-${who}"; SUDO_UID=""; SUDO_USER=""; JSON_MODE=1; "cmd_task_$verb" "$@" ) >/dev/null 2>"$TMP"/err; printf '%s' "$?"; }
+show_of() { ( USER="agent-nobody"; SUDO_UID=""; SUDO_USER=""; JSON_MODE=0; cmd_task_show "$1" ) 2>&1; }
+jf()   { jq -r "$1" 2>/dev/null; }
+has()  { [[ "$1" == *"$2"* ]]; }
+st()   { db "SELECT status FROM tasks WHERE id=$1;"; }
+started() { db "SELECT COALESCE(started_at,'NULL') FROM tasks WHERE id=$1;"; }
+
+JSON_MODE=1
+tasks_db_init
+db "INSERT INTO agents_org (name, reports_to) VALUES ('boss',NULL),('mak','boss'),('vfy','boss'),('bystander','boss');"
+
+# Build a delivered row: mak files + works it, vfy is the grader, mak delivers.
+mk_delivered() {
+  local j id
+  j=$(run_as mak add --assignee=mak --verifier=vfy --priority=high -- "a real deliverable that needs grading and review")
+  id=$(printf '%s' "$j" | jf '.data.id')
+  run_as mak start "$id" >/dev/null
+  run_as mak done  "$id" --result="the work, as delivered" >/dev/null
+  printf '%s' "$id"
+}
+
+# --- T1: LIVENESS — an ordinary start is untouched ---------------------------
+# A guard that refuses everything would pass every other arm in this file.
+plain=$(run_as mak add --assignee=mak --no-verify --priority=high -- "an ordinary task with no verifier rail on it")
+plain_id=$(printf '%s' "$plain" | jf '.data.id')
+plain_rc=$(rc_of mak start "$plain_id")
+[[ "$plain_rc" == "0" && "$(st "$plain_id")" == "in_progress" ]] \
+  && ok_t "T1 liveness: an ordinary (non-delivered) 'task start' still works" \
+  || bad_t "T1 liveness: an ordinary (non-delivered) 'task start' still works" "rc=$plain_rc status=$(st "$plain_id")"
+
+# --- T2: the MAKER is refused, and the write never happened ------------------
+t2=$(mk_delivered)
+[[ "$(st "$t2")" == "todo" && "$(started "$t2")" == "NULL" ]] \
+  && ok_t "T2a fixture is genuinely DELIVERED (status=todo, started_at cleared)" \
+  || bad_t "T2a fixture is genuinely DELIVERED (status=todo, started_at cleared)" "status=$(st "$t2") started=$(started "$t2")"
+t2_rc=$(rc_of mak start "$t2")
+t2_err=$(cat "$TMP"/err)
+[[ "$t2_rc" == "$E_CONFLICT" ]] \
+  && ok_t "T2b the maker's 'task start' over a live delivery exits E_CONFLICT" \
+  || bad_t "T2b the maker's 'task start' over a live delivery exits E_CONFLICT" "rc=$t2_rc want=$E_CONFLICT :: $t2_err"
+# rc alone grades the wrong refusal: assert the ACTION never ran.
+[[ "$(st "$t2")" == "todo" && "$(started "$t2")" == "NULL" ]] \
+  && ok_t "T2c the refused start did NOT write (status still todo, started_at still NULL)" \
+  || bad_t "T2c the refused start did NOT write (status still todo, started_at still NULL)" "status=$(st "$t2") started=$(started "$t2")"
+# ...and that the reason names the CONDITION, not just any conflict.
+has "$t2_err" "DELIVERED to verifier 'vfy'" \
+  && ok_t "T2d the refusal names the verifier holding the row" \
+  || bad_t "T2d the refusal names the verifier holding the row" "$t2_err"
+# ...and names the REMEDY it promises. T5 grades that the remedy actually works;
+# this arm grades that the refusal tells the reader about it. (The DIVE-2510
+# ticket arg is policy_refuse's record field, not part of the printed message,
+# so asserting on it here would be grading the wrong artifact.)
+has "$t2_err" "task reject $(db "SELECT ident FROM tasks WHERE id=${t2};")" \
+  && ok_t "T2e the refusal names the bounce that returns the row to the maker" \
+  || bad_t "T2e the refusal names the bounce that returns the row to the maker" "$t2_err"
+
+# --- T3: a third party is refused too ----------------------------------------
+t3=$(mk_delivered)
+t3_rc=$(rc_of bystander start "$t3")
+[[ "$t3_rc" == "$E_CONFLICT" && "$(st "$t3")" == "todo" ]] \
+  && ok_t "T3 a third party's 'task start' over a live delivery is refused, no write" \
+  || bad_t "T3 a third party's 'task start' over a live delivery is refused, no write" "rc=$t3_rc status=$(st "$t3")"
+
+# --- T4: DIVE-1378 must not regress — the VERIFIER's start is the ACK --------
+t4=$(mk_delivered)
+t4_rc=$(rc_of vfy start "$t4")
+[[ "$t4_rc" == "0" && "$(st "$t4")" == "in_progress" ]] \
+  && ok_t "T4a the VERIFIER's own 'task start' still works (not caught by the guard)" \
+  || bad_t "T4a the VERIFIER's own 'task start' still works (not caught by the guard)" "rc=$t4_rc status=$(st "$t4") :: $(cat "$TMP"/err)"
+[[ -n "$(db "SELECT COALESCE(handoff_ack_at,'') FROM tasks WHERE id=${t4};")" ]] \
+  && ok_t "T4b ...and it still records the DIVE-1378 handoff ACK" \
+  || bad_t "T4b ...and it still records the DIVE-1378 handoff ACK"
+
+# --- T5: the remedy the refusal PROMISES is real ------------------------------
+# The refusal tells the maker to wait for the bounce. Grade the remedy half, not
+# only the predicate: after `task reject`, the maker's start must work again.
+t5=$(mk_delivered)
+run_as vfy reject "$t5" --feedback="needs another pass" >/dev/null
+[[ "$(db "SELECT assignee FROM tasks WHERE id=${t5};")" == "mak" ]] \
+  && ok_t "T5a a reject bounces the row back to the maker" \
+  || bad_t "T5a a reject bounces the row back to the maker" "assignee=$(db "SELECT assignee FROM tasks WHERE id=${t5};")"
+t5_rc=$(rc_of mak start "$t5")
+[[ "$t5_rc" == "0" && "$(st "$t5")" == "in_progress" ]] \
+  && ok_t "T5b ...and the maker's 'task start' then works again (the promised remedy)" \
+  || bad_t "T5b ...and the maker's 'task start' then works again (the promised remedy)" "rc=$t5_rc status=$(st "$t5") :: $(cat "$TMP"/err)"
+
+# --- T6: `cli` stays EXEMPT — and this is where the SURVIVAL claim is measured -
+# An unattributable caller (CI, root cron) is the DIVE-2007 carve-out and keeps
+# its old behaviour. That un-guarded write is exactly the mutation the escalation
+# described, so measure what it actually does to the row.
+t6=$(mk_delivered)
+before=$(db "SELECT COALESCE(handoff_delivered_at,'')||'|'||COALESCE(maker_agent,'')||'|'||COALESCE(iteration,0)||'|'||length(COALESCE(result,'')) FROM tasks WHERE id=${t6};")
+# CONSTRUCT the caller, never inherit it: task_actor falls through $USER to
+# `id -un`, so an EMPTY $USER resolves to whoever is running the harness (an
+# agent-* box yields a real agent name and this arm would grade the runner, not
+# the sentinel). A non-agent $USER is the shape that actually reaches 'cli'.
+t6_rc=$( ( USER="root"; SUDO_UID=""; SUDO_USER=""; JSON_MODE=1; cmd_task_start "$t6" ) >/dev/null 2>"$TMP"/err; printf '%s' "$?" )
+t6_actor=$( USER="root"; SUDO_UID=""; SUDO_USER=""; task_actor )
+if [[ "$t6_actor" != "cli" ]]; then
+  # Do not silently grade a carve-out we could not construct.
+  bad_t "T6 precondition: a non-agent \$USER must resolve to the 'cli' sentinel" "task_actor=$t6_actor"
+else
+  t6_wrote=0
+  if [[ "$t6_rc" == "0" && "$(st "$t6")" == "in_progress" ]]; then
+    t6_wrote=1
+    ok_t "T6a the 'cli' sentinel stays exempt (same carve-out as DIVE-2007)"
+  else
+    bad_t "T6a the 'cli' sentinel stays exempt (same carve-out as DIVE-2007)" "rc=$t6_rc status=$(st "$t6") :: $(cat "$TMP"/err)"
+  fi
+  # NON-VACUITY: T6b/T6c grade what the UNGUARDED write did to the row. If the
+  # write never landed (T6a red — the exemption regressed and `cli` got refused)
+  # then the columns are trivially unchanged and the handoff line trivially still
+  # renders, so both would pass while measuring NOTHING. Fail them instead of
+  # letting a green line stand for an unmeasured claim.
+  if [[ $t6_wrote -eq 0 ]]; then
+    bad_t "T6b THE SCOPE: the un-guarded write touches ONLY status and started_at" "UNGRADED — the write never landed (T6a red), so survival is vacuous here"
+    bad_t "T6c ...and 'task show' STILL renders the handoff line at status=in_progress" "UNGRADED — the write never landed (T6a red)"
+  else
+    after=$(db "SELECT COALESCE(handoff_delivered_at,'')||'|'||COALESCE(maker_agent,'')||'|'||COALESCE(iteration,0)||'|'||length(COALESCE(result,'')) FROM tasks WHERE id=${t6};")
+    [[ "$after" == "$before" && "$before" != "|||0" ]] \
+      && ok_t "T6b THE SCOPE: the un-guarded write touches ONLY status and started_at — handoff_delivered_at/maker_agent/iteration/result are all unmoved" \
+      || bad_t "T6b THE SCOPE: the un-guarded write touches ONLY status and started_at" "before=$before after=$after"
+    has "$(show_of "$t6")" "handoff: delivered (awaiting verifier ACK)" \
+      && ok_t "T6c ...and 'task show' STILL renders the handoff line at status=in_progress" \
+      || bad_t "T6c ...and 'task show' STILL renders the handoff line at status=in_progress" "$(show_of "$t6")"
+    # T6d: the columns a reader might expect to have been "cleared" are NULL by
+    # CONSTRUCTION on a `task done` delivery, so observing them NULL after a
+    # stray start says nothing about that start. Pinned here so nobody re-derives
+    # a data-loss bug from a schema fact.
+    nulls=$(db "SELECT COALESCE(delivered_at,'N')||COALESCE(delivery_ref,'N')||COALESCE(handoff_ack_at,'N') FROM tasks WHERE id=${t6};")
+    [[ "$nulls" == "NNN" ]] \
+      && ok_t "T6d delivered_at/delivery_ref/handoff_ack_at are NULL by construction on a 'task done' delivery (they belong to 'task deliver --pr='), so their NULLness is never evidence of a clearing write" \
+      || bad_t "T6d delivered_at/delivery_ref/handoff_ack_at are NULL by construction on a 'task done' delivery" "got=$nulls want=NNN"
+  fi
+fi
+
+# --- T7: SCOPE — this guard is NOT the iteration fix --------------------------
+# It was proposed as one: "the iteration inflation is downstream of the same
+# thing and should stop with it." Measured instead of assumed. `iteration` has
+# exactly one writer, _task_route_to_verifier, reached only by a `task done` that
+# was NOT refused — and DIVE-2007 refuses the maker's done regardless of what
+# status a stray start left behind. So a re-claim/re-close cycle cannot inflate
+# it, and a climbing iteration means real reject/re-deliver cycles instead.
+# This arm is deliberately actor-'mak' (not the exempt `cli`) so it measures the
+# refusal path a goal re-issue actually takes.
+t7=$(mk_delivered)
+t7_i0=$(db "SELECT iteration FROM tasks WHERE id=${t7};")
+for _ in 1 2 3; do
+  rc_of mak start "$t7" >/dev/null
+  rc_of mak done  "$t7" --result="a re-issued goal trying to redeliver" >/dev/null
+done
+t7_i1=$(db "SELECT iteration FROM tasks WHERE id=${t7};")
+[[ "$t7_i0" == "1" && "$t7_i1" == "1" ]] \
+  && ok_t "T7 three goal re-issues (start+done as the maker) do NOT inflate iteration — it stays $t7_i1, so this guard is not the iteration fix and a climbing counter has a different cause" \
+  || bad_t "T7 three goal re-issues do NOT inflate iteration" "before=$t7_i0 after=$t7_i1 (expected 1 -> 1)"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## DIVE-2510 — `task start` over a live DELIVERED loop

`task start` was the last status writer with no delivered-loop guard:

| verb | guard | ticket |
|---|---|---|
| `task done` | refuses a non-verifier over a live delivery | DIVE-2007 |
| `task reject` | refuses the maker | DIVE-2112 |
| `task start` | refuses a CLOSED row | DIVE-2113 |
| `task start` | **refuses a DELIVERED row** | **this PR** |

A delivered row could still be re-claimed, and the `/goal` nudge the heartbeat writes literally instructs it (*"claim it with `5dive task start <id>`"*). The documented workflow walked makers into it: any delivered row a goal was re-issued over got taken back out of the delivered shape by an agent following instructions correctly.

Keyed on the **actor**, exactly like DIVE-2007, not on who the row is assigned to — delivery flips `assignee` to the verifier, so an assignee test would read the maker's own re-claim as a stranger's. The verifier's own start is the DIVE-1378 ACK and is excluded by that same actor comparison. The `cli` sentinel (unattributable caller: CI, root cron) stays exempt, same carve-out as DIVE-2007.

### The harm is a misrepresented state

The un-guarded write moves exactly two things: `status` (`todo` to `in_progress`) and `started_at`. `task show` keeps printing `handoff: delivered (awaiting verifier ACK)` throughout, because that render keys on `assignee=verifier AND status NOT IN ('done','cancelled')` and `in_progress` passes it.

So the board shows `in_progress` on a row nobody is working — it is sitting in the verifier's queue — and `status='todo' AND assignee=verifier`, the predicate the delivered state is documented as, stops matching. Nothing alarms, and the verifier is never told. A false record is reason enough to refuse.

### No data loss on this rail, and nobody should go hunting one

`delivered_at` and `delivery_ref` have exactly one writer — `cmd_task_deliver`, the `task deliver --pr=` flow. On a loop delivered by `task done` they are NULL and always were. `handoff_ack_at` is set to NULL by `_task_route_to_verifier` **as part of delivering**.

All three are therefore NULL *while the row is legitimately delivered*, which is why observing them NULL after a stray `task start` says nothing about that start. **T6d** pins this directly so the schema fact is not re-derived as a bug later. T6 measures the columns a loop delivery actually populates (`handoff_delivered_at`, `maker_agent`, `iteration`, `result`) and asserts they are unmoved — an arm asserting a NULL column "survived" a write would pass no matter what the code did.

### Scope: this is not the iteration fix

It was proposed as one. Measured rather than assumed (**T7**): `iteration` has one writer, `_task_route_to_verifier`, reached only by a `task done` that was **not** refused — and DIVE-2007 refuses the maker's `done` whatever status a stray `start` left behind. Three `start`+`done` re-issues as the maker leave `iteration` at 1.

A climbing counter on a delivered row therefore means real reject/re-deliver cycles, or the exempt `cli`/verifier actor — not this bug. Worth its own ticket if the inflation is real.

### Grading

`tests/task_start_delivered_guard_unit.sh` — **16 arms**, anchored **RED at 11 passed / 5 failed** with the guard disabled (T2b, T2c, T2d, T2e, T3), **16 passed / 0 failed** with it on.

- **T1 liveness** — an ordinary (non-delivered) start still works, so the file cannot pass on a CLI that refuses everything.
- **T2** the maker is refused, and per the standing rule that rc alone grades the wrong refusal, the **action never ran** (status/`started_at` unmoved) and the reason names the verifier and the remedy.
- **T3** a third party is refused too — the guard is about the delivered shape, not the maker specifically.
- **T4** DIVE-1378 must not regress — the verifier's own start is the ACK and still works, still stamps `handoff_ack_at`.
- **T5** the remedy the refusal *promises* is real: after `task reject` bounces the row back, the maker's start works again.
- **T6** the `cli` carve-out holds; T6b/T6c **refuse to grade** when the unguarded write never landed, rather than reading a trivially-unchanged row as evidence. T6d pins the NULL-by-construction columns.
- **T7** the iteration scope limit above.

Also re-ran green: `task_done_delivered_guard_unit` (20/0), `task_start_closed_unit` (12/0), `task_verifier_rail_unit` (23/0), `heartbeat_dispatcher_claim_unit` (20/0), `heartbeat_stall_sweep_unit` (34/0), `handoff_ack_unit`, `task_start_recurring_guard_unit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
