### PR TITLE
fix(release-cut): a RED we cannot attribute is not a RED we can act on (DIVE-2466)

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -272,6 +272,7 @@ jobs:
             # If our own row is absent we drop nothing extra and behave exactly as
             # before this change (run-id filter only). In real execution the check-run
             # exists before the step runs, so the fallback bought nothing.
+            _self_name=""
             if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
               _self_name=$(awk -F'\t' -v self="/actions/runs/${GITHUB_RUN_ID}/" 'index($4, self) { print $1; exit }' <<<"$runs")
               runs=$(awk -F'\t' -v self="/actions/runs/${GITHUB_RUN_ID}/" 'index($4, self) == 0' <<<"$runs")
@@ -288,7 +289,29 @@ jobs:
 
             # RED FIRST, and it exits before any deadline arithmetic — a red verdict is
             # final, so waiting on it could only delay a refusal that is already correct.
-            if [[ -n "$bad" ]]; then
+            # DIVE-2466: A RED WE CANNOT ATTRIBUTE IS NOT A RED WE CAN ACT ON.
+            # The sibling drop above is conditional on learning our own job's NAME off
+            # our own check-run row. If that row is not in the board yet, `_self_name`
+            # is empty, sibling release-cut rows are NOT dropped — and the RED branch
+            # below used to exit on look 1, before any re-fetch could have found it.
+            # MEASURED 2026-08-02 against the pristine block, self row absent on look 1
+            # and present on look 2 with a poisoned sibling `cut` throughout: RED at
+            # look 1, rc=1, one look. That is the self-latching poison this ticket
+            # exists to kill, surviving in the one window nobody had exercised — the
+            # existing poll arms all run with GITHUB_RUN_ID UNSET, so the filter never
+            # engaged in them. The comment above ("in real execution the check-run
+            # exists before the step runs") may well hold; it was never measured, and
+            # it is load-bearing, so the code no longer relies on it.
+            # DELIBERATELY COARSE: with `_self_name` unknown we cannot tell a sibling
+            # row from a third-party one, so we defer EVERY red until our own row has
+            # been seen once. That delays a genuine third-party refusal by one poll
+            # interval and never suppresses it — the deadline still refuses, fail-closed,
+            # with the same message. Trading one interval of latency for the removal of
+            # a permanent latch is the right side of that exchange.
+            if [[ -n "$bad" && -n "${GITHUB_RUN_ID:-}" && -z "$_self_name" ]]; then
+              echo "CI shows red on ${sha:0:12}, but our OWN check-run row is not visible yet, so sibling release-cut rows could not be dropped — NOT acting on an unattributable red; re-looking (DIVE-2466) [look ${_look}]"
+              printf '%s\n' "$bad" | sed 's/^/  deferred: /'
+            elif [[ -n "$bad" ]]; then
               echo "::error::CI is RED on ${sha:0:12} — refusing to cut ${tag}. Failing:"
               printf '%s\n' "$bad" | sed 's/^/  /'
               exit 1

--- a/tests/release_cut_guards_unit.sh
+++ b/tests/release_cut_guards_unit.sh
@@ -180,6 +180,7 @@ poll_run(){ # $1.. = one check-runs fixture per look ; echoes "<verdict> looks=<
   # that — correctly — as NOT-REACHED, so the never-settles arm graded the stub's
   # bug and not the guard's behaviour.
   out=$(runs="$1" sha=deadbeefcafe tag=v9.9.9 POLLDIR="$POLLDIR" NFIX="$#" \
+        GITHUB_RUN_ID="${POLL_RUNID:-}" \
         RELEASE_CUT_POLL_SECONDS="${POLL_BUDGET:-30}" RELEASE_CUT_POLL_INTERVAL=1 bash -c '
     set -uo pipefail
     _ci_fetch_runs(){
@@ -221,6 +222,28 @@ ok "in-flight then RED -> RED"                     "$(poll_run "$INFLIGHT" "$RED
 # A short budget here: the assertion is that expiry REFUSES, not how long it waits.
 ok "never settles -> still refuses at the deadline" "$(POLL_BUDGET=3 poll_run "$INFLIGHT" | cut -d' ' -f1)" "IN-FLIGHT"
 ok "never reached -> still refuses at the deadline" "$(POLL_BUDGET=3 poll_run "" | cut -d' ' -f1)" "NOT-REACHED"
+
+echo "== DIVE-2466: an UNATTRIBUTABLE red is deferred, not acted on =="
+# The window nobody had exercised. Every poll arm above runs with GITHUB_RUN_ID UNSET,
+# so the self/sibling filter never engages in them; every sibling arm above hands the
+# board over in ONE look, so the filter always has the self row. The race lives in the
+# intersection: filter ON, self row NOT YET in the board. Then `_self_name` is empty,
+# sibling `cut` rows are not dropped, and the RED branch used to exit on look 1 before
+# any re-fetch could find the self row — the self-latching poison this ticket exists to
+# kill, alive in the one place the suite could not see.
+# MEASURED against the pristine block 2026-08-02: RED, looks=1, rc=1.
+RACE_L1=$(printf 'scan\tcompleted\tsuccess\t%s\ncut\tcompleted\tfailure\t%s' "$OTHER_URL" "$SIB_URL")
+RACE_L2=$(printf 'scan\tcompleted\tsuccess\t%s\ncut\tcompleted\tfailure\t%s\ncut\tin_progress\tpending\t%s' "$OTHER_URL" "$SIB_URL" "$SELF_URL")
+ok "self row absent on look 1 -> defer the red, drop the sibling on look 2" \
+   "$(POLL_RUNID=30332498204 poll_run "$RACE_L1" "$RACE_L2")" "GREEN looks=2"
+# The deferral must NOT have widened into "ignore reds while unattributable forever":
+# once our own row is present the sibling is droppable and a THIRD-PARTY red still bites.
+RACE_REAL=$(printf 'test\tcompleted\tfailure\t%s\ncut\tin_progress\tpending\t%s' "$OTHER_URL" "$SELF_URL")
+ok "a third-party red still REFUSES once the self row is visible" \
+   "$(POLL_RUNID=30332498204 poll_run "$RACE_REAL" "$RACE_REAL")" "RED looks=1"
+# And with no run id at all the deferral is inert — unchanged behaviour for that path.
+ok "no GITHUB_RUN_ID -> a red is still immediate" \
+   "$(poll_run "$REDB" "$GREENB")" "RED looks=1"
 
 echo "== DIVE-2466: the poll budget is a CEILING the env knob can only tighten =="
 # A caller that could WIDEN it could park this job on a runner for hours. Tightening is
@@ -315,6 +338,18 @@ fi
 # board that goes green on look 2 is never seen and the day is skipped exactly as
 # before the fix. This is the arm that proves the polling is the fix rather than the
 # loop being decorative.
+# (a4) DIVE-2466: remove the unattributable-red deferral — the latch must return.
+# Without this arm the deferral is unpinned and the next refactor re-introduces a
+# permanent self-latch that only fires on a race nobody reproduces by hand.
+if m=$(mutate 's|if \[\[ -n "$bad" && -n "${GITHUB_RUN_ID:-}" && -z "$_self_name" \]\]; then|if false; then|' GUARD); then
+  GUARD_SAVE="$GUARD"; GUARD="$m"
+  ok "MUTANT drop the unattributable-red deferral: the latch returns" \
+     "$(POLL_RUNID=30332498204 poll_run "$RACE_L1" "$RACE_L2")" "RED looks=1"
+  GUARD="$GUARD_SAVE"
+else
+  vacuous "drop the unattributable-red deferral"
+fi
+
 if m=$(mutate 's/runs=\$(_ci_fetch_runs)$/:/' GUARD); then
   GUARD_SAVE="$GUARD"; GUARD="$m"
   ok "MUTANT drop the re-read: in-flight then green stops reaching GREEN" \


### PR DESCRIPTION
Closes item 1 of olivia's DIVE-2466 iteration-4 reject: *the one arm nobody has measured*.

## The race, measured before anything was changed

The sibling drop is conditional on learning our own job's **name** off our own check-run row. If that row is not in the board yet, `_self_name` is empty, sibling `cut` rows are **not** dropped, and the RED branch exited on look 1 — before any re-fetch could have found it.

Driving the fenced guard block verbatim, with `GITHUB_RUN_ID` set, self row absent on look 1 and present on look 2, a poisoned sibling `cut completed/failure` throughout:

| | verdict |
|---|---|
| before | `RED looks=1 rc=1` |
| after | `GREEN looks=2 rc=0` |

**Why the existing suite could not see it:** every poll arm runs with `GITHUB_RUN_ID` **unset**, so the self/sibling filter never engages in them; every sibling arm hands the board over in **one look**, so the filter always has the self row. The race lives in the intersection, and nothing sat there.

The code comment asserting *"in real execution the check-run exists before the step runs, so the fallback bought nothing"* may well hold — this does not refute it. It was never measured, it is load-bearing, and the code no longer rests on it.

## The fix is deliberately coarse

With `_self_name` unknown we cannot tell a sibling row from a third-party one, so **every** red is deferred until our own row has been seen once. That delays a genuine third-party refusal by one poll interval and never suppresses it — the deadline still refuses, fail-closed, with the same message. One interval of latency against a permanent latch is the right side of that trade.

## Grading

`tests/release_cut_guards_unit.sh` **40 → 44, 0 failed.** Three arms — the race itself; a third-party red still refusing immediately once the self row is visible; the no-run-id path unchanged. Plus a mutant: remove the deferral and the arm goes back to `RED looks=1`, so the fix is pinned rather than decorative.

## What this does NOT do

It does not satisfy DIVE-2466's criterion 2, which requires a **schedule**-event run. Schedule is 0-for-6, and all six predate DIVE-2524's grade fix (`b526298`, merged 08:20Z today). The first fair test is the 02:37Z fire on 08-03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)