### PR TITLE
feat(task): merge-audit LABELS findings delivered-vs-cited, never filters them (DIVE-1975)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Unreleased — feat(task): merge-audit LABELS findings delivered-vs-cited, and never filters them (DIVE-1975)
+
+DIVE-1965 taught the merge *gate* to tell "I shipped this PR" from "I am writing about this PR",
+and to skip the second. `task merge-audit` is the same predicate over the same data feeding a
+different consumer, and it never learned the split: the retrospective sweep still reported a PR
+that a done task merely CITED as if it were that task's own unmerged work.
+
+Every finding now carries `delivered` or `cited`, in the columns and in `--json` (`origin` per row,
+plus `delivered` / `cited` totals in the summary). Nothing is dropped.
+
+The label is the whole change, and the refusal to filter is the load-bearing half. A blocking gate
+and a non-blocking sweep want OPPOSITE safe defaults on the same predicate. The gate blocks a
+close, so over-judging stalls the fleet and its default is CITED with delivery asserted. The sweep
+blocks nothing and a human reads it, so over-reporting costs one line to dismiss while
+under-reporting hides real unmerged work. Filtering to "delivered only" would rebuild the
+blindness DIVE-1955 existed to remove, one layer down and harder to see: the sweep would come back
+clean while the work it was built to find sat unmerged behind a maker's phrasing. DIVE-1965's own
+known coverage seam, an own delivery phrased outside the shipping-verb vocabulary, lands exactly
+there.
+
+Two deliberate widenings of `delivered`, both harmless because nothing is dropped: the
+`delivery_ref` column folds in (it never reaches the gate's prose classifier, but a bound
+delivery_ref is the strongest delivery assertion there is), and the audit row arrives with
+newlines collapsed, so the classifier's line-scoping degrades to text-scoping.
+
+Seven arms added to `tests/task_merge_gate_delivered_vs_cited_unit.sh` (39 total), each
+differential on the same PR number in the same repo so a hardcoded label fails at least one.
+Graded by mutation: always-cited, always-delivered, filter-cited-out, and drop-the-column each
+turn arms red.
+
 ## Unreleased — fix(task): refuse a close that would REPLACE an already-closed row's result (DIVE-2464)
 
 `5dive task done <id> --result=...` on a row that was already done overwrote the result column and

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -56,6 +56,8 @@ _task_usage() {
                                                      # rather than guess, because #N means a different PR in each repo.
   5dive task merge-audit [--limit=N] [--json]         # DIVE-1935: retrospective sweep — DONE tasks whose own record names a PR
                                                      # that never merged (or merged red). Read-only; reports, never reopens.
+                                                     # DIVE-1975: each finding is LABELLED `delivered` (the task claims it as
+                                                     # its own) or `cited` (it only writes about it). A label, never a filter.
                                                      # DIVE-1955: sweeps every repo in FIVE_GATE_REPOS (default: the CLI,
                                                      # 5dive-api and 5dive-frontend), not just the CLI one.
   5dive task verify <id|DIVE-N> [--cmd="<command>"] [--no-done] [--timeout=<s>]
@@ -2930,6 +2932,9 @@ cmd_task_deliver() {
 # result + body, resolves each, and prints the ones that are NOT merged. An
 # unresolvable ref is reported as `unverified`, never counted as clean, so the
 # sweep can't answer "all good" out of a broken token (the DIVE-1935 defect).
+# DIVE-1975: every finding also carries `delivered` or `cited` — the DIVE-1965
+# split, as a LABEL. See the long note at the classification site for why this
+# consumer labels where the gate skips.
 cmd_task_merge_audit() {
   tasks_db_init
   local limit=200
@@ -2947,10 +2952,10 @@ cmd_task_merge_audit() {
   local tok slugs; tok=$(_gate_gh_token); slugs=$(_gate_repo_slugs | paste -sd, -)
   [[ -n "$tok" ]] || fail "$E_GENERIC" "task merge-audit could not resolve a gh token — every PR would report 'unverified', which is not an audit. Authenticate gh (or export GH_TOKEN) and re-run."
   _gate_pr_refs_engine_ok || fail "$E_GENERIC" "task merge-audit cannot parse PR references on this host (grep -oE unusable) — it would report a clean sweep by finding nothing at all. Fix grep and re-run."
-  local rows findings=0 unver=0 amb=0 json_rows=""
+  local rows findings=0 unver=0 amb=0 deliv_n=0 cited_n=0 json_rows=""
   rows=$(db "SELECT ident || '|' || COALESCE(delivery_ref,'') || '|' || REPLACE(REPLACE(COALESCE(delivery_ref,'') || ' ' || COALESCE(result,'') || ' ' || COALESCE(body,''), char(10), ' '), '|', ' ')
                FROM tasks WHERE status='done' ORDER BY COALESCE(done_at, created_at) DESC LIMIT ${limit};")
-  local line tident tdref ttext qref st state rslug tslug
+  local line tident tdref ttext qref st state rslug tslug tdeliv origin
   while IFS= read -r line; do
     [[ -n "$line" ]] || continue
     tident="${line%%|*}"; line="${line#*|}"
@@ -2962,6 +2967,39 @@ cmd_task_merge_audit() {
     # an old CLI one — a resolved-looking verdict about the wrong PR, which the
     # footnote excused only for `unverified`.
     tslug=$(_gate_task_repo_slug "$tdref" "$ttext")
+    # DIVE-1975: LABEL each finding delivered-vs-cited. NEVER filter on it.
+    #
+    # DIVE-1965 split "a PR this task DELIVERED" from "a PR this task WRITES ABOUT"
+    # and taught the gate to skip the second. This sweep is the SAME predicate over
+    # the SAME data feeding a DIFFERENT consumer, and the two want OPPOSITE safe
+    # defaults:
+    #   * the GATE blocks a close. Over-judging stalls the fleet — the exact
+    #     fleet-wide blocker DIVE-1965 exists to prevent — so its default is CITED
+    #     and delivery must be asserted.
+    #   * this SWEEP blocks nothing; a human reads it. Over-reporting costs one line
+    #     to dismiss. Under-reporting HIDES REAL UNMERGED WORK, which is the whole
+    #     job. So it reports every ref and annotates the ones it cannot bind.
+    # Filtering to `delivered` here would rebuild the DIVE-1955 blindness one layer
+    # down and HARDER TO SEE: the sweep would come back clean while the work it was
+    # built to find sat unmerged behind a maker's phrasing. DIVE-1965's own known
+    # coverage seam (an own delivery phrased outside the shipping-verb vocabulary)
+    # lands precisely there. Same shape as DIVE-1955's `ambiguous` branch: report
+    # the non-answer, do not manufacture one and do not swallow it. A label lets the
+    # reader triage; a filter decides for them with the gate's risk model.
+    #
+    # Two deliberate differences from the gate's classification, both widening
+    # `delivered`, which is the harmless direction when nothing is dropped:
+    #   1. the `delivery_ref` COLUMN is folded in. It never reaches the gate's prose
+    #      classifier (a declared ref routes to the declared gate) but it IS part of
+    #      this row's text, and a bound delivery_ref is the strongest delivery
+    #      assertion we have — classifying it as a citation would be plainly wrong.
+    #   2. the row arrives with newlines collapsed to spaces (the reader loop is
+    #      line-based), so the classifier's line-scoping degrades to text-scoping and
+    #      a shipping verb can reach across an original line break. Cosmetic here:
+    #      it can only move a row from `cited` to `delivered` in a report where both
+    #      are printed.
+    tdeliv=$( _gate_pr_refs_qualified_from_text "$tdref"
+              _gate_delivery_refs_from_text "$ttext" )
     while IFS= read -r qref; do
       [[ -n "$qref" ]] || continue
       st=$(_gate_resolve_qualified "$qref" "$tok" "$tident" "$tslug")
@@ -2977,18 +3015,33 @@ cmd_task_merge_audit() {
         esac
       fi
       findings=$((findings+1))
-      json_rows+=$(jq -nc --arg t "$tident" --arg p "${qref#*|}" --arg r "$rslug" --arg s "$state" \
-                     '{ident:$t,pr:("#"+$p),repo:$r,state:$s}')$'\n'
-      [[ "${JSON_MODE:-0}" == "1" ]] || printf '%-12s %-22s PR #%-6s %s\n' "$tident" "$rslug" "${qref#*|}" "$state"
+      # The gate's membership rule, verbatim (DIVE-1965): an exact qualified match,
+      # OR the same number asserted BARE — the extractor may have upgraded a bare
+      # "PR #N" to `slug|N` off a URL elsewhere in the same text, so a number-only
+      # match on the cited side would be too loose and an exact-only match too tight.
+      if printf '%s\n' "$tdeliv" | grep -qxF -e "$qref" -e "|${qref#*|}"; then
+        origin="delivered"; deliv_n=$((deliv_n+1))
+      else
+        origin="cited"; cited_n=$((cited_n+1))
+      fi
+      json_rows+=$(jq -nc --arg t "$tident" --arg p "${qref#*|}" --arg r "$rslug" --arg s "$state" --arg o "$origin" \
+                     '{ident:$t,pr:("#"+$p),repo:$r,state:$s,origin:$o}')$'\n'
+      [[ "${JSON_MODE:-0}" == "1" ]] || printf '%-12s %-22s PR #%-6s %-11s %s\n' "$tident" "$rslug" "${qref#*|}" "$state" "$origin"
     done < <(_gate_pr_refs_qualified_from_text "$ttext")
   done <<<"$rows"
   local payload; payload=$(printf '%s' "$json_rows" | jq -sc '.')
   if [[ "${JSON_MODE:-0}" != "1" ]] && (( unver + amb > 0 )); then
     printf 'note: `unverified` = the number resolves to no PR in the repo(s) searched FOR THAT\n      TASK — the one its own record DECLARES (a delivery_ref URL or a `Repo:` line) when it\n      declares one, else all of %s (DIVE-1963).\n      `ambiguous` = a bare "PR #N" that exists in more than one of them and the task\n      declares no repo, so no single verdict is defensible. NEITHER is evidence of an\n      unmerged PR, and neither is evidence of a clean one. Cite the full pull URL, or\n      add a `Repo: <owner>/<repo>` line to the task body, to have them resolved.\n' "$slugs"
   fi
-  ok "merge-audit: scanned the newest $limit done task(s) across $slugs — $findings PR reference(s) not merged-and-green ($unver unverified, $amb ambiguous)" \
-     '{scanned:($n|tonumber), repos:($rp|split(",")), findings:($f|tonumber), unverified:($u|tonumber), ambiguous:($a|tonumber), rows:($r|fromjson)}' \
-     --arg n "$limit" --arg rp "$slugs" --arg f "$findings" --arg u "$unver" --arg a "$amb" --arg r "$payload"
+  # DIVE-1975: the label is only useful if the reader knows it is a LABEL and not a
+  # filter — otherwise `cited` reads as "already dismissed" and the rows it marks get
+  # skipped, which is the filter we refused to write, executed by the human instead.
+  if [[ "${JSON_MODE:-0}" != "1" ]] && (( findings > 0 )); then
+    printf 'note: `delivered` = the task ASSERTS this PR as its own delivery (a bound delivery_ref,\n      a `Delivered:` line, or a shipping verb next to the ref — DIVE-1965).\n      `cited` = the task names the PR but claims no delivery. It is a LABEL, not a\n      filter: every reference found is listed either way, because a maker who shipped\n      without the phrasing would otherwise vanish from this sweep entirely (DIVE-1975).\n      Triage `delivered` first; `cited` rows are usually another task'"'"'s to answer for.\n'
+  fi
+  ok "merge-audit: scanned the newest $limit done task(s) across $slugs — $findings PR reference(s) not merged-and-green ($deliv_n delivered by the task, $cited_n only cited; $unver unverified, $amb ambiguous)" \
+     '{scanned:($n|tonumber), repos:($rp|split(",")), findings:($f|tonumber), delivered:($d|tonumber), cited:($c|tonumber), unverified:($u|tonumber), ambiguous:($a|tonumber), rows:($r|fromjson)}' \
+     --arg n "$limit" --arg rp "$slugs" --arg f "$findings" --arg d "$deliv_n" --arg c "$cited_n" --arg u "$unver" --arg a "$amb" --arg r "$payload"
 }
 
 # DIVE-477: hand a maker-completed task to its verifier instead of closing it.

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -56,8 +56,8 @@ _task_usage() {
                                                      # rather than guess, because #N means a different PR in each repo.
   5dive task merge-audit [--limit=N] [--json]         # DIVE-1935: retrospective sweep — DONE tasks whose own record names a PR
                                                      # that never merged (or merged red). Read-only; reports, never reopens.
-                                                     # DIVE-1975: each finding is LABELLED `delivered` (the task claims it as
-                                                     # its own) or `cited` (it only writes about it). A label, never a filter.
+                                                     # DIVE-1975: each finding is LABELLED 'delivered' (the task claims it as
+                                                     # its own) or 'cited' (it only writes about it). A label, never a filter.
                                                      # DIVE-1955: sweeps every repo in FIVE_GATE_REPOS (default: the CLI,
                                                      # 5dive-api and 5dive-frontend), not just the CLI one.
   5dive task verify <id|DIVE-N> [--cmd="<command>"] [--no-done] [--timeout=<s>]

--- a/tests/task_merge_gate_delivered_vs_cited_unit.sh
+++ b/tests/task_merge_gate_delivered_vs_cited_unit.sh
@@ -310,5 +310,87 @@ run_done DREF-1 --result='Also reviewed PR #10, still open.'
   && ok_t 'a declared delivery_ref closes over a cited OPEN PR without consulting the prose' \
   || bad_t 'declared path must ignore citations' "rc=$RC status=$(statusof DREF-1) out=$OUT"
 
+# --- 12. DIVE-1975: the OTHER consumer of the same predicate -----------------
+# `task merge-audit` reads delivery_ref + result + body exactly like the gate above,
+# but it BLOCKS NOTHING — a human reads it. So the safe default inverts: the gate
+# skips what it cannot bind to this task, the sweep must still PRINT it and merely
+# label it. A filter here would rebuild the DIVE-1955 blindness one layer down and
+# harder to see, because the sweep would come back clean while the work it exists to
+# find sat unmerged behind a maker's phrasing.
+#
+# Every arm below is DIFFERENTIAL — the same PR number, in the same repo, resolved
+# by the same stub — so a hardcoded label (either one) fails at least one of them.
+# The audit scans the whole store, so the earlier arms' rows are cleared first and
+# only these five exist while it runs.
+clear_fx
+db "DELETE FROM tasks;"
+export GH_STUB_PR_5dive_api_10="$OPEN_X"
+export GH_STUB_PR_5dive_168="$MERGED_OK"
+seed_done() { # <ident> <result> [delivery_ref]
+  db "DELETE FROM tasks WHERE ident='$1';
+      INSERT INTO tasks (ident, title, body, result, delivery_ref, status, created_by, assignee, done_at)
+        VALUES ('$1','t','',$(sqlq "$2"),$(sqlq_or_null "${3:-}"),'done','main','main',datetime('now'));"
+}
+audit_line() { printf '%s\n' "$AUD_OUT" | grep -E "^$1[[:space:]]"; }
+
+seed_done AUD-CITE  'Fixes the crash reported in https://github.com/lodar/5dive-api/pull/10.'
+seed_done AUD-SHIP  'Shipped as https://github.com/lodar/5dive-api/pull/10.'
+seed_done AUD-COL   'Closed out the follow-ups.' 'https://github.com/lodar/5dive-api/pull/10'
+seed_done AUD-PLAIN 'Closed out the follow-ups. https://github.com/lodar/5dive-api/pull/10'
+seed_done AUD-GREEN 'Merged as https://github.com/5dive-ai/5dive/pull/168.'
+AUD_OUT=$(cmd_task_merge_audit --limit=50 2>&1); AUD_RC=$?
+
+# THE LOAD-BEARING HALF: a citation of another task's OPEN PR is REPORTED, not
+# dropped — and it is not reported as this task's own unmerged work either.
+if [[ "$(audit_line AUD-CITE)" == *"#10"*"OPEN"*"cited"* ]]; then
+  ok_t 'merge-audit: a cited OPEN PR is REPORTED and labelled `cited` — never filtered out'
+else
+  bad_t 'a cited ref must still appear in the sweep' "rc=$AUD_RC line=[$(audit_line AUD-CITE)]"
+fi
+# ...and the same ref, same repo, same stub, asserted as a delivery, labels the
+# other way. This pair is what makes the arm above mean something.
+if [[ "$(audit_line AUD-SHIP)" == *"#10"*"OPEN"*"delivered"* ]]; then
+  ok_t 'merge-audit: the same PR asserted with a shipping verb labels `delivered`'
+else
+  bad_t 'an asserted delivery must label delivered' "line=[$(audit_line AUD-SHIP)]"
+fi
+# The delivery_ref COLUMN never reaches the gate's prose classifier (a declared ref
+# routes to the declared gate), but it is the strongest delivery assertion we have
+# and it IS part of this row's text. AUD-COL and AUD-PLAIN carry byte-identical
+# prose and differ ONLY in the column, so this cannot pass on the phrasing.
+if [[ "$(audit_line AUD-COL)" == *delivered* && "$(audit_line AUD-PLAIN)" == *cited* ]]; then
+  ok_t 'merge-audit: a bound delivery_ref labels `delivered` where identical prose alone labels `cited`'
+else
+  bad_t 'the delivery_ref column must fold into the delivered set' \
+        "col=[$(audit_line AUD-COL)] plain=[$(audit_line AUD-PLAIN)]"
+fi
+# Labelling must not change WHAT is reported: a merged+green ref is still no finding.
+[[ -z "$(audit_line AUD-GREEN)" ]] \
+  && ok_t 'merge-audit: labelling did not turn a merged+green delivery into a finding' \
+  || bad_t 'merged+green must stay silent' "line=[$(audit_line AUD-GREEN)]"
+# The summary counts both populations, so "4 findings" cannot hide a 3/1 split.
+[[ "$AUD_OUT" == *"2 delivered by the task, 2 only cited"* ]] \
+  && ok_t 'merge-audit: the summary line reports the delivered/cited split' \
+  || bad_t 'summary must carry both counts' "out=$AUD_OUT"
+# A `cited` label that reads as "already dismissed" is the filter we refused to
+# write, executed by the reader. The note has to say it is a label.
+[[ "$AUD_OUT" == *"It is a LABEL, not a"*filter* ]] \
+  && ok_t 'merge-audit: the note tells the reader `cited` is a label and not a filter' \
+  || bad_t 'the label must be announced as a label' "out=$AUD_OUT"
+
+# --json carries the same split, per row and in the totals — the dashboard and any
+# scripted consumer read this, not the columns.
+JSON_MODE=0
+AUD_JSON=$(cmd_task_merge_audit --limit=50 --json 2>/dev/null); JSON_MODE=0
+j() { printf '%s' "$AUD_JSON" | jq -r ".data|$1" 2>/dev/null; }
+[[ "$(j '.rows[]|select(.ident=="AUD-CITE").origin')" == "cited" \
+&& "$(j '.rows[]|select(.ident=="AUD-SHIP").origin')" == "delivered" \
+&& "$(j '.rows[]|select(.ident=="AUD-COL").origin')"  == "delivered" ]] \
+  && ok_t 'merge-audit --json: every row carries its own `origin`' \
+  || bad_t '--json rows must carry origin' "json=$AUD_JSON"
+[[ "$(j '.delivered')" == "2" && "$(j '.cited')" == "2" && "$(j '.findings')" == "4" ]] \
+  && ok_t 'merge-audit --json: delivered + cited are totalled and sum to findings' \
+  || bad_t '--json totals must carry the split' "json=$AUD_JSON"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Follow-up to DIVE-1965 (PR #169), filed on Marcus's call.

## The gap

`cmd_task_merge_audit` fed `_gate_pr_refs_qualified_from_text` straight into resolution with no
knowledge of DIVE-1965's delivered-vs-cited split. The retrospective sweep therefore reported a PR
that a done task merely **cited** as if it were that task's own unmerged work.

## The change

Every finding now carries `delivered` or `cited` — a fifth column in the human output, an `origin`
field per row in `--json`, and `delivered`/`cited` totals in the summary line and JSON payload.
Same membership rule the gate uses (exact qualified match, or the same number asserted bare).

**Nothing is filtered.** That is the load-bearing half.

## Why label and not filter

A blocking gate and a non-blocking sweep want **opposite safe defaults** on the same predicate over
the same data:

- **The gate** blocks a close. Over-judging stalls the fleet — the exact fleet-wide close blocker
  DIVE-1965 exists to prevent — so its safe default is CITED and delivery must be asserted.
- **The sweep** blocks nothing; a human reads it. Over-reporting costs one line to dismiss.
  Under-reporting **hides real unmerged work**, which is the entire job.

Filter the sweep to "delivered only" and we rebuild the exact blindness DIVE-1955 existed to remove,
one layer down and harder to see — the sweep would come back clean while the work it was built to
find sat unmerged behind a maker's phrasing. DIVE-1965's own known coverage seam (a delivery phrased
outside the shipping-verb vocabulary) lands precisely there. Same shape as DIVE-1955's `ambiguous`
branch: report the non-answer, do not manufacture one and do not swallow it.

## Two deliberate widenings of `delivered`

Both harmless because nothing is dropped — they can only move a row between two printed labels.

1. **The `delivery_ref` column folds in.** It never reaches the gate's prose classifier (a declared
   ref routes to the declared gate), but it *is* part of this row's text, and a bound `delivery_ref`
   is the strongest delivery assertion we have. Classifying it as a citation would be plainly wrong.
2. **Newlines arrive collapsed** (the audit's reader loop is line-based), so the classifier's
   line-scoping degrades to text-scoping and a shipping verb can reach across an original line break.

## Tests

Seven arms added to `tests/task_merge_gate_delivered_vs_cited_unit.sh` — **39 passed, 0 failed**.
Every arm is differential: the same PR number, in the same repo, resolved by the same stub, so a
hardcoded label fails at least one. `AUD-COL` and `AUD-PLAIN` carry byte-identical prose and differ
only in the `delivery_ref` column.

Mutation-graded, each turns arms red:

| mutation | arms killed |
|---|---|
| always `cited` | asserted-delivery, delivery_ref column, `--json` rows |
| always `delivered` | cited-still-appears, delivery_ref column, `--json` rows |
| **filter `cited` out** | **cited-still-appears**, delivery_ref column, `--json` rows |
| drop the `delivery_ref` fold-in | delivery_ref column, summary split, both `--json` arms |

Seven sibling merge-gate suites re-run green (diagnostic, multirepo, inferred-repo, result-pr,
autodetect, ancestry, deliver). `shellcheck -S error` parity with `origin/main` (1 pre-existing
SC2148 on a sourced file, before and after). pii-scan clean on the diff and on `CHANGELOG.md`.

## ACCEPT criteria

- A done task whose result cites another task's open PR appears in `merge-audit` **labelled
  `cited`** — not dropped, not reported as its own unmerged work → `AUD-CITE`.
- A task whose own delivery is unmerged **still reports as before** → `AUD-SHIP`, `AUD-COL`; and
  `AUD-GREEN` pins that labelling did not turn a merged+green delivery into a finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
