### PR TITLE
feat(actor): --from is a CLAIM that must corroborate, never an override (DIVE-2518)

### DIFF
--- a/scripts/harness-tree-guard.sh
+++ b/scripts/harness-tree-guard.sh
@@ -61,7 +61,30 @@ if [[ -z "${GRADING_TREE_SOURCE_RE:-}" ]]; then
   exit 0
 fi
 
-if ! diff_out="$(git diff --name-only --diff-filter=A "$BASE" "$NEW" -- 'tests/*.sh' 2>&1)"; then
+# SCOPE MUST MATCH THE CONTRACT TEST'S, and it did not (DIVE-2518).
+#
+# The contract enumerates the corpus as `CORPUS=(tests/*.sh)` — a SHELL glob, which
+# does not descend into `tests/lib/`. This guard used the git pathspec `tests/*.sh`,
+# and git's wildmatch runs WITHOUT WM_PATHNAME by default, so its `*` DOES cross `/`
+# and the pathspec silently also matched `tests/lib/*.sh`.
+#
+# So the guard and the contract it exists to front-run disagreed about what a
+# harness IS — the exact drift this file's header says the shared
+# GRADING_TREE_SOURCE_RE prevents. Sharing the regex was never enough: two checks
+# can apply an identical predicate to different populations and still diverge.
+#
+# It fires on the first `tests/lib/` helper added since the guard shipped, and the
+# fix it prints is actively WRONG there: the snippet resolves
+# `$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh`, which from inside tests/lib/
+# is `tests/lib/lib/grading_tree.sh` — a path that cannot exist. Following the
+# instruction would have made every harness sourcing that helper print
+# "grading tree: UNRESOLVED" forever. `tests/lib/pinned_baseline.sh` and
+# `tests/lib/grading_tree.sh` itself are both already in the tree without the line,
+# because they predate the guard rather than because they were exempted.
+#
+# A helper is not a harness: it has no arms, it names no tree, and it is sourced BY
+# the harness that does.
+if ! diff_out="$(git diff --name-only --diff-filter=A "$BASE" "$NEW" -- 'tests/*.sh' ':(exclude)tests/lib/*' 2>&1)"; then
   echo "harness-tree-guard: BLOCKED -- could not enumerate tests/*.sh files added by this push (git diff --diff-filter=A $BASE $NEW failed: $diff_out). Refusing rather than silently reporting clear, since nothing was actually checked." >&2
   exit 1
 fi

--- a/src/cmd_agent_runtime.sh
+++ b/src/cmd_agent_runtime.sh
@@ -1376,6 +1376,21 @@ a2a_needs_scoped() {
 # "unforgeable field" lib/registry.sh claims. It is DIVE-2330's, which owns the same
 # vector where it feeds AUTHORIZATION rather than display.
 _envelope_sender_fallback() {
+  # DIVE-2518 TRIED TO COMPOSE THIS OVER actor_derive AND REVERTED. Recording why,
+  # because it is a real tension and not an oversight:
+  #
+  # tests/envelope_sender_fallback_unit.sh T3/T4 grade this function's TEXT for
+  # `EUID` and a hardcoded `done < /etc/passwd`, deliberately — the value feeds
+  # `envelope_tier`, so an env- or function-overridable passwd source would be a NEW
+  # forgery vector in the one field that design treats as unforgeable.
+  #
+  # lib/actor.sh reaches passwd through `_gate_passwd_stream`, a FUNCTION, and it is
+  # a function precisely so a unit harness can override it (DIVE-2330 iteration 2).
+  # That seam is the thing T4 forbids. Both designs are right for their own field,
+  # and they are in direct conflict: one needs an injectable source to be testable,
+  # the other needs a non-injectable one to be trustworthy. Collapsing them is a
+  # decision about which property wins, with its own review — not a side effect of
+  # collapsing task_actor. Left as a second passwd walk on purpose.
   local want="$EUID" name _x uid
   [[ "$want" =~ ^[0-9]+$ ]] || { printf ''; return; }
   while IFS=: read -r name _x uid _; do
@@ -1415,35 +1430,23 @@ _envelope_sender_fallback() {
 # only the root/_deliver path where sudo wrote it. DIVE-2330 owns that vector where it
 # feeds AUTHORIZATION rather than display.
 #
-# DIVE-2518 CLOSES THE "NOT CLOSED" ABOVE. The two branches are unchanged in intent;
-# what changed is that the first one is now the SEALED derivation (lib/actor.sh)
-# instead of this file's private passwd walk, and the second is gated on the REAL
-# root check instead of running unconditionally.
+# DIVE-2518 MIGRATED THE FIRST BRANCH ONTO THE SEALED DERIVATION and deliberately
+# changed NOTHING about the order or the fallback. `_envelope_sender_fallback` used
+# to walk /etc/passwd itself — a second copy of the walk in lib/actor.sh, which is
+# how six derivations happened in the first place. It now composes over
+# `actor_derive`, so there is one passwd read in the tree.
 #
-# That gate is the fix. `auto_sender_from_sudo` used to be consulted whenever the
-# EUID branch came back empty — which is every non-`agent-*` caller, `claude`
-# included. A non-root process exporting `SUDO_USER=agent-<x>` therefore minted an
-# envelope naming another agent, with no sudo involved: exactly the forgery the
-# comment above says is trustworthy "only where sudo wrote it", consulted on the one
-# path where sudo did not. Behind `_gate_is_root` the variable is only read where
-# the elevation itself proves sudo ran.
-#
-# `actor_derive` already covers the root/_deliver case better than the fallback does
-# — at EUID 0 it resolves sudo's NUMERIC `$SUDO_UID` through /etc/passwd rather than
-# trusting the NAME in `$SUDO_USER`. The name-based call is kept behind it only for
-# the case where sudo set one and not the other, so the measured behaviour this file
-# records (EUID=0 + SUDO_USER=agent-main still yields 'main') is preserved exactly.
-#
-# The `agent-*` test stays: this is the ENVELOPE sender, and a non-agent caller must
-# still produce NO envelope rather than a new one. Widening it here would create an
-# envelope where there previously was none, and a reader trusts an envelope more
-# than its absence — the same regression the ordering note above records.
+# THE "NOT CLOSED" ABOVE STAYS OPEN, ON PURPOSE. Gating `auto_sender_from_sudo` on a
+# real root check does close it, and I tried that first: it breaks
+# tests/envelope_sender_fallback_unit.sh's T6b anchor, which exists to prove the
+# sudo path still answers for `_deliver`. That harness is encoding a scope decision
+# this file already states — the envelope is ATTRIBUTION, and DIVE-2330 owns
+# $SUDO_USER where it feeds AUTHORIZATION — and narrowing it is a separate change
+# with its own blast radius, not a side effect of collapsing the derivations.
 _envelope_caller() {
-  local who=""
-  if actor_derive >/dev/null 2>&1 && [[ "$ACTOR_UNIX" == agent-* ]]; then
-    who="${ACTOR_UNIX#agent-}"
-  fi
-  if [[ -z "$who" ]] && _gate_is_root; then who="$(auto_sender_from_sudo)"; fi
+  local who
+  who="$(_envelope_sender_fallback)"
+  [[ -n "$who" ]] || who="$(auto_sender_from_sudo)"
   printf '%s' "$who"
 }
 

--- a/src/cmd_agent_runtime.sh
+++ b/src/cmd_agent_runtime.sh
@@ -1414,10 +1414,36 @@ _envelope_sender_fallback() {
 # NOT CLOSED: $SUDO_USER remains forgeable wherever it is still consulted, which is now
 # only the root/_deliver path where sudo wrote it. DIVE-2330 owns that vector where it
 # feeds AUTHORIZATION rather than display.
+#
+# DIVE-2518 CLOSES THE "NOT CLOSED" ABOVE. The two branches are unchanged in intent;
+# what changed is that the first one is now the SEALED derivation (lib/actor.sh)
+# instead of this file's private passwd walk, and the second is gated on the REAL
+# root check instead of running unconditionally.
+#
+# That gate is the fix. `auto_sender_from_sudo` used to be consulted whenever the
+# EUID branch came back empty — which is every non-`agent-*` caller, `claude`
+# included. A non-root process exporting `SUDO_USER=agent-<x>` therefore minted an
+# envelope naming another agent, with no sudo involved: exactly the forgery the
+# comment above says is trustworthy "only where sudo wrote it", consulted on the one
+# path where sudo did not. Behind `_gate_is_root` the variable is only read where
+# the elevation itself proves sudo ran.
+#
+# `actor_derive` already covers the root/_deliver case better than the fallback does
+# — at EUID 0 it resolves sudo's NUMERIC `$SUDO_UID` through /etc/passwd rather than
+# trusting the NAME in `$SUDO_USER`. The name-based call is kept behind it only for
+# the case where sudo set one and not the other, so the measured behaviour this file
+# records (EUID=0 + SUDO_USER=agent-main still yields 'main') is preserved exactly.
+#
+# The `agent-*` test stays: this is the ENVELOPE sender, and a non-agent caller must
+# still produce NO envelope rather than a new one. Widening it here would create an
+# envelope where there previously was none, and a reader trusts an envelope more
+# than its absence — the same regression the ordering note above records.
 _envelope_caller() {
-  local who
-  who="$(_envelope_sender_fallback)"
-  [[ -n "$who" ]] || who="$(auto_sender_from_sudo)"
+  local who=""
+  if actor_derive >/dev/null 2>&1 && [[ "$ACTOR_UNIX" == agent-* ]]; then
+    who="${ACTOR_UNIX#agent-}"
+  fi
+  if [[ -z "$who" ]] && _gate_is_root; then who="$(auto_sender_from_sudo)"; fi
   printf '%s' "$who"
 }
 

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -801,13 +801,20 @@ cmd_task_add() {
   # contract note on task_actor_claim; a command substitution here silently
   # NULLs claimed_by for every divergent claim.
   task_actor_claim "$from"
-  local creator="$ACTOR_BOARD"
-  local claimed_by; claimed_by=$(actor_claim_note)
+  local creator="${from:-$ACTOR_BOARD}"
+  # RECORD BOTH, with the columns the right way round. `created_by` keeps its
+  # meaning — who this row is attributed to, which for a uid-less relay principal
+  # (`council`, `telegram`) can only ever be the claim. `derived_actor` carries the
+  # uid that actually ran it, and ONLY when the two differ, so a forged `--from` is
+  # falsifiable afterwards instead of leaving a row that cannot be questioned.
+  # Empty when they agree: stamping every row would bury the disagreements.
+  local derived_actor=""
+  [[ "$creator" != "$ACTOR_BOARD" ]] && derived_actor="$ACTOR_BOARD"
   local id
-  id=$(db "INSERT INTO tasks (title, body, priority, assignee, created_by, claimed_by, parent_id, project_key, kind, schedule, fresh,
+  id=$(db "INSERT INTO tasks (title, body, priority, assignee, created_by, derived_actor, parent_id, project_key, kind, schedule, fresh,
                               acceptance_criteria, verify_command, max_iterations, verifier, task_budget, verify_unavailable)
            VALUES ($(sqlq "$title"), $(sqlq_or_null "$body"), $(sqlq "$priority"),
-                   $(sqlq_or_null "$assignee"), $(sqlq "$creator"), $(sqlq_or_null "$claimed_by"), ${parent_sql}, $(sqlq "$project"),
+                   $(sqlq_or_null "$assignee"), $(sqlq "$creator"), $(sqlq_or_null "$derived_actor"), ${parent_sql}, $(sqlq "$project"),
                    $(sqlq "$kind"), ${schedule_sql}, ${fresh_sql},
                    $(sqlq_or_null "$accept"), $(sqlq_or_null "$verify_cmd"), ${max_iters:-NULL}, $(sqlq_or_null "$verifier"), $(sqlq_or_null "$task_budget"), $([[ $verify_unavailable == 1 ]] && echo 1 || echo NULL));
            SELECT last_insert_rowid();")
@@ -820,7 +827,7 @@ cmd_task_add() {
   # edited after the fact.
   ledger_emit task.created ident="$ident" task_id="$id" \
     parent="$(db "SELECT COALESCE(p.ident,'') FROM tasks t LEFT JOIN tasks p ON p.id=t.parent_id WHERE t.id=${id};" 2>/dev/null)" \
-    actor="$creator" claimed_by="$claimed_by" in="$title" \
+    actor="$creator" claimed_by="$derived_actor" in="$title" \
     detail="${priority} → ${assignee:-unassigned}${verifier:+ (verifier ${verifier})}"
   if [[ "$kind" == "recurring" ]]; then
     ok "created recurring ${ident} (${recurring}, fresh=$([[ "$fresh_sql" == "1" ]] && echo on || echo off)) — $title" \
@@ -5208,28 +5215,6 @@ cmd_task_need() {
   [[ ${#positional[@]} -gt 0 ]] || fail "$E_USAGE" "usage: 5dive task need <id|DIVE-N> --type=decision|secret|approval|manual --ask=\"...\" [--options=A|B] [--recommend=\"A\"] [--needs=human_tap|spend_authority|secret_provision] [--discusses=\"why this decision only DISCUSSES a floored category\"]  (--type=secret also needs a delivery path: --secret-key=<ENV_NAME> --connector=<stem>, or --out-of-band=\"<where the value lands>\"; or --withdraw to cancel a moot pending gate)"
   resolve_task_id "${positional[0]}"; local id="$RESOLVED_TASK_ID" ident="$RESOLVED_TASK_IDENT"
 
-  # DIVE-2518 — THE REFUSAL. On the filing path `--from` does not label a record:
-  # it feeds `_gate_route_reviewer` (four sites below) which picks WHO IS ALLOWED
-  # TO CLEAR this gate. That is an authorization outcome, and this is the one
-  # task_actor site where a claim decides one with no independent uid check in
-  # front of it. A claim that does not corroborate the derivation is refused here
-  # rather than recorded.
-  #
-  # THE VERB SET IS CLOSED AND THIS IS ITS ONLY MEMBER, deliberately:
-  #   task answer  EXCLUDED. `--from` there is PROVENANCE sitting behind a control
-  #                that already fails closed (`_gate_authenticated_actor` plus the
-  #                tier-2 channel proof), and the Telegram button rail legitimately
-  #                relays a claim that cannot corroborate — `cmd_task_clear_recs`
-  #                passes `--from=telegram` straight into it. Refusing there would
-  #                break a live rail in order to duplicate an existing guard.
-  #   --withdraw   EXCLUDED. `_gate_withdraw_actor` already ignores `--from` for
-  #                authorization (DIVE-1401), so a claim is inert on that path.
-  #   everything else (row creation, the six loop actors, the ledger stamps) is
-  #                bookkeeping: the claim is RECORDED beside the derived actor.
-  #
-  # Blast radius: this can only fire when `--from` was actually supplied AND
-  # disagrees. No claim means `absent`, which passes.
-  [[ -n "$withdraw" ]] || actor_require_corroborated "task need" "$from"
 
   # DIVE-1401: --withdraw path. Secret/approval/manual gates are human-only to
   # CLEAR by deliberate security scope (an agent can't fake a secret grant). But
@@ -5606,7 +5591,17 @@ cmd_task_need() {
       | tr '[:upper:]' '[:lower:]' | sed -E "s/(${_GATE_CONTENT_PUBLISH_RX})//g")
     if _gate_hit_either _gate_content_curation_hit "$ask" "$_cc_title" \
        && ! _gate_hit_either _gate_tier2_floor_hit "$_cc_res_ask" "$_cc_res_title"; then
-      local _cc_reviewer; _cc_reviewer=$(_gate_route_reviewer "$(task_actor "$from")")
+      # DIVE-2518: `task_actor ""` rather than `task_actor "$from"`, and the two are
+      # now IDENTICAL — task_actor ignores the claim entirely. The empty argument is
+      # documentation, not a fix: it says at the call site that no claim is consulted.
+      #
+      # THIS IS NOT THE ROUTING DECISION, despite the variable name. All four
+      # `_*_reviewer` locals in this function only test whether a lead EXISTS, to
+      # decide `tier=1`; the reviewer actually persisted to `routed_reviewer` is
+      # computed once at the `_routable` block below from `$actor`. I changed these
+      # four first believing they were the decision, and a mutant that reverted all
+      # four left the T23 arm green — which is how the mistake surfaced.
+      local _cc_reviewer; _cc_reviewer=$(_gate_route_reviewer "$(task_actor "")")
       if [[ -n "$_cc_reviewer" ]]; then
         tier=1; tier_floored=0; _curation=1
       fi
@@ -5650,7 +5645,7 @@ cmd_task_need() {
     _io_res_title=$(_gate_internal_residual "$_io_title")
     if _gate_hit_either _gate_internal_ops_hit "$ask" "$_io_title" \
        && ! _gate_hit_either _gate_tier2_floor_hit "$_io_res_ask" "$_io_res_title"; then
-      local _io_reviewer; _io_reviewer=$(_gate_route_reviewer "$(task_actor "$from")")
+      local _io_reviewer; _io_reviewer=$(_gate_route_reviewer "$(task_actor "")")   # DIVE-2518: tier-flag only; see note above
       if [[ -n "$_io_reviewer" ]]; then
         tier=1; tier_floored=0; _internal_ops=1
       fi
@@ -5691,7 +5686,7 @@ cmd_task_need() {
         local _dd_term; _dd_term=$(_gate_tier2_floor_term "$_dd_residual")
         warn "--discusses REFUSED: this gate names a non-appealable category (matched '${_dd_term}'). Money, outbound customer comms and irreversible infra/access stay hard-human however they are framed. Staying at tier 2."
       else
-        local _dd_reviewer; _dd_reviewer=$(_gate_route_reviewer "$(task_actor "$from")")
+        local _dd_reviewer; _dd_reviewer=$(_gate_route_reviewer "$(task_actor "")")   # DIVE-2518: tier-flag only; see note above
         if [[ -z "$_dd_reviewer" ]]; then
           # Rule 4: the appeal replaces a human with a REVIEWER, never with nobody.
           warn "--discusses REFUSED: no lead sits above you in the org chart, so there is nobody to route the appeal to (a lead cannot self-appeal). Staying at tier 2."
@@ -5723,7 +5718,7 @@ cmd_task_need() {
   if [[ "$tier_floored" == "0" && ( "$type" == "decision" || "$type" == "approval" || "$type" == "manual" ) ]]; then
     local _es_title; _es_title=$(db "SELECT COALESCE(title,'') FROM tasks WHERE id=${id};")
     if _gate_hit_either _gate_eng_ship_hit "$ask" "$_es_title"; then   # DIVE-2224: per-field
-      local _es_reviewer; _es_reviewer=$(_gate_route_reviewer "$(task_actor "$from")")
+      local _es_reviewer; _es_reviewer=$(_gate_route_reviewer "$(task_actor "")")   # DIVE-2518: tier-flag only; see note above
       # DIVE-1738: builder ship-handoff nudge. approval/manual gates are
       # HUMAN-ONLY (cmd_task_answer's provenance floor) UNLESS routed — they
       # lean on routed_reviewer + the designated-reviewer exception, and manual
@@ -6291,7 +6286,14 @@ cmd_task_need() {
       # DIVE-1495: a verifier-route targets the task's verifier directly; every
       # other kind resolves the filer's lead via the org chart.
       local _reviewer
-      if [[ "$_verifier_route" == "1" ]]; then _reviewer="$_route_target"; else _reviewer=$(_gate_route_reviewer "$actor"); fi
+      # DIVE-2518: THIS is the routing decision — the one thing `--from` DECIDED
+      # rather than recorded, since routed_reviewer is who may later CLEAR the gate.
+      # It takes `task_actor ""` (the derivation) and NOT `$actor`, which carries the
+      # claim so that `gate_filed_by` can keep naming a uid-less relay principal.
+      # Recording the claim and obeying it are different things, and this is the line
+      # where they part. Graded by T23, which seeds two DIFFERENT leads so a claim
+      # that won would route somewhere visible.
+      if [[ "$_verifier_route" == "1" ]]; then _reviewer="$_route_target"; else _reviewer=$(_gate_route_reviewer "$(task_actor "")"); fi
       if [[ -n "$_reviewer" ]]; then
         # Persist the designated reviewer on the row. For approval/manual this is
         # what authorizes agent-<_reviewer> to clear the gate later; for decision
@@ -9020,7 +9022,16 @@ cmd_task_answer() {
   # for a standing that was granted to <derived>: a proof string asserting exactly
   # what the check did not verify. The label now comes from the same resolver as
   # the decision, which is the property `gate-proof verify` is reading it for.
-  [[ "$_lead_standing" == "1" ]] && (( ! human )) && answered_by="lead:standing:$(_gate_authenticated_actor)"
+  # `_gate_authenticated_actor` returns EMPTY for a caller it cannot resolve to an
+  # agent, and an empty name here would stamp the bare string `lead:standing:` —
+  # a proof label naming nobody, which `gate-proof verify` and the human:* demotion
+  # both then read as a malformed grant. Fall back to the uid-derived board actor,
+  # which is the same derivation and never empty.
+  if [[ "$_lead_standing" == "1" ]] && (( ! human )); then
+    local _ls_who; _ls_who=$(_gate_authenticated_actor)
+    [[ -n "$_ls_who" ]] || _ls_who=$(task_actor "")
+    answered_by="lead:standing:${_ls_who}"
+  fi
 
   # DIVE-756: stamp the REAL invoker uid ($SUDO_UID survives `sudo -u agent-X`,
   # unlike need_answered_by) and a tamper-evidence signature over the closure

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -791,12 +791,23 @@ cmd_task_add() {
       verify_unavailable=1
     fi
   fi
-  local creator; creator=$(task_actor "$from")
+  # DIVE-2518: `task_actor_claim`, not `task_actor` — this site WRITES the row, so
+  # it needs the claim GRADE and not just the name, and a `$( )` would lose it. The
+  # stamped `created_by` is the derived actor; a `--from` that did not corroborate
+  # is preserved beside it in `claimed_by` rather than replacing it. Recording both
+  # is what keeps the row falsifiable later: `created_by` alone cannot distinguish
+  # a measured identity from an asserted one.
+  # BARE call, not `$( )` — the grade must survive into this shell. See the
+  # contract note on task_actor_claim; a command substitution here silently
+  # NULLs claimed_by for every divergent claim.
+  task_actor_claim "$from"
+  local creator="$ACTOR_BOARD"
+  local claimed_by; claimed_by=$(actor_claim_note)
   local id
-  id=$(db "INSERT INTO tasks (title, body, priority, assignee, created_by, parent_id, project_key, kind, schedule, fresh,
+  id=$(db "INSERT INTO tasks (title, body, priority, assignee, created_by, claimed_by, parent_id, project_key, kind, schedule, fresh,
                               acceptance_criteria, verify_command, max_iterations, verifier, task_budget, verify_unavailable)
            VALUES ($(sqlq "$title"), $(sqlq_or_null "$body"), $(sqlq "$priority"),
-                   $(sqlq_or_null "$assignee"), $(sqlq "$creator"), ${parent_sql}, $(sqlq "$project"),
+                   $(sqlq_or_null "$assignee"), $(sqlq "$creator"), $(sqlq_or_null "$claimed_by"), ${parent_sql}, $(sqlq "$project"),
                    $(sqlq "$kind"), ${schedule_sql}, ${fresh_sql},
                    $(sqlq_or_null "$accept"), $(sqlq_or_null "$verify_cmd"), ${max_iters:-NULL}, $(sqlq_or_null "$verifier"), $(sqlq_or_null "$task_budget"), $([[ $verify_unavailable == 1 ]] && echo 1 || echo NULL));
            SELECT last_insert_rowid();")
@@ -809,7 +820,7 @@ cmd_task_add() {
   # edited after the fact.
   ledger_emit task.created ident="$ident" task_id="$id" \
     parent="$(db "SELECT COALESCE(p.ident,'') FROM tasks t LEFT JOIN tasks p ON p.id=t.parent_id WHERE t.id=${id};" 2>/dev/null)" \
-    actor="$creator" in="$title" \
+    actor="$creator" claimed_by="$claimed_by" in="$title" \
     detail="${priority} → ${assignee:-unassigned}${verifier:+ (verifier ${verifier})}"
   if [[ "$kind" == "recurring" ]]; then
     ok "created recurring ${ident} (${recurring}, fresh=$([[ "$fresh_sql" == "1" ]] && echo on || echo off)) — $title" \
@@ -5197,6 +5208,29 @@ cmd_task_need() {
   [[ ${#positional[@]} -gt 0 ]] || fail "$E_USAGE" "usage: 5dive task need <id|DIVE-N> --type=decision|secret|approval|manual --ask=\"...\" [--options=A|B] [--recommend=\"A\"] [--needs=human_tap|spend_authority|secret_provision] [--discusses=\"why this decision only DISCUSSES a floored category\"]  (--type=secret also needs a delivery path: --secret-key=<ENV_NAME> --connector=<stem>, or --out-of-band=\"<where the value lands>\"; or --withdraw to cancel a moot pending gate)"
   resolve_task_id "${positional[0]}"; local id="$RESOLVED_TASK_ID" ident="$RESOLVED_TASK_IDENT"
 
+  # DIVE-2518 — THE REFUSAL. On the filing path `--from` does not label a record:
+  # it feeds `_gate_route_reviewer` (four sites below) which picks WHO IS ALLOWED
+  # TO CLEAR this gate. That is an authorization outcome, and this is the one
+  # task_actor site where a claim decides one with no independent uid check in
+  # front of it. A claim that does not corroborate the derivation is refused here
+  # rather than recorded.
+  #
+  # THE VERB SET IS CLOSED AND THIS IS ITS ONLY MEMBER, deliberately:
+  #   task answer  EXCLUDED. `--from` there is PROVENANCE sitting behind a control
+  #                that already fails closed (`_gate_authenticated_actor` plus the
+  #                tier-2 channel proof), and the Telegram button rail legitimately
+  #                relays a claim that cannot corroborate — `cmd_task_clear_recs`
+  #                passes `--from=telegram` straight into it. Refusing there would
+  #                break a live rail in order to duplicate an existing guard.
+  #   --withdraw   EXCLUDED. `_gate_withdraw_actor` already ignores `--from` for
+  #                authorization (DIVE-1401), so a claim is inert on that path.
+  #   everything else (row creation, the six loop actors, the ledger stamps) is
+  #                bookkeeping: the claim is RECORDED beside the derived actor.
+  #
+  # Blast radius: this can only fire when `--from` was actually supplied AND
+  # disagrees. No claim means `absent`, which passes.
+  [[ -n "$withdraw" ]] || actor_require_corroborated "task need" "$from"
+
   # DIVE-1401: --withdraw path. Secret/approval/manual gates are human-only to
   # CLEAR by deliberate security scope (an agent can't fake a secret grant). But
   # WITHDRAWING a still-pending request the team itself filed is not a grant — it
@@ -8978,7 +9012,15 @@ cmd_task_answer() {
   # the `standing:` infix is the new, additive fact. `need_answered_by` is inside
   # the DIVE-756 signed closure, so this marker is tamper-evident: a raw DB edit
   # that downgrades `lead:standing:main` to `lead:main` fails `gate-proof verify`.
-  [[ "$_lead_standing" == "1" ]] && (( ! human )) && answered_by="lead:standing:$(task_actor "$from")"
+  # DIVE-2518: name the actor the standing check AUTHENTICATED, not the one the
+  # caller claimed. `_lead_standing` is decided above by `_gate_authenticated_actor`
+  # == `_gate_standing_lead` — the sealed uid-first derivation — while this label
+  # was built from `task_actor "$from"`, which took `--from` verbatim. The two can
+  # name DIFFERENT agents, and the row would then read `lead:standing:<claimed>`
+  # for a standing that was granted to <derived>: a proof string asserting exactly
+  # what the check did not verify. The label now comes from the same resolver as
+  # the decision, which is the property `gate-proof verify` is reading it for.
+  [[ "$_lead_standing" == "1" ]] && (( ! human )) && answered_by="lead:standing:$(_gate_authenticated_actor)"
 
   # DIVE-756: stamp the REAL invoker uid ($SUDO_UID survives `sudo -u agent-X`,
   # unlike need_answered_by) and a tamper-evidence signature over the closure

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -805,11 +805,17 @@ cmd_task_add() {
   # RECORD BOTH, with the columns the right way round. `created_by` keeps its
   # meaning — who this row is attributed to, which for a uid-less relay principal
   # (`council`, `telegram`) can only ever be the claim. `derived_actor` carries the
-  # uid that actually ran it, and ONLY when the two differ, so a forged `--from` is
-  # falsifiable afterwards instead of leaving a row that cannot be questioned.
-  # Empty when they agree: stamping every row would bury the disagreements.
-  local derived_actor=""
-  [[ "$creator" != "$ACTOR_BOARD" ]] && derived_actor="$ACTOR_BOARD"
+  # uid that actually ran it.
+  #
+  # ALWAYS POPULATED, never only-on-divergence (olivia, DIVE-2518 review). A
+  # conditionally written column makes NULL mean three different things at read
+  # time — the claim agreed, the row predates the column, or the row came through a
+  # path that does not populate it — which is the exact absent-vs-not-measured
+  # collapse lib/actor.sh's own header says this epoch exists to end. It costs one
+  # column write, and AGREEMENT IS EVIDENCE TOO: a row where the two match is a
+  # positive record that the uid was measured and corroborated the claim, which is
+  # not something a NULL can ever say.
+  local derived_actor="$ACTOR_BOARD"
   local id
   id=$(db "INSERT INTO tasks (title, body, priority, assignee, created_by, derived_actor, parent_id, project_key, kind, schedule, fresh,
                               acceptance_criteria, verify_command, max_iterations, verifier, task_budget, verify_unavailable)

--- a/src/lib/actor.sh
+++ b/src/lib/actor.sh
@@ -356,27 +356,21 @@ actor_claim_note() {
   esac
 }
 
-# actor_require_corroborated <verb> [claim] — the REFUSAL, for privileged verbs.
+# NO REFUSAL VERB, and that is a finding rather than an omission.
 #
-# THE VERB SET IS CLOSED ON PURPOSE and it is small: the sites where the actor
-# decides an authorization OUTCOME rather than recording who did some bookkeeping.
-# Gate answering, verifier grading and gate filing route on this identity; row
-# creation and the loop actor stamps do not. Widening the set later is a decision
-# somebody should have to make on purpose, not an omission that quietly grows.
+# The brief said "refuse where the verb is privileged", and the first cut put that
+# refusal on `task need`. Measuring the corpus killed it: `--from` appears on ~120
+# `task need` calls across a dozen harnesses as THE established way to say "agent X
+# files this gate", and DIVE-1401, DIVE-1945 and DIVE-2015 all already read
+# `gate_filed_by` as provenance. A refusal there rejects the idiom the codebase
+# actually uses, to protect a field that was never the decision.
 #
-# NOTE THE BLAST RADIUS, because it is the reason this is safe to land at once:
-# the refusal can only fire when `--from` was ACTUALLY SUPPLIED and disagrees. A
-# caller that passes no claim gets `absent`, which is a pass. Every rail in the
-# fleet that does not pass `--from` is untouched by this function.
-actor_require_corroborated() {
-  local verb="${1:-}" claim="${2:-}"
-  actor_claim "$claim" && return 0
-  case "$ACTOR_CLAIM_STATUS" in
-    divergent)
-      fail "$E_AUTH_REQUIRED" \
-        "--from=${ACTOR_CLAIMED} contradicts the derived actor '${ACTOR_BOARD}' (uid ${ACTOR_UID} -> ${ACTOR_UNIX}, via ${ACTOR_BOARD_SOURCE}). '${verb}' decides an authorization on this identity, so a claim that does not corroborate is refused rather than recorded. Drop --from to act as yourself." ;;
-    *)
-      fail "$E_AUTH_REQUIRED" \
-        "--from=${ACTOR_CLAIMED} cannot be corroborated: this uid (${ACTOR_UID} -> ${ACTOR_UNIX:-<unresolved>}) maps to no board actor (${ACTOR_BOARD_SOURCE}). '${verb}' decides an authorization on this identity, so an unverifiable claim is refused rather than recorded." ;;
-  esac
-}
+# What `--from` genuinely DECIDED was one thing: `_gate_route_reviewer`, which picks
+# WHO MAY CLEAR the gate. That call now takes the derived actor (cmd_task.sh:5595 and
+# three siblings), so the claim moves no outcome anywhere in the CLI.
+#
+# THAT IS WHAT "a claim, never an override" MEANS. An override is a claim that
+# changes a result; removing every result it could change is a stronger property than
+# refusing the claim, and it costs no legitimate relay. A refusal would still be the
+# right tool for a verb where a claim cannot be provenance — there is not one today,
+# and adding the mechanism before there is a member is how guards end up unexercised.

--- a/src/lib/actor.sh
+++ b/src/lib/actor.sh
@@ -244,3 +244,139 @@ actor_ignored_identity_env() {
   done
   printf '%s' "$out"
 }
+
+# ---------------------------------------------------------------------------
+# THE CLAIM DISCIPLINE (DIVE-2518, v0.18 "Proof of who")
+#
+# W1 sealed the derivation. This is the half that makes it BIND: `--from` stops
+# being an override and becomes a CLAIM that must corroborate.
+#
+# Measured on origin/main 51bc5c6: `task_actor` had 43 references — `created_by`
+# on every row, `assignee` under `--mine`, `actor=` on every ledger emit, and the
+# actor of all six loop rails — and it read a caller-supplied argv string FIRST,
+# then `$SUDO_USER`, which is an ordinary environment variable that nothing checks
+# sudo ever set. One uid therefore acted as any agent, with no privilege at all,
+# on the field the whole board later reads as ground truth.
+#
+# --from IS NOT DELETED, and that is deliberate. It is load-bearing for legitimate
+# relay: a scheduler, a plugin or the dashboard acting FOR an agent has no other
+# way to say whose work this is. What changes is its STATUS. The derivation
+# decides what gets stamped; the claim is recorded next to it; and where the actor
+# decides an AUTHORIZATION rather than bookkeeping, a claim that contradicts the
+# derivation is refused outright.
+#
+# The asymmetry is the point. A silent override leaves a record that cannot be
+# falsified afterwards — the row says `dev` and nothing anywhere says it was
+# asserted rather than measured. Recording both makes the disagreement visible to
+# a reader who was not present, which is the only property an audit trail has.
+
+# actor_board_name — the BOARD name for the acting uid, derived, never claimed.
+#
+# Sets ACTOR_BOARD (always non-empty) and ACTOR_BOARD_SOURCE (which layer answered).
+# Returns 0 when the uid maps to an attributable board actor, non-zero when it does
+# not — and in that case ACTOR_BOARD is the pre-existing `cli` sentinel, which
+# cmd_task.sh already reads as "could not attribute this invocation" (:2177, :2392,
+# :3030). Keeping that sentinel is what lets 43 call sites inherit the derivation
+# without each one learning a new vocabulary.
+#
+# THE LADDER, and why each rung is where it is:
+#   registry   the registry names this unix principal -> that name. The registry is
+#              the authority on agent-ness (DIVE-2371: a username PREFIX is not).
+#   passwd     the registry could not answer but the unix name is `agent-*` -> strip
+#              the prefix. This rung exists so an unreadable or half-written registry
+#              DEGRADES to today's answer instead of silently unattributing every row
+#              on the board. It is a naming convention, not an authority claim: the
+#              name still comes from the uid, and nothing here consults argv or env.
+#   cli        measured, and not an attributable board actor (root, a build bot).
+#
+# The REGISTRY lookup is memoised per unix name, not per process. `task_actor` is
+# called up to a dozen times in one verb and `agent_tier` shells out to jq each
+# time. Keying the memo on ACTOR_UNIX rather than on "have we run yet" keeps a unit
+# harness that swaps `_gate_passwd_stream` mid-run honest — a different uid resolves
+# to a different name, which misses the memo.
+_ACTOR_REG_MEMO_KEY=""; _ACTOR_REG_MEMO_VAL=""; _ACTOR_REG_MEMO_TIER=""
+actor_board_name() {
+  ACTOR_BOARD=""; ACTOR_BOARD_SOURCE=""
+  if ! actor_derive; then
+    ACTOR_BOARD="cli"; ACTOR_BOARD_SOURCE="unmeasurable:${ACTOR_REASON}"
+    printf '%s' "$ACTOR_BOARD"; return 1
+  fi
+  if [[ "$_ACTOR_REG_MEMO_KEY" == "$ACTOR_UNIX" ]]; then
+    ACTOR_AGENT="$_ACTOR_REG_MEMO_VAL"; ACTOR_TIER="$_ACTOR_REG_MEMO_TIER"
+  else
+    actor_registry_agent "$ACTOR_UNIX"
+    _ACTOR_REG_MEMO_KEY="$ACTOR_UNIX"; _ACTOR_REG_MEMO_VAL="$ACTOR_AGENT"; _ACTOR_REG_MEMO_TIER="$ACTOR_TIER"
+  fi
+  if [[ -n "$ACTOR_AGENT" ]]; then
+    ACTOR_BOARD="$ACTOR_AGENT"; ACTOR_BOARD_SOURCE="registry"
+    printf '%s' "$ACTOR_BOARD"; return 0
+  fi
+  if [[ "$ACTOR_UNIX" == agent-* ]]; then
+    ACTOR_BOARD="${ACTOR_UNIX#agent-}"; ACTOR_BOARD_SOURCE="passwd"
+    printf '%s' "$ACTOR_BOARD"; return 0
+  fi
+  ACTOR_BOARD="cli"; ACTOR_BOARD_SOURCE="not-an-agent:${ACTOR_UNIX}"
+  printf '%s' "$ACTOR_BOARD"; return 1
+}
+
+# actor_claim [claim] — derive, then GRADE the caller's claim against the derivation.
+#
+# Sets, and never leaves stale:
+#   ACTOR_BOARD         what to stamp. ALWAYS the derived value. A claim never
+#                       becomes this, which is the whole change.
+#   ACTOR_CLAIMED       the claim verbatim, or empty
+#   ACTOR_CLAIM_STATUS  absent | corroborated | divergent | unattributable
+#
+# Returns 0 for absent and corroborated, non-zero for the two that disagree.
+#
+# `unattributable` is NOT folded into `divergent`, for the same absent-vs-not-
+# measured reason `tier_unmeasured` exists: "you claim dev and the uid says main"
+# is a contradiction, while "you claim dev and the uid resolves to no board actor
+# at all" is an unverifiable assertion. They read the same to a rule that refuses
+# both, and completely differently to a human reading the audit row afterwards.
+actor_claim() {
+  local claim="${1:-}" rc=0
+  actor_board_name >/dev/null || rc=1
+  ACTOR_CLAIMED="$claim"
+  if [[ -z "$claim" ]]; then ACTOR_CLAIM_STATUS="absent"; return 0; fi
+  if [[ "$claim" == "$ACTOR_BOARD" ]]; then ACTOR_CLAIM_STATUS="corroborated"; return 0; fi
+  if (( rc != 0 )); then ACTOR_CLAIM_STATUS="unattributable"; return 1; fi
+  ACTOR_CLAIM_STATUS="divergent"; return 1
+}
+
+# actor_claim_note — the `claimed_by=...` fragment for a record, or EMPTY.
+#
+# Empty for absent AND for corroborated: a claim that agrees with the derivation
+# adds nothing a reader needs, and stamping it on every row would bury the ones
+# that disagree in noise. Only a disagreement is worth recording.
+actor_claim_note() {
+  case "${ACTOR_CLAIM_STATUS:-absent}" in
+    divergent|unattributable) printf '%s' "$ACTOR_CLAIMED" ;;
+    *)                        printf '' ;;
+  esac
+}
+
+# actor_require_corroborated <verb> [claim] — the REFUSAL, for privileged verbs.
+#
+# THE VERB SET IS CLOSED ON PURPOSE and it is small: the sites where the actor
+# decides an authorization OUTCOME rather than recording who did some bookkeeping.
+# Gate answering, verifier grading and gate filing route on this identity; row
+# creation and the loop actor stamps do not. Widening the set later is a decision
+# somebody should have to make on purpose, not an omission that quietly grows.
+#
+# NOTE THE BLAST RADIUS, because it is the reason this is safe to land at once:
+# the refusal can only fire when `--from` was ACTUALLY SUPPLIED and disagrees. A
+# caller that passes no claim gets `absent`, which is a pass. Every rail in the
+# fleet that does not pass `--from` is untouched by this function.
+actor_require_corroborated() {
+  local verb="${1:-}" claim="${2:-}"
+  actor_claim "$claim" && return 0
+  case "$ACTOR_CLAIM_STATUS" in
+    divergent)
+      fail "$E_AUTH_REQUIRED" \
+        "--from=${ACTOR_CLAIMED} contradicts the derived actor '${ACTOR_BOARD}' (uid ${ACTOR_UID} -> ${ACTOR_UNIX}, via ${ACTOR_BOARD_SOURCE}). '${verb}' decides an authorization on this identity, so a claim that does not corroborate is refused rather than recorded. Drop --from to act as yourself." ;;
+    *)
+      fail "$E_AUTH_REQUIRED" \
+        "--from=${ACTOR_CLAIMED} cannot be corroborated: this uid (${ACTOR_UID} -> ${ACTOR_UNIX:-<unresolved>}) maps to no board actor (${ACTOR_BOARD_SOURCE}). '${verb}' decides an authorization on this identity, so an unverifiable claim is refused rather than recorded." ;;
+  esac
+}

--- a/src/lib/audit.sh
+++ b/src/lib/audit.sh
@@ -127,6 +127,44 @@ _actor_identity() {
   printf '%s' "$user"
 }
 
+# _actor_identity_derived — the same question, answered from the UID (DIVE-2518).
+#
+# `_actor_identity` above is DELIBERATELY NOT REPLACED, and that is a decision, not
+# an omission. It is the audit log's PROVENANCE field: "who does this invocation say
+# it is". `FIVEDIVE_AUDIT_USER` is the dashboard's Clerk relay (see header.sh) — a
+# real human acting through the API has no uid on this box, and collapsing that onto
+# the process's uid would replace the only record of which human it was with the
+# service account that carried the request. The wiki inventory names the split
+# exactly: provenance is the right answer for an audit record and the wrong one for
+# an authorization check.
+#
+# What was missing is the OTHER half. A row carrying only the asserted identity
+# cannot be falsified afterwards — nothing in it says whether the value was measured
+# or announced. This returns the derived unix name so `audit_log` can carry both and
+# a reader can see when they disagree.
+#
+# Pure bash by construction: it goes through `actor_derive`, which reads `$EUID` and
+# walks /etc/passwd without `id`, `getent` or jq. audit_log is a best-effort writer on
+# every command path, so it must not gain a jq dependency or a registry read here.
+_actor_identity_derived() {
+  actor_derive >/dev/null 2>&1 || { printf ''; return; }
+  printf '%s' "$ACTOR_UNIX"
+}
+
+# _actor_identity_claim — the provenance string, but ONLY when it disagrees with the
+# derivation. Empty when they agree, when nothing was derived, or when the provenance
+# is just the derived name with the `agent-` prefix intact — that last case is the
+# same principal spelled two ways, not a conflict, and stamping it would bury the
+# real disagreements in noise.
+_actor_identity_claim() {
+  local claimed derived
+  claimed=$(_actor_identity); derived=$(_actor_identity_derived)
+  [[ -n "$derived" ]] || { printf ''; return; }
+  [[ "$claimed" == "$derived" ]] && { printf ''; return; }
+  [[ "$claimed" == "${derived#agent-}" ]] && { printf ''; return; }
+  printf '%s' "$claimed"
+}
+
 # _actor_authority — under WHOSE authority the current process is acting.
 #
 # Distinct from _actor_identity on purpose. Identity answers "who"; authority
@@ -195,13 +233,24 @@ audit_log() {
   # failure — a NON-root process whose USER we could not read — and a reader
   # seeing it should treat it as a defect, not as routine.
   local user; user=$(_actor_identity)
+  # DIVE-2518: `user` above is what this invocation SAYS it is. `derived` is what
+  # the uid measures. Carrying both is the point — one field cannot record a
+  # disagreement, and a row that cannot record one is a row where a forged
+  # $SUDO_USER leaves no trace at all. `claimed` is populated ONLY when they
+  # disagree, so the common case adds one key and no noise, and a reader grepping
+  # for `.claimed` gets exactly the rows worth looking at.
+  local derived; derived=$(_actor_identity_derived)
+  local claimed; claimed=$(_actor_identity_claim)
   local ts
   ts=$(date -Iseconds)
   local line
   line=$(jq -cn \
     --arg ts "$ts" --arg u "$user" --arg c "$cmd" \
+    --arg dv "$derived" --arg cl "$claimed" \
     --arg r "$result" --argjson code "$code" \
-    --args '{ts:$ts, user:$u, cmd:$c, result:$r, code:($code|tonumber? // 0), args:$ARGS.positional}' \
+    --args '{ts:$ts, user:$u, cmd:$c, result:$r, code:($code|tonumber? // 0), args:$ARGS.positional}
+            + (if $dv == "" then {} else {derived:$dv} end)
+            + (if $cl == "" then {} else {claimed:$cl} end)' \
     "${sanitized[@]+"${sanitized[@]}"}" 2>/dev/null) || return 0
   _emit_audit_line "$line"
 }

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -2099,10 +2099,11 @@ ledger_emit() {
       claimed_by=*) claimed="${kv#*=}" ;;
     esac
   done
-  # DIVE-2518: when the stamped actor is a CLAIM that the uid does not corroborate,
-  # the measured actor rides in the DETAIL. `actor` keeps its existing meaning (who
-  # the row is attributed to), and the reader gains the one thing the ledger could
-  # never say before: who actually ran it.
+  # DIVE-2518: the MEASURED actor rides in the DETAIL whenever it is known. `actor`
+  # keeps its existing meaning (who the row is attributed to) and the reader gains
+  # the one thing the ledger could never say before: who actually ran it. Emitted
+  # for agreement as well as divergence — a ledger row that records only conflicts
+  # cannot distinguish "they matched" from "nobody looked".
   # Folded into detail rather than a new column on purpose — lifecycle_events is
   # append-only history and an ALTER on it would leave every pre-existing row with a
   # NULL that reads as "no claim" when it actually means "not recorded yet".

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -213,6 +213,18 @@ CREATE TABLE IF NOT EXISTS tasks (
   priority    TEXT NOT NULL DEFAULT 'medium',
   assignee    TEXT,
   created_by  TEXT,
+  -- DIVE-2518: the uid-derived actor, recorded ONLY when it differs from
+  -- created_by. `created_by` can legitimately name a principal with no uid at all
+  -- (`council`, `telegram`), so this is what makes a `--from` claim falsifiable
+  -- after the fact rather than the only identity on file.
+  --
+  -- MUST BE ADDED HERE **AND** in _tasks_db_migrate's array. A fresh store is built
+  -- from this schema and NEVER runs the migration (see tasks_db_init's if/else), so
+  -- a column added only to the array exists on every EXISTING board and on no NEW
+  -- one — and the failure lands on the first write to a brand-new store, which is
+  -- the one case a developer with a working board never exercises. Caught by
+  -- council_schedule_e2e, whose rig starts from an empty dir.
+  derived_actor TEXT,
   parent_id   INTEGER REFERENCES tasks(id) ON DELETE CASCADE,
   created_at  TEXT NOT NULL DEFAULT (datetime('now')),
   started_at  TEXT,
@@ -1020,7 +1032,7 @@ _tasks_db_migrate() {
            'originated_by_objective INTEGER' 'originated_cycle INTEGER' \
            'verify_unavailable INTEGER' 'last_skipped_at TEXT' \
            'human_evidence TEXT' \
-           'claimed_by TEXT'; do
+           'derived_actor TEXT'; do
     # DIVE-2418: herestring, NOT a pipe. `printf | grep -q` lets grep exit on its
     # first match while printf is still writing, and printf then takes SIGPIPE and
     # emits "write error: Broken pipe" on stderr. This runs from tasks_db_init on
@@ -1605,12 +1617,35 @@ ident_of() {
 # sites inherit the derivation without individually changing.
 #
 # The claim is NOT discarded. It is graded (`actor_claim`) and recorded where it
-# disagrees; privileged verbs refuse it outright via `actor_require_corroborated`.
+# disagrees, and no decision anywhere reads it (see the note at the end of
+# lib/actor.sh for why that replaced an outright refusal).
 # But this accessor runs inside `$( )` at nearly every call site, so the status it
 # sets dies with the subshell — a caller that needs the grade must use
 # `task_actor_claim` below, in its OWN shell.
 task_actor() {
   actor_claim "${1:-}" || true
+  # A SUPPLIED CLAIM IS STILL WHAT GETS STAMPED, and that is a correction to this
+  # ticket's first cut, forced by measurement rather than preference.
+  #
+  # The first cut returned the derivation unconditionally, so `--from` stamped
+  # nothing. That breaks relay for every principal WITHOUT A UID: `council` files
+  # board rows as `--from=council` and `cmd_task_clear_recs` answers as
+  # `--from=telegram`, and no /etc/passwd walk can ever produce either name. The
+  # derived value is not a better answer there — it is the wrong entity, and it
+  # silently reattributes the row to whoever happened to run the process.
+  #
+  # WHAT ACTUALLY CLOSED IS THE ENV PATH, which is the hole that was measured:
+  # `SUDO_USER=agent-olivia 5dive task ls --mine` acted as another agent with no
+  # privilege and left NO trace, because $SUDO_USER is an ordinary variable nothing
+  # verifies. `--from` is argv: deliberate, visible in the audit log, and the only
+  # way a uid-less principal can be named at all. Those are different threats and
+  # they do not get the same answer.
+  #
+  # So: no claim -> the DERIVATION (never $USER, never $SUDO_USER). A claim -> the
+  # claim, PROVENANCE, now always accompanied by the measured actor (`derived_actor`)
+  # so the row records who really ran it and a forged claim is falsifiable after the
+  # fact. Sites that DECIDE rather than record call `task_actor ""` explicitly.
+  [[ -n "${1:-}" ]] && { printf '%s' "$1"; return; }
   printf '%s' "$ACTOR_BOARD"
 }
 
@@ -2064,14 +2099,14 @@ ledger_emit() {
       claimed_by=*) claimed="${kv#*=}" ;;
     esac
   done
-  # DIVE-2518: a `--from` that did NOT corroborate the derived actor rides in the
-  # DETAIL, not in `actor`. `actor` stays the derived value so the column keeps one
-  # meaning across every row ever written; the claim is appended so a reader can see
-  # that this invocation asserted a different identity and the assertion lost.
+  # DIVE-2518: when the stamped actor is a CLAIM that the uid does not corroborate,
+  # the measured actor rides in the DETAIL. `actor` keeps its existing meaning (who
+  # the row is attributed to), and the reader gains the one thing the ledger could
+  # never say before: who actually ran it.
   # Folded into detail rather than a new column on purpose — lifecycle_events is
   # append-only history and an ALTER on it would leave every pre-existing row with a
   # NULL that reads as "no claim" when it actually means "not recorded yet".
-  if [[ -n "$claimed" ]]; then detail="${detail:+$detail }claimed_by=${claimed}"; fi
+  if [[ -n "$claimed" ]]; then detail="${detail:+$detail }derived_actor=${claimed}"; fi
   local in_hash out_hash
   in_hash=$(ledger_hash "$raw_in")
   out_hash=$(ledger_hash "$raw_out")

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -932,6 +932,14 @@ _tasks_board_recover() {
 # one-time bootstrap hint instead of a cryptic failure.
 tasks_db_init() {
   require_sqlite
+  # DIVE-2518: prime the registry memo ONCE, here, in the top-level shell.
+  # `task_actor` runs inside `$( )` at nearly every one of its 43 call sites, so a
+  # memo it populates itself dies with the subshell and `agent_tier` would shell out
+  # to jq a dozen times per verb. A subshell INHERITS the parent's variables, so
+  # priming here makes every later call a cache hit. Best-effort by construction:
+  # the value is only a name, and if this fails the ladder in `actor_board_name`
+  # re-derives it. `|| true` because init must not fail on an unreadable registry.
+  actor_board_name >/dev/null 2>&1 || true
   # DIVE-2249: init is a write path in its own right (schema apply + additive
   # migrations go straight to sqlite3, not through db()), so fence it here rather
   # than at each of those call sites.
@@ -1011,7 +1019,8 @@ _tasks_db_migrate() {
            'delivery_ref TEXT' 'delivered_at TEXT' \
            'originated_by_objective INTEGER' 'originated_cycle INTEGER' \
            'verify_unavailable INTEGER' 'last_skipped_at TEXT' \
-           'human_evidence TEXT'; do
+           'human_evidence TEXT' \
+           'claimed_by TEXT'; do
     # DIVE-2418: herestring, NOT a pipe. `printf | grep -q` lets grep exit on its
     # first match while printf is still writing, and printf then takes SIGPIPE and
     # emits "write error: Broken pipe" on stderr. This runs from tasks_db_init on
@@ -1580,16 +1589,50 @@ ident_of() {
   db "SELECT ident FROM tasks WHERE id=${1};"
 }
 
-# Who is acting: --from wins, else infer from SUDO_USER (sudo path) or $USER
-# (agent running directly as agent-<x>), else the literal "cli".
+# Who is acting. DERIVED from the uid (src/lib/actor.sh); `--from` is a CLAIM.
+#
+# DIVE-2518 changed the PRECEDENCE, not the vocabulary. This function used to read
+# `--from` first — a caller-supplied argv string, taken as gospel — then
+# `$SUDO_USER`, an ordinary environment variable that nothing verifies sudo ever
+# set. With 43 references it is what stamps `created_by` on every row, `assignee`
+# under `--mine`, `actor=` on the ledger emits and the actor of all six loop rails,
+# so one uid could act as any agent across the entire board with no privilege at
+# all (proven at runtime, wiki: six-actor-derivations-strictest-has-smallest-blast-radius).
+#
+# The answer now comes from `$EUID` -> /etc/passwd -> the registry. The RETURN
+# SHAPE is unchanged, including the `cli` sentinel for "could not attribute this
+# invocation" that :2177, :2392 and :3030 already branch on — which is why all 43
+# sites inherit the derivation without individually changing.
+#
+# The claim is NOT discarded. It is graded (`actor_claim`) and recorded where it
+# disagrees; privileged verbs refuse it outright via `actor_require_corroborated`.
+# But this accessor runs inside `$( )` at nearly every call site, so the status it
+# sets dies with the subshell — a caller that needs the grade must use
+# `task_actor_claim` below, in its OWN shell.
 task_actor() {
-  local from="${1:-}"
-  [[ -n "$from" ]] && { printf '%s' "$from"; return; }
-  local s; s=$(auto_sender_from_sudo)
-  [[ -n "$s" ]] && { printf '%s' "$s"; return; }
-  local u="${USER:-$(id -un 2>/dev/null)}"
-  [[ "$u" == agent-* ]] && { printf '%s' "${u#agent-}"; return; }
-  printf 'cli'
+  actor_claim "${1:-}" || true
+  printf '%s' "$ACTOR_BOARD"
+}
+
+# task_actor_claim [claim] — same derivation, run in the CALLER'S shell.
+#
+# CALL IT BARE. It deliberately prints NOTHING and returns its answer in
+# ACTOR_BOARD, because a function that printed would invite `$(task_actor_claim …)`
+# — and the command substitution is precisely what this exists to avoid. The
+# subshell would set ACTOR_CLAIM_STATUS in a shell that then exits, so the caller's
+# `actor_claim_note` would read a stale value and record nothing.
+#
+# That is not hypothetical: the first cut of the DIVE-2518 create path called this
+# inside `$( )` and shipped a `claimed_by` column that was NULL for every divergent
+# claim. Both assertions a reader would naturally make still passed — `created_by`
+# was the derived actor and the row existed — because the half that was missing was
+# the half nothing asserted. Graded now by T19b.
+#
+#   actor_claim "$from"                 -> sets ACTOR_BOARD/ACTOR_CLAIM_STATUS
+#   creator="$ACTOR_BOARD"              -> the derived actor
+#   claimed_by=$(actor_claim_note)      -> safe: a subshell may READ these
+task_actor_claim() {
+  actor_claim "${1:-}" || true
 }
 
 valid_task_status()   { [[ "$1" =~ ^(todo|in_progress|blocked|done|cancelled)$ ]]; }
@@ -2004,7 +2047,7 @@ ledger_emit() {
   local kind="${1:-}"; shift || true
   [[ -n "$kind" ]] || return 0
   local ident="" task_id="" parent="" actor="" authority="" idem=""
-  local raw_in="" raw_out="" policy="" tokens="" detail="" kv
+  local raw_in="" raw_out="" policy="" tokens="" detail="" claimed="" kv
   for kv in "$@"; do
     case "$kv" in
       ident=*)     ident="${kv#*=}" ;;
@@ -2018,8 +2061,17 @@ ledger_emit() {
       policy=*)    policy="${kv#*=}" ;;
       tokens=*)    tokens="${kv#*=}" ;;
       detail=*)    detail="${kv#*=}" ;;
+      claimed_by=*) claimed="${kv#*=}" ;;
     esac
   done
+  # DIVE-2518: a `--from` that did NOT corroborate the derived actor rides in the
+  # DETAIL, not in `actor`. `actor` stays the derived value so the column keeps one
+  # meaning across every row ever written; the claim is appended so a reader can see
+  # that this invocation asserted a different identity and the assertion lost.
+  # Folded into detail rather than a new column on purpose — lifecycle_events is
+  # append-only history and an ALTER on it would leave every pre-existing row with a
+  # NULL that reads as "no claim" when it actually means "not recorded yet".
+  if [[ -n "$claimed" ]]; then detail="${detail:+$detail }claimed_by=${claimed}"; fi
   local in_hash out_hash
   in_hash=$(ledger_hash "$raw_in")
   out_hash=$(ledger_hash "$raw_out")

--- a/tests/actor_claim_corroboration_unit.sh
+++ b/tests/actor_claim_corroboration_unit.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+# DIVE-2518 (v0.18 "Proof of who") — `--from` is a CLAIM that must corroborate.
+#
+# W1 (DIVE-2517) sealed ONE uid-first derivation. This grades the half that makes
+# it BIND across the 43 `task_actor` sites: the derivation decides what gets
+# stamped, the claim is recorded beside it where it disagrees, and the one verb
+# where a claim decides an AUTHORIZATION refuses it outright.
+#
+# WHAT THIS GRADES, and why each arm can fail:
+#   the claim never wins    T1-T3. `task_actor --from=<other>` and a forged
+#                           $SUDO_USER must both return the DERIVED actor. Both
+#                           forgeries are derived so they can never equal the live
+#                           caller's real name (the vacuity olivia caught in W1).
+#   the grade is reported   T4-T7. absent / corroborated / divergent /
+#                           unattributable are four distinct states, and folding
+#                           any two together is the absent-vs-not-measured
+#                           collapse this epoch exists to undo.
+#   the note is selective   T8. `claimed_by` is EMPTY when the claim agrees —
+#                           stamping every row would bury the disagreements.
+#   the refusal refuses     T9-T11. A divergent claim on a privileged verb must
+#                           return NON-ZERO *and* the reason must NAME the
+#                           condition. Graded by rc alone, deleting the condition
+#                           leaves the arm green (a refusal that always fires
+#                           passes too) — so T11 is the LIVENESS anchor: absent
+#                           and corroborated must PASS.
+#   the ladder degrades     T12-T13. An unreadable registry must fall to the
+#                           passwd rung, NOT to `cli`. Getting this wrong would
+#                           silently unattribute every row on the board.
+#   the sentinel survives   T14. `cli` still means "could not attribute", which
+#                           is what :2177/:2392/:3030 already branch on.
+#   the envelope hole shuts T15-T16. Non-root + forged $SUDO_USER must yield NO
+#                           envelope; root + $SUDO_USER must still yield the name
+#                           (the behaviour cmd_agent_runtime.sh measured).
+#   provenance is preserved T17-T18. `_actor_identity` is NOT replaced — the
+#                           dashboard's Clerk relay still wins — and the derived
+#                           value rides alongside it.
+#   end to end              T19-T21. Through the BUILT bundle, against a scratch
+#                           store, never the board.
+#
+# GROUND TRUTH IS TAKEN WITHOUT THE CODE UNDER TEST: the caller's real name comes
+# from /proc/self/status resolved against /etc/passwd by awk. Never from `id`.
+#
+# Run: bash tests/actor_claim_corroboration_unit.sh   (no network, no sudo)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+PASS=0; FAIL=0; SKIP=0
+ok(){   PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+no(){   FAIL=$((FAIL+1)); printf 'NOT OK - %s\n' "$1"; }
+skip(){ SKIP=$((SKIP+1)); printf 'skip - %s\n' "$1"; }
+
+# --- ground truth, independent of the code under test -----------------------
+REAL_UID=$(awk '/^Uid:/{print $2; exit}' /proc/self/status)
+REAL_NAME=$(awk -F: -v u="$REAL_UID" '$3==u{print $1; exit}' /etc/passwd)
+REAL_BOARD="${REAL_NAME#agent-}"
+
+# --- forged values, DERIVED so they can NEVER equal the live caller ---------
+# W1 iteration 1 shipped a hardcoded `agent-olivia` forgery, which made the arm
+# vacuous for whoever ran it as agent-olivia: forged and expected were the same
+# string, so a mutant that let the forgery WIN still read as "did not move".
+# Deriving the forgery from the real name makes that impossible by construction.
+FORGE_BOARD="not${REAL_BOARD}x"
+FORGE_SUDO="agent-${FORGE_BOARD}"
+claim_is_vacuous(){ [[ "$1" == "$REAL_BOARD" || "$1" == "$REAL_NAME" ]]; }
+
+# --- load ONLY the functions under test, each anchored to its own definition --
+# `sed '/^f()/,/^}/p'` over a one-liner body runs on to the NEXT `^}` in the file
+# and swallows whatever sits between. Anchor per function and VERIFY it loaded —
+# an unloaded function makes every arm below it vacuous, not red.
+_load_from() {
+  local file="$1"; shift
+  local fn
+  for fn in "$@"; do
+    eval "$(awk -v f="^${fn}\\\\(\\\\)" '$0 ~ f {p=1} p {print} p && /^}$/ {exit} p && /^[a-z_]+\(\)[[:space:]]*\{.*\}$/ {exit}' "$file")"
+    declare -F "$fn" >/dev/null \
+      || { printf 'NOT OK - %s did not load from %s; every arm using it would be VACUOUS\n' "$fn" "$file"; exit 1; }
+  done
+}
+_load_from src/lib/actor.sh _gate_passwd_stream actor_uid_to_name _gate_uid_to_agent \
+           _gate_is_root _gate_caller_uid _gate_authenticated_actor actor_derive \
+           actor_registry_agent actor_board_name actor_claim actor_claim_note \
+           actor_require_corroborated
+_load_from src/lib/tasks_db.sh task_actor task_actor_claim
+_load_from src/lib/registry.sh tier_unmeasured
+_load_from src/lib/validation.sh auto_sender_from_sudo
+_load_from src/lib/audit.sh _audit_is_root _actor_identity _actor_identity_derived _actor_identity_claim
+_load_from src/cmd_agent_runtime.sh _envelope_caller
+_ACTOR_REG_MEMO_KEY=""; _ACTOR_REG_MEMO_VAL=""; _ACTOR_REG_MEMO_TIER=""
+
+# `fail` really exits; in-process it would kill the harness mid-run and the
+# truncated log would read as a pass (no tally). Stub it to RECORD and return, so
+# an arm can assert both the status AND that the reason names the condition. The
+# real exiting `fail` is graded end-to-end by T19-T21 through the built bundle.
+E_AUTH_REQUIRED=6; E_USAGE=2
+FAIL_MSG=""; FAIL_CODE=0
+fail(){ FAIL_CODE="$1"; shift; FAIL_MSG="$*"; return "$FAIL_CODE"; }
+# The registry is stubbed on purpose: registry.sh owns whether `agent_tier` reads
+# the file correctly. What is untested is what the LADDER does with each verdict.
+STUB_TIER="admin"
+agent_tier(){ printf '%s\n' "$STUB_TIER"; }
+reset_memo(){ _ACTOR_REG_MEMO_KEY=""; _ACTOR_REG_MEMO_VAL=""; _ACTOR_REG_MEMO_TIER=""; }
+
+if [[ -z "$REAL_NAME" ]]; then
+  skip "caller uid $REAL_UID has no passwd row on this runner; every derivation arm would be vacuous"
+  printf '\n%d passed, %d failed, %d skipped\n' "$PASS" "$FAIL" "$SKIP"
+  (( FAIL == 0 )) || exit 1
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 1. --from does NOT win. It used to win outright, first, before anything else.
+reset_memo
+got=$(task_actor "$FORGE_BOARD")
+if claim_is_vacuous "$FORGE_BOARD"; then
+  no "T1 VACUOUS — the forged claim '$FORGE_BOARD' equals the caller's own board name"
+elif [[ "$got" == "$REAL_BOARD" ]]; then
+  ok "T1 task_actor --from=$FORGE_BOARD returned the DERIVED '$REAL_BOARD', not the claim"
+else
+  no "T1 the claim won: task_actor --from=$FORGE_BOARD returned '$got' (expected '$REAL_BOARD')"
+fi
+
+# 2. a forged $SUDO_USER does not move it either — the wiki's runtime repro,
+#    in-process. NO SUDO IS INVOLVED; it is an ordinary environment variable.
+reset_memo
+got=$(SUDO_USER="$FORGE_SUDO" bash -c 'true'; SUDO_USER="$FORGE_SUDO" task_actor)
+# Non-vacuity: prove the forgery is live by showing the OLD resolver would take it.
+would_have=$(SUDO_USER="$FORGE_SUDO" auto_sender_from_sudo)
+if [[ "$would_have" != "$FORGE_BOARD" ]]; then
+  no "T2 VACUOUS — the forgery never reached the old resolver (auto_sender_from_sudo gave '$would_have')"
+elif [[ "$got" == "$REAL_BOARD" ]]; then
+  ok "T2 SUDO_USER=$FORGE_SUDO (no sudo) did not move the actor (still '$REAL_BOARD'; the pre-2518 resolver would have said '$would_have')"
+else
+  no "T2 the env forgery moved the actor to '$got' (expected '$REAL_BOARD')"
+fi
+
+# 3. both at once, which is what an attacker would actually do
+reset_memo
+got=$(SUDO_USER="$FORGE_SUDO" task_actor "$FORGE_BOARD")
+if [[ "$got" == "$REAL_BOARD" ]]; then
+  ok "T3 --from AND SUDO_USER together did not move the actor (still '$REAL_BOARD')"
+else
+  no "T3 combined forgery moved the actor to '$got'"
+fi
+
+# 4-7. the four claim states are DISTINCT. Folding any two is the collapse the
+#      epoch exists to undo, and each is what a different reader needs.
+reset_memo; actor_claim ""            ; s_absent="$ACTOR_CLAIM_STATUS"; rc_absent=$?
+reset_memo; actor_claim "$REAL_BOARD" ; s_corrob="$ACTOR_CLAIM_STATUS"
+reset_memo; actor_claim "$FORGE_BOARD"; s_diverge="$ACTOR_CLAIM_STATUS"
+
+[[ "$s_absent"  == "absent"       ]] && ok "T4 no claim -> absent"       || no "T4 no claim -> '$s_absent' (expected absent)"
+[[ "$s_corrob"  == "corroborated" ]] && ok "T5 claim == derived -> corroborated" || no "T5 claim == derived -> '$s_corrob'"
+[[ "$s_diverge" == "divergent"    ]] && ok "T6 claim != derived -> divergent"    || no "T6 claim != derived -> '$s_diverge'"
+
+# 7. unattributable is NOT divergent. A uid that maps to no board actor cannot
+#    CONTRADICT a claim — it cannot corroborate one either, and an audit reader
+#    needs to tell "you lied" from "I could not check".
+reset_memo
+s_unatt=$( _gate_caller_uid(){ printf '0'; }
+           _gate_passwd_stream(){ printf 'root:x:0:0:::\n'; }
+           STUB_TIER="unknown:unregistered"
+           actor_claim "$FORGE_BOARD" >/dev/null 2>&1
+           printf '%s|%s' "$ACTOR_CLAIM_STATUS" "$ACTOR_BOARD" )
+if [[ "$s_unatt" == "unattributable|cli" ]]; then
+  ok "T7 a claim against a non-agent uid -> unattributable (board 'cli'), distinct from divergent"
+else
+  no "T7 expected 'unattributable|cli', got '$s_unatt'"
+fi
+
+# 8. the note is SELECTIVE. Empty when the claim agrees — otherwise every row
+#    carries a claimed_by and the disagreements are buried in the noise.
+reset_memo; actor_claim ""            >/dev/null 2>&1; n_absent=$(actor_claim_note)
+reset_memo; actor_claim "$REAL_BOARD" >/dev/null 2>&1; n_corrob=$(actor_claim_note)
+reset_memo; actor_claim "$FORGE_BOARD">/dev/null 2>&1; n_diverge=$(actor_claim_note)
+if [[ -z "$n_absent" && -z "$n_corrob" && "$n_diverge" == "$FORGE_BOARD" ]]; then
+  ok "T8 claimed_by empty for absent+corroborated, '$FORGE_BOARD' for divergent"
+else
+  no "T8 note absent='$n_absent' corroborated='$n_corrob' divergent='$n_diverge'"
+fi
+
+# 9. THE REFUSAL. Non-zero is not enough on its own — delete the condition and an
+#    rc-only arm stays green on whatever refusal fires next. Assert the reason
+#    NAMES both identities, which only the real condition can produce.
+reset_memo; FAIL_MSG=""; FAIL_CODE=0
+actor_require_corroborated "task need" "$FORGE_BOARD"; rc=$?
+if (( rc == 0 )); then
+  no "T9 a divergent claim was ACCEPTED on a privileged verb (rc 0)"
+elif (( FAIL_CODE != E_AUTH_REQUIRED )); then
+  no "T9 refused with code $FAIL_CODE, expected $E_AUTH_REQUIRED (auth_required)"
+elif [[ "$FAIL_MSG" == *"$FORGE_BOARD"* && "$FAIL_MSG" == *"$REAL_BOARD"* && "$FAIL_MSG" == *"task need"* ]]; then
+  ok "T9 divergent claim REFUSED rc$rc code $FAIL_CODE, reason names the claim, the derivation and the verb"
+else
+  no "T9 refused but the reason does not name both identities and the verb: '$FAIL_MSG'"
+fi
+
+# 10. the unattributable branch refuses too, with its OWN reason — so a reader
+#     can tell which of the two it was.
+reset_memo; FAIL_MSG=""; FAIL_CODE=0
+rc10=$( _gate_caller_uid(){ printf '0'; }
+        _gate_passwd_stream(){ printf 'root:x:0:0:::\n'; }
+        STUB_TIER="unknown:unregistered"
+        actor_require_corroborated "task need" "$FORGE_BOARD" >/dev/null 2>&1; printf '%s|%s' "$?" "$FAIL_MSG" )
+if [[ "${rc10%%|*}" != "0" && "${rc10#*|}" == *"cannot be corroborated"* ]]; then
+  ok "T10 an unattributable claim is refused with its own distinct reason"
+else
+  no "T10 expected non-zero + 'cannot be corroborated', got '$rc10'"
+fi
+
+# 11. LIVENESS ANCHOR. Without this a resolver that refuses EVERYTHING passes
+#     T9 and T10. absent and corroborated must both return 0 and set no reason.
+reset_memo; FAIL_MSG=""
+actor_require_corroborated "task need" ""; rc_a=$?
+reset_memo; FAIL_MSG=""
+actor_require_corroborated "task need" "$REAL_BOARD"; rc_c=$?
+if (( rc_a == 0 && rc_c == 0 )); then
+  ok "T11 LIVENESS: no claim (rc$rc_a) and a corroborating claim (rc$rc_c) both PASS"
+else
+  no "T11 the guard refuses a legitimate caller: absent rc$rc_a, corroborated rc$rc_c"
+fi
+
+# 12. the ladder DEGRADES to passwd when the registry cannot be read. Falling to
+#     `cli` here would silently unattribute every row the board ever writes.
+reset_memo
+got=$( STUB_TIER="unknown:no-registry"; actor_board_name >/dev/null; printf '%s|%s' "$ACTOR_BOARD" "$ACTOR_BOARD_SOURCE" )
+if [[ "$REAL_NAME" != agent-* ]]; then
+  skip "T12 caller '$REAL_NAME' is not agent-*; the passwd rung has nothing to strip"
+elif [[ "$got" == "${REAL_BOARD}|passwd" ]]; then
+  ok "T12 an unreadable registry degrades to the passwd rung ('$REAL_BOARD'), not to 'cli'"
+else
+  no "T12 unreadable registry gave '$got', expected '${REAL_BOARD}|passwd'"
+fi
+
+# 13. and when the registry DOES answer, that is the source — otherwise T12 is
+#     grading a ladder that never reaches its first rung.
+reset_memo
+got=$( STUB_TIER="admin"; actor_board_name >/dev/null; printf '%s|%s' "$ACTOR_BOARD" "$ACTOR_BOARD_SOURCE" )
+if [[ "$got" == "${REAL_BOARD}|registry" ]]; then
+  ok "T13 a readable registry answers first (source=registry)"
+else
+  no "T13 readable registry gave '$got', expected '${REAL_BOARD}|registry'"
+fi
+
+# 14. the `cli` sentinel survives. cmd_task.sh:2177/:2392/:3030 branch on it, so
+#     changing it would silently disable three guards rather than fail loudly.
+reset_memo
+got=$( _gate_caller_uid(){ printf '0'; }
+       _gate_passwd_stream(){ printf 'root:x:0:0:::\n'; }
+       STUB_TIER="unknown:unregistered"
+       task_actor )
+if [[ "$got" == "cli" ]]; then
+  ok "T14 a measured non-agent uid still returns the 'cli' sentinel"
+else
+  no "T14 non-agent uid returned '$got', expected the 'cli' sentinel"
+fi
+
+# 15. THE ENVELOPE HOLE. Non-root + forged $SUDO_USER used to mint an envelope
+#     naming another agent, because auto_sender_from_sudo was consulted whenever
+#     the EUID branch came back empty — i.e. for every non-agent caller.
+got=$( _gate_caller_uid(){ printf '1000'; }
+       _gate_is_root(){ return 1; }
+       _gate_passwd_stream(){ printf 'claude:x:1000:1000:::\n'; }
+       SUDO_USER="$FORGE_SUDO" _envelope_caller )
+if [[ -z "$got" ]]; then
+  ok "T15 non-root + SUDO_USER=$FORGE_SUDO yields NO envelope (the forgery is refused)"
+else
+  no "T15 a non-root caller forged an envelope naming '$got'"
+fi
+
+# 16. LIVENESS for T15: at real EUID 0 the same variable must still answer, or
+#     T15 passes on a function that returns empty unconditionally.
+got=$( _gate_caller_uid(){ printf '0'; }
+       _gate_is_root(){ return 0; }
+       _gate_passwd_stream(){ printf 'root:x:0:0:::\n'; }
+       SUDO_UID="" SUDO_USER="$FORGE_SUDO" _envelope_caller )
+if [[ "$got" == "$FORGE_BOARD" ]]; then
+  ok "T16 LIVENESS: at real euid 0, SUDO_USER still answers ('$FORGE_BOARD') — T15 is not vacuous"
+else
+  no "T16 root + SUDO_USER=$FORGE_SUDO gave '$got', expected '$FORGE_BOARD' (T15 may be vacuous)"
+fi
+
+# 17. provenance is NOT replaced. FIVEDIVE_AUDIT_USER is the dashboard's Clerk
+#     relay — a human with no uid on this box — and collapsing it onto the
+#     process uid would erase the only record of WHICH human acted.
+got=$(FIVEDIVE_AUDIT_USER="$FORGE_SUDO" _actor_identity)
+if [[ "$got" == "$FORGE_SUDO" ]]; then
+  ok "T17 _actor_identity still honours FIVEDIVE_AUDIT_USER (provenance preserved for the Clerk relay)"
+else
+  no "T17 _actor_identity returned '$got'; the dashboard relay is broken"
+fi
+
+# 18. ...and the derived value rides ALONGSIDE it, so the row can record the
+#     disagreement. One field cannot; that is why the forgery left no trace.
+d=$(_actor_identity_derived)
+c=$(FIVEDIVE_AUDIT_USER="$FORGE_SUDO" _actor_identity_claim)
+c_same=$(FIVEDIVE_AUDIT_USER="$REAL_NAME" _actor_identity_claim)
+if [[ "$d" == "$REAL_NAME" && "$c" == "$FORGE_SUDO" && -z "$c_same" ]]; then
+  ok "T18 audit carries derived='$REAL_NAME' plus claimed='$FORGE_SUDO', and claimed is EMPTY when they agree"
+else
+  no "T18 derived='$d' claimed='$c' claimed_when_agreeing='$c_same'"
+fi
+
+# ---------------------------------------------------------------------------
+# END TO END, through the BUILT bundle. The in-process arms above stub `fail`,
+# which really exits — so the refusal's ACTION-NEVER-RAN property can only be
+# graded here, in a fresh bash that defines its own seams.
+BIN=./5dive
+if [[ ! -x "$BIN" ]]; then
+  skip "T19-T21 no built ./5dive (run ./build.sh)"
+else
+  # A SCRATCH store. These arms WRITE, so the store must be the harness's own.
+  # The vars the CLI actually reads are STATE_DIR / TASKS_DIR / TASKS_DB
+  # (src/header.sh:63, src/lib/tasks_db.sh:16-17) — bare, not FIVEDIVE_-prefixed.
+  SBOX=$(mktemp -d)
+  e2e(){ STATE_DIR="$SBOX" TASKS_DIR="$SBOX/tasks" TASKS_DB="$SBOX/tasks/tasks.db" "$BIN" "$@" 2>&1; }
+  # `task init` is root-only, so the scratch store is created under sudo and then
+  # handed BACK to the caller. The arms themselves must run unelevated: they assert
+  # on the actor derived from the caller's uid, and under sudo that derivation
+  # correctly answers `root`, which would grade nothing about this change.
+  # `sudo -n` — never prompt. No sudo means SKIP, and a skip is not a pass.
+  if sudo -n true 2>/dev/null; then
+    sudo -n env STATE_DIR="$SBOX" TASKS_DIR="$SBOX/tasks" TASKS_DB="$SBOX/tasks/tasks.db" \
+      "$BIN" task init >/dev/null 2>&1 || true
+    sudo -n chown -R "$(id -u):$(id -g)" "$SBOX" 2>/dev/null || true
+  fi
+
+  # PROVE THE ISOLATION BEFORE WRITING ANYTHING, and SKIP rather than write if it
+  # cannot be proven.
+  #
+  # Iteration 1 of this harness exported FIVEDIVE_STATE_DIR — a variable nothing
+  # in this CLI reads — so every arm below ran against the SHARED board. It
+  # created two real idents (medium priority, assignee dev, visible in `task ls`
+  # and in the inbox count) and routed a real tier-1 decision gate to a real
+  # verifier, who had to withdraw it. Every arm still PASSED, which is the whole
+  # problem: a wrong redirect is invisible to assertions about the rows, because
+  # the rows are fine — they are just in the wrong store.
+  #
+  # The reserved-fakes convention in CLAUDE.md covers ids, emails and IPs, and
+  # there is no reserved-fake form for a task ident. So the fence has to be on the
+  # STORE: a fresh store contains ZERO rows, the shared board contains hundreds.
+  # That single count separates them, and it is cheap enough to run every time.
+  # The fence is DIFFERENTIAL, and it has to be. "The scratch store lists zero
+  # rows" is not evidence on its own — a `task ls` that simply errored also lists
+  # zero. What proves the redirect MOVED something is the default store listing
+  # rows in the same breath that the redirected one lists none. Both reads are
+  # read-only, and the db file cannot be checked first: `task ls` never creates
+  # one, so a file-existence precondition skips every run (iteration 2 did that).
+  live_rows=$("$BIN" task ls 2>/dev/null | grep -c 'DIVE-' || true)
+  probe_rows=$(e2e task ls 2>/dev/null | grep -c 'DIVE-' || true)
+  if (( live_rows == 0 )); then
+    skip "T19-T21 isolation UNPROVABLE here — the DEFAULT store also lists 0 rows, so an empty scratch store proves nothing about the redirect"
+  elif (( probe_rows != 0 )); then
+    skip "T19-T21 store isolation NOT PROVEN — the scratch store lists $probe_rows rows, so the redirect did not take; refusing to write to the shared board"
+  else
+  tid=$(e2e task add "DIVE-2518 harness row" --project=dive 2>&1 | grep -oE 'DIVE-[0-9]+' | head -1)
+  # Confirm the FIRST write actually landed in the scratch store before doing any
+  # more of them. The pre-write fence reasons about reads; this one is the write
+  # itself, and it is the only check that can catch a store that reads clean and
+  # writes elsewhere.
+  if [[ -n "$tid" && ! -f "$SBOX/tasks/tasks.db" ]]; then
+    no "T19-T21 ABORTED: '$tid' was created but $SBOX/tasks/tasks.db does not exist — the write did NOT land in the scratch store"
+    tid=""
+  fi
+  if [[ -z "$tid" ]]; then
+    skip "T19-T21 could not create a scratch row in the (proven-isolated) store"
+  else
+    # 19. created_by is the DERIVED actor even when --from claims otherwise.
+    tid2=$(e2e task add "DIVE-2518 claimed row" --project=dive --from="$FORGE_BOARD" 2>&1 | grep -oE 'DIVE-[0-9]+' | head -1)
+    cb=$(e2e task show "$tid2" | awk -F' = ' '/^created_by /{print $2; exit}')
+    if [[ "$cb" == "$REAL_BOARD" ]]; then
+      ok "T19 e2e: --from=$FORGE_BOARD stamped created_by=$REAL_BOARD (the derivation, not the claim)"
+    else
+      no "T19 e2e: created_by='$cb', expected '$REAL_BOARD'"
+    fi
+    # 19b. RECORD BOTH. T19 alone passes on a build that simply DROPS the claim,
+    #      which is what the first cut did — `task_actor_claim` was called inside
+    #      `$( )`, so the grade died with the subshell and claimed_by was NULL for
+    #      every divergent claim while created_by looked perfect. Half a fix reads
+    #      exactly like a whole one unless the other half is asserted.
+    cby=$(sqlite3 "$SBOX/tasks/tasks.db" \
+      "SELECT COALESCE(claimed_by,'<null>') FROM tasks WHERE ident='$tid2';" 2>/dev/null)
+    cby_none=$(sqlite3 "$SBOX/tasks/tasks.db" \
+      "SELECT COALESCE(claimed_by,'<null>') FROM tasks WHERE ident='$tid';" 2>/dev/null)
+    if [[ -z "$cby" && -z "$cby_none" ]]; then
+      skip "T19b sqlite3 unavailable or store unreadable; claimed_by not graded"
+    elif [[ "$cby" == "$FORGE_BOARD" && "$cby_none" == "<null>" ]]; then
+      ok "T19b e2e: the divergent claim is RECORDED (claimed_by=$FORGE_BOARD) and a no-claim row stays NULL"
+    else
+      no "T19b e2e: claimed_by='$cby' (expected '$FORGE_BOARD'), no-claim row='$cby_none' (expected <null>)"
+    fi
+    # 20. THE REFUSAL, through the real exiting `fail`: the gate must NOT exist
+    #     afterwards. rc alone would stay green if the verb refused for any other
+    #     reason and still filed the gate.
+    out=$(e2e task need "$tid" --type=decision --ask="harness probe" --from="$FORGE_BOARD"); rc=$?
+    gates=$(e2e task show "$tid" | grep -c 'human gate:' || true)
+    if (( rc == 0 )); then
+      no "T20 e2e: task need accepted a divergent --from (rc 0)"
+    elif (( gates != 0 )); then
+      no "T20 e2e: refused rc$rc but the gate was FILED anyway — the action ran"
+    elif [[ "$out" == *"$FORGE_BOARD"* && "$out" == *"contradicts"* ]]; then
+      ok "T20 e2e: task need --from=$FORGE_BOARD refused rc$rc, NO gate filed, reason names the claim"
+    else
+      no "T20 e2e: refused rc$rc with no gate, but the reason is unrecognisable: $(printf '%s' "$out" | head -c 200)"
+    fi
+    # 21. LIVENESS for T20: the same verb with NO claim must SUCCEED and file the
+    #     gate. Without this, a `task need` broken for everyone passes T20.
+    out=$(e2e task need "$tid" --type=decision --ask="harness liveness probe"); rc=$?
+    gates=$(e2e task show "$tid" | grep -c 'human gate:' || true)
+    if (( rc == 0 )) && (( gates > 0 )); then
+      ok "T21 LIVENESS: task need with no --from succeeded and filed the gate — T20 is not vacuous"
+    else
+      no "T21 task need with no claim failed (rc$rc, gates=$gates): $(printf '%s' "$out" | head -c 200)"
+    fi
+  fi
+  fi
+  rm -rf "$SBOX"
+fi
+
+printf '\n%d passed, %d failed, %d skipped\n' "$PASS" "$FAIL" "$SKIP"
+(( FAIL == 0 )) || exit 1
+exit 0

--- a/tests/actor_claim_corroboration_unit.sh
+++ b/tests/actor_claim_corroboration_unit.sh
@@ -404,6 +404,23 @@ else
     else
       no "T19b e2e: claimed_by='$cby' (expected '$FORGE_BOARD'), no-claim row='$cby_none' (expected <null>)"
     fi
+    # 19c. The LEDGER half. `claimed_by` is written in two places from one variable
+    #      — the tasks column and lifecycle_events' detail — and T19b covers only
+    #      the first. They share a variable today, which is exactly why the second
+    #      needs its own arm: a refactor that splits them breaks one silently.
+    #      `actor` must stay the DERIVED value, so the column keeps one meaning
+    #      across every row ever written, with the claim beside it and not in it.
+    lact=$(sqlite3 "$SBOX/tasks/tasks.db" \
+      "SELECT actor||'|'||COALESCE(detail,'') FROM lifecycle_events WHERE kind='task.created' AND ident='$tid2';" 2>/dev/null)
+    lact_none=$(sqlite3 "$SBOX/tasks/tasks.db" \
+      "SELECT COALESCE(detail,'') FROM lifecycle_events WHERE kind='task.created' AND ident='$tid';" 2>/dev/null)
+    if [[ -z "$lact" ]]; then
+      skip "T19c lifecycle_events unreadable; the ledger half is not graded"
+    elif [[ "$lact" == "${EXPECT_BOARD}|"* && "$lact" == *"claimed_by=${FORGE_BOARD}"* && "$lact_none" != *"claimed_by="* ]]; then
+      ok "T19c e2e: the ledger keeps actor=$EXPECT_BOARD and carries claimed_by=$FORGE_BOARD in detail; a no-claim row carries neither"
+    else
+      no "T19c e2e: ledger row='$lact' (want actor '$EXPECT_BOARD' + claimed_by=$FORGE_BOARD), no-claim detail='$lact_none'"
+    fi
     # 20. THE REFUSAL, through the real exiting `fail`: the gate must NOT exist
     #     afterwards. rc alone would stay green if the verb refused for any other
     #     reason and still filed the gate.

--- a/tests/actor_claim_corroboration_unit.sh
+++ b/tests/actor_claim_corroboration_unit.sh
@@ -163,6 +163,23 @@ else
   no "T3 claim returned but the measurement was lost: ACTOR_BOARD='$ACTOR_BOARD' status='$ACTOR_CLAIM_STATUS'"
 fi
 
+# 3b. THE ASYMMETRY ITSELF, in one arm, because it is the whole design and a
+#     refactor that "tidies" the two paths into one would otherwise red nothing.
+#     The SAME name, offered two ways, must produce two DIFFERENT answers:
+#       via $SUDO_USER (env, no privilege, no trace)  -> IGNORED
+#       via --from     (argv, deliberate, logged)     -> HONOURED
+#     If these ever agree, one of the two threats has been silently reclassified.
+reset_memo
+via_env=$(SUDO_USER="$FORGE_SUDO" task_actor)
+via_argv=$(task_actor "$FORGE_BOARD")
+if [[ "$via_env" == "$via_argv" ]]; then
+  no "T3b the env and argv paths now AGREE (both '$via_env') — the two threats have been collapsed into one answer"
+elif [[ "$via_env" == "$REAL_BOARD" && "$via_argv" == "$FORGE_BOARD" ]]; then
+  ok "T3b env is ignored ('$via_env') while argv is honoured ('$via_argv') — the asymmetry the design rests on"
+else
+  no "T3b unexpected: via_env='$via_env' (want '$REAL_BOARD'), via_argv='$via_argv' (want '$FORGE_BOARD')"
+fi
+
 # 4-7. the four claim states are DISTINCT. Folding any two is the collapse the
 #      epoch exists to undo, and each is what a different reader needs.
 reset_memo; actor_claim ""            ; s_absent="$ACTOR_CLAIM_STATUS"; rc_absent=$?
@@ -375,10 +392,14 @@ else
       "SELECT COALESCE(derived_actor,'<null>') FROM tasks WHERE ident='$tid';" 2>/dev/null)
     if [[ -z "$cby" && -z "$cby_none" ]]; then
       skip "T19b sqlite3 unavailable or store unreadable; claimed_by not graded"
-    elif [[ "$cby" == "$EXPECT_BOARD" && "$cby_none" == "<null>" ]]; then
-      ok "T19b e2e: the MEASURED actor rides beside the claim (derived_actor=$EXPECT_BOARD); a no-claim row stays NULL"
+    # ALWAYS POPULATED, both rows. A column written only on divergence makes NULL
+    # mean three things — the claim agreed, the row predates the column, or the path
+    # does not populate it — and agreement is evidence in its own right: it says the
+    # uid WAS measured and DID corroborate, which a NULL can never say.
+    elif [[ "$cby" == "$EXPECT_BOARD" && "$cby_none" == "$EXPECT_BOARD" ]]; then
+      ok "T19b e2e: derived_actor=$EXPECT_BOARD on BOTH rows — divergent and agreeing alike; NULL keeps exactly one meaning"
     else
-      no "T19b e2e: derived_actor='$cby' (expected '$EXPECT_BOARD'), no-claim row='$cby_none' (expected <null>)"
+      no "T19b e2e: derived_actor='$cby' (claimed row) / '$cby_none' (no-claim row); both must be '$EXPECT_BOARD'"
     fi
     # 19c. The LEDGER half. `claimed_by` is written in two places from one variable
     #      — the tasks column and lifecycle_events' detail — and T19b covers only
@@ -392,10 +413,10 @@ else
       "SELECT COALESCE(detail,'') FROM lifecycle_events WHERE kind='task.created' AND ident='$tid';" 2>/dev/null)
     if [[ -z "$lact" ]]; then
       skip "T19c lifecycle_events unreadable; the ledger half is not graded"
-    elif [[ "$lact" == "${FORGE_BOARD}|"* && "$lact" == *"derived_actor=${EXPECT_BOARD}"* && "$lact_none" != *"derived_actor="* ]]; then
-      ok "T19c e2e: the ledger keeps actor=$FORGE_BOARD and carries derived_actor=$EXPECT_BOARD in detail; a no-claim row carries neither"
+    elif [[ "$lact" == "${FORGE_BOARD}|"* && "$lact" == *"derived_actor=${EXPECT_BOARD}"* && "$lact_none" == *"derived_actor=${EXPECT_BOARD}"* ]]; then
+      ok "T19c e2e: the ledger keeps actor=$FORGE_BOARD and carries derived_actor=$EXPECT_BOARD — on the agreeing row too"
     else
-      no "T19c e2e: ledger row='$lact' (want actor '$FORGE_BOARD' + derived_actor=$EXPECT_BOARD), no-claim detail='$lact_none'"
+      no "T19c e2e: ledger row='$lact' (want actor '$FORGE_BOARD' + derived_actor=$EXPECT_BOARD), no-claim detail='$lact_none' (want derived_actor=$EXPECT_BOARD)"
     fi
     # 20. THE REFUSAL, through the real exiting `fail`: the gate must NOT exist
     #     afterwards. rc alone would stay green if the verb refused for any other
@@ -410,7 +431,7 @@ else
     fb=$(sqlite3 "$SBOX/tasks/tasks.db" \
       "SELECT COALESCE(gate_filed_by,'') FROM tasks WHERE ident='$tid';" 2>/dev/null)
     if (( rc != 0 )); then
-      no "T20 e2e: task need --from=$FORGE_BOARD was REFUSED (rc$rc) — legitimate relay is broken: $(printf '%s' "$out" | head -c 160)"
+      no "T20 e2e: task need --from=$FORGE_BOARD was REFUSED (rc$rc) — this is the ~120-call-site filing idiom; refusing it truncates unsubshelled callers rather than failing them: $(printf '%s' "$out" | head -c 160)"
     elif [[ "$fb" == "$FORGE_BOARD" ]]; then
       ok "T20 e2e: the gate files and gate_filed_by keeps the claim ($FORGE_BOARD) — provenance, per DIVE-1401/1945/2015; what the claim does NOT get is the routing decision (T23)"
     else
@@ -476,6 +497,25 @@ else
   #     and a real gate to a real verifier while every arm passed. Run the fence's
   #     OWN predicate against the DEFAULT (un-redirected) store: it must trip.
   #     Read-only, and it never writes.
+  # 26. THE UID-LESS PRINCIPAL, which is the measurement that killed design 1.
+  #     `council` and `telegram` are not unix users and never will be, so NO
+  #     derivation can produce them. A build that returns the derived value here
+  #     does not harden the row — it reattributes it to whoever ran the process, and
+  #     `created_by` is what the whole board reads as ground truth. Deliberately
+  #     uses a name that CANNOT be a passwd entry on any runner, so the arm is not
+  #     quietly satisfied by a coincidence of naming.
+  cout=$(e2e task add "DIVE-2518 uid-less relay probe" --project=dive --from=council 2>&1)
+  ctid=$(printf '%s' "$cout" | grep -oE 'DIVE-[0-9]+' | head -1)
+  ccb=$(sqlite3 "$SBOX/tasks/tasks.db" \
+    "SELECT created_by||'|'||COALESCE(derived_actor,'<NULL>') FROM tasks WHERE ident='$ctid';" 2>/dev/null)
+  if [[ -z "$ctid" ]]; then
+    no "T26 the uid-less relay add failed outright: $(printf '%s' "$cout" | head -c 160)"
+  elif [[ "$ccb" == "council|$EXPECT_BOARD" ]]; then
+    ok "T26 a principal with NO uid keeps its name (created_by=council) and the runner is still measured beside it (derived_actor=$EXPECT_BOARD)"
+  else
+    no "T26 uid-less relay wrote '$ccb', expected 'council|$EXPECT_BOARD' — relay attribution is lost"
+  fi
+
   # 25. A BRAND-NEW STORE, where the FIRST WRITE is also the process that creates
   #     the schema. This is a different path from every other e2e arm here: those
   #     run `task init` first, so by the time they write, the store EXISTS and

--- a/tests/actor_claim_corroboration_unit.sh
+++ b/tests/actor_claim_corroboration_unit.sh
@@ -3,39 +3,45 @@
 #
 # W1 (DIVE-2517) sealed ONE uid-first derivation. This grades the half that makes
 # it BIND across the 43 `task_actor` sites: the derivation decides what gets
-# stamped, the claim is recorded beside it where it disagrees, and the one verb
-# where a claim decides an AUTHORIZATION refuses it outright.
+# stamped, the claim is recorded beside it where it disagrees, and no decision
+# anywhere reads the claim.
 #
 # WHAT THIS GRADES, and why each arm can fail:
-#   the claim never wins    T1-T3. `task_actor --from=<other>` and a forged
-#                           $SUDO_USER must both return the DERIVED actor. Both
-#                           forgeries are derived so they can never equal the live
-#                           caller's real name (the vacuity olivia caught in W1).
+#   the ENV path is shut    T1-T2. With no claim the answer comes from the uid and
+#                           never from $USER/$SUDO_USER — the hole that was actually
+#                           MEASURED (a plain env var, no privilege, no trace).
+#                           Forgeries are DERIVED from the runner's own name so they
+#                           can never coincide with it (the vacuity olivia caught in W1).
+#   the claim still relays  T3. A `--from` claim IS returned, deliberately: `council`
+#                           and `telegram` have no uid, so deriving would silently
+#                           reattribute their rows. What makes it safe is that the
+#                           measurement is taken anyway and travels beside it.
 #   the grade is reported   T4-T7. absent / corroborated / divergent /
 #                           unattributable are four distinct states, and folding
 #                           any two together is the absent-vs-not-measured
 #                           collapse this epoch exists to undo.
 #   the note is selective   T8. `claimed_by` is EMPTY when the claim agrees —
 #                           stamping every row would bury the disagreements.
-#   the refusal refuses     T9-T11. A divergent claim on a privileged verb must
-#                           return NON-ZERO *and* the reason must NAME the
-#                           condition. Graded by rc alone, deleting the condition
-#                           leaves the arm green (a refusal that always fires
-#                           passes too) — so T11 is the LIVENESS anchor: absent
-#                           and corroborated must PASS.
+#   the claim decides       T20/T23. NOTHING. `--from` is accepted and recorded and
+#   NOTHING                 believed by no decision: the gate still files (relay is
+#                           not broken), `gate_filed_by` carries the DERIVED actor,
+#                           and the reviewer lookup — the one outcome the claim used
+#                           to move — follows the derivation. T23 seeds two DIFFERENT
+#                           leads so a claim that won would route somewhere visible.
 #   the ladder degrades     T12-T13. An unreadable registry must fall to the
 #                           passwd rung, NOT to `cli`. Getting this wrong would
 #                           silently unattribute every row on the board.
 #   the sentinel survives   T14. `cli` still means "could not attribute", which
 #                           is what :2177/:2392/:3030 already branch on.
-#   the envelope hole shuts T15-T16. Non-root + forged $SUDO_USER must yield NO
-#                           envelope; root + $SUDO_USER must still yield the name
-#                           (the behaviour cmd_agent_runtime.sh measured).
 #   provenance is preserved T17-T18. `_actor_identity` is NOT replaced — the
 #                           dashboard's Clerk relay still wins — and the derived
 #                           value rides alongside it.
-#   end to end              T19-T21. Through the BUILT bundle, against a scratch
-#                           store, never the board.
+#   end to end              T19-T25. Through the BUILT bundle, against a scratch
+#                           store, never the board. T23 is the security arm: the
+#                           reviewer lookup — the one thing the claim DECIDED — now
+#                           follows the derivation, proven with two distinct leads.
+#                           T25 writes to a store the same process is creating, the
+#                           only path that exercises the base schema.
 #
 # GROUND TRUTH IS TAKEN WITHOUT THE CODE UNDER TEST: the caller's real name comes
 # from /proc/self/status resolved against /etc/passwd by awk. Never from `id`.
@@ -80,8 +86,7 @@ _load_from() {
 }
 _load_from src/lib/actor.sh _gate_passwd_stream actor_uid_to_name _gate_uid_to_agent \
            _gate_is_root _gate_caller_uid _gate_authenticated_actor actor_derive \
-           actor_registry_agent actor_board_name actor_claim actor_claim_note \
-           actor_require_corroborated
+           actor_registry_agent actor_board_name actor_claim actor_claim_note
 _load_from src/lib/tasks_db.sh task_actor task_actor_claim
 _load_from src/lib/registry.sh tier_unmeasured
 _load_from src/lib/validation.sh auto_sender_from_sudo
@@ -92,7 +97,7 @@ _ACTOR_REG_MEMO_KEY=""; _ACTOR_REG_MEMO_VAL=""; _ACTOR_REG_MEMO_TIER=""
 # `fail` really exits; in-process it would kill the harness mid-run and the
 # truncated log would read as a pass (no tally). Stub it to RECORD and return, so
 # an arm can assert both the status AND that the reason names the condition. The
-# real exiting `fail` is graded end-to-end by T19-T21 through the built bundle.
+# real exiting `fail` is graded end-to-end by T19-T24 through the built bundle.
 E_AUTH_REQUIRED=6; E_USAGE=2
 FAIL_MSG=""; FAIL_CODE=0
 fail(){ FAIL_CODE="$1"; shift; FAIL_MSG="$*"; return "$FAIL_CODE"; }
@@ -110,15 +115,19 @@ if [[ -z "$REAL_NAME" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 1. --from does NOT win. It used to win outright, first, before anything else.
+# 1. WITH NO CLAIM, the answer comes from the uid — never $USER, never $SUDO_USER.
+#    This is the hole that was MEASURED: `SUDO_USER=agent-olivia 5dive task ls --mine`
+#    acted as another agent with no privilege and left NO trace, because $SUDO_USER is
+#    an ordinary variable nothing verifies. A `--from` claim is a different threat —
+#    argv, deliberate, logged — and gets a different answer (T3).
 reset_memo
-got=$(task_actor "$FORGE_BOARD")
+got=$(SUDO_USER="$FORGE_SUDO" USER="$FORGE_SUDO" LOGNAME="$FORGE_SUDO" task_actor)
 if claim_is_vacuous "$FORGE_BOARD"; then
-  no "T1 VACUOUS — the forged claim '$FORGE_BOARD' equals the caller's own board name"
+  no "T1 VACUOUS — the forged name '$FORGE_BOARD' equals the caller's own board name"
 elif [[ "$got" == "$REAL_BOARD" ]]; then
-  ok "T1 task_actor --from=$FORGE_BOARD returned the DERIVED '$REAL_BOARD', not the claim"
+  ok "T1 no claim + forged SUDO_USER/USER/LOGNAME=$FORGE_SUDO still derives '$REAL_BOARD'"
 else
-  no "T1 the claim won: task_actor --from=$FORGE_BOARD returned '$got' (expected '$REAL_BOARD')"
+  no "T1 the env forgery moved the actor to '$got' (expected '$REAL_BOARD')"
 fi
 
 # 2. a forged $SUDO_USER does not move it either — the wiki's runtime repro,
@@ -135,13 +144,23 @@ else
   no "T2 the env forgery moved the actor to '$got' (expected '$REAL_BOARD')"
 fi
 
-# 3. both at once, which is what an attacker would actually do
+# 3. A CLAIM IS STILL RETURNED, deliberately. `council` files board rows as
+#    --from=council and the Telegram rail answers as --from=telegram; NEITHER HAS A
+#    UID, so no passwd walk can produce them and returning the derived value would
+#    silently reattribute the row to whoever ran the process. What makes it safe is
+#    that the measurement is taken anyway and travels beside it — a forged claim is
+#    falsifiable afterwards instead of being the only thing on file.
 reset_memo
-got=$(SUDO_USER="$FORGE_SUDO" task_actor "$FORGE_BOARD")
-if [[ "$got" == "$REAL_BOARD" ]]; then
-  ok "T3 --from AND SUDO_USER together did not move the actor (still '$REAL_BOARD')"
+got=$(task_actor "$FORGE_BOARD")
+# BARE call for the grade: task_actor above runs in $( ) and its ACTOR_* die with
+# that subshell — the same trap that NULLed claimed_by in the create path.
+actor_claim "$FORGE_BOARD" || true
+if [[ "$got" != "$FORGE_BOARD" ]]; then
+  no "T3 a relay claim was DROPPED: task_actor --from=$FORGE_BOARD returned '$got' — council/telegram attribution would be lost"
+elif [[ "$ACTOR_BOARD" == "$REAL_BOARD" && "$ACTOR_CLAIM_STATUS" == "divergent" ]]; then
+  ok "T3 the claim is returned for the record ('$FORGE_BOARD') while the uid is still MEASURED ('$ACTOR_BOARD', divergent)"
 else
-  no "T3 combined forgery moved the actor to '$got'"
+  no "T3 claim returned but the measurement was lost: ACTOR_BOARD='$ACTOR_BOARD' status='$ACTOR_CLAIM_STATUS'"
 fi
 
 # 4-7. the four claim states are DISTINCT. Folding any two is the collapse the
@@ -180,45 +199,12 @@ else
   no "T8 note absent='$n_absent' corroborated='$n_corrob' divergent='$n_diverge'"
 fi
 
-# 9. THE REFUSAL. Non-zero is not enough on its own — delete the condition and an
-#    rc-only arm stays green on whatever refusal fires next. Assert the reason
-#    NAMES both identities, which only the real condition can produce.
-reset_memo; FAIL_MSG=""; FAIL_CODE=0
-actor_require_corroborated "task need" "$FORGE_BOARD"; rc=$?
-if (( rc == 0 )); then
-  no "T9 a divergent claim was ACCEPTED on a privileged verb (rc 0)"
-elif (( FAIL_CODE != E_AUTH_REQUIRED )); then
-  no "T9 refused with code $FAIL_CODE, expected $E_AUTH_REQUIRED (auth_required)"
-elif [[ "$FAIL_MSG" == *"$FORGE_BOARD"* && "$FAIL_MSG" == *"$REAL_BOARD"* && "$FAIL_MSG" == *"task need"* ]]; then
-  ok "T9 divergent claim REFUSED rc$rc code $FAIL_CODE, reason names the claim, the derivation and the verb"
-else
-  no "T9 refused but the reason does not name both identities and the verb: '$FAIL_MSG'"
-fi
-
-# 10. the unattributable branch refuses too, with its OWN reason — so a reader
-#     can tell which of the two it was.
-reset_memo; FAIL_MSG=""; FAIL_CODE=0
-rc10=$( _gate_caller_uid(){ printf '0'; }
-        _gate_passwd_stream(){ printf 'root:x:0:0:::\n'; }
-        STUB_TIER="unknown:unregistered"
-        actor_require_corroborated "task need" "$FORGE_BOARD" >/dev/null 2>&1; printf '%s|%s' "$?" "$FAIL_MSG" )
-if [[ "${rc10%%|*}" != "0" && "${rc10#*|}" == *"cannot be corroborated"* ]]; then
-  ok "T10 an unattributable claim is refused with its own distinct reason"
-else
-  no "T10 expected non-zero + 'cannot be corroborated', got '$rc10'"
-fi
-
-# 11. LIVENESS ANCHOR. Without this a resolver that refuses EVERYTHING passes
-#     T9 and T10. absent and corroborated must both return 0 and set no reason.
-reset_memo; FAIL_MSG=""
-actor_require_corroborated "task need" ""; rc_a=$?
-reset_memo; FAIL_MSG=""
-actor_require_corroborated "task need" "$REAL_BOARD"; rc_c=$?
-if (( rc_a == 0 && rc_c == 0 )); then
-  ok "T11 LIVENESS: no claim (rc$rc_a) and a corroborating claim (rc$rc_c) both PASS"
-else
-  no "T11 the guard refuses a legitimate caller: absent rc$rc_a, corroborated rc$rc_c"
-fi
+# 9-11 REMOVED along with `actor_require_corroborated`. The refusal they graded is
+# gone: `--from` on `task need` is the corpus's established "agent X files this gate"
+# idiom (~120 call sites) and `gate_filed_by` has always been provenance, so the only
+# thing the claim actually DECIDED was `_gate_route_reviewer`. That call now takes the
+# derivation — a stronger property than refusing, since the claim moves no outcome at
+# all — and it is graded end to end by T23.
 
 # 12. the ladder DEGRADES to passwd when the registry cannot be read. Falling to
 #     `cli` here would silently unattribute every row the board ever writes.
@@ -255,30 +241,17 @@ else
   no "T14 non-agent uid returned '$got', expected the 'cli' sentinel"
 fi
 
-# 15. THE ENVELOPE HOLE. Non-root + forged $SUDO_USER used to mint an envelope
-#     naming another agent, because auto_sender_from_sudo was consulted whenever
-#     the EUID branch came back empty — i.e. for every non-agent caller.
-got=$( _gate_caller_uid(){ printf '1000'; }
-       _gate_is_root(){ return 1; }
-       _gate_passwd_stream(){ printf 'claude:x:1000:1000:::\n'; }
-       SUDO_USER="$FORGE_SUDO" _envelope_caller )
-if [[ -z "$got" ]]; then
-  ok "T15 non-root + SUDO_USER=$FORGE_SUDO yields NO envelope (the forgery is refused)"
-else
-  no "T15 a non-root caller forged an envelope naming '$got'"
-fi
-
-# 16. LIVENESS for T15: at real EUID 0 the same variable must still answer, or
-#     T15 passes on a function that returns empty unconditionally.
-got=$( _gate_caller_uid(){ printf '0'; }
-       _gate_is_root(){ return 0; }
-       _gate_passwd_stream(){ printf 'root:x:0:0:::\n'; }
-       SUDO_UID="" SUDO_USER="$FORGE_SUDO" _envelope_caller )
-if [[ "$got" == "$FORGE_BOARD" ]]; then
-  ok "T16 LIVENESS: at real euid 0, SUDO_USER still answers ('$FORGE_BOARD') — T15 is not vacuous"
-else
-  no "T16 root + SUDO_USER=$FORGE_SUDO gave '$got', expected '$FORGE_BOARD' (T15 may be vacuous)"
-fi
+# 15-16 REMOVED. They graded a root-gate on `_envelope_caller`'s $SUDO_USER fallback
+# that this ticket tried and REVERTED — tests/envelope_sender_fallback_unit.sh T3/T4
+# grade that resolver's TEXT for a self-contained `$EUID` + hardcoded
+# `done < /etc/passwd`, because its value feeds `envelope_tier` and an overridable
+# passwd source would be a new forgery vector there. lib/actor.sh reaches passwd
+# through `_gate_passwd_stream`, a FUNCTION, specifically so a harness can override
+# it. One field needs an injectable source to be testable, the other needs a
+# non-injectable one to be trustworthy, and that is a decision with its own review
+# rather than a side effect of collapsing task_actor. `_envelope_caller` is
+# unchanged here, so this harness asserts nothing about it — and
+# envelope_sender_fallback_unit (13/0) still owns it.
 
 # 17. provenance is NOT replaced. FIVEDIVE_AUDIT_USER is the dashboard's Clerk
 #     relay — a human with no uid on this box — and collapsing it onto the
@@ -383,10 +356,13 @@ else
     fi
     tid2=$(e2e task add "DIVE-2518 claimed row" --project=dive --from="$FORGE_BOARD" 2>&1 | grep -oE 'DIVE-[0-9]+' | head -1)
     cb=$(e2e task show "$tid2" | awk -F' = ' '/^created_by /{print $2; exit}')
-    if [[ "$cb" == "$EXPECT_BOARD" ]]; then
-      ok "T19 e2e: --from=$FORGE_BOARD stamped created_by=$EXPECT_BOARD (the derivation, not the claim)"
+    # created_by keeps the CLAIM — for a uid-less relay principal that is the only
+    # true answer — and `derived_actor` carries the uid that ran it. T19b is the half
+    # that makes the claim falsifiable; neither arm means anything without the other.
+    if [[ "$cb" == "$FORGE_BOARD" ]]; then
+      ok "T19 e2e: --from=$FORGE_BOARD stamped created_by=$FORGE_BOARD (relay attribution preserved)"
     else
-      no "T19 e2e: created_by='$cb', expected '$EXPECT_BOARD' (runner '$REAL_NAME')"
+      no "T19 e2e: created_by='$cb', expected the claim '$FORGE_BOARD' (relay would be lost)"
     fi
     # 19b. RECORD BOTH. T19 alone passes on a build that simply DROPS the claim,
     #      which is what the first cut did — `task_actor_claim` was called inside
@@ -394,15 +370,15 @@ else
     #      every divergent claim while created_by looked perfect. Half a fix reads
     #      exactly like a whole one unless the other half is asserted.
     cby=$(sqlite3 "$SBOX/tasks/tasks.db" \
-      "SELECT COALESCE(claimed_by,'<null>') FROM tasks WHERE ident='$tid2';" 2>/dev/null)
+      "SELECT COALESCE(derived_actor,'<null>') FROM tasks WHERE ident='$tid2';" 2>/dev/null)
     cby_none=$(sqlite3 "$SBOX/tasks/tasks.db" \
-      "SELECT COALESCE(claimed_by,'<null>') FROM tasks WHERE ident='$tid';" 2>/dev/null)
+      "SELECT COALESCE(derived_actor,'<null>') FROM tasks WHERE ident='$tid';" 2>/dev/null)
     if [[ -z "$cby" && -z "$cby_none" ]]; then
       skip "T19b sqlite3 unavailable or store unreadable; claimed_by not graded"
-    elif [[ "$cby" == "$FORGE_BOARD" && "$cby_none" == "<null>" ]]; then
-      ok "T19b e2e: the divergent claim is RECORDED (claimed_by=$FORGE_BOARD) and a no-claim row stays NULL"
+    elif [[ "$cby" == "$EXPECT_BOARD" && "$cby_none" == "<null>" ]]; then
+      ok "T19b e2e: the MEASURED actor rides beside the claim (derived_actor=$EXPECT_BOARD); a no-claim row stays NULL"
     else
-      no "T19b e2e: claimed_by='$cby' (expected '$FORGE_BOARD'), no-claim row='$cby_none' (expected <null>)"
+      no "T19b e2e: derived_actor='$cby' (expected '$EXPECT_BOARD'), no-claim row='$cby_none' (expected <null>)"
     fi
     # 19c. The LEDGER half. `claimed_by` is written in two places from one variable
     #      — the tasks column and lifecycle_events' detail — and T19b covers only
@@ -416,32 +392,31 @@ else
       "SELECT COALESCE(detail,'') FROM lifecycle_events WHERE kind='task.created' AND ident='$tid';" 2>/dev/null)
     if [[ -z "$lact" ]]; then
       skip "T19c lifecycle_events unreadable; the ledger half is not graded"
-    elif [[ "$lact" == "${EXPECT_BOARD}|"* && "$lact" == *"claimed_by=${FORGE_BOARD}"* && "$lact_none" != *"claimed_by="* ]]; then
-      ok "T19c e2e: the ledger keeps actor=$EXPECT_BOARD and carries claimed_by=$FORGE_BOARD in detail; a no-claim row carries neither"
+    elif [[ "$lact" == "${FORGE_BOARD}|"* && "$lact" == *"derived_actor=${EXPECT_BOARD}"* && "$lact_none" != *"derived_actor="* ]]; then
+      ok "T19c e2e: the ledger keeps actor=$FORGE_BOARD and carries derived_actor=$EXPECT_BOARD in detail; a no-claim row carries neither"
     else
-      no "T19c e2e: ledger row='$lact' (want actor '$EXPECT_BOARD' + claimed_by=$FORGE_BOARD), no-claim detail='$lact_none'"
+      no "T19c e2e: ledger row='$lact' (want actor '$FORGE_BOARD' + derived_actor=$EXPECT_BOARD), no-claim detail='$lact_none'"
     fi
     # 20. THE REFUSAL, through the real exiting `fail`: the gate must NOT exist
     #     afterwards. rc alone would stay green if the verb refused for any other
     #     reason and still filed the gate.
     out=$(e2e task need "$tid" --type=decision --ask="harness probe" --from="$FORGE_BOARD"); rc=$?
     gates=$(e2e task show "$tid" | grep -c 'human gate:' || true)
-    # The refusal CLASS depends on the runner too, and the two are not
-    # interchangeable: a runner the registry attributes gets `divergent` ("you
-    # claim X and the uid says Y"), one it cannot attribute gets `unattributable`
-    # ("I could not check"). Asserting only "some refusal happened" would accept
-    # either on any runner and stop grading the partition the code exists to draw.
-    if [[ "$EXPECT_BOARD" == "cli" ]]; then WANT_REASON="cannot be corroborated"
-    else                                    WANT_REASON="contradicts the derived actor"; fi
-    if (( rc == 0 )); then
-      no "T20 e2e: task need accepted a divergent --from (rc 0)"
-    elif (( gates != 0 )); then
-      no "T20 e2e: refused rc$rc but the gate was FILED anyway — the action ran"
-    elif [[ "$out" == *"$FORGE_BOARD"* && "$out" == *"$WANT_REASON"* ]]; then
-      ok "T20 e2e: task need --from=$FORGE_BOARD refused rc$rc, NO gate filed, reason names the claim ('$WANT_REASON' — correct class for runner '$REAL_NAME')"
+    # 20. `task need --from=<other>` now SUCCEEDS — the claim is not refused, it is
+    #     simply not believed. The gate IS filed, and `gate_filed_by` carries the
+    #     DERIVED actor, so a forged claim cannot put another agent's name on the
+    #     filer-of-record column.
+    out=$(e2e task need "$tid" --type=decision --ask="claim probe" --from="$FORGE_BOARD"); rc=$?
+    fb=$(sqlite3 "$SBOX/tasks/tasks.db" \
+      "SELECT COALESCE(gate_filed_by,'') FROM tasks WHERE ident='$tid';" 2>/dev/null)
+    if (( rc != 0 )); then
+      no "T20 e2e: task need --from=$FORGE_BOARD was REFUSED (rc$rc) — legitimate relay is broken: $(printf '%s' "$out" | head -c 160)"
+    elif [[ "$fb" == "$FORGE_BOARD" ]]; then
+      ok "T20 e2e: the gate files and gate_filed_by keeps the claim ($FORGE_BOARD) — provenance, per DIVE-1401/1945/2015; what the claim does NOT get is the routing decision (T23)"
     else
-      no "T20 e2e: refused rc$rc with no gate, but the reason is not the '$WANT_REASON' class: $(printf '%s' "$out" | head -c 200)"
+      no "T20 e2e: gate_filed_by='$fb', expected the claim '$FORGE_BOARD'"
     fi
+
     # 21. LIVENESS for T20: the same verb with NO claim must SUCCEED and file the
     #     gate. Without this, a `task need` broken for everyone passes T20.
     out=$(e2e task need "$tid" --type=decision --ask="harness liveness probe"); rc=$?
@@ -452,31 +427,46 @@ else
       no "T21 task need with no claim failed (rc$rc, gates=$gates): $(printf '%s' "$out" | head -c 200)"
     fi
 
-    # 22. THE EXCLUSION, EXERCISED. `task answer` is deliberately outside the
-    #     privileged set: `--from` there is provenance behind a control that
-    #     already fails closed, and the Telegram button rail relays a claim that
-    #     can never corroborate (`cmd_task_clear_recs` passes --from=telegram).
-    #     An exclusion nobody exercises is a hole with a comment on it — so assert
-    #     that the corroboration guard does NOT fire here. The verb may still
-    #     refuse for its own reasons (tier, proof, gate state); what must never
-    #     appear is THIS guard's refusal.
+    # 22. THE RELAY SURVIVES. `task answer --from=telegram` is the Telegram button
+    #     rail (cmd_task_clear_recs passes exactly that), and it must not be refused
+    #     or slowed by anything this ticket added.
     out=$(e2e task answer "$tid" --value=A --from=telegram)
     if [[ "$out" == *"contradicts the derived actor"* || "$out" == *"cannot be corroborated"* ]]; then
-      no "T22 the corroboration guard fired on 'task answer', which is excluded by design — this breaks the Telegram button rail: $(printf '%s' "$out" | head -c 200)"
+      no "T22 a corroboration refusal fired on 'task answer' — the Telegram relay rail is broken: $(printf '%s' "$out" | head -c 200)"
     else
-      ok "T22 'task answer --from=telegram' is NOT refused by the corroboration guard (the relay rail survives)"
+      ok "T22 'task answer --from=telegram' is not refused — the relay rail survives"
     fi
 
-    # 23. DIFFERENTIAL for T22. Without this, T22 passes on a build where the
-    #     guard was never wired at all. The SAME non-corroborating claim, on the
-    #     verb that IS in the set, must produce exactly the refusal T22 forbids.
-    tid3=$(e2e task add "DIVE-2518 exclusion differential" --project=dive 2>&1 | grep -oE 'DIVE-[0-9]+' | head -1)
-    out=$(e2e task need "$tid3" --type=decision --ask="differential probe" --from=telegram); rc=$?
-    if (( rc != 0 )) && [[ "$out" == *"contradicts the derived actor"* || "$out" == *"cannot be corroborated"* ]]; then
-      ok "T23 the SAME claim on 'task need' IS refused — the exclusion is verb-scoped, not a dead guard"
+    # 23. THE ONE OUTCOME THE CLAIM USED TO MOVE: `_gate_route_reviewer` picks WHO
+    #     MAY CLEAR the gate, from the filer. Seed the org so the CLAIMED agent and
+    #     the DERIVED agent report to two DIFFERENT leads, then file with the claim.
+    #     `routed_reviewer` must follow the derivation. Two distinct leads is the
+    #     whole design of the arm — with one lead, or none, both answers coincide
+    #     and a claim that WON would look identical to one that lost.
+    sqlite3 "$SBOX/tasks/tasks.db" \
+      "INSERT OR REPLACE INTO agents_org(name,reports_to) VALUES('leadclaimed',NULL),('leadderived',NULL),('$FORGE_BOARD','leadclaimed'),('$EXPECT_BOARD','leadderived');" 2>/dev/null
+    tid4=$(e2e task add "DIVE-2518 routing probe" --project=dive 2>&1 | grep -oE 'DIVE-[0-9]+' | head -1)
+    #     The ASK has to trip the internal-ops carve-out, because that is one of the
+    #     four branches that calls _gate_route_reviewer at all — a generic ask files a
+    #     gate that never consults the org table, which is what made the first cut of
+    #     this arm SKIP with an empty routed_reviewer.
+    e2e task need "$tid4" --type=decision \
+      --ask="Wipe the test board rows and rebuild the task board from the audit log?" \
+      --from="$FORGE_BOARD" >/dev/null 2>&1
+    rr=$(sqlite3 "$SBOX/tasks/tasks.db" \
+      "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='$tid4';" 2>/dev/null)
+    seeded=$(sqlite3 "$SBOX/tasks/tasks.db" \
+      "SELECT COUNT(*) FROM agents_org WHERE name IN('$FORGE_BOARD','$EXPECT_BOARD');" 2>/dev/null)
+    if [[ "$seeded" != "2" ]]; then
+      skip "T23 could not seed two distinct leads (agents_org rows=$seeded); the arm would not distinguish claimed from derived"
+    elif [[ "$rr" == "leadclaimed" ]]; then
+      no "T23 the CLAIM chose the reviewer: routed_reviewer='leadclaimed' — --from still moves an authorization outcome"
+    elif [[ "$rr" == "leadderived" ]]; then
+      ok "T23 the reviewer follows the DERIVATION (routed_reviewer=leadderived), not the claim '$FORGE_BOARD'->leadclaimed"
     else
-      no "T23 'task need --from=telegram' was not refused (rc$rc) — T22 proves nothing: $(printf '%s' "$out" | head -c 200)"
+      skip "T23 routed_reviewer='$rr' — neither seeded lead; routing did not reach the org table on this store"
     fi
+
   fi
   fi
 
@@ -486,6 +476,27 @@ else
   #     and a real gate to a real verifier while every arm passed. Run the fence's
   #     OWN predicate against the DEFAULT (un-redirected) store: it must trip.
   #     Read-only, and it never writes.
+  # 25. A BRAND-NEW STORE, where the FIRST WRITE is also the process that creates
+  #     the schema. This is a different path from every other e2e arm here: those
+  #     run `task init` first, so by the time they write, the store EXISTS and
+  #     `_tasks_db_migrate` has run. A fresh store is built from `_tasks_schema` and
+  #     never runs the migration at all, so a column added only to the migration
+  #     array is present on every existing board and absent from every new one —
+  #     and the error surfaces only on a first write, which nobody with a working
+  #     board ever performs. That is exactly what shipped and what council caught.
+  NBOX=$(mktemp -d)
+  nout=$(STATE_DIR="$NBOX" TASKS_DIR="$NBOX" TASKS_DB="$NBOX/tasks.db" \
+         "$BIN" task add "DIVE-2518 fresh-store probe" --project=dive --from=council 2>&1); nrc=$?
+  ncb=$(sqlite3 "$NBOX/tasks.db" "SELECT created_by||'|'||COALESCE(derived_actor,'') FROM tasks LIMIT 1;" 2>/dev/null)
+  if (( nrc != 0 )) || [[ -z "$ncb" ]]; then
+    no "T25 the FIRST write to a brand-new store failed (rc$nrc): $(printf '%s' "$nout" | head -c 160)"
+  elif [[ "$ncb" == "council|$EXPECT_BOARD" ]]; then
+    ok "T25 a brand-new store accepts its first write and records both (created_by=council, derived_actor=$EXPECT_BOARD)"
+  else
+    no "T25 fresh store wrote '$ncb', expected 'council|$EXPECT_BOARD'"
+  fi
+  rm -rf "$NBOX"
+
   unfenced=$("$BIN" task ls 2>/dev/null | grep -c 'DIVE-' || true)
   if (( unfenced == 0 )); then
     skip "T24 the default store lists 0 rows on this runner, so the fence has nothing to trip on"

--- a/tests/actor_claim_corroboration_unit.sh
+++ b/tests/actor_claim_corroboration_unit.sh
@@ -366,12 +366,27 @@ else
     skip "T19-T21 could not create a scratch row in the (proven-isolated) store"
   else
     # 19. created_by is the DERIVED actor even when --from claims otherwise.
+    # DERIVE the expected board name; do NOT assume the runner is a registered
+    # agent. The in-process arms above stub `agent_tier` (registry.sh owns whether
+    # the file is read correctly), so they see every caller as registered — but
+    # these arms go through the REAL registry, and a principal it does not list is
+    # the `cli` sentinel by design. Hardcoding `$REAL_BOARD` here made T19/T20 red
+    # for `claude` (uid 1000, not a registered agent) while the product was behaving
+    # exactly as specified. Ground truth is the registry FILE, read directly, not
+    # `actor_registry_agent` — that is the function under test.
+    EXPECT_BOARD="cli"
+    if jq -e --arg n "$REAL_BOARD" '(.agents|type=="object") and (.agents|has($n))' \
+         /var/lib/5dive/agents.json >/dev/null 2>&1; then
+      EXPECT_BOARD="$REAL_BOARD"
+    elif [[ "$REAL_NAME" == agent-* ]]; then
+      EXPECT_BOARD="$REAL_BOARD"     # the passwd rung: registry silent, name is agent-*
+    fi
     tid2=$(e2e task add "DIVE-2518 claimed row" --project=dive --from="$FORGE_BOARD" 2>&1 | grep -oE 'DIVE-[0-9]+' | head -1)
     cb=$(e2e task show "$tid2" | awk -F' = ' '/^created_by /{print $2; exit}')
-    if [[ "$cb" == "$REAL_BOARD" ]]; then
-      ok "T19 e2e: --from=$FORGE_BOARD stamped created_by=$REAL_BOARD (the derivation, not the claim)"
+    if [[ "$cb" == "$EXPECT_BOARD" ]]; then
+      ok "T19 e2e: --from=$FORGE_BOARD stamped created_by=$EXPECT_BOARD (the derivation, not the claim)"
     else
-      no "T19 e2e: created_by='$cb', expected '$REAL_BOARD'"
+      no "T19 e2e: created_by='$cb', expected '$EXPECT_BOARD' (runner '$REAL_NAME')"
     fi
     # 19b. RECORD BOTH. T19 alone passes on a build that simply DROPS the claim,
     #      which is what the first cut did — `task_actor_claim` was called inside
@@ -394,14 +409,21 @@ else
     #     reason and still filed the gate.
     out=$(e2e task need "$tid" --type=decision --ask="harness probe" --from="$FORGE_BOARD"); rc=$?
     gates=$(e2e task show "$tid" | grep -c 'human gate:' || true)
+    # The refusal CLASS depends on the runner too, and the two are not
+    # interchangeable: a runner the registry attributes gets `divergent` ("you
+    # claim X and the uid says Y"), one it cannot attribute gets `unattributable`
+    # ("I could not check"). Asserting only "some refusal happened" would accept
+    # either on any runner and stop grading the partition the code exists to draw.
+    if [[ "$EXPECT_BOARD" == "cli" ]]; then WANT_REASON="cannot be corroborated"
+    else                                    WANT_REASON="contradicts the derived actor"; fi
     if (( rc == 0 )); then
       no "T20 e2e: task need accepted a divergent --from (rc 0)"
     elif (( gates != 0 )); then
       no "T20 e2e: refused rc$rc but the gate was FILED anyway — the action ran"
-    elif [[ "$out" == *"$FORGE_BOARD"* && "$out" == *"contradicts"* ]]; then
-      ok "T20 e2e: task need --from=$FORGE_BOARD refused rc$rc, NO gate filed, reason names the claim"
+    elif [[ "$out" == *"$FORGE_BOARD"* && "$out" == *"$WANT_REASON"* ]]; then
+      ok "T20 e2e: task need --from=$FORGE_BOARD refused rc$rc, NO gate filed, reason names the claim ('$WANT_REASON' — correct class for runner '$REAL_NAME')"
     else
-      no "T20 e2e: refused rc$rc with no gate, but the reason is unrecognisable: $(printf '%s' "$out" | head -c 200)"
+      no "T20 e2e: refused rc$rc with no gate, but the reason is not the '$WANT_REASON' class: $(printf '%s' "$out" | head -c 200)"
     fi
     # 21. LIVENESS for T20: the same verb with NO claim must SUCCEED and file the
     #     gate. Without this, a `task need` broken for everyone passes T20.
@@ -412,7 +434,46 @@ else
     else
       no "T21 task need with no claim failed (rc$rc, gates=$gates): $(printf '%s' "$out" | head -c 200)"
     fi
+
+    # 22. THE EXCLUSION, EXERCISED. `task answer` is deliberately outside the
+    #     privileged set: `--from` there is provenance behind a control that
+    #     already fails closed, and the Telegram button rail relays a claim that
+    #     can never corroborate (`cmd_task_clear_recs` passes --from=telegram).
+    #     An exclusion nobody exercises is a hole with a comment on it — so assert
+    #     that the corroboration guard does NOT fire here. The verb may still
+    #     refuse for its own reasons (tier, proof, gate state); what must never
+    #     appear is THIS guard's refusal.
+    out=$(e2e task answer "$tid" --value=A --from=telegram)
+    if [[ "$out" == *"contradicts the derived actor"* || "$out" == *"cannot be corroborated"* ]]; then
+      no "T22 the corroboration guard fired on 'task answer', which is excluded by design — this breaks the Telegram button rail: $(printf '%s' "$out" | head -c 200)"
+    else
+      ok "T22 'task answer --from=telegram' is NOT refused by the corroboration guard (the relay rail survives)"
+    fi
+
+    # 23. DIFFERENTIAL for T22. Without this, T22 passes on a build where the
+    #     guard was never wired at all. The SAME non-corroborating claim, on the
+    #     verb that IS in the set, must produce exactly the refusal T22 forbids.
+    tid3=$(e2e task add "DIVE-2518 exclusion differential" --project=dive 2>&1 | grep -oE 'DIVE-[0-9]+' | head -1)
+    out=$(e2e task need "$tid3" --type=decision --ask="differential probe" --from=telegram); rc=$?
+    if (( rc != 0 )) && [[ "$out" == *"contradicts the derived actor"* || "$out" == *"cannot be corroborated"* ]]; then
+      ok "T23 the SAME claim on 'task need' IS refused — the exclusion is verb-scoped, not a dead guard"
+    else
+      no "T23 'task need --from=telegram' was not refused (rc$rc) — T22 proves nothing: $(printf '%s' "$out" | head -c 200)"
+    fi
   fi
+  fi
+
+  # 24. THE ISOLATION FENCE MUST BE ABLE TO GO RED. A fence that passes whether or
+  #     not the store is isolated is the same defect one layer up — and this exact
+  #     harness shipped an iteration that wrote two real rows to the shared board
+  #     and a real gate to a real verifier while every arm passed. Run the fence's
+  #     OWN predicate against the DEFAULT (un-redirected) store: it must trip.
+  #     Read-only, and it never writes.
+  unfenced=$("$BIN" task ls 2>/dev/null | grep -c 'DIVE-' || true)
+  if (( unfenced == 0 )); then
+    skip "T24 the default store lists 0 rows on this runner, so the fence has nothing to trip on"
+  elif (( unfenced != 0 )); then
+    ok "T24 the isolation fence's predicate TRIPS on the un-redirected store ($unfenced rows) — it is not a fence that passes either way"
   fi
   rm -rf "$SBOX"
 fi

--- a/tests/gate_channelless_escalation_unit.sh
+++ b/tests/gate_channelless_escalation_unit.sh
@@ -27,6 +27,9 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: `--from` is a CLAIM that must corroborate the uid-derived actor,
+# so filing a gate AS dev3 now means DERIVING as dev3. tests/lib/actor_seam.sh.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-chanless.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
@@ -169,7 +172,7 @@ db "INSERT INTO tasks (ident,title,priority,assignee,created_by,kind,status)
     VALUES ('DIVE-9004','unnotified','high','dev3','dev3','standard','todo');"
 did=$(db "SELECT id FROM tasks WHERE ident='DIVE-9004';")
 FILER_SELF=dev3 READABLE="" PAIRED=""
-out=$( (cmd_task_need DIVE-9004 --type=decision --ask="which way?" --options="A|B" --recommend="A" --from=dev3) 2>&1 ); rc=$?
+out=$( (actor_seam_as dev3; cmd_task_need DIVE-9004 --type=decision --ask="which way?" --options="A|B" --recommend="A" --from=dev3) 2>&1 ); rc=$?
 [[ "$rc" == "0" ]] && ok_t "cmd_task_need still FILES the gate when nobody can be pinged" \
   || bad_t "unnotified gate still files" "rc=$rc out=${out:0:200}"
 row=$(db "SELECT status||'|'||COALESCE(need_type,'-')||'|'||COALESCE(gate_pinged_at,'NULL') FROM tasks WHERE id=${did};")

--- a/tests/gate_filer_of_record_unit.sh
+++ b/tests/gate_filer_of_record_unit.sh
@@ -32,6 +32,9 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: `--from` is a CLAIM that must corroborate the uid-derived actor,
+# so filing a gate AS dev3 now means DERIVING as dev3. tests/lib/actor_seam.sh.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-filer-record.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
@@ -108,7 +111,7 @@ run_esc() { : >"$TMP/out"; cmd_task_gate_escalate "$1" >"$TMP/out" 2>&1; local r
 db "INSERT INTO tasks (ident,title,priority,assignee,created_by,kind,status)
     VALUES ('DIVE-9101','creators task','high','main','main','standard','todo');"
 FILER_SELF=""; READABLE=""; PAIRED=""
-out=$( (cmd_task_need DIVE-9101 --type=decision --ask="which way?" --options="A|B" --recommend="A" --from=dev3) 2>&1 )
+out=$( (actor_seam_as dev3; cmd_task_need DIVE-9101 --type=decision --ask="which way?" --options="A|B" --recommend="A" --from=dev3) 2>&1 )
 row=$(db "SELECT COALESCE(gate_filed_by,'NULL')||'|'||COALESCE(created_by,'NULL')||'|'||COALESCE(assignee,'NULL')
           FROM tasks WHERE ident='DIVE-9101';")
 [[ "$row" == "dev3|main|dev3" ]] \
@@ -162,7 +165,7 @@ run_esc DIVE-9102; rc=$?
 
 # ---- 4. withdraw clears the stamp with the rest of the provenance ------------
 FILER_SELF=""; READABLE="qa olivia main"; PAIRED="qa olivia main"
-out=$( (cmd_task_need DIVE-9101 --withdraw --from=dev3) 2>&1 ); rc=$?
+out=$( (actor_seam_as dev3; cmd_task_need DIVE-9101 --withdraw --from=dev3) 2>&1 ); rc=$?
 left=$(db "SELECT COALESCE(gate_filed_by,'NULL')||'|'||COALESCE(need_type,'NULL') FROM tasks WHERE ident='DIVE-9101';")
 [[ "$left" == "NULL|NULL" ]] \
   && ok_t "task need --withdraw clears gate_filed_by with the gate" \

--- a/tests/gate_floor_declared_discussion_unit.sh
+++ b/tests/gate_floor_declared_discussion_unit.sh
@@ -48,6 +48,9 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: `--from` is provenance; the TIER and ROUTING decisions read the uid
+# derivation, so an arm impersonating a filer must DERIVE as them.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-discusses-unit.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
@@ -101,7 +104,7 @@ DESIGN_WHY="this is a data-model sizing question about how to REPRESENT credenti
 # ---------------------------------------------------------------------------
 # 1: THE REPRO, ask axis — a design decision naming 'credential' reaches the LEAD
 route_reset; seed DIVE-401
-cmd_task_need DIVE-401 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-401 --type=decision --from=dev \
   --ask="$DESIGN_ASK" --options="capability|clearance" --recommend="clearance" \
   --discusses="$DESIGN_WHY" >/dev/null 2>&1
 [[ "$(tierof DIVE-401)" == "1" ]] && ok_t "repro/ask: declared design decision downgraded to tier 1" || bad_t "repro/ask tier 1" "got '$(tierof DIVE-401)'"
@@ -112,7 +115,7 @@ cmd_task_need DIVE-401 --type=decision --from=dev \
 # 2: THE REPRO, TITLE axis (DIVE-1957) — the ask is byte-neutral and the floor
 #    keyword lives ONLY in the task title, which the filer cannot reword.
 route_reset; seed DIVE-402 "design the token exchange between the runtime and the broker"
-cmd_task_need DIVE-402 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-402 --type=decision --from=dev \
   --ask="Should the exchange be modelled as a synchronous call or an async queue?" \
   --options="sync|async" --recommend="async" \
   --discusses="a transport-shape design question; the title names the subsystem, nothing is being minted or handled" >/dev/null 2>&1
@@ -123,7 +126,7 @@ cmd_task_need DIVE-402 --type=decision --from=dev \
 #    If these ever pass at tier 1 the suite above is grading a floor that stopped
 #    firing for some other reason, and every arm is vacuous.
 route_reset; seed DIVE-403
-cmd_task_need DIVE-403 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-403 --type=decision --from=dev \
   --ask="$DESIGN_ASK" --options="capability|clearance" --recommend="clearance" >/dev/null 2>&1
 [[ "$(tierof DIVE-403)" == "2" ]] && ok_t "mutation: same ask WITHOUT --discusses still floors to tier 2" || bad_t "mutation ask tier 2" "got '$(tierof DIVE-403)'"
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "mutation: same ask WITHOUT --discusses still pings the human" || bad_t "mutation ask pings human" "HUMAN_PINGED=$HUMAN_PINGED"
@@ -142,7 +145,7 @@ res404=$( JSON_MODE=0; cmd_task_need DIVE-404 --type=decision --from=dev \
 
 # 4: SAFETY — the non-appealable MONEY core survives any declaration.
 route_reset; seed DIVE-405
-cmd_task_need DIVE-405 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-405 --type=decision --from=dev \
   --ask="How should we model the credential store, and do we refund the affected customers \$500 each?" \
   --options="A|B" --recommend="A" --discusses="mostly a data-model question" >/dev/null 2>&1
 [[ "$(tierof DIVE-405)" == "2" ]] && ok_t "safety: money residual refuses the appeal, stays tier 2" || bad_t "safety money tier 2" "got '$(tierof DIVE-405)'"
@@ -150,7 +153,7 @@ cmd_task_need DIVE-405 --type=decision --from=dev \
 
 # 5: SAFETY — the non-appealable IRREVERSIBLE-INFRA core survives any declaration.
 route_reset; seed DIVE-406
-cmd_task_need DIVE-406 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-406 --type=decision --from=dev \
   --ask="Model the credential lifecycle — and revoke the leaked key + move the dns record while we are here?" \
   --options="A|B" --recommend="A" --discusses="framing it as a lifecycle design question" >/dev/null 2>&1
 [[ "$(tierof DIVE-406)" == "2" ]] && ok_t "safety: revoke/dns residual refuses the appeal, stays tier 2" || bad_t "safety infra tier 2" "got '$(tierof DIVE-406)'"
@@ -197,13 +200,13 @@ _gate_tier2_floor_hit "${SR_ASK_2146} ${SR_TITLE_2146}" \
   && bad_t "precondition: the floor is NOT the self-restart confirm's enforcer" "floor matched '$(_gate_tier2_floor_term "${SR_ASK_2146} ${SR_TITLE_2146}")' — the DIVE-2146 entanglement is now REAL and this ticket must re-open it" \
   || ok_t "precondition REFUTED: the real DIVE-2146 ask+title trip NO floor term — the floor never enforced the self-restart confirm"
 route_reset; seed DIVE-408 "$SR_TITLE_2146"
-cmd_task_need DIVE-408 --type=approval --from=dev --ask="$SR_ASK_2146" >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-408 --type=approval --from=dev --ask="$SR_ASK_2146" >/dev/null 2>&1
 sr_tier="$(tierof DIVE-408)"; sr_ping="$HUMAN_PINGED"
 [[ "$sr_ping" == "1" ]] && ok_t "precondition: the self-restart gate still reaches the paired human (tier $sr_tier), unchanged" || bad_t "precondition human reached" "tier=$sr_tier ping=$sr_ping"
 # And the counterfactual olivia actually cares about: hand main its pin back and
 # the gate is hard-human, by the pin, with or without this ticket.
 route_reset; seed DIVE-419 "$SR_TITLE_2146"
-cmd_task_need DIVE-419 --type=approval --from=dev --tier=2 --ask="$SR_ASK_2146" >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-419 --type=approval --from=dev --tier=2 --ask="$SR_ASK_2146" >/dev/null 2>&1
 [[ "$(tierof DIVE-419)" == "2" && "$HUMAN_PINGED" == "1" ]] \
   && ok_t "precondition: the pinned re-file (what DIVE-2146 actually did) is hard-human independent of the floor" \
   || bad_t "precondition pinned refile" "tier=$(tierof DIVE-419) ping=$HUMAN_PINGED"
@@ -211,7 +214,7 @@ cmd_task_need DIVE-419 --type=approval --from=dev --tier=2 --ask="$SR_ASK_2146" 
 # 8: SAFETY — an explicit --tier=2 pin is the caller's hard-human contract and
 #    outranks the appeal (DIVE-1957). Warn, do not obey.
 route_reset; seed DIVE-409
-cmd_task_need DIVE-409 --type=decision --from=dev --tier=2 \
+actor_seam_as dev; cmd_task_need DIVE-409 --type=decision --from=dev --tier=2 \
   --ask="$DESIGN_ASK" --options="capability|clearance" --recommend="clearance" \
   --discusses="$DESIGN_WHY" >/dev/null 2>&1
 [[ "$(tierof DIVE-409)" == "2" ]] && ok_t "safety: --tier=2 pin vetoes the appeal" || bad_t "safety pin tier 2" "got '$(tierof DIVE-409)'"
@@ -219,7 +222,7 @@ cmd_task_need DIVE-409 --type=decision --from=dev --tier=2 \
 
 # 9: SAFETY — the LEAD has no reviewer above them, so there is nobody to appeal TO.
 route_reset; seed DIVE-410
-cmd_task_need DIVE-410 --type=decision --from=main \
+actor_seam_as main; cmd_task_need DIVE-410 --type=decision --from=main \
   --ask="$DESIGN_ASK" --options="capability|clearance" --recommend="clearance" \
   --discusses="$DESIGN_WHY" >/dev/null 2>&1
 [[ "$(tierof DIVE-410)" == "2" ]] && ok_t "safety: lead-filed appeal has no reviewer, stays tier 2" || bad_t "safety lead tier 2" "got '$(tierof DIVE-410)'"
@@ -227,7 +230,7 @@ cmd_task_need DIVE-410 --type=decision --from=main \
 # 10: NO-OP — a decision the floor never touched is unchanged by the flag's absence
 #     AND by its presence (the appeal warns rather than silently re-tiering).
 route_reset; seed DIVE-411
-cmd_task_need DIVE-411 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-411 --type=decision --from=dev \
   --ask="Should the dashboard column order be priority-first or age-first?" \
   --options="priority|age" --recommend="priority" >/dev/null 2>&1
 [[ "$(tierof DIVE-411)" == "1" ]] && ok_t "no-op: an unfloored decision is untouched (tier 1)" || bad_t "no-op tier 1" "got '$(tierof DIVE-411)'"
@@ -252,13 +255,13 @@ grep -q -- "--discusses" <<<"$ann2" && bad_t "announce/approval must NOT adverti
 # 13: AUDIT — the declaration is on the record whether it applied or was refused.
 #     That attributability is the whole reason a declaration beats a reworded ask.
 route_reset; seed DIVE-414
-cmd_task_need DIVE-414 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-414 --type=decision --from=dev \
   --ask="$DESIGN_ASK" --options="capability|clearance" --recommend="clearance" \
   --discusses="$DESIGN_WHY" >/dev/null 2>&1
 grep -q "floor-appeal applied" "$AUDIT_FILE" && ok_t "audit: an APPLIED appeal is recorded" || bad_t "audit applied" "$(cat "$AUDIT_FILE")"
 grep -q "declared=" "$AUDIT_FILE" && ok_t "audit: the declared reason is recorded verbatim" || bad_t "audit declared" "$(cat "$AUDIT_FILE")"
 route_reset; seed DIVE-415
-cmd_task_need DIVE-415 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-415 --type=decision --from=dev \
   --ask="Model the store, and refund the customer \$500?" --options="A|B" --recommend="A" \
   --discusses="claiming this is only design" >/dev/null 2>&1
 grep -q "floor-appeal refused" "$AUDIT_FILE" && ok_t "audit: a REFUSED appeal is recorded too (an attempt is evidence)" || bad_t "audit refused" "$(cat "$AUDIT_FILE")"

--- a/tests/gate_internal_ops_floor_unit.sh
+++ b/tests/gate_internal_ops_floor_unit.sh
@@ -25,6 +25,9 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: `--from` is provenance; TIER and ROUTING read the uid derivation, so an
+# arm impersonating a filer must DERIVE as them. tests/lib/actor_seam.sh.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-internalops-unit.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
@@ -73,7 +76,7 @@ routedof()  { db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='$1
 
 # --- 1: THE REPRO — dev's board-wipe keep/discard decision routes to the LEAD, not lodar
 route_reset; seed DIVE-301
-cmd_task_need DIVE-301 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-301 --type=decision --from=dev \
   --ask="The task board was wiped/destroyed at 04:20 and my in-flight work is at risk — keep or discard my uncommitted work and rebuild the board from the audit log?" \
   --options="keep|discard" --recommend="keep" >/dev/null 2>&1
 [[ "$(tierof DIVE-301)" == "1" ]] && ok_t "repro: board-wipe decision downgraded to tier 1 (not hard-human)" || bad_t "repro tier 1" "got '$(tierof DIVE-301)'"
@@ -83,7 +86,7 @@ cmd_task_need DIVE-301 --type=decision --from=dev \
 
 # --- 2: SAFETY — a genuine prod-destructive ask (no internal-ops vocab) stays hard-human
 route_reset; seed DIVE-302
-cmd_task_need DIVE-302 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-302 --type=decision --from=dev \
   --ask="Drop the production customers table to reclaim space — irreversible, confirm?" \
   --options="yes|no" --recommend="no" >/dev/null 2>&1
 [[ "$(tierof DIVE-302)" == "2" ]] && ok_t "safety: prod drop-table stays tier 2 (human)" || bad_t "safety prod tier 2" "got '$(tierof DIVE-302)'"
@@ -91,28 +94,28 @@ cmd_task_need DIVE-302 --type=decision --from=dev \
 
 # --- 3: SAFETY — internal-ops vocab BUT a real residual floor term (revoke) still floors
 route_reset; seed DIVE-303
-cmd_task_need DIVE-303 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-303 --type=decision --from=dev \
   --ask="Rebuild the task board after the wipe AND revoke the leaked API key — proceed?" \
   --options="yes|no" --recommend="yes" >/dev/null 2>&1
 [[ "$(tierof DIVE-303)" == "2" ]] && ok_t "safety: internal-ops + 'revoke' residual stays tier 2 (human)" || bad_t "safety revoke residual" "got '$(tierof DIVE-303)'"
 
 # --- 4: SAFETY — money residual (refund/$) inside an internal-ops ask still floors
 route_reset; seed DIVE-304
-cmd_task_need DIVE-304 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-304 --type=decision --from=dev \
   --ask="Wipe the board test rows after refunding the customer \$500 — go?" \
   --options="yes|no" --recommend="no" >/dev/null 2>&1
 [[ "$(tierof DIVE-304)" == "2" ]] && ok_t "safety: internal-ops + money residual stays tier 2 (human)" || bad_t "safety money residual" "got '$(tierof DIVE-304)'"
 
 # --- 5: SAFETY — the LEAD filing it has no reviewer, so it is NOT downgraded (human)
 route_reset; seed DIVE-305
-cmd_task_need DIVE-305 --type=decision --from=main \
+actor_seam_as main; cmd_task_need DIVE-305 --type=decision --from=main \
   --ask="Board wiped — discard my uncommitted work and rebuild from the audit log?" \
   --options="keep|discard" --recommend="keep" >/dev/null 2>&1
 [[ "$(tierof DIVE-305)" == "2" ]] && ok_t "safety: lead-filed internal-ops stays tier 2 (no reviewer)" || bad_t "safety lead tier 2" "got '$(tierof DIVE-305)'"
 
 # --- 6: NO-OP — a non-floored internal decision is untouched (default tier-1 routing)
 route_reset; seed DIVE-306
-cmd_task_need DIVE-306 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-306 --type=decision --from=dev \
   --ask="Which task board column order should we show, priority-first or age-first?" \
   --options="priority|age" --recommend="priority" >/dev/null 2>&1
 [[ "$(tierof DIVE-306)" == "1" ]] && ok_t "no-op: non-floored internal decision stays tier 1 (unchanged)" || bad_t "no-op tier 1" "got '$(tierof DIVE-306)'"
@@ -120,7 +123,7 @@ cmd_task_need DIVE-306 --type=decision --from=dev \
 
 # --- 7: SAFETY — a plain destructive decision with NO internal-ops vocab still floors
 route_reset; seed DIVE-307
-cmd_task_need DIVE-307 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-307 --type=decision --from=dev \
   --ask="Delete all the old render artifacts to free disk — destroy them permanently?" \
   --options="yes|no" --recommend="yes" >/dev/null 2>&1
 [[ "$(tierof DIVE-307)" == "2" ]] && ok_t "safety: destructive w/o internal-ops vocab stays tier 2 (human)" || bad_t "safety plain destructive" "got '$(tierof DIVE-307)'"
@@ -130,7 +133,7 @@ cmd_task_need DIVE-307 --type=decision --from=dev \
 #        governs the PRODUCTION DATABASE, not the board, so 'delete' is NOT
 #        co-referent to an internal object → survives the residual → stays tier 2.
 route_reset; seed DIVE-308
-cmd_task_need DIVE-308 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-308 --type=decision --from=dev \
   --ask="Delete the production database as part of the board recovery — proceed?" \
   --options="yes|no" --recommend="no" >/dev/null 2>&1
 [[ "$(tierof DIVE-308)" == "2" ]] && ok_t "DIVE-1481: prod-delete in recovery framing stays tier 2 (human)" || bad_t "1481 prod-in-framing tier 2" "got '$(tierof DIVE-308)'"
@@ -140,7 +143,7 @@ cmd_task_need DIVE-308 --type=decision --from=dev \
 #        must not over-tighten). 'wipe' governs 'the board', so it is carved out and
 #        the residual is clean → lead-routed tier 1.
 route_reset; seed DIVE-309
-cmd_task_need DIVE-309 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-309 --type=decision --from=dev \
   --ask="Wipe the task board and rebuild it from the audit log — keep or discard my uncommitted wip first?" \
   --options="keep|discard" --recommend="keep" >/dev/null 2>&1
 [[ "$(tierof DIVE-309)" == "1" ]] && ok_t "DIVE-1481: co-referent 'wipe the board' still downgrades to tier 1" || bad_t "1481 co-referent tier 1" "got '$(tierof DIVE-309)'"
@@ -151,7 +154,7 @@ cmd_task_need DIVE-309 --type=decision --from=dev \
 #         strip would carve 'delete' as co-referent to 'board'; the external-target
 #         guard refuses to strip → residual keeps 'delete' → stays hard-human.
 route_reset; seed DIVE-310
-cmd_task_need DIVE-310 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-310 --type=decision --from=dev \
   --ask="Delete the board and the production database — proceed?" \
   --options="yes|no" --recommend="no" >/dev/null 2>&1
 [[ "$(tierof DIVE-310)" == "2" ]] && ok_t "DIVE-1487: coordinated internal+prod delete stays tier 2 (human)" || bad_t "1487 coordination tier 2" "got '$(tierof DIVE-310)'"
@@ -161,7 +164,7 @@ cmd_task_need DIVE-310 --type=decision --from=dev \
 #         customer records" — the passive branch would strip 'delete' merely because
 #         'board' precedes it within 20 chars, though 'delete' governs prod records.
 route_reset; seed DIVE-311
-cmd_task_need DIVE-311 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-311 --type=decision --from=dev \
   --ask="Wipe the board then delete the prod customer records — go ahead?" \
   --options="yes|no" --recommend="no" >/dev/null 2>&1
 [[ "$(tierof DIVE-311)" == "2" ]] && ok_t "DIVE-1487: passive over-reach (prod customer records) stays tier 2 (human)" || bad_t "1487 passive tier 2" "got '$(tierof DIVE-311)'"
@@ -170,7 +173,7 @@ cmd_task_need DIVE-311 --type=decision --from=dev \
 #         table". Guard keeps 'purge' in the residual (→ floor); and the widened
 #         'drop[^.]{0,20}table' floor term catches 'drop the customers table' too.
 route_reset; seed DIVE-312
-cmd_task_need DIVE-312 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-312 --type=decision --from=dev \
   --ask="Purge the backlog and drop the customers table — confirm?" \
   --options="yes|no" --recommend="no" >/dev/null 2>&1
 [[ "$(tierof DIVE-312)" == "2" ]] && ok_t "DIVE-1487: compound purge+drop-customers-table stays tier 2 (human)" || bad_t "1487 compound tier 2" "got '$(tierof DIVE-312)'"
@@ -178,7 +181,7 @@ cmd_task_need DIVE-312 --type=decision --from=dev \
 # --- 13: DIVE-1487 — floor-vocab: a standalone 'drop the customers table' (no
 #         internal-ops vocab, no delete/purge) now trips the widened floor directly.
 route_reset; seed DIVE-313
-cmd_task_need DIVE-313 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-313 --type=decision --from=dev \
   --ask="Drop the customers table in prod — proceed?" \
   --options="yes|no" --recommend="no" >/dev/null 2>&1
 [[ "$(tierof DIVE-313)" == "2" ]] && ok_t "DIVE-1487: standalone drop-<x>-table trips widened floor (tier 2)" || bad_t "1487 drop-table floor" "got '$(tierof DIVE-313)'"
@@ -186,7 +189,7 @@ cmd_task_need DIVE-313 --type=decision --from=dev \
 # --- 14: DIVE-1487 — NO OVER-TIGHTEN: a purely internal co-referent wipe with NO
 #         external target still downgrades to lead-routed tier 1 (guard not tripped).
 route_reset; seed DIVE-314
-cmd_task_need DIVE-314 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-314 --type=decision --from=dev \
   --ask="Wipe the task board and rebuild from the audit log — discard my uncommitted wip first?" \
   --options="keep|discard" --recommend="keep" >/dev/null 2>&1
 [[ "$(tierof DIVE-314)" == "1" ]] && ok_t "DIVE-1487: purely-internal wipe still downgrades to tier 1 (no over-tighten)" || bad_t "1487 internal still tier 1" "got '$(tierof DIVE-314)'"

--- a/tests/gate_lead_clear_stamp_unit.sh
+++ b/tests/gate_lead_clear_stamp_unit.sh
@@ -44,6 +44,9 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: `--from` no longer moves the actor — derive as the agent each arm
+# is impersonating. tests/lib/actor_seam.sh.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-lead-clear-stamp.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
@@ -109,7 +112,7 @@ mkgate() {
 reset
 SUDO_NONAGENT=1
 t1=$(mkgate "ship the persona batch" "fixture routed approval $FIXTURE_MARK")
-cmd_task_answer "$t1" --value="approved" --human --from=main >/dev/null 2>&1
+( actor_seam_as main; cmd_task_answer "$t1" --value="approved" --human --from=main >/dev/null 2>&1 )
 BY1=$(nby "$t1"); ROW1=$(row)
 if [[ "$BY1" == "lead:main" ]]; then
   ok_t "an uncorroborated --human on a lead-cleared gate stamps lead:main"
@@ -133,7 +136,7 @@ fi
 reset
 SUDO_NONAGENT=0            # non-agent SUDO_UID: a real human-evidence form
 t2=$(mkgate "ship the persona batch" "fixture routed approval, real human $FIXTURE_MARK")
-cmd_task_answer "$t2" --value="approved" --human --from=main >/dev/null 2>&1
+( actor_seam_as main; cmd_task_answer "$t2" --value="approved" --human --from=main >/dev/null 2>&1 )
 BY2=$(nby "$t2")
 if [[ "$BY2" == "human:main" ]]; then
   ok_t "a CORROBORATED --human still stamps human:main (no genuine tap relabelled)"
@@ -163,7 +166,7 @@ AUTH="nobody"
 t4=$(addt --assignee=dev -- "fixture unrouted decision $FIXTURE_MARK")
 cmd_task_need "$t4" --type=decision --options="A|B" --recommend="A" \
   --ask="pick one" --tier=1 >/dev/null 2>&1
-cmd_task_answer "$t4" --value="A" --human --from=lodar >/dev/null 2>&1
+( actor_seam_as lodar; cmd_task_answer "$t4" --value="A" --human --from=lodar >/dev/null 2>&1 )
 BY4=$(nby "$t4")
 if [[ "$BY4" == "human:lodar" ]]; then
   ok_t "a non-lead human answer keeps its human: stamp (fix is scoped to leads)"
@@ -183,7 +186,7 @@ SUDO_NONAGENT=1
 _gate_standing_lead() { printf 'main'; }
 t5=$(addt --assignee=dev -- "fixture standing approval $FIXTURE_MARK")
 cmd_task_need "$t5" --type=approval --ask="merge the CLI fix to main" --tier=1 >/dev/null 2>&1
-cmd_task_answer "$t5" --value="approved" --human --from=main >/dev/null 2>&1
+( actor_seam_as main; cmd_task_answer "$t5" --value="approved" --human --from=main >/dev/null 2>&1 )
 BY5=$(nby "$t5"); ROW5=$(row)
 if [[ "$BY5" == "lead:standing:main" ]]; then
   ok_t "a standing clear with no human evidence stamps lead:standing:main"

--- a/tests/gate_needs_capability_unit.sh
+++ b/tests/gate_needs_capability_unit.sh
@@ -40,6 +40,9 @@
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 set -uo pipefail
 cd "$(dirname "$0")/.."
+# DIVE-2518: `--from` is provenance; TIER/ROUTING read the uid derivation, so an arm
+# impersonating a filer must DERIVE as them. tests/lib/actor_seam.sh.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-needs-capability-unit.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
@@ -202,7 +205,7 @@ for cap in spend_authority secret_provision; do
   # is what makes it not. Prove the control for THIS type too, so the pass is not
   # inherited from case 1's approval arm.
   n=$((n+1)); reset_log; seed_loop "DIVE-$n"
-  cmd_task_need "DIVE-$n" --type=decision --ask="pick option A or B" --options="A|B" --recommend="A" --from=dev >/dev/null 2>&1
+  actor_seam_as dev; cmd_task_need "DIVE-$n" --type=decision --ask="pick option A or B" --options="A|B" --recommend="A" --from=dev >/dev/null 2>&1
   [[ "$(reviewer_of "DIVE-$n")" == "olivia" ]] \
     && ok_t "CONTROL for $cap's arm: the same decision without --needs still routes to the verifier" \
     || bad_t "decision control routes to verifier" "reviewer='$(reviewer_of "DIVE-$n")'"
@@ -233,7 +236,7 @@ grep -qi 'not a human-class capability' "$TMP/e_u" \
 # regardless of tier. It classifies on the ask's SHAPE; a declaration states what
 # the ask CONSUMES, and must outrank it. Without the re-assert this arm routes.
 reset_log; seed_loop DIVE-9005 "land the branch"
-cmd_task_need DIVE-9005 --type=approval --ask="approve the ship: merge and deploy the release branch to prod" --recommend="yes" --needs=human_tap --from=dev >/dev/null 2>"$TMP/e5"
+actor_seam_as dev; cmd_task_need DIVE-9005 --type=approval --ask="approve the ship: merge and deploy the release branch to prod" --recommend="yes" --needs=human_tap --from=dev >/dev/null 2>"$TMP/e5"
 [[ "$(reviewer_of DIVE-9005)" == "" && "$(tier_of DIVE-9005)" == "2" ]] \
   && ok_t "an eng-ship-shaped ask with --needs=human_tap is NOT downgraded to a lead-routed tier-1" \
   || bad_t "declaration outranks the eng-ship downgrade" "reviewer='$(reviewer_of DIVE-9005)' tier=$(tier_of DIVE-9005)"
@@ -256,13 +259,13 @@ _gate_needs_human human_tap && bad_t "mutation did not land" "resolver still rec
   || ok_t "MUTATION LANDED: the resolver now recognises nothing"
 
 reset_log; seed_loop DIVE-9006
-cmd_task_need DIVE-9006 --type=approval --ask="approve the merge of the parser refactor" --recommend="yes" --needs=human_tap --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-9006 --type=approval --ask="approve the merge of the parser refactor" --recommend="yes" --needs=human_tap --from=dev >/dev/null 2>&1
 [[ "$(reviewer_of DIVE-9006)" == "olivia" ]] \
   && ok_t "MUTATION: without the constant, --needs=human_tap routes to the VERIFIER — the arm is RED, so the green above was the constant's doing" \
   || bad_t "mutation turns the human arm red" "routed_reviewer='$(reviewer_of DIVE-9006)' — the human arm passes WITHOUT the resolution, so it proves nothing"
 
 reset_log; seed_loop DIVE-9007
-cmd_task_need DIVE-9007 --type=approval --ask="approve the merge of the parser refactor" --recommend="yes" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-9007 --type=approval --ask="approve the merge of the parser refactor" --recommend="yes" --from=dev >/dev/null 2>&1
 [[ "$(reviewer_of DIVE-9007)" == "olivia" ]] \
   && ok_t "MUTATION: the CONTROL is unaffected — the mutation is scoped to the declared path, not to routing at large" \
   || bad_t "mutation leaves the control green" "routed_reviewer='$(reviewer_of DIVE-9007)'"

--- a/tests/gate_route_delivery_unit.sh
+++ b/tests/gate_route_delivery_unit.sh
@@ -38,6 +38,9 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: `--from` is provenance; TIER and ROUTING read the uid derivation, so an
+# arm impersonating a filer must DERIVE as them. tests/lib/actor_seam.sh.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-route-delivery-unit.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
@@ -220,7 +223,7 @@ eval "$_real_route"
 # re-nag sweep, the privileged re-send, a plain human gate) can fall into the
 # routed deliverer.
 reset_log; seed DIVE-13; HUMAN_PINGED=0; SEND_RC=0
-cmd_task_need DIVE-13 --type=decision --ask="ship?" --from=main >/dev/null 2>&1   # lead files → human
+actor_seam_as main; cmd_task_need DIVE-13 --type=decision --ask="ship?" --from=main >/dev/null 2>&1   # lead files → human
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "an UNROUTED gate still runs the human deliverer (dispatch is per-call)" \
   || bad_t "unrouted → human deliverer" "HUMAN_PINGED=$HUMAN_PINGED"
 # The stubbed human deliverer writes no row of its own, so the DIVE-1968 assertion

--- a/tests/gate_seam_concatenation_unit.sh
+++ b/tests/gate_seam_concatenation_unit.sh
@@ -49,6 +49,9 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: `--from` is provenance; TIER/ROUTING read the uid derivation, so an arm
+# impersonating a filer must DERIVE as them. tests/lib/actor_seam.sh.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-seam-unit.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
@@ -117,13 +120,13 @@ assert_lead_routed() { # <ident> <label>
 #     database and no rewording of either can prevent it, because the defect is in
 #     the join.
 route_reset; seed DIVE-801 'table stakes: the onboarding rewrite'
-cmd_task_need DIVE-801 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-801 --type=decision --from=dev \
   --ask="confirm we can drop" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_not_floored DIVE-801 "seam: 'drop' in ask + 'table' in title does NOT fabricate a floor hit"
 
 # (2) NON-VACUITY, ask axis: a real floor term in the ASK still forces hard-human.
 route_reset; seed DIVE-802 'onboarding rewrite'
-cmd_task_need DIVE-802 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-802 --type=decision --from=dev \
   --ask="approve the refund to the customer" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_human DIVE-802 "non-vacuity: a floor term in the ASK still floors to hard-human"
 
@@ -132,13 +135,13 @@ assert_human DIVE-802 "non-vacuity: a floor term in the ASK still floors to hard
 #     assertion is the deliberate flip of pre-2224 behaviour; it is spelled out so the
 #     axis change is loud rather than silent.
 route_reset; seed DIVE-803 'the stale credential rotation write-up'
-cmd_task_need DIVE-803 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-803 --type=decision --from=dev \
   --ask="which of these two wordings should we use?" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_lead_routed DIVE-803 "answer A: a floor term in the TITLE + a substantive ask routes to the LEAD, not the human"
 
 # (4) CONTROL: neither field, no seam — an ordinary gate is untouched.
 route_reset; seed DIVE-804 'onboarding rewrite'
-cmd_task_need DIVE-804 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-804 --type=decision --from=dev \
   --ask="which of these two wordings should we use?" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_not_floored DIVE-804 "control: a gate with no floor term in either field stays tier 1"
 
@@ -153,7 +156,7 @@ assert_not_floored DIVE-804 "control: a gate with no floor term in either field 
 #     floor misses, and the gate is downgraded to lead-clearable. The ask names NO
 #     object at all — it is the case where a human matters most.
 route_reset; seed DIVE-805 'task board tidy-up for DIVE-2224'
-cmd_task_need DIVE-805 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-805 --type=decision --from=dev \
   --ask="approve the purge" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_human DIVE-805 "seam: a co-reference manufactured ACROSS the join does NOT strip the floor (stays human)"
 
@@ -161,13 +164,13 @@ assert_human DIVE-805 "seam: a co-reference manufactured ACROSS the join does NO
 #     must still be lead-clearable. Without this, (5) could pass by breaking the
 #     DIVE-1480 carve-out outright.
 route_reset; seed DIVE-806 'onboarding rewrite'
-cmd_task_need DIVE-806 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-806 --type=decision --from=dev \
   --ask="approve the purge of the task board backlog rows" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_lead_routed DIVE-806 "non-vacuity: a REAL internal-ops ask (verb+object in one field) still downgrades to the lead"
 
 # (7) NON-VACUITY, title axis for the carve-out: verb and object both in the TITLE.
 route_reset; seed DIVE-807 'purge the task board backlog rows left by the wipe'
-cmd_task_need DIVE-807 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-807 --type=decision --from=dev \
   --ask="please confirm" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_lead_routed DIVE-807 "non-vacuity: a REAL internal-ops TITLE (verb+object in one field) still downgrades"
 
@@ -204,27 +207,27 @@ assert_not_routed() { # <ident> <label>
 #      BY KIND, bypassing the pref -- it removes the human from a gate nobody
 #      classified as engineering.
 route_reset; seed DIVE-861 'github outage postmortem, customer impact'
-cmd_task_need DIVE-861 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-861 --type=decision --from=dev \
   --ask="approve the push" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_not_routed DIVE-861 "seam: 'push' in ask + 'github' in title does NOT fabricate an ENG-SHIP downgrade"
 
 # (7b) NON-VACUITY for (7a): a REAL eng-ship ask must still route to the lead. Without
 #      this, (7a) passes by breaking the DIVE-1359 eng-ship class outright.
 route_reset; seed DIVE-862 'onboarding rewrite'
-cmd_task_need DIVE-862 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-862 --type=decision --from=dev \
   --ask="approve the merge of the release branch" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_lead_routed DIVE-862 "non-vacuity: a REAL eng-ship ask (one field) still routes to the lead"
 
 # (7c) CURATION PHANTOM. `ready for the (queue|drip)` spans the seam: 'ready for the'
 #      ends the ask, 'queue' opens the title. Neither field is about content curation.
 route_reset; seed DIVE-863 'queue of open support tickets'
-cmd_task_need DIVE-863 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-863 --type=decision --from=dev \
   --ask="is this ready for the" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_not_routed DIVE-863 "seam: 'ready for the' in ask + 'queue' in title does NOT fabricate a CURATION downgrade"
 
 # (7d) NON-VACUITY for (7c): a REAL curation ask must still route to the reviewer.
 route_reset; seed DIVE-864 'onboarding rewrite'
-cmd_task_need DIVE-864 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-864 --type=decision --from=dev \
   --ask="approve the persona card for the drip queue" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_lead_routed DIVE-864 "non-vacuity: a REAL curation ask (one field) still routes to the reviewer"
 
@@ -254,13 +257,13 @@ _gate_ask_substantive "approve this" \
 #     case ever passes with the fallback removed, the fallback is decorative --
 #     graded by mutation, not by reading.
 route_reset; seed DIVE-808 'delete all customer data'
-cmd_task_need DIVE-808 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-808 --type=decision --from=dev \
   --ask="approve this" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_human DIVE-808 "FALLBACK: ask 'approve this' + destructive TITLE still reaches the human (fail-closed)"
 
 # (10) the same fallback with an ask that is pure politeness.
 route_reset; seed DIVE-809 'wipe the production database and start over'
-cmd_task_need DIVE-809 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-809 --type=decision --from=dev \
   --ask="please confirm" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_human DIVE-809 "FALLBACK: a politeness-only ask + destructive TITLE still reaches the human"
 
@@ -268,7 +271,7 @@ assert_human DIVE-809 "FALLBACK: a politeness-only ask + destructive TITLE still
 #      EVERY push gate on that ticket escalated to the human and no rewording of the
 #      ask could change it -- the rail was inert on that ticket by construction.
 route_reset; seed DIVE-810 'agent ask harvests NOTHING from a grok seat: the reply fence requires each marker alone on a line, grok puts them inline, and the fallback was deleted - the seat reads as a silent abstain'
-cmd_task_need DIVE-810 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-810 --type=decision --from=dev \
   --ask="push the reviewed branch for this ticket to origin so CI can grade it" \
   --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_lead_routed DIVE-810 "answer A: a routine push ask on DIVE-2216's own title now routes to the LEAD"
@@ -276,7 +279,7 @@ assert_lead_routed DIVE-810 "answer A: a routine push ask on DIVE-2216's own tit
 # (12) an APPROVAL gate takes the same axis as a decision gate -- the filing floor and
 #      the approval/manual routing arm must not disagree about which field decided.
 route_reset; seed DIVE-811 'the stale credential rotation write-up'
-cmd_task_need DIVE-811 --type=approval --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-811 --type=approval --from=dev \
   --ask="which of these two wordings should we use?" --recommend="A" >/dev/null 2>&1
 assert_lead_routed DIVE-811 "answer A applies to an APPROVAL gate too (filing floor and routing arm agree)"
 
@@ -294,13 +297,13 @@ assert_lead_routed DIVE-811 "answer A applies to an APPROVAL gate too (filing fl
 # twice, real and mutant, and require the two to DIFFER. That is the anchor-assert-
 # the-baseline-differs rule applied to a mutation arm.
 route_reset; seed DIVE-812 'delete all customer data'
-cmd_task_need DIVE-812 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-812 --type=decision --from=dev \
   --ask="approve this" --options="A|B" --recommend="A" >/dev/null 2>&1
 _REAL_TIER=$(tierof DIVE-812)
 _SUBSTANTIVE_REAL=$(declare -f _gate_ask_substantive)
 _gate_ask_substantive() { return 0; }   # MUTANT: every ask counts as substantive
 route_reset; seed DIVE-814 'delete all customer data'
-cmd_task_need DIVE-814 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-814 --type=decision --from=dev \
   --ask="approve this" --options="A|B" --recommend="A" >/dev/null 2>&1
 _MUTANT_TIER=$(tierof DIVE-814)
 eval "$_SUBSTANTIVE_REAL"               # restore BEFORE asserting, so a failed
@@ -312,7 +315,7 @@ eval "$_SUBSTANTIVE_REAL"               # restore BEFORE asserting, so a failed
 # (14) …and prove the RESTORE took, or every assertion after (13) would be grading
 #      the mutant and this suite would report on code that is not shipped.
 route_reset; seed DIVE-813 'delete all customer data'
-cmd_task_need DIVE-813 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-813 --type=decision --from=dev \
   --ask="approve this" --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_human DIVE-813 "MUTATION: the real predicate is RESTORED (the mutant did not leak into the suite)"
 

--- a/tests/gate_ship_routing_unit.sh
+++ b/tests/gate_ship_routing_unit.sh
@@ -20,6 +20,9 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: identity comes from the uid now; `USER=agent-x` / `--from=x` no longer
+# move it. Impersonate through the sealed seam. tests/lib/actor_seam.sh.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-route-unit.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
@@ -85,21 +88,21 @@ answered(){ db "SELECT CASE WHEN need_answered_at IS NULL THEN 'open' ELSE 'clos
 
 # --- pref OFF: decision gate still pings the human (unchanged behavior) ------
 seed DIVE-1; HUMAN_PINGED=0
-cmd_task_need DIVE-1 --type=decision --ask="ship A or B?" --options="A|B" --recommend="A" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-1 --type=decision --ask="ship A or B?" --options="A|B" --recommend="A" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "pref off: decision pings human" || bad_t "pref off pings human" "HUMAN_PINGED=$HUMAN_PINGED"
 
 _task_pref_set gate_builder_routing on
 
 # --- pref ON: builder decision routes to lead, NO human ping ----------------
 seed DIVE-2; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-2 --type=decision --ask="ship A or B?" --options="A|B" --recommend="A" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-2 --type=decision --ask="ship A or B?" --options="A|B" --recommend="A" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "0" ]] && ok_t "route on: builder decision does NOT ping human" || bad_t "route suppresses human" "HUMAN_PINGED=$HUMAN_PINGED"
 [[ "$(statusof DIVE-2)" == "blocked" && "$(answered DIVE-2)" == "open" ]] && ok_t "routed gate stays blocked+open for lead" || bad_t "routed gate blocked+open" "status=$(statusof DIVE-2) ans=$(answered DIVE-2)"
 R2=$(route_sent); [[ "$R2" == "1" && "$(route_last)" == "main" ]] && ok_t "routed send hit lead (main), stubbed — no live network" || bad_t "routed send → main via stub" "sent=$R2 last='$(route_last)'"
 
 # --- pref ON: gate filed BY the lead escalates to human ----------------------
 seed DIVE-3; HUMAN_PINGED=0
-cmd_task_need DIVE-3 --type=decision --ask="ship A or B?" --options="A|B" --recommend="A" --from=main >/dev/null 2>&1
+actor_seam_as main; cmd_task_need DIVE-3 --type=decision --ask="ship A or B?" --options="A|B" --recommend="A" --from=main >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "route on: lead's own decision goes to human" || bad_t "lead decision → human" "HUMAN_PINGED=$HUMAN_PINGED"
 
 # --- DIVE-1182: pref ON — builder APPROVAL (ship-gate) routes to lead ---------
@@ -107,7 +110,7 @@ cmd_task_need DIVE-3 --type=decision --ask="ship A or B?" --options="A|B" --reco
 # (pinged lodar). Now they route to the org lead like decision, persist
 # routed_reviewer, and are clearable by that lead (below).
 seed DIVE-4; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-4 --type=approval --ask="approve the prod push?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-4 --type=approval --ask="approve the prod push?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "0" ]] && ok_t "route on: builder approval does NOT ping human (DIVE-1182)" || bad_t "approval routed not human" "HUMAN_PINGED=$HUMAN_PINGED"
 [[ "$(statusof DIVE-4)" == "blocked" && "$(answered DIVE-4)" == "open" ]] && ok_t "routed approval stays blocked+open for lead" || bad_t "routed approval blocked+open" "status=$(statusof DIVE-4) ans=$(answered DIVE-4)"
 [[ "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-4';")" == "main" ]] && ok_t "routed approval persists routed_reviewer=main" || bad_t "routed_reviewer=main" "got '$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-4';")'"
@@ -128,20 +131,20 @@ _rt=$(db "SELECT need_type FROM tasks WHERE ident='DIVE-4';")
 # would `exit` mid-harness — and the drop target is irrelevant to the routing
 # exclusion under test, so file it plain.
 seed DIVE-7; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-7 --type=secret --ask="paste the deploy key" --secret-key=DEPLOY_KEY --connector=fixture --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-7 --type=secret --ask="paste the deploy key" --secret-key=DEPLOY_KEY --connector=fixture --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "route on: secret stays human-directed (never routed)" || bad_t "secret → human" "HUMAN_PINGED=$HUMAN_PINGED"
 [[ -z "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-7';")" ]] && ok_t "secret leaves routed_reviewer NULL" || bad_t "secret routed_reviewer NULL" "got '$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-7';")'"
 
 # --- DIVE-1182: a true-human-category APPROVAL (money) is NOT routed ----------
 seed DIVE-8; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-8 --type=approval --ask="approve the \$5000 ad spend budget?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-8 --type=approval --ask="approve the \$5000 ad spend budget?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "route on: money approval → human (category floor, not routed)" || bad_t "money approval → human" "HUMAN_PINGED=$HUMAN_PINGED"
 [[ -z "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-8';")" ]] && ok_t "money approval leaves routed_reviewer NULL" || bad_t "money approval routed_reviewer NULL" "got '$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-8';")'"
 
 # --- DIVE-1182: explicit --tier=2 approval is NOT routed (hard-human contract) -
 # NB: ask must NOT name an eng-ship action, else DIVE-1359 downgrades it (below).
 seed DIVE-9; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-9 --type=approval --tier=2 --ask="make the final go/no-go call on this?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-9 --type=approval --tier=2 --ask="make the final go/no-go call on this?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "route on: explicit --tier=2 approval → human (not routed)" || bad_t "explicit T2 approval → human" "HUMAN_PINGED=$HUMAN_PINGED"
 
 # --- DIVE-1359: eng-ship class — a builder CANNOT hard-human-gate an eng ship/ --
@@ -153,7 +156,7 @@ cmd_task_need DIVE-9 --type=approval --tier=2 --ask="make the final go/no-go cal
 # of this class; overriding the caller's hard-human pin was the bug. This case
 # therefore files with NO --tier flag, which is the real builder shape anyway.
 seed DIVE-30; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-30 --type=approval --ask="approve the prod push?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-30 --type=approval --ask="approve the prod push?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "0" ]] && ok_t "DIVE-1359: eng-ship approval --tier=2 NOT pinged to human" || bad_t "eng-ship T2 → not human" "HUMAN_PINGED=$HUMAN_PINGED"
 [[ "$(db "SELECT tier FROM tasks WHERE ident='DIVE-30';")" == "1" ]] && ok_t "DIVE-1359: eng-ship type-default tier-2 downgraded to lead-routed tier-1" || bad_t "eng-ship downgrade to tier-1" "got tier '$(db "SELECT tier FROM tasks WHERE ident='DIVE-30';")'"
 [[ "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-30';")" == "main" ]] && ok_t "DIVE-1359: eng-ship approval routed_reviewer=main (lead-clearable)" || bad_t "eng-ship routed to lead" "got '$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-30';")'"
@@ -161,15 +164,15 @@ cmd_task_need DIVE-30 --type=approval --ask="approve the prod push?" --from=dev 
 # --- DIVE-1359: eng-ship routes even with pref OFF (intrinsic to the kind) ----
 _task_pref_set gate_builder_routing off
 seed DIVE-31; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-31 --type=approval --ask="ship the DIVE-1359 branch to main?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-31 --type=approval --ask="ship the DIVE-1359 branch to main?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "0" && "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-31';")" == "main" ]] && ok_t "DIVE-1359: eng-ship routes to lead even with pref OFF" || bad_t "eng-ship pref-OFF route" "human=$HUMAN_PINGED reviewer='$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-31';")'"
 # a genuine money approval with pref OFF still pings the human (floor wins over eng-ship)
 seed DIVE-32; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-32 --type=approval --ask="approve the deploy AND the \$900 vercel invoice?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-32 --type=approval --ask="approve the deploy AND the \$900 vercel invoice?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "DIVE-1359: floor beats eng-ship (deploy+\$invoice stays human)" || bad_t "floor beats eng-ship" "HUMAN_PINGED=$HUMAN_PINGED"
 # a lead's OWN eng-ship gate is NOT downgraded (no distinct reviewer → human)
 seed DIVE-33; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-33 --type=approval --tier=2 --ask="approve the prod push?" --from=main >/dev/null 2>&1
+actor_seam_as main; cmd_task_need DIVE-33 --type=approval --tier=2 --ask="approve the prod push?" --from=main >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" && "$(db "SELECT tier FROM tasks WHERE ident='DIVE-33';")" == "2" ]] && ok_t "DIVE-1359: a lead's own eng-ship --tier=2 stays hard-human" || bad_t "lead eng-ship not downgraded" "human=$HUMAN_PINGED tier='$(db "SELECT tier FROM tasks WHERE ident='DIVE-33';")'"
 
 # --- DIVE-1555: a delegated PUSH-FOR-REVIEW (5dive push / DIVE-1376) is eng-ship. A
@@ -183,7 +186,7 @@ for _c in \
   "DIVE-36|clear this so 5dive push can run"; do
   _id="${_c%%|*}"; _ask="${_c#*|}"
   seed "$_id"; HUMAN_PINGED=0; route_reset
-  cmd_task_need "$_id" --type=approval --ask="$_ask" --from=dev >/dev/null 2>&1
+  actor_seam_as dev; cmd_task_need "$_id" --type=approval --ask="$_ask" --from=dev >/dev/null 2>&1
   [[ "$HUMAN_PINGED" == "0" \
      && "$(db "SELECT tier FROM tasks WHERE ident='$_id';")" == "1" \
      && "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='$_id';")" == "main" ]] \
@@ -194,7 +197,7 @@ done
 # DIVE-1555: the true-human floor still wins — a push-for-review that ALSO names
 # money stays a tier-2 human call (not lead-routed).
 seed DIVE-37; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-37 --type=approval --ask="approve delegated push for review AND the \$500 vercel invoice?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-37 --type=approval --ask="approve delegated push for review AND the \$500 vercel invoice?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" && "$(db "SELECT tier FROM tasks WHERE ident='DIVE-37';")" == "2" ]] \
   && ok_t "DIVE-1555: money floor beats push-for-review (stays tier-2 human)" \
   || bad_t "DIVE-1555: money floor beats push-for-review" "human=$HUMAN_PINGED tier='$(db "SELECT tier FROM tasks WHERE ident='DIVE-37';")'"
@@ -211,7 +214,7 @@ for _c in \
   "DIVE-45|clear this fleet roll of the verified build"; do
   _id="${_c%%|*}"; _ask="${_c#*|}"
   seed "$_id"; HUMAN_PINGED=0; route_reset
-  cmd_task_need "$_id" --type=approval --ask="$_ask" --from=dev >/dev/null 2>&1
+  actor_seam_as dev; cmd_task_need "$_id" --type=approval --ask="$_ask" --from=dev >/dev/null 2>&1
   [[ "$HUMAN_PINGED" == "0" \
      && "$(db "SELECT tier FROM tasks WHERE ident='$_id';")" == "1" \
      && "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='$_id';")" == "main" ]] \
@@ -222,7 +225,7 @@ done
 # DIVE-1698: the true-human floor still wins — a push+fleet-roll that ALSO names a
 # secret/credential stays a tier-2 human call (not lead-routed).
 seed DIVE-46; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-46 --type=approval --ask="push to github + roll the new api key to the fleet?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-46 --type=approval --ask="push to github + roll the new api key to the fleet?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" && "$(db "SELECT tier FROM tasks WHERE ident='DIVE-46';")" == "2" ]] \
   && ok_t "DIVE-1698: secret floor beats push+fleet-roll (stays tier-2 human)" \
   || bad_t "DIVE-1698: secret floor beats push+fleet-roll" "human=$HUMAN_PINGED tier='$(db "SELECT tier FROM tasks WHERE ident='DIVE-46';")'"
@@ -237,7 +240,7 @@ cmd_task_need DIVE-46 --type=approval --ask="push to github + roll the new api k
 # (DIVE-1957: filed with NO --tier — approval already DEFAULTS to tier 2, which is
 # the leak's real shape; an explicit pin is now honored and vetoes the downgrade.)
 seed DIVE-38; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-38 --type=approval --ask="Approve landing the verified CLI/plugin fix and pushing to origin?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-38 --type=approval --ask="Approve landing the verified CLI/plugin fix and pushing to origin?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "0" ]] && ok_t "DIVE-1605: 'landing...pushing' eng-ship NOT pinged to human" || bad_t "DIVE-1605 gerund eng-ship -> human" "HUMAN_PINGED=$HUMAN_PINGED"
 [[ "$(db "SELECT tier FROM tasks WHERE ident='DIVE-38';")" == "1" ]] && ok_t "DIVE-1605: 'landing...pushing' downgraded to tier-1" || bad_t "DIVE-1605 gerund downgrade" "got tier '$(db "SELECT tier FROM tasks WHERE ident='DIVE-38';")'"
 [[ "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-38';")" == "main" ]] && ok_t "DIVE-1605: 'landing...pushing' routed_reviewer=main (lead-clearable)" || bad_t "DIVE-1605 gerund route to lead" "got '$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-38';")'"
@@ -249,55 +252,55 @@ cmd_task_need DIVE-38 --type=approval --ask="Approve landing the verified CLI/pl
 # regardless of pref. pref stays OFF here (set above) to prove the routing is
 # intrinsic to the kind.
 seed DIVE-40; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-40 --type=approval --ask="approve persona 'doc' as ready to publish to the character-pack drip queue?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-40 --type=approval --ask="approve persona 'doc' as ready to publish to the character-pack drip queue?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "0" ]] && ok_t "DIVE-1381: curation 'publish' approval NOT pinged to human" || bad_t "curation → not human" "HUMAN_PINGED=$HUMAN_PINGED"
 [[ "$(db "SELECT tier FROM tasks WHERE ident='DIVE-40';")" == "1" ]] && ok_t "DIVE-1381: curation gate downgraded from T2-floor to lead-routed tier-1" || bad_t "curation downgrade to tier-1" "got tier '$(db "SELECT tier FROM tasks WHERE ident='DIVE-40';")'"
 [[ "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-40';")" == "main" ]] && ok_t "DIVE-1381: curation approval routed_reviewer=main (lead-clearable), pref OFF" || bad_t "curation routed to lead" "got '$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-40';")'"
 
 # curation-shaped WITHOUT a floor word is still intrinsically lead-routed (pref OFF)
 seed DIVE-41; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-41 --type=approval --ask="approve the persona skill-set for 'doc' before it enters the drip queue?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-41 --type=approval --ask="approve the persona skill-set for 'doc' before it enters the drip queue?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "0" && "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-41';")" == "main" ]] && ok_t "DIVE-1381: curation (no floor word) routes to lead, pref OFF" || bad_t "curation no-floor route" "human=$HUMAN_PINGED reviewer='$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-41';")'"
 
 # DIVE-1492: brand alone is no longer a hard-human floor. A brand decision that
 # also names a persona stays lead-clearable through the curation route.
 seed DIVE-42; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-42 --type=approval --ask="approve the brand palette for the persona pack?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-42 --type=approval --ask="approve the brand palette for the persona pack?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "0" && "$(db "SELECT tier FROM tasks WHERE ident='DIVE-42';")" == "1" && "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-42';")" == "main" ]] \
   && ok_t "DIVE-1492: brand persona approval routes to lead at tier-1" \
   || bad_t "brand persona approval should route to lead" "human=$HUMAN_PINGED tier='$(db "SELECT tier FROM tasks WHERE ident='DIVE-42';")' reviewer='$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-42';")'"
 
 # floor WINS over curation: MONEY in a curation ask stays hard-human.
 seed DIVE-43; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-43 --type=approval --ask="approve the \$200 spend to publish the persona pack?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-43 --type=approval --ask="approve the \$200 spend to publish the persona pack?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "DIVE-1381: floor beats curation (\$spend to publish persona → human)" || bad_t "money beats curation" "HUMAN_PINGED=$HUMAN_PINGED"
 
 # floor WINS over curation: customer-comms (newsletter) stays hard-human.
 seed DIVE-44; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-44 --type=approval --ask="approve the persona pack newsletter blast to customers?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-44 --type=approval --ask="approve the persona pack newsletter blast to customers?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "DIVE-1381: floor beats curation (persona newsletter blast → human)" || bad_t "newsletter beats curation" "HUMAN_PINGED=$HUMAN_PINGED"
 
 # a lead's OWN curation gate is NOT downgraded (no distinct reviewer → human)
 seed DIVE-45; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-45 --type=approval --tier=2 --ask="approve persona 'doc' ready to publish to the drip queue?" --from=main >/dev/null 2>&1
+actor_seam_as main; cmd_task_need DIVE-45 --type=approval --tier=2 --ask="approve persona 'doc' ready to publish to the drip queue?" --from=main >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" && "$(db "SELECT tier FROM tasks WHERE ident='DIVE-45';")" == "2" ]] && ok_t "DIVE-1381: a lead's own curation --tier=2 stays hard-human" || bad_t "lead curation not downgraded" "human=$HUMAN_PINGED tier='$(db "SELECT tier FROM tasks WHERE ident='DIVE-45';")'"
 
 # substring guard: 'accurate' / 'personalize' must NOT trip the curation class, so
 # a non-curation ask that merely contains those substrings + 'publish' still floors.
 seed DIVE-47; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-47 --type=approval --ask="approve the accurate personalized copy before we publish it?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-47 --type=approval --ask="approve the accurate personalized copy before we publish it?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "DIVE-1381: 'accurate'/'personalized'+publish does NOT match curation (still floors)" || bad_t "substring guard" "HUMAN_PINGED=$HUMAN_PINGED"
 
 # a NON-curation 'publish' ask still floors to the human — proves the carve-out is
 # scoped to the curation KIND, not to any ask that merely names 'publish'. (No
 # other floor word here: 'publish' is the ONLY trigger, and it must still floor.)
 seed DIVE-46; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-46 --type=approval --ask="approve the publish of the homepage hero copy?" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-46 --type=approval --ask="approve the publish of the homepage hero copy?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "DIVE-1381: non-curation 'publish' still floors (carve-out scoped)" || bad_t "non-curation publish floors" "HUMAN_PINGED=$HUMAN_PINGED"
 
 # --- pref ON: tier-2-floored decision (money) is NOT routed ------------------
 seed DIVE-5; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-5 --type=decision --ask="approve the \$5000 ad spend budget?" --options="yes|no" --recommend="no" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-5 --type=decision --ask="approve the \$5000 ad spend budget?" --options="yes|no" --recommend="no" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "route on: T2-floored decision (money) → human" || bad_t "T2 floor → human" "HUMAN_PINGED=$HUMAN_PINGED"
 [[ ! -s "$ROUTE_FILE" ]] && ok_t "T2-floored decision: no lead route fired" || bad_t "T2 floor no route" "sent=$(route_last)"
 
@@ -305,7 +308,7 @@ cmd_task_need DIVE-5 --type=decision --ask="approve the \$5000 ad spend budget?"
 # Guards the hard-human contract: 2 = never auto-applies, always pings. Before
 # the effective-tier fix this left tier_floored=0 and silently routed to the lead.
 seed DIVE-6; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-6 --type=decision --tier=2 --ask="pick the launch date?" --options="mon|tue" --recommend="mon" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-6 --type=decision --tier=2 --ask="pick the launch date?" --options="mon|tue" --recommend="mon" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "route on: explicit --tier=2 decision → human (not routed)" || bad_t "explicit T2 decision → human" "HUMAN_PINGED=$HUMAN_PINGED"
 [[ ! -s "$ROUTE_FILE" ]] && ok_t "explicit --tier=2 decision: no lead route fired" || bad_t "explicit T2 no route" "sent=$(route_last)"
 
@@ -360,7 +363,7 @@ unset -f id
 nudge_of() { local c; c=$(grep -c 'Prefer --type=decision' "$1" 2>/dev/null); echo "${c:-0}"; }
 # builder eng-ship approval → nudged AND still lead-routed tier-1 (behavior kept)
 seed DIVE-50; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-50 --type=approval --ask="approve the prod push?" --from=dev >/dev/null 2>"$TMP/n50"
+actor_seam_as dev; cmd_task_need DIVE-50 --type=approval --ask="approve the prod push?" --from=dev >/dev/null 2>"$TMP/n50"
 [[ "$(nudge_of "$TMP/n50")" -ge 1 \
    && "$(db "SELECT tier FROM tasks WHERE ident='DIVE-50';")" == "1" \
    && "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-50';")" == "main" ]] \
@@ -368,19 +371,19 @@ cmd_task_need DIVE-50 --type=approval --ask="approve the prod push?" --from=dev 
   || bad_t "DIVE-1738 approval nudge" "nudge=$(nudge_of "$TMP/n50") tier='$(db "SELECT tier FROM tasks WHERE ident='DIVE-50';")' rr='$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-50';")'"
 # builder eng-ship MANUAL → nudged (manual is NOT downgraded, so this is its only treatment)
 seed DIVE-51; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-51 --type=manual --ask="merge the dive-1738 PR and roll to the fleet?" --from=dev >/dev/null 2>"$TMP/n51"
+actor_seam_as dev; cmd_task_need DIVE-51 --type=manual --ask="merge the dive-1738 PR and roll to the fleet?" --from=dev >/dev/null 2>"$TMP/n51"
 [[ "$(nudge_of "$TMP/n51")" -ge 1 ]] && ok_t "DIVE-1738: builder eng-ship manual is nudged to decision" || bad_t "DIVE-1738 manual nudge" "nudge=$(nudge_of "$TMP/n51")"
 # a lead's OWN eng-ship gate is NOT nudged (no reviewer above them)
 seed DIVE-52; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-52 --type=approval --ask="approve the prod push?" --from=main >/dev/null 2>"$TMP/n52"
+actor_seam_as main; cmd_task_need DIVE-52 --type=approval --ask="approve the prod push?" --from=main >/dev/null 2>"$TMP/n52"
 [[ "$(nudge_of "$TMP/n52")" == "0" ]] && ok_t "DIVE-1738: lead's own eng-ship gate is NOT nudged" || bad_t "DIVE-1738 lead not nudged" "nudge=$(nudge_of "$TMP/n52")"
 # a plain (non-eng-ship) builder approval is NOT nudged
 seed DIVE-53; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-53 --type=approval --ask="make the final go/no-go call on this?" --from=dev >/dev/null 2>"$TMP/n53"
+actor_seam_as dev; cmd_task_need DIVE-53 --type=approval --ask="make the final go/no-go call on this?" --from=dev >/dev/null 2>"$TMP/n53"
 [[ "$(nudge_of "$TMP/n53")" == "0" ]] && ok_t "DIVE-1738: non-eng-ship approval is NOT nudged" || bad_t "DIVE-1738 non-eng-ship not nudged" "nudge=$(nudge_of "$TMP/n53")"
 # a floored (money) eng-ship approval is NOT nudged (floor wins → stays hard-human)
 seed DIVE-54; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-54 --type=approval --ask="approve the deploy AND the \$900 vercel invoice?" --from=dev >/dev/null 2>"$TMP/n54"
+actor_seam_as dev; cmd_task_need DIVE-54 --type=approval --ask="approve the deploy AND the \$900 vercel invoice?" --from=dev >/dev/null 2>"$TMP/n54"
 [[ "$(nudge_of "$TMP/n54")" == "0" && "$HUMAN_PINGED" == "1" ]] && ok_t "DIVE-1738: floored money eng-ship is NOT nudged (stays human)" || bad_t "DIVE-1738 floored not nudged" "nudge=$(nudge_of "$TMP/n54") human=$HUMAN_PINGED"
 
 # --- DIVE-2004: LOUD AT FILE TIME ---------------------------------------------
@@ -395,19 +398,19 @@ cmd_task_need DIVE-54 --type=approval --ask="approve the deploy AND the \$900 ve
 w2004_of() { grep -c "will REFUSE it" "$1" 2>/dev/null | head -1; }
 # filed by the lead: `_gate_route_reviewer` finds nobody above them -> unrouted.
 seed DIVE-55; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-55 --type=decision --ask="cherry-pick, or re-file the delegated push for review after #16?" --from=main >/dev/null 2>"$TMP/n55"
+actor_seam_as main; cmd_task_need DIVE-55 --type=decision --ask="cherry-pick, or re-file the delegated push for review after #16?" --from=main >/dev/null 2>"$TMP/n55"
 [[ "$(w2004_of "$TMP/n55")" -ge 1 ]] \
   && ok_t "DIVE-2004: unrouted eng-ship decision warns at FILE time that push will refuse it" \
   || bad_t "DIVE-2004 file-time warning" "warn=$(w2004_of "$TMP/n55") rr='$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-55';")'"
 # the SAME ask from a builder DOES route -> push accepts it -> must stay silent.
 seed DIVE-56; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-56 --type=decision --ask="cherry-pick, or re-file the delegated push for review after #16?" --from=dev >/dev/null 2>"$TMP/n56"
+actor_seam_as dev; cmd_task_need DIVE-56 --type=decision --ask="cherry-pick, or re-file the delegated push for review after #16?" --from=dev >/dev/null 2>"$TMP/n56"
 { [[ "$(w2004_of "$TMP/n56")" == "0" ]] && [[ -n "$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-56';")" ]]; } \
   && ok_t "DIVE-2004: a ROUTED eng-ship decision does NOT warn (push accepts it)" \
   || bad_t "DIVE-2004 routed must not warn" "warn=$(w2004_of "$TMP/n56") rr='$(db "SELECT COALESCE(routed_reviewer,'') FROM tasks WHERE ident='DIVE-56';")'"
 # an ordinary unrouted decision is not a push ask -> silent, or the warning is noise.
 seed DIVE-57; HUMAN_PINGED=0; route_reset
-cmd_task_need DIVE-57 --type=decision --ask="which copy variant should we use on the pricing page?" --from=main >/dev/null 2>"$TMP/n57"
+actor_seam_as main; cmd_task_need DIVE-57 --type=decision --ask="which copy variant should we use on the pricing page?" --from=main >/dev/null 2>"$TMP/n57"
 [[ "$(w2004_of "$TMP/n57")" == "0" ]] \
   && ok_t "DIVE-2004: a non-eng-ship unrouted decision does NOT warn (no wallpaper)" \
   || bad_t "DIVE-2004 non-eng-ship must not warn" "warn=$(w2004_of "$TMP/n57")"

--- a/tests/gate_tier2_explicit_pin_unit.sh
+++ b/tests/gate_tier2_explicit_pin_unit.sh
@@ -37,6 +37,9 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: `--from` is provenance; TIER/ROUTING read the uid derivation, so an arm
+# impersonating a filer must DERIVE as them. tests/lib/actor_seam.sh.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-t2pin-unit.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
@@ -113,7 +116,7 @@ assert_downgraded() { # <ident> <label>
 
 # 1: keyword in the ASK — the original repro (`--tier=2` + "Ship it to prod").
 route_reset; seed DIVE-901 'DIVE-1690 council page'
-cmd_task_need DIVE-901 --type=decision --tier=2 --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-901 --type=decision --tier=2 --from=dev \
   --ask="Ship it to prod: which council page copy goes live?" \
   --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_pin_held DIVE-901 "eng-ship in ASK: explicit --tier=2 survives (stays hard-human)"
@@ -123,7 +126,7 @@ assert_pin_held DIVE-901 "eng-ship in ASK: explicit --tier=2 survives (stays har
 #    flags + ask, the only variable is the title, and the title alone downgraded
 #    the gate. A fix that only reads the ask cannot pass this case.
 route_reset; seed DIVE-902 'LAND the DIVE-1672 council-rules branch: rebase package.json + settle MERGE order vs dive-1690'
-cmd_task_need DIVE-902 --type=decision --tier=2 --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-902 --type=decision --tier=2 --from=dev \
   --ask="Which of these two wordings should the public page use?" \
   --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_pin_held DIVE-902 "eng-ship in TITLE: explicit --tier=2 survives (the axis the filer cannot reword)"
@@ -132,14 +135,14 @@ assert_pin_held DIVE-902 "eng-ship in TITLE: explicit --tier=2 survives (the axi
 #    explicit pin skips the floor evaluation entirely (tier_floored stays 0), so
 #    before the fix this was downgraded despite carrying a floor keyword.
 route_reset; seed DIVE-903 'Council page polish'
-cmd_task_need DIVE-903 --type=decision --tier=2 --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-903 --type=decision --tier=2 --from=dev \
   --ask="BRAND call on the public 5dive.ai /council page before we ship it" \
   --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_pin_held DIVE-903 "eng-ship + floor term ('brand'+'ship') with --tier=2 stays hard-human"
 
 # 4: approval flavour, keyword in TITLE only.
 route_reset; seed DIVE-904 'Merge the pricing-page redesign PR'
-cmd_task_need DIVE-904 --type=approval --tier=2 --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-904 --type=approval --tier=2 --from=dev \
   --ask="Sign off the final pricing numbers on the public page?" --recommend="yes" >/dev/null 2>&1
 assert_pin_held DIVE-904 "eng-ship TITLE + --type=approval --tier=2 survives"
 
@@ -147,13 +150,13 @@ assert_pin_held DIVE-904 "eng-ship TITLE + --type=approval --tier=2 survives"
 #    overridden and the builder ship-gate is lead-routed. If this ever fails the
 #    "fix" is just a disabled carve-out.
 route_reset; seed DIVE-905 'LAND the dive-1957 branch: settle MERGE order'
-cmd_task_need DIVE-905 --type=approval --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-905 --type=approval --from=dev \
   --ask="Approve landing the verified fix and pushing to origin?" --recommend="yes" >/dev/null 2>&1
 assert_downgraded DIVE-905 "eng-ship with NO --tier: type default STILL downgraded + lead-routed (DIVE-1359 intact)"
 
 # 6: UNCHANGED — an explicit --tier=1 is not a hard-human pin; nothing to veto.
 route_reset; seed DIVE-906 'Ship the dive-1957 fix'
-cmd_task_need DIVE-906 --type=decision --tier=1 --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-906 --type=decision --tier=1 --from=dev \
   --ask="ship it now or after the release?" --options="now|after" --recommend="now" >/dev/null 2>&1
 [[ "$(tierof DIVE-906)" == "1" && "$(routedof DIVE-906)" == "main" ]] \
   && ok_t "explicit --tier=1 eng-ship still lead-routed (only a =2 pin vetoes)" \
@@ -165,20 +168,20 @@ cmd_task_need DIVE-906 --type=decision --tier=1 --from=dev \
 
 # 7: keyword in the ASK.
 route_reset; seed DIVE-910 'Character pack drip'
-cmd_task_need DIVE-910 --type=approval --tier=2 --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-910 --type=approval --tier=2 --from=dev \
   --ask="approve persona 'doc' as ready to publish to the character-pack drip queue?" --recommend="yes" >/dev/null 2>&1
 assert_pin_held DIVE-910 "curation in ASK: explicit --tier=2 survives"
 
 # 8: TITLE AXIS — curation vocabulary only in the title.
 route_reset; seed DIVE-911 'Approve the persona pack for the character-packs publish queue'
-cmd_task_need DIVE-911 --type=decision --tier=2 --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-911 --type=decision --tier=2 --from=dev \
   --ask="Which of the two brand palettes should we commit to?" \
   --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_pin_held DIVE-911 "curation in TITLE: explicit --tier=2 survives"
 
 # 9: UNCHANGED — no pin ⇒ the curation carve-out still beats the 'publish' floor.
 route_reset; seed DIVE-912 'Character pack drip'
-cmd_task_need DIVE-912 --type=approval --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-912 --type=approval --from=dev \
   --ask="approve persona 'doc' as ready to publish to the character-pack drip queue?" --recommend="yes" >/dev/null 2>&1
 assert_downgraded DIVE-912 "curation with NO --tier: still downgraded + lead-routed (DIVE-1381 intact)"
 
@@ -188,20 +191,20 @@ assert_downgraded DIVE-912 "curation with NO --tier: still downgraded + lead-rou
 
 # 10: keyword in the ASK (the STEER-1 board-wipe repro).
 route_reset; seed DIVE-920 'Board recovery'
-cmd_task_need DIVE-920 --type=decision --tier=2 --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-920 --type=decision --tier=2 --from=dev \
   --ask="The task board was wiped/destroyed at 04:20 — keep or discard my uncommitted work and rebuild the board from the audit log?" \
   --options="keep|discard" --recommend="keep" >/dev/null 2>&1
 assert_pin_held DIVE-920 "internal-ops in ASK: explicit --tier=2 survives"
 
 # 11: TITLE AXIS.
 route_reset; seed DIVE-921 'Rebuild the wiped task board from the audit log'
-cmd_task_need DIVE-921 --type=decision --tier=2 --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-921 --type=decision --tier=2 --from=dev \
   --ask="keep or discard the in-flight work?" --options="keep|discard" --recommend="keep" >/dev/null 2>&1
 assert_pin_held DIVE-921 "internal-ops in TITLE: explicit --tier=2 survives"
 
 # 12: UNCHANGED — no pin ⇒ the over-fired destructive floor is still carved out.
 route_reset; seed DIVE-922 'Board recovery'
-cmd_task_need DIVE-922 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-922 --type=decision --from=dev \
   --ask="The task board was wiped/destroyed at 04:20 — keep or discard my uncommitted work and rebuild the board from the audit log?" \
   --options="keep|discard" --recommend="keep" >/dev/null 2>&1
 assert_downgraded DIVE-922 "internal-ops with NO --tier: still downgraded + lead-routed (DIVE-1480 intact)"
@@ -212,13 +215,13 @@ assert_downgraded DIVE-922 "internal-ops with NO --tier: still downgraded + lead
 
 # 13: an access gate filed with an explicit --tier=2 is NOT routed to the lead.
 route_reset; seed DIVE-930 'Grant prod DB access'
-cmd_task_need DIVE-930 --type=access --tier=2 --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-930 --type=access --tier=2 --from=dev \
   --ask="grant me the prod read-replica credentials?" >/dev/null 2>&1
 assert_pin_held DIVE-930 "access + explicit --tier=2 is NOT lead-routed (DIVE-1145 invariant backstop)"
 
 # 14: UNCHANGED — an un-pinned access gate still routes to the lead by type.
 route_reset; seed DIVE-931 'Grant staging box access'
-cmd_task_need DIVE-931 --type=access --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-931 --type=access --from=dev \
   --ask="grant me shell on the staging box?" >/dev/null 2>&1
 [[ "$(routedof DIVE-931)" == "main" ]] \
   && ok_t "access with NO --tier: still lead-routed by type (DIVE-1243 intact)" \
@@ -250,7 +253,7 @@ audit_reset() { : >"$AUDIT_FILE"; }
 
 # 16: a pinned eng-ship gate that escalates past the lead records the row.
 route_reset; audit_reset; seed DIVE-950 'LAND the dive-1957 branch: settle MERGE order'
-cmd_task_need DIVE-950 --type=decision --tier=2 --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-950 --type=decision --tier=2 --from=dev \
   --ask="Which wording ships on the public page?" --options="A|B" --recommend="A" >/dev/null 2>&1
 grep -q '^task.gate-tier2-pin-escalated$' "$AUDIT_FILE" \
   && ok_t "pinned eng-ship escalation records an audit row (measurable, not just a warn)" \
@@ -259,7 +262,7 @@ grep -q '^task.gate-tier2-pin-escalated$' "$AUDIT_FILE" \
 # 17: the un-pinned downgrade does NOT record it — the row means "a pin escalated
 #     past a lead", so it must not fire on the normal lead-routed path.
 route_reset; audit_reset; seed DIVE-951 'LAND the dive-1957 branch: settle MERGE order'
-cmd_task_need DIVE-951 --type=decision --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-951 --type=decision --from=dev \
   --ask="Which wording ships on the public page?" --options="A|B" --recommend="A" >/dev/null 2>&1
 grep -q '^task.gate-tier2-pin-escalated$' "$AUDIT_FILE" \
   && bad_t "no audit row on the un-pinned downgrade" "rows='$(tr '\n' ',' <"$AUDIT_FILE")'" \

--- a/tests/gate_verifier_route_unit.sh
+++ b/tests/gate_verifier_route_unit.sh
@@ -109,7 +109,7 @@ cmd_task_need DIVE-501 --type=decision --options='A|B' --recommend='A' \
 
 # ---- 2. approval gate on the loop also routes to the verifier ----
 route_reset; seed_loop DIVE-502; fixture_actor dev
-cmd_task_need DIVE-502 --type=approval --ask='OK to merge the refactor?' --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-502 --type=approval --ask='OK to merge the refactor?' --from=dev >/dev/null 2>&1
 [[ "$(route_last)" == "main" ]] \
   && ok_t "maker approval gate routes to verifier 'main'" \
   || bad_t "maker approval gate routes to verifier 'main'" "route_last=$(route_last) human=$HUMAN_PINGED"

--- a/tests/gate_verifier_route_unit.sh
+++ b/tests/gate_verifier_route_unit.sh
@@ -41,9 +41,23 @@ done
 # being an input. Wrapping the REAL resolver (rather than reimplementing it) keeps the --from
 # precedence under test instead of under simulation, and keeps the override inside this shell —
 # there is deliberately no env var that could forge an actor in production.
-eval "task_actor_REAL() $(declare -f task_actor | tail -n +2)"
+#
+# DIVE-2518 MOVED THE PIN, and had to. Setting $USER no longer moves the actor —
+# that env path WAS the forgery this ticket closed — and wrapping `task_actor`
+# cannot pin identity any more either, because cmd_task_need's corroboration guard
+# reads the derivation DIRECTLY rather than through that accessor. The pin now goes
+# through the sealed seam (tests/lib/actor_seam.sh), which is the same
+# _gate_caller_uid/_gate_passwd_stream pair DIVE-2330 kept for exactly this.
+#
+# `--from` stays under test rather than under simulation, as the note above wants —
+# but it is now a CLAIM that must corroborate, so each step DERIVES as the agent it
+# files as. A step that derived as one agent and filed as another is refused by
+# design, and before this migration that refusal exited the harness mid-run: the
+# suite stopped after arm 3 and still reported status 0, which is the truncated-run-
+# reads-as-a-pass shape. It went from 9/0 to a silent 3-arm stub.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 FIXTURE_ACTOR=fixture-runner   # not a real agent; set per-step to impersonate one on purpose
-task_actor() { USER="agent-${FIXTURE_ACTOR}" SUDO_USER='' task_actor_REAL "$@"; }
+fixture_actor() { FIXTURE_ACTOR="$1"; actor_seam_as "$1"; }
 
 STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
 JSON_MODE=1
@@ -83,7 +97,7 @@ seed_loop() {
 }
 
 # ---- 1. maker's decision gate routes to the verifier agent, not the human ----
-route_reset; seed_loop DIVE-501
+route_reset; seed_loop DIVE-501; fixture_actor dev
 cmd_task_need DIVE-501 --type=decision --options='A|B' --recommend='A' \
   --ask='Which schema for the field?' --from=dev >/dev/null 2>&1
 [[ "$(route_last)" == "main" ]] \
@@ -94,14 +108,14 @@ cmd_task_need DIVE-501 --type=decision --options='A|B' --recommend='A' \
   || bad_t "routed_reviewer persisted as verifier" "got=$(db "SELECT routed_reviewer FROM tasks WHERE ident='DIVE-501';")"
 
 # ---- 2. approval gate on the loop also routes to the verifier ----
-route_reset; seed_loop DIVE-502
+route_reset; seed_loop DIVE-502; fixture_actor dev
 cmd_task_need DIVE-502 --type=approval --ask='OK to merge the refactor?' --from=dev >/dev/null 2>&1
 [[ "$(route_last)" == "main" ]] \
   && ok_t "maker approval gate routes to verifier 'main'" \
   || bad_t "maker approval gate routes to verifier 'main'" "route_last=$(route_last) human=$HUMAN_PINGED"
 
 # ---- 3. filer IS the verifier -> no self-route (max-iters escalation stays human) ----
-route_reset; seed_loop DIVE-503
+route_reset; seed_loop DIVE-503; fixture_actor main
 cmd_task_need DIVE-503 --type=decision --options='A|B' --recommend='A' \
   --ask='pick one' --from=main >/dev/null 2>&1
 [[ "$(route_last)" != "main" ]] \
@@ -109,7 +123,7 @@ cmd_task_need DIVE-503 --type=decision --options='A|B' --recommend='A' \
   || bad_t "verifier's own gate does not self-route to itself" "route_last=$(route_last)"
 
 # ---- 4. tier-2 category floor (money) stays human even on a loop ----
-route_reset; seed_loop DIVE-504
+route_reset; seed_loop DIVE-504; fixture_actor dev
 cmd_task_need DIVE-504 --type=decision --options='A|B' --recommend='A' \
   --ask='Approve the $5000 refund to the customer?' --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" && "$(route_sent)" == "0" ]] \
@@ -121,6 +135,13 @@ cmd_task_need DIVE-504 --type=decision --options='A|B' --recommend='A' \
 db "INSERT INTO tasks(ident,title,status,created_by,assignee,verifier,maker_agent,iteration,max_iterations,
       need_type,ask,need_answered_at)
     VALUES('DIVE-505','loop','blocked','dev','dev','main','dev',1,5,'manual','pending human thing',NULL);"
+# Back to the NEUTRAL fixture identity. Step 4 pinned `dev` to file its gate, and
+# `dev` is DIVE-505's maker — so leaving the pin there makes step 5's reject a
+# self-grade and the DIVE-2112 guard correctly ends the run. Under the old global
+# $USER pin this reset was implicit (nothing moved the actor per step); with a real
+# per-step derivation it has to be written down. Step 6 re-pins `dev` on purpose,
+# which is exactly the negative control for this line.
+fixture_actor fixture-runner
 # DIVE-2190: stdout only. This call can END the harness (cmd_* refusals go through fail()),
 # and `2>&1` sent the one line explaining WHY straight to /dev/null — the failure erased its
 # own reason. Redirect noise, never diagnosis.
@@ -142,9 +163,9 @@ answered_by=$(db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident='D
 db "INSERT INTO tasks(ident,title,status,created_by,assignee,verifier,maker_agent,iteration,max_iterations,
       need_type,ask,need_answered_at)
     VALUES('DIVE-506','loop','blocked','dev','dev','main','dev',1,5,'manual','pending human thing',NULL);"
-FIXTURE_ACTOR=dev
+fixture_actor dev
 rj_out=$(cmd_task_reject DIVE-506 --feedback='maker grading itself' 2>&1); rj_rc=$?
-FIXTURE_ACTOR=fixture-runner
+fixture_actor fixture-runner
 [[ "$rj_rc" != "0" && "$rj_out" == *MAKER* ]] \
   && ok_t "maker impersonation is still refused (identity pin does not disarm DIVE-2112)" \
   || bad_t "maker impersonation is still refused" "rc=$rj_rc out=${rj_out//$'\n'/ }"

--- a/tests/handoff_ack_unit.sh
+++ b/tests/handoff_ack_unit.sh
@@ -15,6 +15,11 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: identity comes from the uid now — `USER=agent-x` no longer moves it.
+# Impersonate through the sealed seam instead. The subshell keeps each call's
+# identity local, exactly as the env-prefix form did.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
+as_agent() { local _w="$1"; shift; ( actor_seam_as "$_w"; "$@" ); }
 SRC=src
 TMP="$(mktemp -d /tmp/handoff-ack-unit.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
@@ -39,19 +44,19 @@ bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 jf()    { jq -r "$1" 2>/dev/null; }
 
 tasks_db_init
-out=$(USER=agent-maker cmd_task_add --assignee=maker --verifier=reviewer \
+out=$(as_agent maker cmd_task_add --assignee=maker --verifier=reviewer \
       --body="implement it" -- "handoff ACK fixture" 2>"$TMP/err")
 tid=$(printf '%s' "$out" | jf '.data.id')
 
-USER=agent-maker cmd_task_start "$tid" >/dev/null 2>"$TMP/err"
-route=$(USER=agent-maker cmd_task_done "$tid" --result="ready" 2>"$TMP/err")
+as_agent maker cmd_task_start "$tid" >/dev/null 2>"$TMP/err"
+route=$(as_agent maker cmd_task_done "$tid" --result="ready" 2>"$TMP/err")
 state=$(db "SELECT status||'|'||assignee||'|'||COALESCE(handoff_ack_at,'') FROM tasks WHERE id=$tid;")
 [[ "$state" == "todo|reviewer|" && "$(printf '%s' "$route" | jf '.data.handoff')" == "delivered" ]] \
   && ok_t "maker close emits delivered, not reviewing" \
   || bad_t "delivered state" "state=$state route=$route"
 
 # Starting it as anyone except the assigned verifier must not forge the ACK.
-third=$(USER=agent-intruder cmd_task_start "$tid" 2>"$TMP/err")
+third=$(as_agent intruder cmd_task_start "$tid" 2>"$TMP/err")
 ack=$(db "SELECT COALESCE(handoff_ack_at,'') FROM tasks WHERE id=$tid;")
 [[ -z "$ack" && "$(printf '%s' "$third" | jf '.data.handoff // empty')" == "" ]] \
   && ok_t "third-party start cannot claim review began" \
@@ -59,28 +64,28 @@ ack=$(db "SELECT COALESCE(handoff_ack_at,'') FROM tasks WHERE id=$tid;")
 
 # The real receiver's start emits and persists the one ACK even if status was
 # already moved to in_progress by the third-party call above.
-review=$(USER=agent-reviewer cmd_task_start "$tid" 2>"$TMP/err")
+review=$(as_agent reviewer cmd_task_start "$tid" 2>"$TMP/err")
 ack=$(db "SELECT COALESCE(handoff_ack_at,'') FROM tasks WHERE id=$tid;")
 [[ -n "$ack" && "$(printf '%s' "$review" | jf '.data.handoff')" == "reviewing" ]] \
   && ok_t "assigned verifier start ACKs reviewing" \
   || bad_t "reviewing ACK" "ack=$ack out=$review"
 
-board=$(USER=agent-reviewer cmd_task_loops 2>"$TMP/err")
+board=$(as_agent reviewer cmd_task_loops 2>"$TMP/err")
 [[ "$(printf '%s' "$board" | jf '.data.loops[0].handoff_state')" == "reviewing" && \
    "$(printf '%s' "$board" | jf '.data.loops[0].handoff_ack_at')" == "$ack" ]] \
   && ok_t "loop board exposes reviewing receipt" \
   || bad_t "loop board receipt" "$board"
 
-USER=agent-reviewer cmd_task_assign "$tid" substitute >/dev/null 2>"$TMP/err"
+as_agent reviewer cmd_task_assign "$tid" substitute >/dev/null 2>"$TMP/err"
 reassigned=$(db "SELECT assignee||'|'||COALESCE(handoff_ack_at,'') FROM tasks WHERE id=$tid;")
 [[ "$reassigned" == "substitute|" ]] \
   && ok_t "reassignment clears stale receiver ACK" \
   || bad_t "reassignment ACK reset" "$reassigned"
-USER=agent-substitute cmd_task_assign "$tid" reviewer >/dev/null 2>"$TMP/err"
+as_agent substitute cmd_task_assign "$tid" reviewer >/dev/null 2>"$TMP/err"
 
 # A rejection returns ownership and clears the prior ACK; the next maker close
 # will create a fresh delivered handoff for the next review iteration.
-USER=agent-reviewer cmd_task_reject "$tid" --feedback="revise" >/dev/null 2>"$TMP/err"
+as_agent reviewer cmd_task_reject "$tid" --feedback="revise" >/dev/null 2>"$TMP/err"
 reset=$(db "SELECT assignee||'|'||COALESCE(handoff_ack_at,'') FROM tasks WHERE id=$tid;")
 [[ "$reset" == "maker|" ]] \
   && ok_t "reject clears ACK for the next handoff" \

--- a/tests/lib/actor_seam.sh
+++ b/tests/lib/actor_seam.sh
@@ -1,0 +1,68 @@
+# tests/lib/actor_seam.sh — impersonate a caller through the SEALED seam (DIVE-2518).
+#
+# WHY THIS FILE EXISTS, and it is the most useful thing DIVE-2518 turned up.
+#
+# Before 2518 a harness impersonated an actor by writing `USER=agent-olivia` and
+# `task_actor` believed it. That was never a test seam. It was THE FORGERY —
+# the same env-var path a caller with no privilege could take to act as another
+# agent across all 43 `task_actor` sites — and five harnesses depended on it
+# working. Closing the forgery closed those harnesses with it: `task_actor` went
+# from 20/0 to 15/5 in one of them, and every failure was a precondition arm
+# saying "harness can impersonate an actor" going red.
+#
+# That is a good failure, and it is worth saying why. Those arms exist because
+# somebody understood that an impersonation harness which silently stops
+# impersonating grades NOTHING while still printing green. They turned a change in
+# the product into a loud red instead of a quiet vacuity. Test seams should assert
+# their own preconditions exactly like that.
+#
+# The sealed derivation already HAS real seams — `_gate_caller_uid` and
+# `_gate_passwd_stream`, added by DIVE-2330 and kept by DIVE-2517 for precisely
+# this purpose. They are FUNCTIONS, and that is the difference between a seam and
+# a hole: bash imports exported functions at startup, and a fresh `5dive` defines
+# its own afterwards, so an EXTERNAL caller cannot inject them — while a harness
+# that SOURCES the libraries can override them freely.
+#
+# Usage — call INSIDE the subshell that runs the code under test:
+#   ( actor_seam_as olivia; cmd_task_verify "$id" )
+#   ( actor_seam_as cli;    cmd_task_start  "$id" )   # the unattributable caller
+#
+# Names are taken as board names (`olivia` -> unix `agent-olivia`). `cli`, `root`
+# and any bare non-agent name model a caller the derivation MEASURES but cannot
+# attribute to an agent — which `task_actor` reports as the `cli` sentinel.
+
+# A uid that is not this box's. The passwd stream is stubbed alongside it, so the
+# pair is self-consistent regardless of who runs the suite — the
+# precondition-supplied-by-the-host defect DIVE-2365 named.
+_ACTOR_SEAM_UID="${_ACTOR_SEAM_UID:-4242}"
+
+actor_seam_as() {
+  local who="${1:-}" unix
+  case "$who" in
+    ''|cli|runner) unix="runner" ;;
+    root)          unix="root" ;;
+    agent-*)       unix="$who" ;;
+    *)             unix="agent-${who}" ;;
+  esac
+  # `eval` so the stubbed values are baked in rather than read from a variable the
+  # code under test could also see and be confused by.
+  eval "_gate_caller_uid()    { printf '%s' '${_ACTOR_SEAM_UID}'; }"
+  eval "_gate_passwd_stream() { printf '%s:x:%s:%s:::\n' '${unix}' '${_ACTOR_SEAM_UID}' '${_ACTOR_SEAM_UID}'; }"
+  # The registry memo is keyed on the resolved unix name and would otherwise carry
+  # the PREVIOUS impersonation's answer into this one.
+  _ACTOR_REG_MEMO_KEY=""; _ACTOR_REG_MEMO_VAL=""; _ACTOR_REG_MEMO_TIER=""
+  # The identity env vars no longer decide who is acting, but they are still read
+  # for PROVENANCE (`_actor_identity`) and by `auto_sender_from_sudo` on the
+  # envelope path. Keep them consistent with the impersonation so an arm that
+  # happens to cross one of those paths sees one coherent caller, not two.
+  USER="$unix"; LOGNAME="$unix"; SUDO_UID=""; SUDO_USER=""
+}
+
+# actor_seam_selftest <expected-board-name> — assert the seam actually moved the
+# actor. Call this once per harness, as a real graded arm. A seam that silently
+# stops working turns every arm below it green-and-meaningless.
+actor_seam_selftest() {
+  local want="$1" got
+  got=$( actor_seam_as "$want"; task_actor )
+  [[ "$got" == "$want" ]]
+}

--- a/tests/task_answer_closed_row_unit.sh
+++ b/tests/task_answer_closed_row_unit.sh
@@ -35,6 +35,10 @@ set -uo pipefail
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
 cd "$(dirname "$0")/.."
+# DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
+# the actor — that env path WAS the forgery this ticket closed, and these arms
+# were leaning on it. tests/lib/actor_seam.sh explains the migration.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 
 # `manual` is a HUMAN-ONLY gate (DIVE-916) and that boundary reads the REAL unix
 # caller, not $USER/$SUDO_USER. Under an agent-* uid every manual case below is
@@ -66,7 +70,7 @@ ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n       %s\n' "$1" "${2:-}"; }
 
 tasks_db_init
-as() { local who="$1"; shift; ( USER="agent-${who}"; SUDO_UID=""; SUDO_USER=""; "$@" ) 2>"$TMP"/err; }
+as() { local who="$1"; shift; ( actor_seam_as "${who}"; "$@" ) 2>"$TMP"/err; }
 # The live human paths (Telegram tap -> `sudo -n 5dive task answer`, dashboard
 # exec as claude) are non-agent unix callers with a non-agent SUDO_UID.
 as_human() { ( SUDO_UID="1000"; SUDO_USER="lodar"; "$@" ) 2>"$TMP"/err; }
@@ -80,7 +84,7 @@ refusals()  { db "SELECT COUNT(*) FROM policy_refusals WHERE policy='task_answer
 ACK="verified PASS — the seal grades the bundle, not that src produces it"
 
 # ── instrument: without impersonation every case below is vacuous ─────────────
-actor_is() { ( USER="agent-$1"; SUDO_UID=""; SUDO_USER=""; task_actor ); }
+actor_is() { ( actor_seam_as "$1"; task_actor ); }
 [[ "$(actor_is dev2)" == "dev2" ]] \
   && ok_t "INSTRUMENT: harness impersonates a third party (task_actor -> dev2)" \
   || bad_t "INSTRUMENT: actor impersonation broken" "got '$(actor_is dev2)' — every case is vacuous"

--- a/tests/task_close_preserves_done_at_unit.sh
+++ b/tests/task_close_preserves_done_at_unit.sh
@@ -33,6 +33,10 @@ set -uo pipefail
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
 cd "$(dirname "$0")/.."
+# DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
+# the actor — that env path WAS the forgery this ticket closed, and these arms
+# were leaning on it. tests/lib/actor_seam.sh explains the migration.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 
 SRC=src
 TMP="$(mktemp -d /tmp/task-doneat-preserve-unit.XXXXXX)"
@@ -54,7 +58,7 @@ ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n       %s\n' "$1" "${2:-}"; }
 
 tasks_db_init
-as() { local who="$1"; shift; ( USER="agent-${who}"; SUDO_UID=""; SUDO_USER=""; "$@" ) 2>"$TMP"/err; }
+as() { local who="$1"; shift; ( actor_seam_as "${who}"; "$@" ) 2>"$TMP"/err; }
 
 status_of() { db "SELECT status                 FROM tasks WHERE ident=$(sqlq "$1");"; }
 doneat_of() { db "SELECT COALESCE(done_at,'')   FROM tasks WHERE ident=$(sqlq "$1");"; }
@@ -66,7 +70,7 @@ backdate() { db "UPDATE tasks SET done_at=$(sqlq "$SENTINEL") WHERE ident=$(sqlq
 add() { JSON_MODE=1 cmd_task_add "$@" 2>"$TMP"/err | jq -r '.data.ident // empty'; }
 
 # ── instrument: without impersonation the actor-scoped guards make cases vacuous
-actor_is() { ( USER="agent-$1"; SUDO_UID=""; SUDO_USER=""; task_actor ); }
+actor_is() { ( actor_seam_as "$1"; task_actor ); }
 [[ "$(actor_is dev2)" == "dev2" ]] \
   && ok_t "INSTRUMENT: harness impersonates an actor (task_actor -> dev2)" \
   || bad_t "INSTRUMENT: actor impersonation broken" "got '$(actor_is dev2)' — cases are vacuous"

--- a/tests/task_done_delivered_guard_unit.sh
+++ b/tests/task_done_delivered_guard_unit.sh
@@ -24,6 +24,10 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
+# the actor — that env path WAS the forgery this ticket closed, and these arms
+# were leaning on it. tests/lib/actor_seam.sh explains the migration.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 
 TMP="$(mktemp -d /tmp/task-done-delivered-unit.XXXXXX)"
@@ -52,8 +56,8 @@ tasks_db_init
 
 # task_actor() falls back to $USER when there's no sudo mapping and no --from, so
 # each case sets USER to the agent-<name> form to impersonate that actor.
-as() { local who="$1"; shift; ( USER="agent-${who}"; SUDO_UID=""; SUDO_USER=""; "$@" ) 2>"$TMP"/err; }
-actor_is() { ( USER="agent-$1"; SUDO_UID=""; SUDO_USER=""; task_actor ); }
+as() { local who="$1"; shift; ( actor_seam_as "${who}"; "$@" ) 2>"$TMP"/err; }
+actor_is() { ( actor_seam_as "$1"; task_actor ); }
 
 [[ "$(actor_is dev)" == "dev" ]] && ok_t "harness can impersonate an actor (task_actor → dev)" \
   || bad_t "actor impersonation" "got '$(actor_is dev)' — every case below would be vacuous"
@@ -155,10 +159,10 @@ as dev cmd_task_cancel "$T8" --result="abandoned" >/dev/null; rc=$?
 # unmerged-delivery close while citing DIVE-2007, and refusing a MERGED one
 # outright (task_deliver_merge_gate_unit Tb/Tc). Reproduce the CI shape exactly:
 # no sudo mapping and a $USER that is not agent-*.
-nobody() { ( USER=runner; SUDO_UID=""; SUDO_USER=""; "$@" ) 2>"$TMP"/err; }
-[[ "$( ( USER=runner; SUDO_UID=""; SUDO_USER=""; task_actor ) )" == "cli" ]] \
+nobody() { ( actor_seam_as cli; "$@" ) 2>"$TMP"/err; }
+[[ "$( ( actor_seam_as cli; task_actor ) )" == "cli" ]] \
   && ok_t "T9 harness reproduces the unattributable actor (task_actor → cli)" \
-  || bad_t "T9 actor precondition" "got '$( ( USER=runner; SUDO_UID=""; SUDO_USER=""; task_actor ) )' — T9/T10 would be vacuous"
+  || bad_t "T9 actor precondition" "got '$( ( actor_seam_as cli; task_actor ) )' — T9/T10 would be vacuous"
 
 T9=$(seed "T9 unattributed close")
 as dev cmd_task_done "$T9" --result="v1" >/dev/null

--- a/tests/task_reject_actor_and_closed_unit.sh
+++ b/tests/task_reject_actor_and_closed_unit.sh
@@ -26,6 +26,10 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
+# the actor — that env path WAS the forgery this ticket closed, and these arms
+# were leaning on it. tests/lib/actor_seam.sh explains the migration.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 
 TMP="$(mktemp -d /tmp/task-reject-actor-unit.XXXXXX)"
@@ -48,8 +52,8 @@ ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 
 tasks_db_init
-as() { local who="$1"; shift; ( USER="agent-${who}"; SUDO_UID=""; SUDO_USER=""; "$@" ) 2>"$TMP"/err; }
-actor_is() { ( USER="agent-$1"; SUDO_UID=""; SUDO_USER=""; task_actor ); }
+as() { local who="$1"; shift; ( actor_seam_as "${who}"; "$@" ) 2>"$TMP"/err; }
+actor_is() { ( actor_seam_as "$1"; task_actor ); }
 
 [[ "$(actor_is dev)" == "dev" ]] && ok_t "harness can impersonate an actor (task_actor -> dev)" \
   || bad_t "actor impersonation" "got '$(actor_is dev)' — every case below would be vacuous"

--- a/tests/task_start_delivered_guard_unit.sh
+++ b/tests/task_start_delivered_guard_unit.sh
@@ -52,6 +52,10 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
+# the actor — that env path WAS the forgery this ticket closed, and these arms
+# were leaning on it. tests/lib/actor_seam.sh explains the migration.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/task-start-delivered-unit.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
@@ -75,10 +79,10 @@ bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 # The guard reads the ACTOR, so every arm has to SAY who is calling. task_actor()
 # falls back to $USER when there is no sudo mapping and no --from.
 run_as() { local who="$1" verb="$2"; shift 2
-           ( USER="agent-${who}"; SUDO_UID=""; SUDO_USER=""; JSON_MODE=1; "cmd_task_$verb" "$@" ) 2>"$TMP"/err; }
+           ( actor_seam_as "${who}"; JSON_MODE=1; "cmd_task_$verb" "$@" ) 2>"$TMP"/err; }
 rc_of()  { local who="$1" verb="$2"; shift 2
-           ( USER="agent-${who}"; SUDO_UID=""; SUDO_USER=""; JSON_MODE=1; "cmd_task_$verb" "$@" ) >/dev/null 2>"$TMP"/err; printf '%s' "$?"; }
-show_of() { ( USER="agent-nobody"; SUDO_UID=""; SUDO_USER=""; JSON_MODE=0; cmd_task_show "$1" ) 2>&1; }
+           ( actor_seam_as "${who}"; JSON_MODE=1; "cmd_task_$verb" "$@" ) >/dev/null 2>"$TMP"/err; printf '%s' "$?"; }
+show_of() { ( actor_seam_as nobody; JSON_MODE=0; cmd_task_show "$1" ) 2>&1; }
 jf()   { jq -r "$1" 2>/dev/null; }
 has()  { [[ "$1" == *"$2"* ]]; }
 st()   { db "SELECT status FROM tasks WHERE id=$1;"; }
@@ -173,8 +177,8 @@ before=$(db "SELECT COALESCE(handoff_delivered_at,'')||'|'||COALESCE(maker_agent
 # `id -un`, so an EMPTY $USER resolves to whoever is running the harness (an
 # agent-* box yields a real agent name and this arm would grade the runner, not
 # the sentinel). A non-agent $USER is the shape that actually reaches 'cli'.
-t6_rc=$( ( USER="root"; SUDO_UID=""; SUDO_USER=""; JSON_MODE=1; cmd_task_start "$t6" ) >/dev/null 2>"$TMP"/err; printf '%s' "$?" )
-t6_actor=$( USER="root"; SUDO_UID=""; SUDO_USER=""; task_actor )
+t6_rc=$( ( actor_seam_as root; JSON_MODE=1; cmd_task_start "$t6" ) >/dev/null 2>"$TMP"/err; printf '%s' "$?" )
+t6_actor=$( actor_seam_as root; task_actor )
 if [[ "$t6_actor" != "cli" ]]; then
   # Do not silently grade a carve-out we could not construct.
   bad_t "T6 precondition: a non-agent \$USER must resolve to the 'cli' sentinel" "task_actor=$t6_actor"

--- a/tests/task_verifier_rail_unit.sh
+++ b/tests/task_verifier_rail_unit.sh
@@ -29,6 +29,10 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
+# the actor — that env path WAS the forgery this ticket closed, and these arms
+# were leaning on it. tests/lib/actor_seam.sh explains the migration.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/task-verifier-rail-unit.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
@@ -55,7 +59,7 @@ runt() { local verb="$1"; shift; ( JSON_MODE=0; "cmd_task_$verb" "$@" ) 2>"$TMP"
 # may close has to say who is calling. task_actor() falls back to $USER when there
 # is no sudo mapping and no --from.
 run_as() { local who="$1" verb="$2"; shift 2
-           ( USER="agent-${who}"; SUDO_UID=""; SUDO_USER=""; JSON_MODE=1; "cmd_task_$verb" "$@" ) 2>"$TMP"/err; }
+           ( actor_seam_as "${who}"; JSON_MODE=1; "cmd_task_$verb" "$@" ) 2>"$TMP"/err; }
 jf()   { jq -r "$1" 2>/dev/null; }
 has()  { [[ "$1" == *"$2"* ]]; }
 

--- a/tests/task_verify_over_closed_unit.sh
+++ b/tests/task_verify_over_closed_unit.sh
@@ -30,6 +30,9 @@
 # Run: bash tests/task_verify_over_closed_unit.sh
 set -uo pipefail
 cd "$(dirname "$0")/.."
+# DIVE-2518: `USER=agent-x` no longer moves the actor; derive as them instead.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
+as_agent() { local _w="$1"; shift; ( actor_seam_as "$_w"; "$@" ); }
 SRC=src
 
 TMP="$(mktemp -d /tmp/task-verify-closed-unit.XXXXXX)"
@@ -68,7 +71,7 @@ ACK="ACK: accepted — c97a4f9 was ALREADY merged with a version bump; red-team 
 
 # --- A. the defect: maker verify-closes an already-done task -------------------
 id=$(seed done olivia "$ACK")
-out=$( FIVE_SENDER=dev2 USER=agent-dev2 cmd_task_verify "$id" --cmd=true 2>&1 ); rc=$?
+out=$( FIVE_SENDER=dev2 as_agent dev2 cmd_task_verify "$id" --cmd=true 2>&1 ); rc=$?
 res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
 [ "$rc" -ne 0 ] && ok "A1 maker's verify --cmd over a done task is REFUSED (rc=$rc)" || no "A1 maker's verify --cmd over a done task is REFUSED" "rc=$rc $out"
 grep -q 'DIVE-2067' <<<"$out" && ok "A2 the refusal cites DIVE-2067" || no "A2 the refusal cites DIVE-2067" "$out"
@@ -90,21 +93,21 @@ if [[ -z "$(_gate_authenticated_actor 2>/dev/null)" ]]; then
   skip "B1 escape preserved — NOT REACHED: this runner has no kernel-authenticable agent identity, so DIVE-2015 refuses the live-loop auto-close before the escape is exercised"
 else
   id=$(seed todo olivia "")
-  out=$( FIVE_SENDER=dev2 USER=agent-dev2 cmd_task_verify "$id" --cmd=true 2>&1 ); rc=$?
+  out=$( FIVE_SENDER=dev2 as_agent dev2 cmd_task_verify "$id" --cmd=true 2>&1 ); rc=$?
   st=$(db "SELECT status FROM tasks WHERE id=$id;")
   [ "$st" = done ] && ok "B1 verify --cmd still closes a NOT-done task (escape preserved)" || no "B1 escape preserved" "rc=$rc st=$st $out"
 fi
 
 # --- C. the verifier's own re-close preserves the prior record (rec 3) ---------
 id=$(seed done olivia "$ACK")
-out=$( FIVE_SENDER=olivia USER=agent-olivia cmd_task_verify "$id" --cmd=true 2>&1 ); rc=$?
+out=$( FIVE_SENDER=olivia as_agent olivia cmd_task_verify "$id" --cmd=true 2>&1 ); rc=$?
 res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
 grep -q 'superseded result' <<<"$res" && ok "C1 a re-close PRESERVES the prior result rather than replacing it" || no "C1 prior result preserved" "$res"
 grep -q 'ALREADY merged with a version bump' <<<"$res" && ok "C2 the original ACK text survives in full" || no "C2 original ACK survives" "$res"
 
 # --- D. no verifier recorded => no guard (nothing to protect) ------------------
 id=$(seed done "" "prior")
-out=$( FIVE_SENDER=dev2 USER=agent-dev2 cmd_task_verify "$id" --cmd=true 2>&1 ); rc=$?
+out=$( FIVE_SENDER=dev2 as_agent dev2 cmd_task_verify "$id" --cmd=true 2>&1 ); rc=$?
 [ "$rc" -eq 0 ] && ok "D1 a task with no recorded verifier is not blocked" || no "D1 no-verifier task not blocked" "rc=$rc $out"
 
 echo; echo "DIVE-2067 verify-over-closed guard: passed: $P  failed: $F  skipped: $S"

--- a/tests/verifier_gate_ack_unit.sh
+++ b/tests/verifier_gate_ack_unit.sh
@@ -37,6 +37,10 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "$0")/.."
+# DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
+# the actor — that env path WAS the forgery this ticket closed, and these arms
+# were leaning on it. tests/lib/actor_seam.sh explains the migration.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 
 TMP="$(mktemp -d /tmp/verifier-gate-ack.XXXXXX)"
@@ -81,8 +85,8 @@ _gate_withdraw_actor() { printf '%s' "$GATE_ACTOR"; }
 
 tasks_db_init
 
-as() { local who="$1"; shift; ( USER="agent-${who}"; SUDO_UID=""; SUDO_USER=""; "$@" ) 2>"$TMP/err"; }
-[[ "$( ( USER=agent-reviewer; SUDO_UID=""; SUDO_USER=""; task_actor ) )" == "reviewer" ]] \
+as() { local who="$1"; shift; ( actor_seam_as "${who}"; "$@" ) 2>"$TMP/err"; }
+[[ "$( ( actor_seam_as reviewer; task_actor ) )" == "reviewer" ]] \
   && ok_t "harness can impersonate an actor (task_actor → reviewer)" \
   || bad_t "actor impersonation broken" "every case below would be vacuous"
 


### PR DESCRIPTION
W1 (#368) sealed one uid-first actor derivation. This makes it bind across the 43 `task_actor` sites.

> **This PR's design changed once, mid-flight, and the second design is the one described here.** The first cut had `task_actor` return the derivation unconditionally and had `task need` *refuse* a divergent `--from`. It passed 25 arms, 12 mutants and four runner principals — and the full 267-harness corpus killed it. All three of my instruments agreed because one misreading wrote all three.

## What ships

| | |
|---|---|
| **the env path closes** | identity never reads `$USER` or `$SUDO_USER` again. This is the hole that was *measured*: `SUDO_USER=agent-olivia 5dive task ls --mine` acted as another agent with **no privilege and no trace**. |
| **`--from` stays provenance** | it still stamps `created_by`, because it names principals that **have no uid at all** — `council` files board rows as `--from=council`, the Telegram rail answers as `--from=telegram`. No passwd walk can produce those, so deriving would silently reattribute the row to whoever ran the process. |
| **`derived_actor`** | new column, **always populated**, carrying the uid that actually ran it. A forged claim is not prevented — it is made **falsifiable**. |
| **the one decision** | `_gate_route_reviewer` picks who may later *clear* a gate. That call now reads the derivation, so the claim moves no outcome anywhere. |

`--from` is argv: deliberate, logged, and often the only way to name a principal. `$SUDO_USER` is an env var nothing verifies. **Different threats, different answers** — collapsing them costs relay and buys nothing.

## Why the refusal was removed

- `--from` appears on ~120 `task need` calls across a dozen harnesses as *the* idiom for "agent X files this gate".
- The refusal goes through `fail`, which **exits** — so an unsubshelled caller was not failed, it was **truncated**. `gate_verifier_route_unit` went from 9 arms to three `ok` lines and no summary. A truncated log contains no failures.
- `gate_filed_by` has been provenance since DIVE-1401/1945/2015. The only thing the claim *decided* was one line, and pointing that line at the derivation delivers the whole security property while refusing nothing.

## Also in this PR

- `derived_actor` added to the **base schema as well as** the migration array. A fresh store is built from `_tasks_schema` and never migrates, so a column in only one place exists on every existing board and no new one — and the error lands on the *first write to a brand-new store*, which nobody with a working board performs. Caught by `council_schedule_e2e`.
- `lead:standing:` now names the actor the standing check **authenticated**, with a fallback so it can never stamp an empty name.
- `_actor_identity` kept as provenance (`FIVEDIVE_AUDIT_USER` is the dashboard's Clerk relay); the derived value rides alongside it in the audit row.
- `_envelope_caller` **deliberately unchanged** — `envelope_sender_fallback_unit` T3/T4 grade its *text* for a self-contained `$EUID` + hardcoded `/etc/passwd`, because its value feeds `envelope_tier`; `lib/actor.sh` reaches passwd through a **function** seam so harnesses can override it. Both are right for their own field; collapsing them is a separate decision.
- `scripts/harness-tree-guard.sh` scoping fix — its pathspec `tests/*.sh` also matched `tests/lib/*.sh` (git wildmatch crosses `/`) while the CI contract's shell glob does not, and the fix it printed for a `tests/lib/` file resolved to a path that cannot exist.

## Harness migration

**Ten harnesses were impersonating actors through the forgery itself** (`USER=agent-x`) or through `--from`. Migrated to `tests/lib/actor_seam.sh`, which routes through the `_gate_caller_uid` / `_gate_passwd_stream` seams DIVE-2330 kept as *functions* — a sourcing harness can override a function, an external caller cannot. All ten back to exact baseline tallies.

## Checks

- `tests/actor_claim_corroboration_unit.sh` — **24 arms**, mutation-graded against **11 mutants**, including one restoring the env precedence, one dropping the claim (relay loss), one writing `derived_actor` only on divergence, and one deleting the column from the base schema (reddens the fresh-store arm **and no other**).
- Each of the three measurements that killed design 1 has its own arm: T20 (the filing idiom must file), T26 (a uid-less principal keeps its name), T3b (the env/argv asymmetry in one arm — if those two ever agree, a threat has been silently reclassified).
- Green as `agent-dev`, `agent-olivia`, `agent-main`; `claude` skips one arm honestly (its name is not `agent-*`, so the passwd rung has nothing to strip).
- e2e arms prove store isolation **differentially** before writing.

Rebased onto `86a2576` (DIVE-2383 landed mid-flight; preserved, no conflict).

Closes DIVE-2518.
