### PR TITLE
feat(actor): 5dive whoami — one sealed uid-first actor derivation that refuses when unmeasurable (DIVE-2517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased — feat(actor): `5dive whoami`, one sealed actor derivation (DIVE-2517)
+
+The CLI had **six** actor derivations and they disagreed. Only one failed closed;
+the rest resolved identity from something the caller can set — `--from` on argv,
+`$USER`, `$SUDO_USER`, `FIVEDIVE_AUDIT_USER`, or an `agent-` username prefix —
+and none of them refused when they could not measure.
+
+`src/lib/actor.sh` promotes the uid-first resolver into the single derivation.
+Identity comes from `$EUID`, a kernel-backed bash builtin, mapped through
+`/etc/passwd` in pure bash — no `id`, no `getent`, both of which resolve through
+the caller's `PATH` (DIVE-2330). `$SUDO_UID` is honoured only at real EUID 0,
+where forging it would require already being root. Agent-ness is the registry's
+answer, never a username prefix. Authority is not redefined here: `_actor_authority`
+in `lib/audit.sh` already single-sources `root` / `sudo:<who>` / `self`, and the
+verb wires it.
+
+`5dive whoami` reports actor, authority and tier **with the source of each**, plus
+`--json`. An actor it cannot measure is an **exit 6**, not the word `unknown`
+printed with `rc=0` — that refusal is the point of the verb, and it is
+mutation-graded rather than asserted.
+
 ## Unreleased — fix(task): refuse a close that would REPLACE an already-closed row's result (DIVE-2464)
 
 `5dive task done <id> --result=...` on a row that was already done overwrote the result column and

--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,7 @@ cat \
   src/lib/audit.sh \
   src/lib/registry.sh \
   src/lib/tasks_db.sh \
+  src/lib/actor.sh \
   src/cmd_auth.sh \
   src/cmd_account.sh \
   src/cmd_agent.sh \
@@ -52,6 +53,7 @@ cat \
   src/cmd_doctor.sh \
   src/cmd_watch.sh \
   src/cmd_compose.sh \
+  src/cmd_whoami.sh \
   src/cmd_task.sh \
   src/cmd_trace.sh \
   src/cmd_org.sh \

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -585,7 +585,8 @@ _gate_route_reviewer() {
 # (an agent that truly sudo's then forges) is shared with the whole gate system and
 # out of scope here — same boundary cmd_task_answer draws. _gate_is_root is a seam so
 # the unit harness can exercise BOTH branches with the REAL resolver (not stubbed).
-_gate_is_root() { [[ $EUID -eq 0 ]]; }
+# _gate_is_root now lives in src/lib/actor.sh alongside the rest of the sealed
+# derivation (DIVE-2517). Unchanged body, unchanged seam contract.
 _gate_withdraw_actor() {
   if _gate_is_root; then
     local a; a=$(auto_sender_from_sudo)
@@ -4253,89 +4254,11 @@ _gate_floor_axis() {
 # `fleet roll` so a tested-code push+fleet-roll files as a lead-routed tier-1. The
 # true-human floor still runs FIRST and wins (a "push the pricing change" gate
 # stays human), so these can only ever cost the lead one clear.
-# _gate_authenticated_actor — DIVE-2004. The agent identity the KERNEL enforced for
-# this invocation, or EMPTY when it cannot be established. This is deliberately NOT
-# `task_actor`: that resolves `--from=<who>` verbatim, so it answers "who does the
-# caller SAY they are" (provenance, right for the audit record) and must never be
-# asked "who is the caller" (authentication). Two trustworthy sources:
-#   1. the real process user — `agent-X` can only be reached by actually being X.
-#   2. `$SUDO_UID`, but ONLY at EUID 0 (DIVE-1413): sudo sets it, and a non-root
-#      process forging it cannot also become root. Below EUID 0 it is a plain env
-#      var, which is why DIVE-950 dropped the agent-forgeable `--proof` form.
-# FAILS CLOSED by design: neither source resolving means "unidentified", never
-# "trusted". The cost of a false empty is re-filing a gate; the cost of a false
-# identity is a self-authorized delegated push.
-# The dashboard path is unaffected and needs no marker: shelld runs as `claude`
-# (a NON-agent user) and sends `--human`, so those answers are `human:*` — already
-# authorized everywhere `lead:*` is, and never in want of a lead stamp.
-# DIVE-2330: resolve a uid to an agent name in PURE BASH over /etc/passwd. No
-# `id`, no `getent` — both resolve through the CALLER'S PATH, and every agent can
-# set its own PATH. Measured on this host before the fix: a shim on PATH printing
-# `agent-lodar` made `id -un` return exactly that, from a process whose real uid
-# was 1004 (agent-main). Same shape as the landed DIVE-2281 fix in
-# `_envelope_sender_fallback`.
-# SEAM for the passwd SOURCE, added iteration 2 (DIVE-2330). A harness needs to
-# model a caller uid that maps to an `agent-*` name; before this it could only
-# pick a uid that happens to exist ON THIS HOST, which is the same
-# precondition-supplied-by-the-host defect DIVE-2365 named — and it is why the
-# T8 arm was vacuous (there is no `agent-evil` here, so `id -u agent-evil` failed
-# and the override fell back to uid 0, i.e. root: T8 modelled no agent at all).
-#
-# A FUNCTION, deliberately NOT `${_GATE_PASSWD_FILE:-/etc/passwd}`. An env-settable
-# source would be a new forgery vector in the field this whole row exists to make
-# unforgeable — the same reasoning `_envelope_sender_fallback` records in
-# cmd_agent_runtime.sh ("NO ENV OVERRIDE for the passwd path, deliberately"). A
-# function cannot be injected: bash imports exported functions at startup, and the
-# script's own definition executes AFTER that import and overwrites it. Same
-# property `_gate_is_root` and `_gate_caller_uid` already rely on.
-# Pure bash — no `cat`, which would be PATH-resolved.
-_gate_passwd_stream() { printf '%s\n' "$(</etc/passwd)"; }
-
-_gate_uid_to_agent() {
-  local want="${1:-}" name _x uid
-  [[ "$want" =~ ^[0-9]+$ ]] || { printf ''; return; }
-  while IFS=: read -r name _x uid _; do
-    [[ "$uid" == "$want" ]] || continue
-    [[ "$name" == agent-* ]] || { printf ''; return; }
-    printf '%s' "${name#agent-}"; return
-  done < <(_gate_passwd_stream)
-  printf ''
-}
-
-# `$EUID` is a bash BUILTIN reflecting the kernel's view of this process. It is not
-# PATH-resolved and cannot be set from the environment, which is the whole property
-# an authorization check needs. SUDO_UID is consulted only when EUID is 0, exactly
-# as before: sudo writes it, the caller does not.
-# SEAM (mirrors _gate_is_root): the harness overrides THIS to exercise both
-# branches with the real resolver. An external caller cannot — invoking `5dive`
-# starts a fresh bash that defines the function itself, so there is nothing in the
-# environment to override. That is the difference between a seam and a hole: the
-# old code let a PATH shim answer, which any agent could set.
-_gate_caller_uid() { printf '%s' "$EUID"; }
-
-_gate_authenticated_actor() {
-  local a; a=$(_gate_uid_to_agent "$(_gate_caller_uid)")
-  if [[ -n "$a" ]]; then printf '%s' "$a"; return; fi
-  # The SUDO_UID branch stays gated on the REAL root check (_gate_is_root, itself
-  # the pre-existing seam), NOT on _gate_caller_uid. Routing it through the seam
-  # would let a harness modelling "caller is root" also unlock the SUDO_UID path
-  # and widen who resolves to an agent — a behaviour change, not a fix.
-  if _gate_is_root && [[ -n "${SUDO_UID:-}" ]]; then
-    a=$(_gate_uid_to_agent "$SUDO_UID")
-    [[ -n "$a" ]] && { printf '%s' "$a"; return; }
-  fi
-  printf ''
-}
-
-# _gate_agent_for_uid <uid> — the agent name owning a numeric uid, or EMPTY. Used
-# to re-check a STORED `need_answered_uid` (DIVE-756 stamps the real pre-sudo
-# invoker) against a claimed `need_answered_by`, so a `--from` spoof is visible
-# after the fact and not only at answer time.
-_gate_agent_for_uid() {
-  # DIVE-2330: was `getent passwd`, which is PATH-resolved and therefore forgeable
-  # by the caller it is meant to check. Same pure-bash resolver as above.
-  _gate_uid_to_agent "${1:-}"
-}
+# _gate_authenticated_actor, _gate_uid_to_agent, _gate_caller_uid, _gate_is_root,
+# _gate_passwd_stream and _gate_agent_for_uid MOVED to src/lib/actor.sh (DIVE-2517,
+# v0.18 "Proof of who"). Same names, same semantics, one definition — the strict
+# uid-first derivation is now the shared one in lib/ rather than a local helper in
+# the file that happened to need it first. Call sites here are unchanged.
 
 _GATE_ENG_SHIP_RX='\bmerg(e|es|ed|ing)\b|pull request|\bpr\b|\bdiff\b|ship it|ship the|ship this|\bship(ping|ped)\b|deploy|redeploy|roll ?out|\broll(ing|ed)? out\b|land the|land it|land this|\bland(ing|ed)\b|rebase|hotfix|cut a branch|cut the release|push(es|ed|ing)? to (main|prod|production|origin)|push[^.]*github|delegated push|push[- ]for[- ]review|push .*(branch|for review|for a? ?pr|for code review)|5dive push|roll[^.]*fleet|fleet[- ]?roll|code review|approve the (merge|diff|change|pr|build|deploy|ship|commit)|build\.sh|smoke test|ci\b'
 _gate_eng_ship_hit() {

--- a/src/cmd_whoami.sh
+++ b/src/cmd_whoami.sh
@@ -1,0 +1,135 @@
+
+# -------- 5dive whoami (DIVE-2517, v0.18 "Proof of who") --------
+#
+# Print the actor, the authority, the tier — and the SOURCE of each — from the one
+# sealed derivation in lib/actor.sh. Read-only: no lock, no write, no audit row.
+#
+# The verb exists because "who is acting" had six answers in this CLI and no way to
+# ask which one a given rail would use. Printing the source next to each value is
+# the payload, not decoration: `sudo:claude` and `self` can carry the same identity
+# and are not the same act, and an operator debugging a gate refusal needs to see
+# that the identity came from the kernel while the elevation's NAME came from an
+# env var.
+#
+# EXIT STATUS IS PART OF THE CONTRACT. An unmeasurable actor exits
+# E_AUTH_REQUIRED, never rc=0 with the word `unknown` printed. A caller that can
+# branch on `5dive whoami >/dev/null` is the smallest useful form of this verb, and
+# it only works if the failure is in the status.
+
+cmd_whoami() {
+  local a
+  for a in "$@"; do
+    case "$a" in
+      -h|--help)
+        cat <<'EOF'
+5dive whoami [--json]
+
+Print the actor, authority and tier of the CURRENT process, with the source of each.
+
+  actor      the unix principal owning the acting uid, and the board agent the
+             registry maps it to. Read from $EUID (a kernel-backed bash builtin)
+             resolved against /etc/passwd in pure bash. At real EUID 0, sudo's
+             $SUDO_UID names the pre-elevation invoker instead.
+  authority  root | sudo:<who> | self — under whose powers this process acts.
+  tier       the registry's isolation tier for the resolved agent.
+
+NOT consulted for identity: --from/argv, created_by, $USER, $SUDO_USER,
+$LOGNAME, $FIVEDIVE_AUDIT_USER, `id`, `getent`. The first six are caller-supplied
+and the last two resolve through the caller's own PATH.
+
+Exit status: 0 when the actor was measured, 6 (auth_required) when it was not.
+"Not an agent" is a MEASUREMENT and exits 0; "this uid resolves to nothing" is not.
+EOF
+        return 0 ;;
+      *) fail "$E_USAGE" "unknown flag: $a" ;;
+    esac
+  done
+
+  local measured=1
+  actor_derive || measured=0
+  # jq wants real booleans, and a uid that failed to resolve must be `null` rather
+  # than an empty string pretending to be a number.
+  local j_measured=true; (( measured )) || j_measured=false
+  local j_uid=null; [[ "$ACTOR_UID" =~ ^[0-9]+$ ]] && j_uid="$ACTOR_UID"
+  actor_registry_agent "$ACTOR_UNIX"
+
+  local authority; authority=$(_actor_authority)
+  # Name the source honestly per branch. `sudo:<who>` is the one value on this
+  # report whose payload is env-derived — the elevation is proven by EUID 0, but
+  # WHO elevated is read from $SUDO_USER. Saying so is the difference between a
+  # report and a claim.
+  local auth_src
+  case "$authority" in
+    sudo:*) auth_src='euid=0 + $SUDO_USER (env: names the invoker, elevation itself proven by euid)' ;;
+    root)   auth_src='euid=0, no invoking user' ;;
+    *)      auth_src='euid (unelevated)' ;;
+  esac
+
+  local id_src
+  case "$ACTOR_SOURCE" in
+    sudo_uid) id_src='$SUDO_UID (trusted: real euid=0) -> /etc/passwd (pure bash)' ;;
+    *)        id_src='$EUID (kernel) -> /etc/passwd (pure bash)' ;;
+  esac
+
+  # `unknown:unregistered` is a MEASUREMENT (this principal is not an agent), which
+  # is why tier_unmeasured() excludes it. Every other unknown:* means the lookup
+  # itself did not happen, and the report must say so rather than print a hole.
+  local tier_src='registry .agents[<agent>].isolation'
+  if tier_unmeasured "$ACTOR_TIER"; then tier_src='registry — NOT measured'; fi
+
+  local ignored; ignored=$(actor_ignored_identity_env)
+
+  if (( JSON_MODE )); then
+    # Superset of the standard envelope on purpose: `.ok` and `.error.code` keep
+    # their usual meaning, and `.data` is present on BOTH branches so a caller that
+    # exits non-zero can still read what was measured before the refusal.
+    local expr='{
+      actor: {measured: $m, unix: $u, agent: $ag, uid: $uid, source: $isrc, reason: $rsn},
+      authority: {value: $auth, source: $asrc},
+      tier: {value: $tier, measured: $tm, source: $tsrc},
+      ignored_for_identity: $ign
+    }'
+    local -a jargs=(
+      --argjson m  "$j_measured"
+      --arg     u  "$ACTOR_UNIX"
+      --arg     ag "$ACTOR_AGENT"
+      --argjson uid "$j_uid"
+      --arg     isrc "$ACTOR_SOURCE"
+      --arg     rsn  "$ACTOR_REASON"
+      --arg     auth "$authority"
+      --arg     asrc "$auth_src"
+      --arg     tier "$ACTOR_TIER"
+      --argjson tm   "$(tier_unmeasured "$ACTOR_TIER" && echo false || echo true)"
+      --arg     tsrc "$tier_src"
+      --arg     ign  "$ignored"
+    )
+    if (( measured )); then
+      jq -cn "${jargs[@]}" "{ok:true, data: ($expr)}"
+      return 0
+    fi
+    jq -cn "${jargs[@]}" \
+      --argjson c 6 --arg cl auth_required \
+      --arg m2 "actor is UNMEASURABLE ($ACTOR_REASON) — refusing to guess" \
+      "{ok:false, error:{code:\$c, class:\$cl, message:\$m2}, data: ($expr)}"
+    echo "error: actor is UNMEASURABLE ($ACTOR_REASON) — refusing to guess" >&2
+    exit "$E_AUTH_REQUIRED"
+  fi
+
+  if (( measured )); then
+    printf 'actor      %s\n' "${ACTOR_AGENT:-$ACTOR_UNIX}"
+    printf '           unix=%s uid=%s%s\n' "$ACTOR_UNIX" "$ACTOR_UID" \
+      "$( [[ -n "$ACTOR_AGENT" ]] && printf ' agent=%s' "$ACTOR_AGENT" || printf ' agent=<none> (not a registered agent)' )"
+    printf '           source: %s\n' "$id_src"
+  else
+    printf 'actor      UNMEASURABLE (%s)\n' "$ACTOR_REASON"
+    printf '           uid=%s source: %s\n' "${ACTOR_UID:-<none>}" "$id_src"
+  fi
+  printf 'authority  %s\n' "$authority"
+  printf '           source: %s\n' "$auth_src"
+  printf 'tier       %s\n' "$ACTOR_TIER"
+  printf '           source: %s\n' "$tier_src"
+  printf 'ignored for identity: %s\n' "${ignored:-<none set>}"
+
+  (( measured )) || fail "$E_AUTH_REQUIRED" "actor is UNMEASURABLE ($ACTOR_REASON) — refusing to guess"
+  return 0
+}

--- a/src/lib/actor.sh
+++ b/src/lib/actor.sh
@@ -1,0 +1,196 @@
+
+# -------- the sealed actor derivation (DIVE-2517, v0.18 "Proof of who") --------
+#
+# ONE derivation for "who is acting", and it fails CLOSED.
+#
+# Measured on origin/main 51bc5c6 (DIVE-2515, wiki:
+# six-actor-derivations-strictest-has-smallest-blast-radius): this CLI derived the
+# actor in SIX places and they disagreed. Exactly one of the six fails closed —
+# `_gate_authenticated_actor`, uid-first, 8 references — and the widest one
+# (`task_actor`, 43 references, the field the whole board later reads as ground
+# truth) takes an argv string as gospel and can be redirected by a plain
+# `SUDO_USER=` env var with no privilege at all.
+#
+# This file is the promotion of the strict one out of cmd_task.sh and into lib/,
+# where every caller can reach it. The functions below are MOVED, not rewritten:
+# `_gate_passwd_stream`, `_gate_uid_to_agent`, `_gate_caller_uid`, `_gate_is_root`,
+# `_gate_authenticated_actor` and `_gate_agent_for_uid` keep their names and their
+# semantics so all 8 existing gate call sites are byte-for-byte unaffected. What is
+# NEW is the layer on top: `actor_derive`, which answers the same question but also
+# reports WHICH SOURCE answered and, when nothing did, WHY.
+#
+# The identity axis reads exactly two things and nothing else:
+#   1. `$EUID` — a bash builtin reflecting the KERNEL's view of this process. Not
+#      PATH-resolved, not settable from the environment.
+#   2. /etc/passwd, walked in PURE BASH (DIVE-2330: `id` and `getent` both resolve
+#      through the CALLER'S PATH, and every agent sets its own PATH; a shim on PATH
+#      printing `agent-lodar` made `id -un` return exactly that from a process whose
+#      real uid was 1004).
+# It does NOT consult argv, `--from`, `created_by`, `$USER`, `$SUDO_USER`, or
+# `$FIVEDIVE_AUDIT_USER`. Those are provenance ("who does the caller SAY they are"),
+# which is the right answer for an audit record and the wrong one for an
+# authorization check.
+#
+# The AUTHORITY axis is not redefined here. `_actor_authority` (lib/audit.sh) is
+# already single-sourced and correct — one function, built once by INST-4 — and
+# this file WIRES it rather than growing a seventh opinion. That asymmetry is the
+# finding the inventory recorded: a field built once by one ticket has an owner; a
+# field that accretes has none and forks silently.
+
+# SEAM for the passwd SOURCE (DIVE-2330 iteration 2). A harness needs to model a
+# caller uid that maps to an `agent-*` name; without this it could only pick a uid
+# that happens to exist ON THIS HOST — the same precondition-supplied-by-the-host
+# defect DIVE-2365 named.
+#
+# A FUNCTION, deliberately NOT `${_GATE_PASSWD_FILE:-/etc/passwd}`. An env-settable
+# source would be a new forgery vector in the one field this whole file exists to
+# make unforgeable (same reasoning `_envelope_sender_fallback` records in
+# cmd_agent_runtime.sh). A function cannot be injected: bash imports exported
+# functions at startup, and the script's own definition executes AFTER that import
+# and overwrites it.
+# Pure bash — no `cat`, which would be PATH-resolved.
+_gate_passwd_stream() { printf '%s\n' "$(</etc/passwd)"; }
+
+# uid -> the unix NAME that owns it, or EMPTY when no passwd row claims that uid.
+#
+# NO PREFIX RULE HERE, on purpose. DIVE-2371: agent-ness decided by a username
+# prefix is why the primary `claude` agent reads as a HUMAN. The name a uid owns is
+# a measurement; whether that principal is an agent is the REGISTRY's answer
+# (`actor_registry_agent` below), not a substring's.
+actor_uid_to_name() {
+  local want="${1:-}" name _x uid
+  [[ "$want" =~ ^[0-9]+$ ]] || { printf ''; return; }
+  while IFS=: read -r name _x uid _; do
+    [[ "$uid" == "$want" ]] || continue
+    printf '%s' "$name"; return
+  done < <(_gate_passwd_stream)
+  printf ''
+}
+
+# uid -> agent short name, or EMPTY. UNCHANGED semantics (DIVE-2330): a uid whose
+# passwd name is not `agent-*` returns empty, exactly as before. The 8 gate call
+# sites read that empty as "unidentified", and widening it here would widen who can
+# self-authorize a delegated push. Composed over `actor_uid_to_name` so there is
+# one passwd walk in the tree rather than two that can drift.
+_gate_uid_to_agent() {
+  local name; name=$(actor_uid_to_name "${1:-}")
+  [[ "$name" == agent-* ]] || { printf ''; return; }
+  printf '%s' "${name#agent-}"
+}
+
+# SEAMS. `$EUID` is READONLY in bash, so a unit harness cannot exercise the root
+# branch by assigning it — which is exactly how a check behind an unreachable root
+# test survived a year in audit.sh, and how two of `_actor_authority`'s three
+# branches shipped unexercised in its first cut. The harness overrides THESE. An
+# external caller cannot: invoking `5dive` starts a fresh bash that defines the
+# functions itself, so there is nothing in the environment to override. That is the
+# difference between a seam and a hole.
+#
+# There are already two root seams in this tree (`_gate_is_root` here, `_audit_is_root`
+# in lib/audit.sh). Route through the one that exists for your axis; do not add a third.
+_gate_is_root()     { [[ $EUID -eq 0 ]]; }
+_gate_caller_uid()  { printf '%s' "$EUID"; }
+
+_gate_authenticated_actor() {
+  local a; a=$(_gate_uid_to_agent "$(_gate_caller_uid)")
+  if [[ -n "$a" ]]; then printf '%s' "$a"; return; fi
+  # The SUDO_UID branch stays gated on the REAL root check (_gate_is_root, itself
+  # the pre-existing seam), NOT on _gate_caller_uid. Routing it through the seam
+  # would let a harness modelling "caller is root" also unlock the SUDO_UID path
+  # and widen who resolves to an agent — a behaviour change, not a fix.
+  if _gate_is_root && [[ -n "${SUDO_UID:-}" ]]; then
+    a=$(_gate_uid_to_agent "$SUDO_UID")
+    [[ -n "$a" ]] && { printf '%s' "$a"; return; }
+  fi
+  printf ''
+}
+
+# _gate_agent_for_uid <uid> — the agent name owning a numeric uid, or EMPTY. Used
+# to re-check a STORED `need_answered_uid` (DIVE-756 stamps the real pre-sudo
+# invoker) against a claimed `need_answered_by`, so a `--from` spoof is visible
+# after the fact and not only at answer time.
+_gate_agent_for_uid() { _gate_uid_to_agent "${1:-}"; }
+
+# ---------------------------------------------------------------------------
+# actor_derive — the same uid-first derivation, but it REPORTS its work.
+#
+# Sets, and never leaves stale:
+#   ACTOR_UNIX     the unforgeable unix name owning the acting uid ("agent-dev",
+#                  "claude", "root"), or EMPTY when unmeasurable
+#   ACTOR_UID      the uid the identity was read from
+#   ACTOR_SOURCE   euid | sudo_uid   — WHICH of the two trusted sources answered
+#   ACTOR_REASON   populated ONLY on failure, and it names the failure
+#
+# Returns 0 when the actor was MEASURED, non-zero when it was not. That return is
+# the whole point of the epoch: "unmeasurable" must be a refusal, never the string
+# `unknown` handed back with a success status. This codebase has paid for that
+# collapse repeatedly — DIVE-2210's envelope tier, DIVE-2213's heartbeat guard,
+# DIVE-1927's paired probe — every time because a reader could not tell "measured,
+# nothing to report" from "we could not look".
+#
+# NOTE the partition, and it is deliberate: a caller who is a real unix user but
+# NOT an agent (`claude`, `root`) is MEASURED, not unmeasurable. "This uid is not an
+# agent" is an answer. Unmeasurable means the uid resolves to nothing at all — no
+# passwd row (an NSS-only or deleted account), an unreadable passwd, a non-numeric
+# uid. Same absent-vs-not-measured line `tier_unmeasured` already draws for tiers.
+actor_derive() {
+  ACTOR_UNIX=""; ACTOR_UID=""; ACTOR_SOURCE="euid"; ACTOR_REASON=""
+  local uid; uid=$(_gate_caller_uid)
+  ACTOR_UID="$uid"
+  # sudo's record of the pre-elevation invoker, trusted ONLY behind the REAL root
+  # check (DIVE-1413): sudo writes SUDO_UID, and a non-root process forging it
+  # cannot also become root. Below EUID 0 it is a plain env var, which is why
+  # DIVE-950 dropped the agent-forgeable `--proof` form.
+  if _gate_is_root && [[ -n "${SUDO_UID:-}" ]]; then
+    [[ "$SUDO_UID" =~ ^[0-9]+$ ]] || { ACTOR_REASON="sudo-uid-not-numeric"; return 1; }
+    ACTOR_UID="$SUDO_UID"; ACTOR_SOURCE="sudo_uid"
+  fi
+  [[ "$ACTOR_UID" =~ ^[0-9]+$ ]] || { ACTOR_REASON="uid-not-numeric"; return 1; }
+  # `$(</etc/passwd)` on an unreadable file expands to empty and still leaves
+  # printf's status 0, so emptiness — not the exit code — is the signal here.
+  local body; body=$(_gate_passwd_stream)
+  [[ -n "$body" ]] || { ACTOR_REASON="passwd-unreadable"; return 1; }
+  ACTOR_UNIX=$(actor_uid_to_name "$ACTOR_UID")
+  [[ -n "$ACTOR_UNIX" ]] || { ACTOR_REASON="uid-not-in-passwd"; return 1; }
+  return 0
+}
+
+# actor_registry_agent <unix-name> — the BOARD name for a unix principal, decided
+# by the registry, plus the tier that decided it.
+#
+# Sets ACTOR_AGENT (board name, or empty) and ACTOR_TIER (agent_tier's vocabulary,
+# never empty). Candidates are tried `agent-dev` -> `dev` -> `dev` as-is: the
+# `agent-` strip is a LOOKUP CANDIDATE, not the decision. The registry answers.
+#
+# agent_tier's three-way split is load-bearing here:
+#   a real tier / unknown:no-tier   the key IS under .agents  -> registered
+#   unknown:unregistered            the key is NOT            -> a MEASUREMENT, try next
+#   any other unknown:*             we could not look at all  -> report it, claim nothing
+actor_registry_agent() {
+  local unix="${1:-}" cand t
+  ACTOR_AGENT=""; ACTOR_TIER="unknown:no-caller"
+  [[ -n "$unix" ]] || return 0
+  for cand in "${unix#agent-}" "$unix"; do
+    [[ -n "$cand" ]] || continue
+    t=$(agent_tier "$cand")
+    case "$t" in
+      unknown:unregistered) ACTOR_TIER="$t"; continue ;;
+      unknown:no-tier)      ACTOR_AGENT="$cand"; ACTOR_TIER="$t"; return 0 ;;
+      unknown:*)            ACTOR_TIER="$t"; return 0 ;;   # registry unreadable — claim nothing
+      *)                    ACTOR_AGENT="$cand"; ACTOR_TIER="$t"; return 0 ;;
+    esac
+  done
+  return 0
+}
+
+# The env vars this derivation deliberately IGNORES for identity. Printed by
+# `5dive whoami` so the refusal is visible rather than merely documented — a reader
+# holding a forged SUDO_USER should be able to see that it was read and discarded.
+actor_ignored_identity_env() {
+  local n v out=""
+  for n in SUDO_USER USER LOGNAME FIVEDIVE_AUDIT_USER; do
+    v="${!n:-}"
+    [[ -n "$v" ]] && out+="${out:+, }${n}=${v}"
+  done
+  printf '%s' "$out"
+}

--- a/src/lib/actor.sh
+++ b/src/lib/actor.sh
@@ -163,9 +163,23 @@ actor_derive() {
 # `agent-` strip is a LOOKUP CANDIDATE, not the decision. The registry answers.
 #
 # agent_tier's three-way split is load-bearing here:
-#   a real tier / unknown:no-tier   the key IS under .agents  -> registered
+#   a real tier                     registered, tier usable
+#   unknown:no-tier                 the key IS under .agents, isolation absent
+#   unknown:malformed-tier          the key IS under .agents, isolation unusable
 #   unknown:unregistered            the key is NOT            -> a MEASUREMENT, try next
 #   any other unknown:*             we could not look at all  -> report it, claim nothing
+#
+# no-tier and malformed-tier both NAME THE AGENT and flag the tier as not measured.
+# Both mean the registry answered "yes, this is an agent" and then failed only on the
+# tier value; dropping the agent name because its tier was unusable would throw away
+# the half that WAS measured — the same two-things-in-one-bucket collapse agent_tier
+# itself exists to undo.
+#
+# The residual `unknown:*` branch RETURNS rather than trying the next candidate, and
+# that is load-bearing. A registry we could not read is not an invitation to guess
+# again with a different name: `continue` there would let a second candidate's
+# success paper over the first candidate's failed lookup and report a confident
+# agent identity built on a read that did not happen. Graded by T17.
 actor_registry_agent() {
   local unix="${1:-}" cand t
   ACTOR_AGENT=""; ACTOR_TIER="unknown:no-caller"
@@ -174,10 +188,10 @@ actor_registry_agent() {
     [[ -n "$cand" ]] || continue
     t=$(agent_tier "$cand")
     case "$t" in
-      unknown:unregistered) ACTOR_TIER="$t"; continue ;;
-      unknown:no-tier)      ACTOR_AGENT="$cand"; ACTOR_TIER="$t"; return 0 ;;
-      unknown:*)            ACTOR_TIER="$t"; return 0 ;;   # registry unreadable — claim nothing
-      *)                    ACTOR_AGENT="$cand"; ACTOR_TIER="$t"; return 0 ;;
+      unknown:unregistered)                 ACTOR_TIER="$t"; continue ;;
+      unknown:no-tier|unknown:malformed-tier) ACTOR_AGENT="$cand"; ACTOR_TIER="$t"; return 0 ;;
+      unknown:*)                            ACTOR_TIER="$t"; return 0 ;;   # could not look — claim nothing
+      *)                                    ACTOR_AGENT="$cand"; ACTOR_TIER="$t"; return 0 ;;
     esac
   done
   return 0

--- a/src/main.sh
+++ b/src/main.sh
@@ -270,6 +270,15 @@ Actor-routed gh (DIVE-2448):
   # An agent gh write authenticates as the HUMAN account, so the audit trail cannot tell agent from human
   # (DIVE-2232). The PAT stays root-side in /etc/5dive/connectors/github-bot.env — the agent never holds it.
 
+Identity:
+  5dive whoami [--json]
+    Who is acting, under whose authority, at what tier — and the SOURCE of each.
+    Identity is uid-first: $EUID (or sudo's $SUDO_UID at real root) resolved
+    against /etc/passwd in pure bash. Never argv/--from, $USER, $SUDO_USER or
+    $FIVEDIVE_AUDIT_USER, and never `id`/`getent` (both PATH-resolved).
+    An UNMEASURABLE actor exits 6 (auth_required) — it is never printed as
+    `unknown` with a success status.
+
 Models:
   5dive models [--json]
     Current Claude model id per short alias (opus / sonnet / fable / haiku).
@@ -651,6 +660,12 @@ main() {
           with_registry_lock cmd_account_set_active_provider "$@" ;;
         *) fail "$E_USAGE" "unknown account command: $acctcmd" ;;
       esac ;;
+    whoami)
+      # DIVE-2517 (v0.18 "Proof of who"): the one sealed actor derivation, printed
+      # with the provenance of every field. Read-only — no state, no lock, and
+      # deliberately NO audit row: a verb whose whole job is to report the caller's
+      # identity must not need the caller's identity to be writable first.
+      cmd_whoami "$@" ;;
     models)
       # DIVE-1883: print the alias -> current model id map (source of truth in
       # src/lib/models.sh). Read-only. The telegram plugin reads

--- a/tests/audit_task_store_fence_unit.sh
+++ b/tests/audit_task_store_fence_unit.sh
@@ -43,7 +43,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/company_unit.sh
+++ b/tests/company_unit.sh
@@ -30,7 +30,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_objective.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_objective.sh \
          cmd_init.sh cmd_company.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"

--- a/tests/constitution_gate_floor_unit.sh
+++ b/tests/constitution_gate_floor_unit.sh
@@ -16,7 +16,7 @@ cd "$(dirname "$0")/.."
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_council.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_council.sh; do
   # shellcheck source=/dev/null
   source "src/$f"
 done

--- a/tests/gate_actor_path_forgery_unit.sh
+++ b/tests/gate_actor_path_forgery_unit.sh
@@ -46,12 +46,19 @@ EXPECT=""; [[ "$REAL_NAME" == agent-* ]] && EXPECT="${REAL_NAME#agent-}"
 # `_gate_uid_to_agent` now reads its passwd source through `_gate_passwd_stream`,
 # so that must load too or the resolver returns empty for every uid and arms 1-3
 # pass vacuously.
-eval "$(sed -n '/^_gate_passwd_stream()/,/^}/p'        src/cmd_task.sh)"
-eval "$(sed -n '/^_gate_is_root()/,/^}/p'             src/cmd_task.sh)"
-eval "$(sed -n '/^_gate_uid_to_agent()/,/^}/p'        src/cmd_task.sh)"
-eval "$(sed -n '/^_gate_caller_uid()/,/^}/p'          src/cmd_task.sh)"
-eval "$(sed -n '/^_gate_authenticated_actor()/,/^}/p' src/cmd_task.sh)"
-for _f in _gate_passwd_stream _gate_is_root _gate_uid_to_agent _gate_caller_uid _gate_authenticated_actor; do
+# DIVE-2517: these six MOVED from src/cmd_task.sh to src/lib/actor.sh when the
+# strict uid-first derivation was promoted to the single one. Same names, same
+# bodies — only the file changed. `actor_uid_to_name` is NOT optional: it is the
+# passwd walk `_gate_uid_to_agent` now composes over, and without it the resolver
+# returns empty for every uid and arms 1-3 pass vacuously (the same way
+# `_gate_passwd_stream` had to be added in iteration 2).
+eval "$(sed -n '/^_gate_passwd_stream()/,/^}/p'        src/lib/actor.sh)"
+eval "$(sed -n '/^_gate_is_root()/,/^}/p'             src/lib/actor.sh)"
+eval "$(sed -n '/^actor_uid_to_name()/,/^}/p'         src/lib/actor.sh)"
+eval "$(sed -n '/^_gate_uid_to_agent()/,/^}/p'        src/lib/actor.sh)"
+eval "$(sed -n '/^_gate_caller_uid()/,/^}/p'          src/lib/actor.sh)"
+eval "$(sed -n '/^_gate_authenticated_actor()/,/^}/p' src/lib/actor.sh)"
+for _f in _gate_passwd_stream _gate_is_root actor_uid_to_name _gate_uid_to_agent _gate_caller_uid _gate_authenticated_actor; do
   declare -F "$_f" >/dev/null || { printf 'NOT OK - %s did not load; the arms below would be vacuous\n' "$_f"; exit 1; }
 done
 

--- a/tests/gate_answer_audit_unit.sh
+++ b/tests/gate_answer_audit_unit.sh
@@ -54,7 +54,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/gate_approval_routing_unit.sh
+++ b/tests/gate_approval_routing_unit.sh
@@ -34,7 +34,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_channel_proof_unit.sh
+++ b/tests/gate_channel_proof_unit.sh
@@ -30,7 +30,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_channel_session_t2_unit.sh
+++ b/tests/gate_channel_session_t2_unit.sh
@@ -43,7 +43,7 @@ fi
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_class_over_tier_unit.sh
+++ b/tests/gate_class_over_tier_unit.sh
@@ -40,7 +40,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_agent.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_agent.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_clear_leads_reader_unit.sh
+++ b/tests/gate_clear_leads_reader_unit.sh
@@ -29,7 +29,7 @@ STATE_DIR="$TMP"
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_council.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_council.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_floor_declared_discussion_unit.sh
+++ b/tests/gate_floor_declared_discussion_unit.sh
@@ -55,7 +55,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_floor_word_boundary_unit.sh
+++ b/tests/gate_floor_word_boundary_unit.sh
@@ -45,7 +45,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_history_unit.sh
+++ b/tests/gate_history_unit.sh
@@ -55,7 +55,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_proof.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_proof.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/gate_internal_ops_floor_unit.sh
+++ b/tests/gate_internal_ops_floor_unit.sh
@@ -32,7 +32,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_lead_clear_stamp_unit.sh
+++ b/tests/gate_lead_clear_stamp_unit.sh
@@ -51,7 +51,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/gate_lead_standing_unit.sh
+++ b/tests/gate_lead_standing_unit.sh
@@ -42,7 +42,7 @@ STATE_DIR="$TMP"
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_council.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_council.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_needs_capability_unit.sh
+++ b/tests/gate_needs_capability_unit.sh
@@ -47,7 +47,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_nonce_unit.sh
+++ b/tests/gate_nonce_unit.sh
@@ -35,7 +35,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_option_account_frame_unit.sh
+++ b/tests/gate_option_account_frame_unit.sh
@@ -21,7 +21,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   source "$SRC/$f"
 done
 set +e

--- a/tests/gate_parity_smoke.sh
+++ b/tests/gate_parity_smoke.sh
@@ -48,7 +48,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_secret.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_secret.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_precedent_unit.sh
+++ b/tests/gate_precedent_unit.sh
@@ -31,7 +31,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_proof_verify_unit.sh
+++ b/tests/gate_proof_verify_unit.sh
@@ -34,7 +34,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/gate_route_delivery_unit.sh
+++ b/tests/gate_route_delivery_unit.sh
@@ -45,7 +45,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_seam_concatenation_unit.sh
+++ b/tests/gate_seam_concatenation_unit.sh
@@ -55,7 +55,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_ship_routing_unit.sh
+++ b/tests/gate_ship_routing_unit.sh
@@ -27,7 +27,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_sudo_uid_forge_unit.sh
+++ b/tests/gate_sudo_uid_forge_unit.sh
@@ -46,7 +46,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_t2_nonce_proof_unit.sh
+++ b/tests/gate_t2_nonce_proof_unit.sh
@@ -36,7 +36,7 @@ STATE_DIR="$TMP"
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_council.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_council.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_t2_routed_escalate_unit.sh
+++ b/tests/gate_t2_routed_escalate_unit.sh
@@ -32,7 +32,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_tier2_decision_nonce_unit.sh
+++ b/tests/gate_tier2_decision_nonce_unit.sh
@@ -40,7 +40,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_tier2_explicit_pin_unit.sh
+++ b/tests/gate_tier2_explicit_pin_unit.sh
@@ -43,7 +43,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_tier2_floor_unit.sh
+++ b/tests/gate_tier2_floor_unit.sh
@@ -31,7 +31,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_verifier_route_unit.sh
+++ b/tests/gate_verifier_route_unit.sh
@@ -29,7 +29,7 @@ trap 'rc=$?; rm -rf "$TMP"; [[ "$SUMMARY_PRINTED" == 1 ]] || printf "ABORTED - g
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/gate_withdraw_unit.sh
+++ b/tests/gate_withdraw_unit.sh
@@ -41,7 +41,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/goal_add_unit.sh
+++ b/tests/goal_add_unit.sh
@@ -30,7 +30,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_goal.sh cmd_loop.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_goal.sh cmd_loop.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/goal_async_unit.sh
+++ b/tests/goal_async_unit.sh
@@ -33,7 +33,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_goal.sh cmd_loop.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_goal.sh cmd_loop.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/handoff_ack_unit.sh
+++ b/tests/handoff_ack_unit.sh
@@ -22,7 +22,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/heartbeat_active_defer_unit.sh
+++ b/tests/heartbeat_active_defer_unit.sh
@@ -29,7 +29,7 @@ SRC=src
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh \
          cmd_agent_runtime.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"

--- a/tests/heartbeat_dispatcher_claim_unit.sh
+++ b/tests/heartbeat_dispatcher_claim_unit.sh
@@ -51,7 +51,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/heartbeat_gate_escalate_unit.sh
+++ b/tests/heartbeat_gate_escalate_unit.sh
@@ -27,7 +27,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_agent.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_agent.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/heartbeat_gate_renag_unit.sh
+++ b/tests/heartbeat_gate_renag_unit.sh
@@ -20,7 +20,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_agent.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_agent.sh cmd_heartbeat.sh; do
   source "$SRC/$f"
 done
 set +e

--- a/tests/heartbeat_gate_shipped_unit.sh
+++ b/tests/heartbeat_gate_shipped_unit.sh
@@ -27,7 +27,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_agent.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_agent.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/heartbeat_goal_loop_terminal_unit.sh
+++ b/tests/heartbeat_goal_loop_terminal_unit.sh
@@ -47,7 +47,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/heartbeat_idle_marker_unit.sh
+++ b/tests/heartbeat_idle_marker_unit.sh
@@ -27,7 +27,7 @@ SRC=src
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh \
          cmd_agent_runtime.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"

--- a/tests/heartbeat_materialize_recurring_unit.sh
+++ b/tests/heartbeat_materialize_recurring_unit.sh
@@ -32,7 +32,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/heartbeat_pick_unit.sh
+++ b/tests/heartbeat_pick_unit.sh
@@ -29,7 +29,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/heartbeat_recall_compile_unit.sh
+++ b/tests/heartbeat_recall_compile_unit.sh
@@ -30,7 +30,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_memory.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_memory.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/heartbeat_stall_sweep_unit.sh
+++ b/tests/heartbeat_stall_sweep_unit.sh
@@ -34,7 +34,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/heartbeat_usage_heal_unit.sh
+++ b/tests/heartbeat_usage_heal_unit.sh
@@ -30,7 +30,7 @@ SRC=src
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh \
          cmd_agent_runtime.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"

--- a/tests/heartbeat_wake_guard_unit.sh
+++ b/tests/heartbeat_wake_guard_unit.sh
@@ -32,7 +32,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/loop_batch_unit.sh
+++ b/tests/loop_batch_unit.sh
@@ -28,7 +28,7 @@ trap 'rm -rf "$TMP"; [[ -n "${SIMPID:-}" ]] && kill "$SIMPID" 2>/dev/null' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/loop_ceiling_enforce_unit.sh
+++ b/tests/loop_ceiling_enforce_unit.sh
@@ -22,7 +22,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh cmd_usage.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh cmd_usage.sh cmd_heartbeat.sh; do
   source "$SRC/$f"
 done
 STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"

--- a/tests/loop_control_unit.sh
+++ b/tests/loop_control_unit.sh
@@ -26,7 +26,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh cmd_usage.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh cmd_usage.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/loop_grade_unit.sh
+++ b/tests/loop_grade_unit.sh
@@ -27,7 +27,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/loop_id_collision_unit.sh
+++ b/tests/loop_id_collision_unit.sh
@@ -41,7 +41,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/loop_panel_unit.sh
+++ b/tests/loop_panel_unit.sh
@@ -29,7 +29,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/loop_spawn_unit.sh
+++ b/tests/loop_spawn_unit.sh
@@ -30,7 +30,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/loop_spend_not_reached_unit.sh
+++ b/tests/loop_spend_not_reached_unit.sh
@@ -33,7 +33,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh \
          cmd_usage.sh cmd_heartbeat.sh; do
   source "$SRC/$f"
 done

--- a/tests/loop_status_unit.sh
+++ b/tests/loop_status_unit.sh
@@ -24,7 +24,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/loop_verify_unit.sh
+++ b/tests/loop_verify_unit.sh
@@ -25,7 +25,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_loop.sh; do
   source "$SRC/$f"
 done
 STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"

--- a/tests/loop_wake_wait_unit.sh
+++ b/tests/loop_wake_wait_unit.sh
@@ -31,7 +31,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_goal.sh cmd_loop.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_goal.sh cmd_loop.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/objective_preflight_unit.sh
+++ b/tests/objective_preflight_unit.sh
@@ -34,7 +34,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_goal.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_goal.sh \
          cmd_loop.sh cmd_objective.sh; do
   source "$SRC/$f"
 done

--- a/tests/objective_reconcile_unit.sh
+++ b/tests/objective_reconcile_unit.sh
@@ -32,7 +32,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_goal.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_goal.sh \
          cmd_loop.sh cmd_objective.sh cmd_heartbeat.sh; do
   source "$SRC/$f"
 done

--- a/tests/objective_replan_unit.sh
+++ b/tests/objective_replan_unit.sh
@@ -34,7 +34,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_goal.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_goal.sh \
          cmd_loop.sh cmd_objective.sh; do
   source "$SRC/$f"
 done

--- a/tests/objective_status_unit.sh
+++ b/tests/objective_status_unit.sh
@@ -37,7 +37,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_objective.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_objective.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/objective_unit.sh
+++ b/tests/objective_unit.sh
@@ -31,7 +31,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_objective.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_objective.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/org_write_authz_unit.sh
+++ b/tests/org_write_authz_unit.sh
@@ -38,7 +38,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/project_show_graph_unit.sh
+++ b/tests/project_show_graph_unit.sh
@@ -34,7 +34,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/push_unit.sh
+++ b/tests/push_unit.sh
@@ -38,7 +38,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_agent_create.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_push.sh cmd_agent_create.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done
@@ -343,7 +343,10 @@ out=$(authoritative_gate_check DIVE-2004C); rc=$?
 
 unset -f _gate_agent_for_uid
 # shellcheck source=/dev/null
-source "$SRC/cmd_task.sh"   # restore the real helper for the cases below
+source "$SRC/lib/actor.sh"  # restore the real helper for the cases below — the
+                            # sealed derivation owns it since DIVE-2517; re-sourcing
+                            # cmd_task.sh would leave it UNDEFINED and every arm below
+                            # would grade an absent function rather than the real one.
 
 # _gate_authenticated_actor: the kernel-enforced identity, EMPTY when unknown.
 # Not `task_actor` — that returns --from verbatim, which is the whole bug.

--- a/tests/secret_drop_unit.sh
+++ b/tests/secret_drop_unit.sh
@@ -29,7 +29,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_secret.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_secret.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/secret_gate_delivery_path_unit.sh
+++ b/tests/secret_gate_delivery_path_unit.sh
@@ -68,7 +68,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/task_answer_closed_row_unit.sh
+++ b/tests/task_answer_closed_row_unit.sh
@@ -52,7 +52,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
+         lib/disk.sh lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/task_block_anchor_unit.sh
+++ b/tests/task_block_anchor_unit.sh
@@ -29,7 +29,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/task_cascade_unblock_unit.sh
+++ b/tests/task_cascade_unblock_unit.sh
@@ -30,7 +30,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_heartbeat.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_heartbeat.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/task_core_unit.sh
+++ b/tests/task_core_unit.sh
@@ -27,7 +27,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/task_done_delivered_guard_unit.sh
+++ b/tests/task_done_delivered_guard_unit.sh
@@ -32,7 +32,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
+         lib/disk.sh lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/task_done_over_closed_result_unit.sh
+++ b/tests/task_done_over_closed_result_unit.sh
@@ -42,7 +42,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
+         lib/disk.sh lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/task_fixture_send_guard_unit.sh
+++ b/tests/task_fixture_send_guard_unit.sh
@@ -24,7 +24,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   source "$SRC/$f"
 done
 set +e

--- a/tests/task_inbox_send_unit.sh
+++ b/tests/task_inbox_send_unit.sh
@@ -21,7 +21,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   source "$SRC/$f"
 done
 set +e

--- a/tests/task_need_t0_auto_unit.sh
+++ b/tests/task_need_t0_auto_unit.sh
@@ -31,7 +31,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/task_park_gate_guard_unit.sh
+++ b/tests/task_park_gate_guard_unit.sh
@@ -29,7 +29,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/task_reject_actor_and_closed_unit.sh
+++ b/tests/task_reject_actor_and_closed_unit.sh
@@ -34,7 +34,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
+         lib/disk.sh lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/task_set_body_unit.sh
+++ b/tests/task_set_body_unit.sh
@@ -23,7 +23,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/task_set_branch_unit.sh
+++ b/tests/task_set_branch_unit.sh
@@ -25,7 +25,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_push.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_push.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/task_start_delivered_guard_unit.sh
+++ b/tests/task_start_delivered_guard_unit.sh
@@ -59,7 +59,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/task_start_recurring_guard_unit.sh
+++ b/tests/task_start_recurring_guard_unit.sh
@@ -30,7 +30,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/task_verifier_rail_unit.sh
+++ b/tests/task_verifier_rail_unit.sh
@@ -36,7 +36,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/task_verify_over_closed_unit.sh
+++ b/tests/task_verify_over_closed_unit.sh
@@ -38,7 +38,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
+         lib/disk.sh lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/task_verify_self_close_visibility_unit.sh
+++ b/tests/task_verify_self_close_visibility_unit.sh
@@ -24,7 +24,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   source "$SRC/$f"
 done
 

--- a/tests/verifier_gate_ack_unit.sh
+++ b/tests/verifier_gate_ack_unit.sh
@@ -45,7 +45,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/disk.sh lib/tasks_db.sh cmd_task.sh cmd_push.sh cmd_org.sh \
+         lib/disk.sh lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_push.sh cmd_org.sh \
          cmd_project.sh cmd_heartbeat.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"

--- a/tests/whoami_sealed_actor_unit.sh
+++ b/tests/whoami_sealed_actor_unit.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# DIVE-2517 (v0.18 "Proof of who") — `5dive whoami` and the ONE sealed actor
+# derivation in src/lib/actor.sh.
+#
+# WHAT THIS GRADES, and why each arm can fail:
+#   identity is uid-first    the answer comes from $EUID -> /etc/passwd and from
+#                            nothing else. Arms 2 and 3 run the REAL forgeries
+#                            (a PATH shim for `id`/`getent`; SUDO_USER, USER,
+#                            LOGNAME and FIVEDIVE_AUDIT_USER all naming another
+#                            agent) and demand the real name back.
+#   the prefix rule is gone  from the IDENTITY axis (DIVE-2371). Arm 4 is
+#                            differential: it fails if the two resolvers AGREE,
+#                            because then it is grading nothing.
+#   unmeasurable REFUSES     arms 5, 6 and 9 make the actor genuinely
+#                            unresolvable and demand a NON-ZERO return plus a
+#                            reason that names the failure. Each is anchored
+#                            against a baseline that must SUCCEED, so a resolver
+#                            that always fails cannot pass them.
+#   not-an-agent is MEASURED arm 7. `root` is an answer, not a hole, and it must
+#                            return 0 — the absent-vs-not-measured line
+#                            tier_unmeasured() already draws for tiers.
+#   the SUDO_UID branch      arm 8 exercises both sides of the real root check.
+#   the verb, end to end     arms 10-12 run the BUILT bundle, including the exit
+#                            status under a bind-mounted passwd in a mount
+#                            namespace — the only way to reach the refusal
+#                            through a fresh bash that redefines its own seams.
+#
+# GROUND TRUTH IS TAKEN WITHOUT THE CODE UNDER TEST: the expected name comes from
+# /proc/self/status's real uid resolved against /etc/passwd by awk. Never from
+# `id`, never from the resolver being graded.
+#
+# Run: bash tests/whoami_sealed_actor_unit.sh   (no network; arm 12 wants sudo)
+set -uo pipefail
+
+# DIVE-2211 / DIVE-2286: name the tree this harness grades. Sourced BEFORE the cd
+# so ${BASH_SOURCE[0]} still resolves relative to tests/. Deliberately NO
+# `2>/dev/null` — redirecting it also swallows the helper's own stderr line, which
+# IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+PASS=0; FAIL=0; SKIP=0
+ok(){   PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+no(){   FAIL=$((FAIL+1)); printf 'NOT OK - %s\n' "$1"; }
+# A skip is NOT a pass. An unavailable precondition must never inflate a green log.
+skip(){ SKIP=$((SKIP+1)); printf 'skip - %s\n' "$1"; }
+
+# --- ground truth, independent of the code under test -----------------------
+REAL_UID=$(awk '/^Uid:/{print $2; exit}' /proc/self/status)
+REAL_GID=$(awk '/^Gid:/{print $2; exit}' /proc/self/status)
+REAL_NAME=$(awk -F: -v u="$REAL_UID" '$3==u{print $1; exit}' /etc/passwd)
+
+# --- load the sealed derivation, and NOTHING else ---------------------------
+# One-liner bodies included: `sed '/^f()/,/^}/p'` over `f() { ...; }` on a single
+# line captures that line and then runs to the NEXT `^}` in the file, swallowing
+# whatever sits between. Anchor each extraction to its own definition and verify
+# the function loaded rather than trusting the range.
+for _fn in _gate_passwd_stream actor_uid_to_name _gate_uid_to_agent _gate_is_root \
+           _gate_caller_uid _gate_authenticated_actor actor_derive; do
+  eval "$(awk -v f="^${_fn}\\\\(\\\\)" '$0 ~ f {p=1} p {print} p && /^}$/ {exit} p && /^[a-z_]+\(\)[[:space:]]*\{.*\}$/ {exit}' src/lib/actor.sh)"
+done
+for _f in _gate_passwd_stream actor_uid_to_name _gate_uid_to_agent _gate_is_root \
+          _gate_caller_uid _gate_authenticated_actor actor_derive; do
+  declare -F "$_f" >/dev/null || { printf 'NOT OK - %s did not load; every arm below would be vacuous\n' "$_f"; exit 1; }
+done
+
+# ---------------------------------------------------------------------------
+# 1. identity is the uid's passwd name, taken from the kernel
+if [[ -z "$REAL_NAME" ]]; then
+  skip "T1 caller uid $REAL_UID has no passwd row on this runner"
+else
+  actor_derive; rc=$?
+  if (( rc == 0 )) && [[ "$ACTOR_UNIX" == "$REAL_NAME" && "$ACTOR_UID" == "$REAL_UID" && "$ACTOR_SOURCE" == "euid" ]]; then
+    ok "T1 actor_derive = $REAL_NAME (uid $REAL_UID, source euid), rc 0"
+  else
+    no "T1 expected $REAL_NAME/$REAL_UID/euid rc0, got '$ACTOR_UNIX'/'$ACTOR_UID'/'$ACTOR_SOURCE' rc$rc"
+  fi
+fi
+
+# 2. a PATH shim for `id` and `getent` must change nothing
+SHIM=$(mktemp -d)
+printf '#!/bin/sh\necho agent-lodar\n'          > "$SHIM/id";     chmod +x "$SHIM/id"
+printf '#!/bin/sh\necho agent-lodar:x:0:0:::\n' > "$SHIM/getent"; chmod +x "$SHIM/getent"
+if [[ -z "$REAL_NAME" ]]; then
+  skip "T2 no passwd row for the caller; the forgery has nothing to displace"
+else
+  ( PATH="$SHIM:$PATH"; actor_derive; printf '%s' "$ACTOR_UNIX" ) > "$SHIM/out"
+  got=$(<"$SHIM/out")
+  # Non-vacuity: the shim must actually be winning PATH, or this arm proves nothing.
+  shimmed=$(PATH="$SHIM:$PATH" id -un 2>/dev/null)
+  if [[ "$shimmed" != "agent-lodar" ]]; then
+    no "T2 VACUOUS — the PATH shim never took effect (\`id -un\` returned '$shimmed')"
+  elif [[ "$got" == "$REAL_NAME" ]]; then
+    ok "T2 PATH shim printing agent-lodar did not move the identity (still $REAL_NAME)"
+  else
+    no "T2 PATH shim moved the identity to '$got'"
+  fi
+fi
+
+# 3. the four caller-supplied identity env vars must all be ignored
+if [[ -z "$REAL_NAME" ]]; then
+  skip "T3 no passwd row for the caller"
+else
+  # In-process, not `bash -c`: a fresh shell would not have the function loaded and
+  # the arm would grade an empty string against an empty string.
+  ( export SUDO_USER=agent-olivia USER=claude LOGNAME=claude FIVEDIVE_AUDIT_USER=lodar
+    actor_derive; printf '%s' "$ACTOR_UNIX" ) > "$SHIM/out3"
+  got=$(<"$SHIM/out3")
+  if [[ "$got" == "$REAL_NAME" ]]; then
+    ok "T3 SUDO_USER/USER/LOGNAME/FIVEDIVE_AUDIT_USER=<other> did not move the identity"
+  else
+    no "T3 env forgery moved the identity to '$got'"
+  fi
+fi
+
+# 4. DIFFERENTIAL: the identity read has no `agent-` prefix rule; the legacy gate
+#    resolver still does. If they agree, this arm is grading nothing and FAILS.
+root_name=$(actor_uid_to_name 0)
+root_agent=$(_gate_uid_to_agent 0)
+if [[ "$root_name" != "root" ]]; then
+  no "T4 precondition: uid 0 did not resolve to 'root' (got '$root_name')"
+elif [[ -n "$root_agent" ]]; then
+  no "T4 _gate_uid_to_agent(0) returned '$root_agent'; the gate resolver's prefix rule regressed"
+elif [[ "$root_name" == "$root_agent" ]]; then
+  no "T4 VACUOUS — both resolvers agree on uid 0, so the axis split is not being graded"
+else
+  ok "T4 uid 0: identity='root' (no prefix rule) vs gate resolver='' (prefix rule kept)"
+fi
+
+# 5. UNMEASURABLE: the uid has no passwd row -> non-zero, and the reason names it.
+#    Anchored: the SAME call against the real passwd must SUCCEED, so a resolver
+#    that always refuses cannot pass this.
+FIX=$(mktemp -d)/passwd
+printf 'root:x:0:0:root:/root:/bin/sh\nnobody:x:65534:65534::/:/usr/sbin/nologin\n' > "$FIX"
+(
+  actor_derive; base_rc=$?
+  _gate_caller_uid() { printf '424242'; }
+  actor_derive; mut_rc=$?
+  if (( base_rc != 0 )); then
+    printf 'ANCHOR_FAIL %s\n' "$base_rc"
+  elif (( mut_rc == 0 )); then
+    printf 'MUT_PASSED %s\n' "$ACTOR_UNIX"
+  else
+    printf 'REFUSED %s %s\n' "$ACTOR_REASON" "${ACTOR_UNIX:-<empty>}"
+  fi
+) > "$SHIM/out5"
+read -r verdict a b < "$SHIM/out5"
+case "$verdict" in
+  REFUSED) if [[ "$a" == "uid-not-in-passwd" && "$b" == "<empty>" ]]; then
+             ok "T5 uid with no passwd row -> rc!=0, reason=uid-not-in-passwd, name empty"
+           else no "T5 refused but reason='$a' name='$b'"; fi ;;
+  MUT_PASSED)  no "T5 an unresolvable uid returned rc 0 as '$a'" ;;
+  ANCHOR_FAIL) no "T5 ANCHOR — the baseline derive already failed (rc $a); the mutant proves nothing" ;;
+  *)           no "T5 harness produced no verdict" ;;
+esac
+
+# 6. UNMEASURABLE: passwd itself unreadable. `$(</etc/passwd)` leaves printf's
+#    status at 0 on a failed open, so emptiness — not rc — has to be the signal.
+(
+  _gate_passwd_stream() { printf ''; }
+  actor_derive; rc=$?
+  printf '%s %s\n' "$rc" "${ACTOR_REASON:-<none>}"
+) > "$SHIM/out6"
+read -r rc reason < "$SHIM/out6"
+if (( rc != 0 )) && [[ "$reason" == "passwd-unreadable" ]]; then
+  ok "T6 empty passwd stream -> rc $rc, reason=passwd-unreadable (not a silent empty name)"
+else
+  no "T6 expected rc!=0 + passwd-unreadable, got rc=$rc reason=$reason"
+fi
+
+# 7. not-an-agent is a MEASUREMENT, not a hole: uid 0 -> root, rc 0.
+(
+  _gate_caller_uid() { printf '0'; }
+  _gate_is_root()    { return 1; }   # model a non-root caller whose uid maps to root
+  actor_derive; printf '%s %s\n' "$?" "${ACTOR_UNIX:-<empty>}"
+) > "$SHIM/out7"
+read -r rc name < "$SHIM/out7"
+if (( rc == 0 )) && [[ "$name" == "root" ]]; then
+  ok "T7 a non-agent uid is MEASURED (root, rc 0), not reported as unmeasurable"
+else
+  no "T7 expected rc 0 + root, got rc=$rc name=$name"
+fi
+
+# 8. the SUDO_UID branch is gated on the REAL root check, both ways.
+(
+  _gate_caller_uid() { printf '0'; }
+  _gate_is_root()    { return 1; }
+  SUDO_UID=65534 actor_derive
+  printf 'nonroot %s %s\n' "$ACTOR_SOURCE" "$ACTOR_UNIX"
+) > "$SHIM/out8a"
+(
+  _gate_caller_uid() { printf '0'; }
+  _gate_is_root()    { return 0; }
+  SUDO_UID=65534 actor_derive
+  printf 'root %s %s\n' "$ACTOR_SOURCE" "$ACTOR_UNIX"
+) > "$SHIM/out8b"
+read -r _ s_a n_a < "$SHIM/out8a"
+read -r _ s_b n_b < "$SHIM/out8b"
+nobody=$(awk -F: '$3==65534{print $1; exit}' /etc/passwd)
+if [[ -z "$nobody" ]]; then
+  skip "T8 no uid 65534 on this runner to model the pre-elevation invoker"
+elif [[ "$s_a" == "euid" && "$n_a" == "root" && "$s_b" == "sudo_uid" && "$n_b" == "$nobody" ]]; then
+  ok "T8 SUDO_UID ignored below root (euid/root) and honoured at real root (sudo_uid/$nobody)"
+else
+  no "T8 expected euid+root then sudo_uid+$nobody, got '$s_a'+'$n_a' then '$s_b'+'$n_b'"
+fi
+
+# 9. a malformed SUDO_UID at root REFUSES rather than silently falling back to the
+#    (root) euid — a fallback there would launder a broken elevation into an identity.
+(
+  _gate_caller_uid() { printf '0'; }
+  _gate_is_root()    { return 0; }
+  SUDO_UID='0; rm -rf /' actor_derive; rc=$?
+  printf '%s %s %s\n' "$rc" "${ACTOR_REASON:-<none>}" "${ACTOR_UNIX:-<empty>}"
+) > "$SHIM/out9"
+read -r rc reason name < "$SHIM/out9"
+if (( rc != 0 )) && [[ "$reason" == "sudo-uid-not-numeric" && "$name" == "<empty>" ]]; then
+  ok "T9 malformed SUDO_UID at root -> rc $rc, reason=sudo-uid-not-numeric, no fallback identity"
+else
+  no "T9 expected rc!=0 + sudo-uid-not-numeric + empty, got rc=$rc reason=$reason name=$name"
+fi
+
+# ---------------------------------------------------------------------------
+# END TO END, through the BUILT bundle.
+BIN=./5dive
+if [[ ! -x "$BIN" ]]; then
+  skip "T10-T12 no built ./5dive bundle in the tree"
+else
+  # 10. the verb reports the ground-truth identity and exits 0.
+  out=$("$BIN" whoami 2>&1); rc=$?
+  if [[ -z "$REAL_NAME" ]]; then
+    skip "T10 no passwd row for the caller"
+  elif (( rc == 0 )) && grep -q "unix=$REAL_NAME" <<<"$out"; then
+    ok "T10 \`5dive whoami\` rc 0 and reports unix=$REAL_NAME"
+  else
+    no "T10 rc=$rc, output did not carry unix=$REAL_NAME: $(head -2 <<<"$out" | tr '\n' ' ')"
+  fi
+
+  # 11. --json carries the same identity, real booleans, and a numeric uid.
+  j=$("$BIN" whoami --json 2>/dev/null)
+  if ! jq -e . >/dev/null 2>&1 <<<"$j"; then
+    no "T11 --json did not emit parseable JSON"
+  else
+    j_unix=$(jq -r '.data.actor.unix' <<<"$j")
+    j_meas=$(jq -r '.data.actor.measured|type' <<<"$j")
+    j_uid=$(jq -r '.data.actor.uid|type' <<<"$j")
+    j_ok=$(jq -r '.ok' <<<"$j")
+    if [[ "$j_unix" == "$REAL_NAME" && "$j_meas" == "boolean" && "$j_uid" == "number" && "$j_ok" == "true" ]]; then
+      ok "T11 --json: ok=true, actor.unix=$REAL_NAME, measured is a boolean, uid is a number"
+    else
+      no "T11 --json shape wrong: unix=$j_unix measured:$j_meas uid:$j_uid ok=$j_ok"
+    fi
+  fi
+
+  # 12. THE CONTRACT: unmeasurable exits NON-ZERO through the real bundle.
+  #     A fresh bash redefines its own seams, so the only honest way in is to
+  #     change what /etc/passwd IS — bind-mounted inside a private mount
+  #     namespace, so nothing on the host is touched. setpriv drops back to the
+  #     caller's uid WITHOUT needing a passwd lookup to do it.
+  if ! command -v unshare >/dev/null || ! command -v setpriv >/dev/null; then
+    skip "T12 unshare/setpriv unavailable — the exit-status contract is UNPROBED here, not proven"
+  elif ! sudo -n true 2>/dev/null; then
+    skip "T12 no non-interactive sudo — the exit-status contract is UNPROBED here, not proven"
+  else
+    e2e=$(sudo -n unshare -m -- bash -c \
+      "mount --bind '$FIX' /etc/passwd && setpriv --reuid=$REAL_UID --regid=$REAL_GID --clear-groups $PWD/5dive whoami --json" \
+      2>/dev/null); e2erc=$?
+    e2e_reason=$(jq -r '.data.actor.reason // empty' <<<"$e2e" 2>/dev/null)
+    # NOT `.ok // empty` — jq's `//` treats a literal `false` as absent, so the one
+    # value this arm exists to see would read as unset on the branch that matters.
+    e2e_ok=$(jq -r 'if has("ok") then (.ok|tostring) else "" end' <<<"$e2e" 2>/dev/null)
+    e2e_code=$(jq -r '.error.code // empty'         <<<"$e2e" 2>/dev/null)
+    if (( e2erc == 6 )) && [[ "$e2e_ok" == "false" && "$e2e_code" == "6" && "$e2e_reason" == "uid-not-in-passwd" ]]; then
+      ok "T12 bundle under a passwd with no row for uid $REAL_UID: exit 6, ok=false, reason=uid-not-in-passwd"
+    elif (( e2erc == 0 )); then
+      no "T12 the bundle exited 0 with an unmeasurable actor — the whole contract of this verb"
+    else
+      no "T12 expected exit 6 + ok:false + uid-not-in-passwd, got rc=$e2erc ok=$e2e_ok code=$e2e_code reason=$e2e_reason"
+    fi
+  fi
+fi
+
+rm -rf "$SHIM" "${FIX%/passwd}"
+printf '\n%s passed, %s failed, %s skipped\n' "$PASS" "$FAIL" "$SKIP"
+(( FAIL == 0 ))

--- a/tests/whoami_sealed_actor_unit.sh
+++ b/tests/whoami_sealed_actor_unit.sh
@@ -56,13 +56,19 @@ REAL_NAME=$(awk -F: -v u="$REAL_UID" '$3==u{print $1; exit}' /etc/passwd)
 # whatever sits between. Anchor each extraction to its own definition and verify
 # the function loaded rather than trusting the range.
 for _fn in _gate_passwd_stream actor_uid_to_name _gate_uid_to_agent _gate_is_root \
-           _gate_caller_uid _gate_authenticated_actor actor_derive; do
+           _gate_caller_uid _gate_authenticated_actor actor_derive actor_registry_agent; do
   eval "$(awk -v f="^${_fn}\\\\(\\\\)" '$0 ~ f {p=1} p {print} p && /^}$/ {exit} p && /^[a-z_]+\(\)[[:space:]]*\{.*\}$/ {exit}' src/lib/actor.sh)"
 done
 for _f in _gate_passwd_stream actor_uid_to_name _gate_uid_to_agent _gate_is_root \
-          _gate_caller_uid _gate_authenticated_actor actor_derive; do
+          _gate_caller_uid _gate_authenticated_actor actor_derive actor_registry_agent; do
   declare -F "$_f" >/dev/null || { printf 'NOT OK - %s did not load; every arm below would be vacuous\n' "$_f"; exit 1; }
 done
+# tier_unmeasured is registry.sh's, not this file's — arms 13-15 grade
+# actor_registry_agent's PARTITION over it, with agent_tier stubbed. Stubbing the
+# lookup is deliberate: registry.sh already owns whether agent_tier reads the file
+# correctly, and what is untested is what actor_registry_agent DOES with each verdict.
+eval "$(sed -n '/^tier_unmeasured()/,/^}/p' src/lib/registry.sh)"
+declare -F tier_unmeasured >/dev/null || { printf 'NOT OK - tier_unmeasured did not load\n'; exit 1; }
 
 # ---------------------------------------------------------------------------
 # 1. identity is the uid's passwd name, taken from the kernel
@@ -221,6 +227,88 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 13. the THREE registry verdicts must stay distinguishable in the report. This is
+#     the absent-vs-not-measured line DIVE-2213 drew for tiers, re-drawn one layer
+#     up: `not an agent` is an ANSWER, `could not read the registry` is not, and a
+#     registered agent with no isolation is a hole that must still name the agent.
+#     The arm FAILS if any two of the three collapse.
+probe13() {  # $1 = stubbed agent_tier verdict; prints "<agent>|<tier>|<measured>"
+  local verdict="$1"
+  ( agent_tier() { printf '%s' "$verdict"; }
+    actor_registry_agent "agent-dev"
+    tier_unmeasured "$ACTOR_TIER" && m=no || m=yes
+    printf '%s|%s|%s' "${ACTOR_AGENT:-<none>}" "$ACTOR_TIER" "$m" )
+}
+r_unreg=$(probe13 'unknown:unregistered')
+r_notier=$(probe13 'unknown:no-tier')
+r_noreg=$(probe13 'unknown:no-registry')
+r_real=$(probe13 'shared')
+if [[ "$r_unreg" == "$r_noreg" || "$r_unreg" == "$r_notier" || "$r_notier" == "$r_noreg" ]]; then
+  no "T13 COLLAPSED — two registry verdicts render identically (unreg=$r_unreg no-tier=$r_notier no-registry=$r_noreg)"
+elif [[ "$r_unreg" == "<none>|unknown:unregistered|yes" \
+     && "$r_notier" == "dev|unknown:no-tier|no" \
+     && "$r_noreg"  == "<none>|unknown:no-registry|no" \
+     && "$r_real"   == "dev|shared|yes" ]]; then
+  ok "T13 unregistered=MEASURED/no agent, no-tier=agent named/NOT measured, no-registry=claims nothing, shared=dev"
+else
+  no "T13 unreg=$r_unreg no-tier=$r_notier no-registry=$r_noreg real=$r_real"
+fi
+
+# 17. a FAILED LOOKUP must not be rescued by the next candidate. The stub answers
+#     differently per name — lookup-failed for the stripped one, a real tier for the
+#     full one — which is the only shape that separates `return` from `continue` on
+#     the residual unknown:* branch. Continuing there launders a read that did not
+#     happen into a confident agent identity.
+f_out=$( agent_tier() { [[ "$1" == dev ]] && printf 'unknown:lookup-failed' || printf 'shared'; }
+         actor_registry_agent "agent-dev"; printf '%s|%s' "${ACTOR_AGENT:-<none>}" "$ACTOR_TIER" )
+if [[ "$f_out" == "<none>|unknown:lookup-failed" ]]; then
+  ok "T17 a failed registry lookup stops the search and claims no agent (not rescued by candidate 2)"
+elif [[ "$f_out" == "agent-dev|shared" ]]; then
+  no "T17 a failed lookup on candidate 1 was papered over by candidate 2 -> reported agent-dev/shared"
+else
+  no "T17 expected <none>|unknown:lookup-failed, got $f_out"
+fi
+
+# 18. malformed-tier means REGISTERED with an unusable tier: name the agent, flag the
+#     tier. It must NOT render like an unreadable registry, which names nobody.
+m_out=$( agent_tier() { printf 'unknown:malformed-tier'; }
+         actor_registry_agent "agent-dev"; printf '%s|%s' "${ACTOR_AGENT:-<none>}" "$ACTOR_TIER" )
+u_out=$( agent_tier() { printf 'unknown:registry-unreadable'; }
+         actor_registry_agent "agent-dev"; printf '%s|%s' "${ACTOR_AGENT:-<none>}" "$ACTOR_TIER" )
+if [[ "$m_out" == "$u_out" ]]; then
+  no "T18 COLLAPSED — malformed-tier and registry-unreadable render identically ($m_out)"
+elif [[ "$m_out" == "dev|unknown:malformed-tier" && "$u_out" == "<none>|unknown:registry-unreadable" ]]; then
+  ok "T18 malformed-tier names the agent (dev) while an unreadable registry names nobody"
+else
+  no "T18 expected dev|unknown:malformed-tier vs <none>|unknown:registry-unreadable, got $m_out vs $u_out"
+fi
+
+# 14. DIVE-2371: agent-ness is the REGISTRY's answer, not a username prefix. Under a
+#     registry where only `claude` is an agent, the non-prefixed unix user resolves
+#     to an agent and the `agent-`-prefixed one does NOT. Same stub, opposite result
+#     — a prefix rule anywhere on this path cannot produce that pair.
+stub_only_claude() { agent_tier() { [[ "$1" == claude ]] && printf 'shared' || printf 'unknown:unregistered'; }; }
+c_out=$( stub_only_claude; actor_registry_agent "claude";    printf '%s' "${ACTOR_AGENT:-<none>}" )
+d_out=$( stub_only_claude; actor_registry_agent "agent-dev"; printf '%s' "${ACTOR_AGENT:-<none>}" )
+if [[ "$c_out" == "claude" && "$d_out" == "<none>" ]]; then
+  ok "T14 registry decides agent-ness: claude=agent, agent-dev=<none> under the same stub (DIVE-2371)"
+elif [[ "$c_out" == "$d_out" ]]; then
+  no "T14 VACUOUS — both names resolved the same ('$c_out'); the registry is not deciding"
+else
+  no "T14 expected claude/<none>, got '$c_out'/'$d_out'"
+fi
+
+# 15. the `agent-` strip is a LOOKUP CANDIDATE, not the decision: with only the
+#     stripped name registered, the board name is the stripped one.
+s_out=$( agent_tier() { [[ "$1" == dev ]] && printf 'admin' || printf 'unknown:unregistered'; }
+         actor_registry_agent "agent-dev"; printf '%s|%s' "$ACTOR_AGENT" "$ACTOR_TIER" )
+if [[ "$s_out" == "dev|admin" ]]; then
+  ok "T15 agent-dev -> board name dev via the stripped lookup candidate (tier admin)"
+else
+  no "T15 expected dev|admin, got $s_out"
+fi
+
+# ---------------------------------------------------------------------------
 # END TO END, through the BUILT bundle.
 BIN=./5dive
 if [[ ! -x "$BIN" ]]; then
@@ -277,6 +365,17 @@ else
     else
       no "T12 expected exit 6 + ok:false + uid-not-in-passwd, got rc=$e2erc ok=$e2e_ok code=$e2e_code reason=$e2e_reason"
     fi
+  fi
+
+  # 16. the other two exit contracts, which are just as much part of the verb: an
+  #     unknown flag is a usage error (2), and --help succeeds and STATES the
+  #     exit-status rule rather than leaving it to be discovered from source.
+  "$BIN" whoami --nope >/dev/null 2>&1; bad_rc=$?
+  helptxt=$("$BIN" whoami --help 2>&1); help_rc=$?
+  if (( bad_rc == 2 )) && (( help_rc == 0 )) && grep -qi 'exit status' <<<"$helptxt"; then
+    ok "T16 unknown flag -> 2, --help -> 0 and documents the exit-status contract"
+  else
+    no "T16 bad-flag rc=$bad_rc (want 2), help rc=$help_rc (want 0), help names exit status: $(grep -qi 'exit status' <<<"$helptxt" && echo yes || echo NO)"
   fi
 fi
 

--- a/tests/worktree_reclaim_unit.sh
+++ b/tests/worktree_reclaim_unit.sh
@@ -26,7 +26,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/disk.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
   source "$SRC/$f"
 done
 


### PR DESCRIPTION
## DIVE-2517 — v0.18 W1: one sealed actor derivation

The CLI had **six** actor derivations and they disagreed. Only `_gate_authenticated_actor` failed closed. The rest resolved identity from something the caller can set — `--from` on argv, `$USER`, `$SUDO_USER`, `FIVEDIVE_AUDIT_USER`, or an `agent-` username prefix — and none refused when they could not measure.

`src/lib/actor.sh` promotes the uid-first resolver into the single derivation, and `5dive whoami` reports what it measured **and where each value came from**.

### What it derives

| axis | source | forgeable by the caller? |
|---|---|---|
| identity | `$EUID` (kernel builtin) → `/etc/passwd`, pure bash | no |
| agent name | the **registry's** answer, not a username prefix | no |
| authority | `_actor_authority` in `lib/audit.sh`, **wired not rewritten** | no |
| tier | `registry .agents[<agent>].isolation` | no |

No `id`, no `getent` — both resolve through the caller's `PATH` (DIVE-2330). `$SUDO_UID` is honoured only at real EUID 0, where forging it would require already being root.

**Unmeasurable is `exit 6`**, not the word `unknown` printed with `rc=0`. That refusal is the point of the verb.

### The regression this PR also fixes — and how it was caught

Promoting six functions out of `cmd_task.sh` broke every harness that names its source files explicitly. 89 lists jumped straight from `lib/tasks_db.sh` to `cmd_task.sh`, modelling a bundle that **cannot exist** — `build.sh` puts `actor.sh` between them.

Baselined at `51bc5c6` before believing it. All five were 0-failed on main; **26 arms** red on the feature commit:

| harness | main | feature commit | now |
|---|---|---|---|
| `gate_lead_standing_unit` | 73/0 | 62/**11** | 73/0 |
| `gate_t2_routed_escalate_unit` | 17/0 | 10/**7** | 17/0 |
| `task_verify_self_close_visibility_unit` | 10/0 | 3/**7** | 10/0 |
| `gate_nonce_unit` | 19/0 | **refused at the seam pin** | 19/0 |
| `push_unit` | 82/0 | 81/**1** | 82/0 |

Worth naming *which* one failed usefully: `gate_nonce_unit` pins its seam before any arm runs — it asserts `_gate_uid_to_agent` resolves to `evil` and aborts if not — so a resolver that had vanished from the sourced set **refused the run** instead of grading an absent function. The other four had no such pin and quietly went red. That pin is the reason this was one grep rather than an afternoon.

`push_unit:346` needed a *different* fix, not the same one. It unsets `_gate_agent_for_uid` and re-sources to restore it; that helper moved too, so restoring from `cmd_task.sh` would have left it **undefined** and the arms below would have graded an absent function — green for the wrong reason. It now sources `lib/actor.sh`.

### How it was checked

`tests/whoami_sealed_actor_unit.sh` — **18 passed, 0 failed**. Mutation-graded three ways, each caught by its intended arm rather than by the harness name:

| mutant | caught by |
|---|---|
| unmeasurable exits `0` instead of `6` | T12 — *"the bundle exited 0 with an unmeasurable actor"* |
| identity consults `$SUDO_USER` | T3 — *"env forgery moved the identity to 'agent-olivia'"* |
| residual `unknown:*` `continue`s instead of returning | T17 — *"papered over by candidate 2"* |

T13/T14/T18 fail explicitly on **collapse** and on **vacuity** — they refuse when two registry verdicts render identically, or when both names resolve the same way and the registry is demonstrably not deciding.

The seam contract in the ticket is kept: `$EUID` is read at exactly two places, `_gate_is_root` and `_gate_caller_uid` (`actor.sh:91-92`). No second seam. `lib/audit.sh` is untouched.

### Honest limits

- The **local 264-harness sweep was still running** when this PR was opened (51/264, 0 failures at that point). CI is the authority on the full corpus; if it disagrees with my partial sweep, believe CI.
- `--from` is rejected as an unknown flag (`rc=2`), so the verb takes no identity from argv. The *other five* derivations still exist and still disagree — this PR builds the sealed one and wires the gate path to it. Retiring the remaining callers is not in this row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
