### PR TITLE
fix(release-cut): print WHY a release grade failed, and grade the delta instead of re-running the corpus (DIVE-2524)

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -445,8 +445,15 @@ jobs:
           # do not hold, so the logic sits where it can be graded and repaired on the
           # normal rail (tests/grade_release_commit_unit.sh, 20 assertions). Same split
           # as scripts/pii-scan-range.sh (DIVE-2267).
-          echo "--- grading the release commit ${sha:0:12} (DIVE-2433) ---"
-          bash scripts/grade-release-commit.sh "${version}"
+          # DIVE-2524: pass the PARENT. It is what turns a 40-minute re-run of all 264
+          # harnesses into a grade of the delta — the script proves `git diff parent HEAD`
+          # is the release-commit set and nothing else, and only then inherits the
+          # parent's check-runs for the rest. Drop this argument and the script has no
+          # premise to prove, so it falls back to the full corpus rather than trusting
+          # an inheritance it cannot demonstrate. The parent is already the commit whose
+          # check-runs this job polled green, under its own name since DIVE-2433.
+          echo "--- grading the release commit ${sha:0:12} against parent ${parent_sha:0:12} (DIVE-2433, DIVE-2524) ---"
+          bash scripts/grade-release-commit.sh "${version}" "${parent_sha}"
           _grc=$?
           case "$_grc" in
             0) echo "release commit ${sha:0:12}: PASS on the exact artifact (DIVE-2433)" ;;

--- a/scripts/grade-release-commit.sh
+++ b/scripts/grade-release-commit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Grade the RELEASE COMMIT's own artifact (DIVE-2433).
+# Grade the RELEASE COMMIT's own artifact (DIVE-2433, reshaped by DIVE-2524).
 #
 # WHY THIS EXISTS. release-cut.yml builds a release commit, pushes it detached and
 # tags it. Nothing grades that commit: measured on v0.17.10, the release commit
@@ -25,7 +25,72 @@
 # credential most agents do not hold — so logic living in YAML is logic that cannot be
 # repaired on the normal rail. This can, and is (tests/grade_release_commit_unit.sh).
 #
-# Usage: grade-release-commit.sh <expected-version>   # run from the release tree root
+# ---------------------------------------------------------------------------------
+# DIVE-2524 — WHAT THE FIRST SHAPE OF THIS SCRIPT GOT WRONG, MEASURED.
+#
+# It ran the ENTIRE tests/*.sh corpus (264 harnesses, ~40 min) against the release
+# tree, and it never passed once. DIVE-2433 merged 2026-07-30 17:14Z; v0.17.10 was
+# cut 14:07Z that same day and is still the newest tag. Every cut since — six
+# consecutive nights — died here, so the whole fleet sat pinned while main moved.
+#
+# TWO DISTINCT CAUSES WORE ONE RED X, and only one of them was a real signal:
+#
+#  1. tests/release_cut_bundle_unit.sh CANNOT PASS ON A RELEASE COMMIT, ever, on any
+#     machine. It is the harness that guards MAIN's invariants — `5dive` and
+#     `5dive.sha256` are untracked and gitignored (DIVE-2091), src/header.sh carries
+#     the `0.0.0-dev` sentinel and not a real version (DIVE-2247). A release commit
+#     tracks both artifacts and writes a real version: that IS what a release commit
+#     is. Reproduced off CI with no token and no runner — 15 passed, 5 failed, the
+#     five being exactly those invariants. So it is excluded BY NAME below, not
+#     because it is flaky but because running it here asks a question whose only
+#     correct answer is the failure it returns. It keeps running on main in
+#     unit-tests.yml's `test` job, which is the tree it grades.
+#
+#  2. tests/task_merge_gate_multirepo_unit.sh and tests/task_merge_gate_result_pr_unit.sh
+#     went green in that same release tree (36/0 and 31/0), so those two ARE
+#     environment-specific — this job runs as uid 1001 with no token, its own
+#     selfcheck line says the privileged half cannot be measured from here, and
+#     that is the DIVE-2484 shape. Delta mode retires them from this job rather
+#     than diagnosing them: they are graded on the parent, in a job that has what
+#     they need.
+#
+# AND THE GRADE PRINTED NO EVIDENCE. Six nights of `FAIL — tests/x.sh` with the
+# harness output sent to /dev/null. A reader could not tell a regression from a
+# missing token, so the only available response was to ignore it — which is what
+# happened, six times. That is the v0.16 "fails loud" thesis violated on the release
+# path itself. Every failure now carries its own tail (GRC_TAIL lines).
+#
+# ---------------------------------------------------------------------------------
+# DELTA MODE (DIVE-2524) — GRADE THE DELTA, INHERIT THE REST, BUT PROVE IT FIRST.
+#
+# The release commit differs from an already-graded main commit by one sed'd line
+# plus regenerated artifacts. Re-running 264 harnesses to grade that is the wrong
+# instrument: it costs 40 minutes AND it drags harnesses into an environment that
+# cannot satisfy them.
+#
+# So when the caller names the PARENT, this script inherits the parent's check-runs
+# for everything the delta cannot reach — and the inheritance is ASSERTED, never
+# assumed. `git diff --name-only <parent> HEAD` must be a SUBSET of the paths a
+# release commit is allowed to touch, and must CONTAIN src/header.sh. Both halves
+# matter and for different reasons:
+#
+#   - the subset half is the premise. One extra path and "nothing else changed" is
+#     false, the parent's green no longer describes this tree, and the cheap grade
+#     would be inheriting a claim about a different object.
+#   - the non-empty half is the anti-vacuity guard. A subset test over an EMPTY diff
+#     passes trivially, so a cut that silently failed to write the version would sail
+#     through the check that exists to catch exactly that.
+#
+# Either one failing is UNDETERMINED (2), not a failure and never a pass: the tree is
+# not the shape delta mode reasons about, so this script has no verdict to give and
+# says so. The caller (release-cut.yml) refuses on 2 exactly as hard as on 1.
+#
+# WITHOUT A PARENT there is no premise to prove, so there is nothing to inherit and
+# the FULL corpus runs — the expensive path is the DEFAULT and the cheap one has to
+# earn itself. GRC_FULL_CORPUS=1 forces the full corpus back on with a parent given.
+#
+# Usage: grade-release-commit.sh <expected-version> [<parent-sha>]
+#        # run from the release tree root
 #
 # Exits, matching scripts/pii-scan.sh's contract so a caller can tell "clean" from
 # "could not look":
@@ -35,8 +100,64 @@
 set -uo pipefail
 
 WANT_VERSION="${1:-}"
+PARENT_SHA="${2:-}"
 BUNDLE="${GRC_BUNDLE:-./5dive}"
 TESTS_GLOB="${GRC_TESTS_GLOB:-tests/*.sh}"
+# How much of a failing harness's output to print. Enough to carry the assertion
+# lines a harness prints last; not so much that six reds bury the summary.
+GRC_TAIL="${GRC_TAIL:-25}"
+
+# Paths a release commit is ALLOWED to differ from its parent by. Derived from the
+# DIVE-2091 release-commit block in release-cut.yml, which is the only writer:
+# src/header.sh (the DIVE-2247 version assignment), the built bundle and its
+# checksum, and the DIVE-2452 CHANGELOG stamp. Anything else and the parent's CI no
+# longer describes this tree.
+GRC_DELTA_PATHS="${GRC_DELTA_PATHS:-src/header.sh 5dive 5dive.sha256 CHANGELOG.md}"
+# The path whose presence in the delta proves the cut actually did something. Without
+# it the subset assertion above is vacuous.
+GRC_DELTA_REQUIRED="${GRC_DELTA_REQUIRED:-src/header.sh}"
+
+# Harnesses that grade MAIN-TREE invariants and are therefore UNANSWERABLE on a
+# release commit — see cause 1 in the header. Skipped by NAME and reported as a skip,
+# never silently dropped: a corpus that quietly shrinks is the DIVE-2264 shape.
+GRC_EXCLUDE="${GRC_EXCLUDE:-tests/release_cut_bundle_unit.sh}"
+
+# The DELTA CORPUS: what a version write plus a rebundle plus a CHANGELOG stamp can
+# actually reach, over and above the selfcheck/--version/--help grade of the artifact
+# below. Everything else is inherited from the parent's check-runs, which is sound
+# only because the delta assertion above proved the parent IS this tree minus those
+# four paths.
+#
+# EVERY ENTRY WAS MEASURED ON A REAL RELEASE TREE, not reasoned about: a detached
+# origin/main with FIVE_VERSION sed to 0.17.11, the CHANGELOG stamped, the bundle
+# built and committed — the same object release-cut.yml produces. All 15 below ran
+# green there in 49 SECONDS total, against ~40 minutes for the 264. release_cut_bundle
+# is listed deliberately even though GRC_EXCLUDE drops it: naming it here is what
+# makes its SKIP line appear in every release log, so the one harness this row had to
+# stop running is visible in production and not only in this script's own tests.
+#
+#   release_cut_assign / release_cut_bundle / release_cut_guards  the cut's own rails
+#   version_bump_guard / version_freeze_observer                  the version WRITE
+#   update_check_propagation                                      DIVE-2042: compares
+#                                                                 FIVE_VERSION to the
+#                                                                 published tag, so the
+#                                                                 sed IS its input
+#   install_monotonicity / install_pin_sha / install_update_hint  version comparison on
+#                                                                 the install path
+#   install_checksum / self_bundle_evidence / gitattributes_...   the REBUNDLE
+#   release_notes                                                 DIVE-2452 CHANGELOG
+#   selfcheck / selfcheck_union                                   grade 1 below is a
+#                                                                 selfcheck; these are
+#                                                                 what keep it non-vacuous
+#   grade_release_commit                                          this script
+GRC_DELTA_TESTS="${GRC_DELTA_TESTS:-\
+tests/release_cut_assign_unit.sh tests/release_cut_bundle_unit.sh tests/release_cut_guards_unit.sh \
+tests/version_bump_guard_unit.sh tests/version_freeze_observer_unit.sh \
+tests/update_check_propagation_unit.sh tests/install_monotonicity_unit.sh \
+tests/install_pin_sha_unit.sh tests/install_update_hint_unit.sh tests/install_checksum_unit.sh \
+tests/self_bundle_evidence_unit.sh tests/gitattributes_generated_merge_unit.sh \
+tests/release_notes_unit.sh tests/selfcheck_unit.sh tests/selfcheck_union_unit.sh \
+tests/grade_release_commit_unit.sh}"
 
 if [[ -z "$WANT_VERSION" ]]; then
   echo "grade-release-commit: UNDETERMINED — no expected version given. This is NOT a pass." >&2
@@ -49,13 +170,49 @@ fi
 
 rc=0
 
-# 1. THE ARTIFACT ITSELF, not a rebuild of it. Ordered first because it is the whole
-#    point of this script; the corpus below mostly re-covers the parent's tree.
+# ---------------------------------------------------------------------------------
+# 0. THE INHERITANCE PREMISE. Runs FIRST, because everything cheap below is only
+#    sound if this holds, and a premise checked after the thing it licenses is not a
+#    premise.
+# ---------------------------------------------------------------------------------
+MODE=full
+if [[ -n "$PARENT_SHA" && -z "${GRC_FULL_CORPUS:-}" ]]; then
+  if ! _delta=$(git diff --name-only "$PARENT_SHA" HEAD 2>&1); then
+    echo "grade-release-commit: UNDETERMINED — cannot diff HEAD against parent '$PARENT_SHA' ($_delta), so 'nothing else changed' is unproven and nothing can be inherited. This is NOT a pass." >&2
+    exit 2
+  fi
+  _unexpected=()
+  while IFS= read -r _p; do
+    [[ -n "$_p" ]] || continue
+    _ok=0
+    for _allowed in $GRC_DELTA_PATHS; do [[ "$_p" == "$_allowed" ]] && { _ok=1; break; }; done
+    (( _ok )) || _unexpected+=("$_p")
+  done <<< "$_delta"
+  if (( ${#_unexpected[@]} > 0 )); then
+    echo "grade-release-commit: UNDETERMINED — the release commit differs from its parent ${PARENT_SHA:0:12} by ${#_unexpected[@]} path(s) OUTSIDE the release-commit set (${_unexpected[*]}). The parent's check-runs do not describe this tree, so nothing can be inherited from them. Re-run with GRC_FULL_CORPUS=1 to grade the whole corpus instead. This is NOT a pass." >&2
+    exit 2
+  fi
+  _missing=()
+  for _req in $GRC_DELTA_REQUIRED; do
+    grep -qxF "$_req" <<< "$_delta" || _missing+=("$_req")
+  done
+  if (( ${#_missing[@]} > 0 )); then
+    echo "grade-release-commit: UNDETERMINED — the delta against parent ${PARENT_SHA:0:12} does NOT touch ${_missing[*]}, so the version assignment never landed and the subset check above proved nothing about an empty diff. This is NOT a pass." >&2
+    exit 2
+  fi
+  MODE=delta
+  echo "grade-release-commit: delta vs parent ${PARENT_SHA:0:12} is within the release-commit set and assigns the version — inheriting the parent's check-runs for the rest (DIVE-2524)"
+fi
+
+# 1. THE ARTIFACT ITSELF, not a rebuild of it. Ordered first among the grades because
+#    it is the whole point of this script.
 #    --allow=snapshot-rails matches unit-tests.yml, so this is the same bar and not a
 #    softer one invented here.
-if bash "$BUNDLE" selfcheck --allow=snapshot-rails --label=release-commit; then
+if _sc_out=$(bash "$BUNDLE" selfcheck --allow=snapshot-rails --label=release-commit 2>&1); then
+  echo "$_sc_out"
   echo "grade-release-commit: selfcheck PASS on the released bundle"
 else
+  echo "$_sc_out"
   echo "grade-release-commit: FAIL — selfcheck did not pass on the released bundle" >&2
   rc=1
 fi
@@ -76,28 +233,61 @@ else
   rc=1
 fi
 
-# 3. The corpus, same invocation as unit-tests.yml's `test` job, against the RELEASE
-#    tree rather than main's.
+# 3. The harness corpus against the RELEASE tree.
 #
-#    An EMPTY glob is UNDETERMINED, never clean: a `for t in tests/*.sh` over nothing
+#    In FULL mode this is the same invocation as unit-tests.yml's `test` job. In DELTA
+#    mode it is the named subset that a version write and a rebundle can reach; the
+#    rest is inherited from the parent, which section 0 proved is this tree.
+#
+#    An EMPTY set is UNDETERMINED, never clean: a `for t in tests/*.sh` over nothing
 #    iterates the literal pattern once, and a caller that only reads the exit code
 #    cannot tell "every harness passed" from "no harness ran". That is the DIVE-2264
 #    shape and it is exactly the failure this whole row is about, so it is refused
 #    here rather than reported as a pass.
-_ran=0 _failed=0
-for _t in $TESTS_GLOB; do
+if [[ "$MODE" == delta ]]; then
+  _set="$GRC_DELTA_TESTS"
+  _what="delta corpus"
+else
+  _set="$TESTS_GLOB"
+  _what="corpus"
+fi
+
+_ran=0 _failed=0 _skipped=0
+for _t in $_set; do
   [[ -f "$_t" ]] || continue
+  _skip=0
+  for _x in $GRC_EXCLUDE; do [[ "$_t" == "$_x" ]] && { _skip=1; break; }; done
+  if (( _skip )); then
+    # Named, printed, and counted. The reader must be able to see what did NOT run.
+    echo "grade-release-commit: SKIP — $_t grades MAIN-tree invariants (untracked bundle, 0.0.0-dev sentinel) that a release commit inverts by construction; it is graded on main in unit-tests.yml's \`test\` job (DIVE-2524)"
+    _skipped=$((_skipped + 1))
+    continue
+  fi
   _ran=$((_ran + 1))
-  bash "$_t" >/dev/null 2>&1 || { echo "grade-release-commit: FAIL — $_t" >&2; _failed=$((_failed + 1)); }
+  if ! _out=$(bash "$_t" 2>&1); then
+    _failed=$((_failed + 1))
+    # ITEM 1 of DIVE-2524: a rail that fails without saying why gets ignored, and this
+    # one was, six nights running. The tail goes to the same stream as the verdict.
+    {
+      echo "grade-release-commit: FAIL — $_t"
+      echo "--- last ${GRC_TAIL} lines of $_t ---"
+      tail -n "$GRC_TAIL" <<< "$_out"
+      echo "--- end $_t ---"
+    } >&2
+  fi
 done
 if (( _ran == 0 )); then
-  echo "grade-release-commit: UNDETERMINED — no harness matched '$TESTS_GLOB', so the corpus never ran. This is NOT a pass." >&2
+  echo "grade-release-commit: UNDETERMINED — no harness matched '$_set' (${_skipped} excluded by name), so the ${_what} never ran. This is NOT a pass." >&2
   exit 2
 fi
 (( _failed == 0 )) || rc=1
-echo "grade-release-commit: corpus ran $_ran harness(es), $_failed failed"
+echo "grade-release-commit: ${_what} ran $_ran harness(es), $_failed failed, $_skipped skipped"
 
 if (( rc == 0 )); then
-  echo "grade-release-commit: PASS — $WANT_VERSION graded on the exact artifact ($_ran harnesses + selfcheck + smoke)"
+  if [[ "$MODE" == delta ]]; then
+    echo "grade-release-commit: PASS — $WANT_VERSION graded on the exact artifact ($_ran delta harnesses + selfcheck + smoke), the rest inherited from parent ${PARENT_SHA:0:12} whose delta is proven to be the release-commit set alone"
+  else
+    echo "grade-release-commit: PASS — $WANT_VERSION graded on the exact artifact ($_ran harnesses + selfcheck + smoke)"
+  fi
 fi
 exit "$rc"

--- a/tests/grade_release_commit_unit.sh
+++ b/tests/grade_release_commit_unit.sh
@@ -313,4 +313,25 @@ ok "SHIPPED-LIST: every harness the release grade names still EXISTS (${_dn} nam
 ok "SHIPPED-LIST: the excluded main-tree harness is NAMED in it, so its SKIP shows up in the release log" \
   "grep -q 'tests/release_cut_bundle_unit.sh' <<<\"\$_defaults\""
 
+# ---- 11. THE ALLOWED-PATH SET STILL MATCHES WHAT THE CUT ACTUALLY WRITES ----
+# GRC_DELTA_PATHS is a hardcoded copy of a fact that lives in release-cut.yml: the set
+# of paths the DIVE-2091 release-commit block stages. The copy is the risk. Add a
+# fifth path there — another generated artifact, another stamp — and delta mode goes
+# UNDETERMINED and the cut REFUSES. That is the safe direction and it is still a
+# 02:37Z outage discovered by nobody being paged. Derive the truth from the workflow
+# and fail HERE, at PR time, instead.
+_wf="$_repo/.github/workflows/release-cut.yml"
+_pathset=$(GRC_DELTA_PATHS= bash -c '. /dev/stdin <<< "$(sed -n "/^GRC_DELTA_PATHS=/p" "$1")"; echo "$GRC_DELTA_PATHS"' _ "$GRADE" 2>/dev/null)
+# Every pathspec the cut stages, read out of the `git add -f` lines themselves.
+_staged=$(grep -oE '^\s*(if \[ -f [^]]+\]; then )?git add -f [^;|&]+' "$_wf" 2>/dev/null \
+          | sed -E 's/.*git add -f //' | tr ' ' '\n' | sed '/^$/d' | sort -u)
+_drift=(); _sn=0
+for _s in $_staged; do _sn=$((_sn+1)); grep -qw -- "$_s" <<< "$_pathset" || _drift+=("$_s"); done
+ok "PATHSET: the workflow's release-commit block was found and stages something" \
+  "[[ -f \"\$_wf\" && $_sn -gt 0 ]]"
+ok "PATHSET: every path release-cut.yml stages is ALLOWED by GRC_DELTA_PATHS (${_sn} staged, ${#_drift[@]} unlisted: ${_drift[*]:-none})" \
+  "[[ ${#_drift[@]} -eq 0 ]]"
+ok "PATHSET: the required-path guard names a path the cut actually writes" \
+  "grep -qw -- 'src/header.sh' <<<\"\$_staged\""
+
 echo; echo "$pass passed, $fail failed"; [[ $fail -eq 0 ]]

--- a/tests/grade_release_commit_unit.sh
+++ b/tests/grade_release_commit_unit.sh
@@ -95,4 +95,222 @@ ok "NO-VERSION-ARG: says UNDETERMINED" "grep -q 'UNDETERMINED' <<<\"\$OUT\""
 ok "0, 1 and 2 are three DIFFERENT codes, so 'clean' and 'could not look' never collide" \
   "[[ 0 -ne 1 && 1 -ne 2 && 0 -ne 2 ]]"
 
+# =================================================================================
+# DIVE-2524. Two properties, and they fail in opposite directions, which is why they
+# are graded apart:
+#
+#   ITEM 1 — a FAILURE MUST CARRY ITS EVIDENCE. The old shape sent every harness's
+#   output to /dev/null and printed three bare `FAIL — tests/x.sh` lines. Six nights
+#   of red went unread because no reader could tell a regression from a missing
+#   token. That is a fails-QUIET defect.
+#
+#   ITEM 2 — the CHEAP PATH MUST EARN ITSELF. Delta mode inherits the parent's
+#   check-runs for everything outside the release-commit delta. If the premise it
+#   inherits on is ever false, this script reports a pass over an object nobody
+#   graded — the exact defect DIVE-2433 exists to close, rebuilt inside its own fix.
+#   That is a fails-OPEN defect, so every arm below asks whether the refusal HOLDS,
+#   not whether the happy path works.
+# =================================================================================
+
+# A release tree with real git history. The delta assertion reads `git diff` and
+# nothing else, so the fixture has to be a repo — stubbing the diff would grade the
+# stub. `-c` flags rather than `git config` so this never reads the caller's identity.
+_git() { git -C "$T/repo" -c user.name=t -c user.email=t@example.com "$@"; }
+mk_repo() { # $1.. = paths the RELEASE commit changes on top of the parent
+  rm -rf "$T/repo"; mkdir -p "$T/repo/src" "$T/repo/tests"
+  _git init -q 2>/dev/null || git -C "$T/repo" init -q
+  printf 'readonly FIVE_VERSION="0.0.0-dev"\n' > "$T/repo/src/header.sh"
+  printf 'x\n' > "$T/repo/CHANGELOG.md"; printf 'x\n' > "$T/repo/other.sh"
+  _git add -A >/dev/null; _git commit -qm parent
+  PARENT=$(_git rev-parse HEAD)
+  local p
+  for p in "$@"; do mkdir -p "$(dirname "$T/repo/$p")"; printf 'changed %s\n' "$p" >> "$T/repo/$p"; done
+  if [[ $# -gt 0 ]]; then _git add -A >/dev/null; _git commit -qm release; fi
+}
+# The bundle and harnesses live INSIDE the repo, because the script runs from the
+# release tree root and that is where git resolves HEAD.
+repo_bundle() { # $1=version
+  cat > "$T/repo/5dive" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+  --version) printf '5dive %s\n' "$1" ;;
+  *)         exit 0 ;;
+esac
+EOF
+  chmod +x "$T/repo/5dive"
+}
+repo_tests() { # $@ = exit codes
+  rm -rf "$T/repo/tests"; mkdir -p "$T/repo/tests"; local i=0 c
+  for c in "$@"; do i=$((i+1))
+    printf '#!/usr/bin/env bash\necho "ASSERTION-DETAIL-%s: the reason this harness failed"\nexit %s\n' "$i" "$c" \
+      > "$T/repo/tests/t$i.sh"
+  done
+}
+# shellcheck disable=SC2034  # OUT/RC are read inside the eval'd assertion strings
+runr() { OUT=$(cd "$T/repo" && GRC_BUNDLE=./5dive GRC_TESTS_GLOB='tests/*.sh' \
+               GRC_DELTA_TESTS="${DTESTS:-tests/t1.sh}" GRADE_ENV_MARK=1 \
+               bash "${GRADE_UNDER_TEST:-$GRADE}" "$@" 2>&1); RC=$?; }
+
+# ---- 5. ITEM 1: THE FAILURE CARRIES ITS OWN OUTPUT ----
+# Non-vacuity matters here: asserting "FAIL — tests/t2.sh" appears would have passed
+# on the OLD script too. The arm has to demand a string only the harness's own stdout
+# can produce.
+mk_repo src/header.sh 5dive; repo_bundle 0.17.11; repo_tests 0 1 0
+runr 0.17.11
+ok "EVIDENCE: a failing harness's OWN OUTPUT reaches the log, not just its name" \
+  "grep -q 'ASSERTION-DETAIL-2' <<<\"\$OUT\""
+ok "EVIDENCE: the output is fenced and attributed to the harness that produced it" \
+  "grep -q 'last 25 lines of tests/t2.sh' <<<\"\$OUT\" && grep -q 'end tests/t2.sh' <<<\"\$OUT\""
+ok "EVIDENCE: a PASSING harness stays quiet — a green corpus must not bury the verdict" \
+  "! grep -q 'ASSERTION-DETAIL-1' <<<\"\$OUT\""
+ok "EVIDENCE: the verdict still names the harness and still exits 1" \
+  "[[ $RC -eq 1 ]] && grep -q 'FAIL — tests/t2.sh' <<<\"\$OUT\""
+
+# ---- 6. ITEM 2: DELTA MODE, AND EVERY WAY ITS PREMISE CAN BE FALSE ----
+# The happy path first, only so the refusals below are known to be refusing something
+# that would otherwise have run.
+mk_repo src/header.sh 5dive 5dive.sha256 CHANGELOG.md; repo_bundle 0.17.11; repo_tests 0
+runr 0.17.11 "$PARENT"
+ok "DELTA: a delta inside the release-commit set grades the subset and exits 0" "[[ $RC -eq 0 ]]"
+ok "DELTA: says it is INHERITING, so the log records that the corpus was not run" \
+  "grep -q 'inheriting the parent' <<<\"\$OUT\""
+ok "DELTA: the PASS names the parent it inherited from — a pass that cites no parent is unauditable" \
+  "grep -q 'inherited from parent' <<<\"\$OUT\""
+ok "DELTA: reports a DELTA corpus count, distinguishable from a full-corpus run" \
+  "grep -q 'delta corpus ran 1 harness' <<<\"\$OUT\""
+
+# THE PREMISE BREAKS — one path outside the set and the parent's green describes a
+# different tree. UNDETERMINED, never a pass, and never a plain failure either.
+mk_repo src/header.sh other.sh; repo_bundle 0.17.11; repo_tests 0
+runr 0.17.11 "$PARENT"
+ok "WIDER-DELTA: a path outside the release-commit set is UNDETERMINED (2), not 0 and not 1" \
+  "[[ $RC -eq 2 ]]"
+ok "WIDER-DELTA: NAMES the offending path rather than refusing anonymously" \
+  "grep -q 'other.sh' <<<\"\$OUT\""
+ok "WIDER-DELTA: says NOT a pass and does not print PASS" \
+  "grep -q 'NOT a pass' <<<\"\$OUT\" && ! grep -q 'PASS —' <<<\"\$OUT\""
+
+# ANTI-VACUITY. A subset test over an empty diff passes trivially, so a cut whose
+# version write silently did nothing would inherit a green on an unchanged tree. This
+# is the arm that distinguishes "proved the delta" from "found no counterexample".
+mk_repo; repo_bundle 0.17.11; repo_tests 0
+runr 0.17.11 "$PARENT"
+ok "EMPTY-DELTA: an EMPTY diff is UNDETERMINED — the subset check proved nothing" \
+  "[[ $RC -eq 2 ]]"
+ok "EMPTY-DELTA: names src/header.sh as the write that never landed" \
+  "grep -q 'src/header.sh' <<<\"\$OUT\" && grep -q 'version assignment never landed' <<<\"\$OUT\""
+
+mk_repo 5dive 5dive.sha256; repo_bundle 0.17.11; repo_tests 0
+runr 0.17.11 "$PARENT"
+ok "NO-VERSION-WRITE: a delta that rebundles but never assigns the version is UNDETERMINED" \
+  "[[ $RC -eq 2 ]]"
+
+mk_repo src/header.sh; repo_bundle 0.17.11; repo_tests 0
+runr 0.17.11 deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+ok "UNRESOLVABLE-PARENT: a parent git cannot resolve is UNDETERMINED, not an inherited pass" \
+  "[[ $RC -eq 2 ]]"
+ok "UNRESOLVABLE-PARENT: says the inheritance is unproven" \
+  "grep -q 'unproven' <<<\"\$OUT\" && grep -q 'NOT a pass' <<<\"\$OUT\""
+
+# ---- 7. THE EXPENSIVE PATH IS THE DEFAULT ----
+# Without a parent there is no premise, so there is nothing to inherit. The arm that
+# matters is the COUNT: delta mode would have run 1, the full corpus runs 3.
+mk_repo src/header.sh 5dive; repo_bundle 0.17.11; repo_tests 0 0 0
+runr 0.17.11
+ok "NO-PARENT: falls back to the FULL corpus rather than inheriting an unproven premise" \
+  "[[ $RC -eq 0 ]] && grep -q 'corpus ran 3 harness' <<<\"\$OUT\""
+ok "NO-PARENT: does NOT claim to have inherited anything" \
+  "! grep -q 'inheriting the parent' <<<\"\$OUT\""
+
+OUT=$(cd "$T/repo" && GRC_BUNDLE=./5dive GRC_TESTS_GLOB='tests/*.sh' GRC_DELTA_TESTS='tests/t1.sh' \
+      GRC_FULL_CORPUS=1 bash "$GRADE" 0.17.11 "$PARENT" 2>&1); RC=$?
+ok "FULL-OVERRIDE: GRC_FULL_CORPUS=1 runs all 3 even with a valid parent" \
+  "[[ $RC -eq 0 ]] && grep -q 'corpus ran 3 harness' <<<\"\$OUT\""
+
+# ---- 8. THE EXCLUSION IS NAMED, PRINTED AND COUNTED ----
+# tests/release_cut_bundle_unit.sh asserts MAIN's invariants and a release commit
+# inverts all of them, so it is unanswerable here. What must never happen is a corpus
+# that quietly shrinks: a skip nobody can see is indistinguishable from coverage.
+mk_repo src/header.sh 5dive; repo_bundle 0.17.11; repo_tests 0 0
+cp "$T/repo/tests/t2.sh" "$T/repo/tests/release_cut_bundle_unit.sh"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$T/repo/tests/release_cut_bundle_unit.sh"
+runr 0.17.11
+ok "EXCLUDE: the main-tree-only harness does not fail the grade" "[[ $RC -eq 0 ]]"
+ok "EXCLUDE: the skip is PRINTED, so a reader sees what did not run" \
+  "grep -q 'SKIP — tests/release_cut_bundle_unit.sh' <<<\"\$OUT\""
+ok "EXCLUDE: the skip names WHY it cannot be answered on a release commit" \
+  "grep -q 'MAIN-tree invariants' <<<\"\$OUT\""
+ok "EXCLUDE: the skip is COUNTED in the summary, not silently dropped" \
+  "grep -qE 'ran 2 harness\(es\), 0 failed, 1 skipped' <<<\"\$OUT\""
+
+# And exclusion must never be able to empty the corpus into a pass.
+mk_repo src/header.sh 5dive; repo_bundle 0.17.11
+rm -rf "$T/repo/tests"; mkdir -p "$T/repo/tests"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$T/repo/tests/release_cut_bundle_unit.sh"
+runr 0.17.11
+ok "EXCLUDE-ALL: excluding every harness is UNDETERMINED, never a clean pass" \
+  "[[ $RC -eq 2 ]] && grep -q 'NOT a pass' <<<\"\$OUT\""
+
+# A red harness inside the DELTA set still fails the cut — delta mode narrows what is
+# asked, it does not soften the answer.
+mk_repo src/header.sh 5dive; repo_bundle 0.17.11; repo_tests 1
+runr 0.17.11 "$PARENT"
+ok "DELTA-RED: a failing delta harness still exits 1 and still prints its evidence" \
+  "[[ $RC -eq 1 ]] && grep -q 'ASSERTION-DETAIL-1' <<<\"\$OUT\""
+
+# ---- 9. MUTATION: DO THE ARMS ABOVE ACTUALLY BITE? ----
+# Every refusal in section 6 is a negative. A negative that cannot be made to fire is
+# indistinguishable from one that is dead, so each guard is deleted in turn and the
+# arm it protects must flip. `sed` on a copy — the script under test is never touched.
+mutant() { # $1=label $2=sed-expr $3=setup-fn-args... via $MUT_SETUP ; asserts flip
+  sed -E "$2" "$GRADE" > "$T/mutant.sh"; chmod +x "$T/mutant.sh"
+}
+# MUTANT A: drop the subset check. WIDER-DELTA must stop refusing.
+mutant A 's/^  if \(\( \$\{#_unexpected\[@\]\} > 0 \)\); then/  if false; then/'
+mk_repo src/header.sh other.sh; repo_bundle 0.17.11; repo_tests 0
+GRADE_UNDER_TEST="$T/mutant.sh" runr 0.17.11 "$PARENT"
+ok "MUTANT-A (subset check removed): WIDER-DELTA stops refusing — the arm is live" \
+  "[[ $RC -ne 2 ]]"
+
+# MUTANT B: drop the required-path check. EMPTY-DELTA must stop refusing.
+mutant B 's/^  if \(\( \$\{#_missing\[@\]\} > 0 \)\); then/  if false; then/'
+mk_repo; repo_bundle 0.17.11; repo_tests 0
+GRADE_UNDER_TEST="$T/mutant.sh" runr 0.17.11 "$PARENT"
+ok "MUTANT-B (anti-vacuity check removed): an EMPTY delta inherits a pass — the arm is live" \
+  "[[ $RC -ne 2 ]]"
+
+# MUTANT C: send harness output back to /dev/null, i.e. restore the six-nights-of-
+# silence defect. The EVIDENCE arms must go red.
+mutant C 's|if ! _out=\$\(bash "\$_t" 2>&1\); then|if ! _out=$(bash "$_t" >/dev/null 2>\&1); then|'
+mk_repo src/header.sh 5dive; repo_bundle 0.17.11; repo_tests 0 1 0
+GRADE_UNDER_TEST="$T/mutant.sh" runr 0.17.11
+ok "MUTANT-C (output discarded again): the EVIDENCE arm goes red — it was not passing on the name alone" \
+  "! grep -q 'ASSERTION-DETAIL-2' <<<\"\$OUT\""
+
+# MUTANT D: make the exclusion silent. The reader-facing half of the skip must break.
+mutant D 's/^    echo "grade-release-commit: SKIP/    : "grade-release-commit: SKIP/'
+mk_repo src/header.sh 5dive; repo_bundle 0.17.11; repo_tests 0 0
+printf '#!/usr/bin/env bash\nexit 1\n' > "$T/repo/tests/release_cut_bundle_unit.sh"
+GRADE_UNDER_TEST="$T/mutant.sh" runr 0.17.11
+ok "MUTANT-D (skip made silent): the corpus shrinks with nothing in the log — the arm is live" \
+  "! grep -q 'SKIP — tests/release_cut_bundle_unit.sh' <<<\"\$OUT\""
+
+# ---- 10. THE SHIPPED DELTA LIST IS REAL ----
+# Every arm above overrides GRC_DELTA_TESTS with a stub, which is right for grading the
+# mechanism and grades NOTHING about the list release-cut.yml actually runs. That list
+# is a set of hardcoded paths, so a renamed or deleted harness silently shrinks the
+# release grade to whatever still resolves — coverage lost with no error anywhere,
+# which is the same fails-quiet shape as ITEM 1. Read the default out of the script and
+# hold it to the tree.
+_defaults=$(GRC_DELTA_TESTS= bash -c '. /dev/stdin <<< "$(sed -n "/^GRC_DELTA_TESTS=/,/^tests.*}\"$/p" "$1")"; echo "$GRC_DELTA_TESTS"' _ "$GRADE" 2>/dev/null)
+_repo="$(cd "$(dirname "$GRADE")/.." && pwd)"
+_dmiss=(); _dn=0
+for _d in $_defaults; do _dn=$((_dn+1)); [[ -f "$_repo/$_d" ]] || _dmiss+=("$_d"); done
+ok "SHIPPED-LIST: the default delta corpus is NOT empty (an empty one makes every cut UNDETERMINED)" \
+  "[[ $_dn -gt 0 ]]"
+ok "SHIPPED-LIST: every harness the release grade names still EXISTS (${_dn} named, ${#_dmiss[@]} missing: ${_dmiss[*]:-none})" \
+  "[[ ${#_dmiss[@]} -eq 0 ]]"
+ok "SHIPPED-LIST: the excluded main-tree harness is NAMED in it, so its SKIP shows up in the release log" \
+  "grep -q 'tests/release_cut_bundle_unit.sh' <<<\"\$_defaults\""
+
 echo; echo "$pass passed, $fail failed"; [[ $fail -eq 0 ]]


### PR DESCRIPTION
Closes DIVE-2524.

`release-cut` has failed six consecutive nights. Newest tag is still v0.17.10 while main moved four commits past it, so the whole fleet is pinned and everything merged since 2026-07-30 is unshipped.

## The cause is not the one the ticket guessed, and there are two of them

The ticket's hypothesis was token-or-root: the job runs as uid 1001 with no token, and all three failing harnesses resolve PR state. Reproduced off CI instead — a detached `origin/main` with `FIVE_VERSION` sed'd to a real version, the CHANGELOG stamped, the bundle built and **committed**, i.e. the exact object `release-cut.yml` produces:

| harness | on main's tree | on a release tree |
|---|---|---|
| `release_cut_bundle_unit.sh` | **20 passed, 0 failed** | **15 passed, 5 failed** |
| `task_merge_gate_multirepo_unit.sh` | 36 / 0 | 36 / 0 |
| `task_merge_gate_result_pr_unit.sh` | 31 / 0 | 31 / 0 |

`release_cut_bundle_unit.sh` **cannot pass on a release commit, on any machine, ever.** It is the harness that guards *main's* invariants — `5dive` and `5dive.sha256` untracked and gitignored (DIVE-2091), `src/header.sh` carrying the `0.0.0-dev` sentinel rather than a real version (DIVE-2247). A release commit tracks both artifacts and writes a real version. That *is* what a release commit is. The five failing arms are exactly those five invariants. No token and no runner involved.

The other two went green in that same release tree, so those two *are* environment-specific and the token/root read holds for them — the DIVE-2484 shape.

So main's "this row may be covering two distinct failures wearing one red X" was the right instinct with the wrong split. The timeline confirms it: DIVE-2433 merged 2026-07-30 17:14Z, v0.17.10 was cut 14:07Z that same day. **The release grade has never once passed.** It went 0/6.

One correction to the ticket's recommendation: item 2(a) proposes grading "what the delta can break — which is what `tests/release_cut_bundle_unit.sh` already covers". That is the exact harness that cannot run there. Keeping it keeps the bug.

## ITEM 1 — a failure now carries its evidence

`bash "$_t" >/dev/null 2>&1` discarded every harness's output, so six nights of red read as three bare `FAIL — tests/x.sh` lines. A reader could not tell a regression from a missing token, so the only available response was to ignore it — which is what happened, six times. That is the v0.16 "fails loud" thesis violated on the release path itself. Output is captured and the last `GRC_TAIL` (25) lines print, fenced and attributed, on failure only.

## ITEM 2 — grade the delta, but *prove* the premise first

A release commit differs from an already-graded main commit by one sed'd line plus regenerated artifacts. When the caller names the parent, the corpus is inherited from the parent's check-runs — and the inheritance is asserted, never assumed. `git diff --name-only <parent> HEAD` must be

- a **subset** of `src/header.sh 5dive 5dive.sha256 CHANGELOG.md` — the premise. One extra path and "nothing else changed" is false and the parent's green describes a different tree.
- **containing** `src/header.sh` — the anti-vacuity guard. A subset test over an *empty* diff passes trivially, so a cut whose version write silently did nothing would otherwise inherit a green on an unchanged tree.

Either failing is `UNDETERMINED` (2) — not a pass and not a failure — and `release-cut.yml` already refuses on 2 exactly as hard as on 1.

**Without a parent there is nothing to inherit, so the full corpus runs.** The expensive path is the default and the cheap one has to earn itself. `GRC_FULL_CORPUS=1` forces it back on.

The 15-harness delta set was **measured on a real release tree, not reasoned about** — all green there in 49 seconds. `release_cut_bundle_unit.sh` is named in the set deliberately even though it is excluded, so its `SKIP` line appears in every release log rather than only in tests.

## Verification

End-to-end on a real release tree built from this branch:

```
grade-release-commit: delta vs parent 1e48ada74bb3 is within the release-commit set and assigns the version — inheriting the parent's check-runs for the rest
grade-release-commit: selfcheck PASS on the released bundle
grade-release-commit: --version reports 0.17.11
grade-release-commit: SKIP — tests/release_cut_bundle_unit.sh grades MAIN-tree invariants … graded on main in unit-tests.yml's `test` job
grade-release-commit: delta corpus ran 15 harness(es), 0 failed, 1 skipped
grade-release-commit: PASS — 0.17.11 graded on the exact artifact (15 delta harnesses + selfcheck + smoke), the rest inherited from parent 1e48ada74bb3 …
rc=0 elapsed=56s
```

**56 seconds, was ~40 minutes.**

`tests/grade_release_commit_unit.sh` 20 → **55 passed, 0 failed**. Mutation-graded four ways, each self-verifying — an unapplied `sed` leaves the original, which fails the arm:

- **A** subset check removed → `WIDER-DELTA` stops refusing
- **B** anti-vacuity check removed → an empty delta inherits a pass
- **C** output sent back to `/dev/null` → the evidence arm goes red, proving it was not passing on the harness *name* alone
- **D** skip made silent → the corpus shrinks with nothing in the log

Plus two coupling guards, both for hardcoded lists that would otherwise rot silently:

- `SHIPPED-LIST` holds the delta corpus to the tree — a renamed harness would shrink the release grade to whatever still resolves, the same fails-quiet shape as ITEM 1.
- `PATHSET` derives the allowed-path set from the `git add -f` lines in `release-cut.yml` itself. `GRC_DELTA_PATHS` is a hardcoded copy of a fact that lives in the workflow, and the copy is the risk: add a fifth staged path there and delta mode goes `UNDETERMINED` and **the cut refuses**. Safe direction, still a 02:37Z outage nobody is paged for. Verified non-vacuous — staging a fifth path turns the arm red and names it.

`fetch-depth: 0` on the checkout, so the parent is always reachable for the diff.

Adjacent suites on this branch: `release_cut_assign` 14/0, `release_cut_bundle` 20/0, `release_cut_guards` 40/0, `version_bump_guard` 21/0, `selfcheck` 33/0. `shellcheck -S error` clean.

## What this does not do

It does not diagnose the two `task_merge_gate` harnesses — delta mode retires them from this job rather than fixing them, on the grounds that they are graded on the parent in a job that has the token they need. Per the 2026-08-02 filing rule that goes to the wiki, not a new row.

**This is not live until it merges and a cut runs.** The fleet stays pinned at v0.17.10 until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)