### PR TITLE
fix(release): the cutter could only ever increment the PATCH, so v0.18.0 was unreachable (DIVE-2539)

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -160,6 +160,14 @@ jobs:
           # extracting and RUNNING these exact bytes rather than grading a copy.
           # Unset (the nightly schedule, which declares no input) means patch, so the
           # scheduled path is behaviourally identical to before this change.
+          # DO NOT ADD `set -e` TO THIS STEP. It runs under `set -uo pipefail` on purpose,
+          # which is why every refusal below is an EXPLICIT `exit 1` rather than a bare
+          # failing command. tests/release_cut_assign_unit.sh evals these same bytes, and
+          # its mutation grade depends on it: removing the explicit exit on an unknown
+          # level turns a refusal into a silent patch derivation and reddens exactly ONE
+          # arm. Under `set -e` that arm would still pass for the wrong reason, and the
+          # refusal would look pinned when it was only incidentally covered. (olivia,
+          # DIVE-2539.)
           _level="${RELEASE_LEVEL:-patch}"
           case "$_level" in
             patch) version="${_maj}.${_min}.$(( _pat + 1 ))" ;;

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -69,6 +69,12 @@ on:
         description: 'Why this cut is being made by hand (hotfix, incident, first cut)'
         required: true
         type: string
+      level:
+        description: 'Which component to increment. patch = the nightly behaviour. minor/major DECLARE AN EPOCH and are only correct when the headline capability has landed.'
+        required: false
+        default: patch
+        type: choice
+        options: [patch, minor, major]
 
 concurrency:
   group: release-cut
@@ -90,6 +96,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           MANUAL_REASON: ${{ inputs.reason }}
+          RELEASE_LEVEL: ${{ inputs.level }}
         run: |
           set -uo pipefail
 
@@ -139,7 +146,35 @@ jobs:
             echo "::error::could not derive a successor from floor='${floor}' incumbent='${incumbent}' — refusing to cut."
             exit 1
           fi
-          version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$(( BASH_REMATCH[3] + 1 ))"
+          _maj="${BASH_REMATCH[1]}" _min="${BASH_REMATCH[2]}" _pat="${BASH_REMATCH[3]}"
+          # DIVE-2539: WHICH COMPONENT MOVES. This used to be patch-only, unconditionally,
+          # and that was invisible for its whole life because every cut since DIVE-2247 has
+          # been a patch — a capability that was never built reads exactly like one that
+          # works until the day it has different work. v0.18's headline verb (whoami,
+          # DIVE-2517) landed and the epoch could not be declared: major and minor were
+          # copied verbatim from the base, so 0.18.0 was unreachable from any path, and the
+          # fleet would have kept installing 0.17.x builds that already contained the work.
+          #
+          # RELEASE_LEVEL comes from the dispatch input via env, NOT from a ${{ }} template,
+          # so this block stays pure bash and tests/release_cut_assign_unit.sh can keep
+          # extracting and RUNNING these exact bytes rather than grading a copy.
+          # Unset (the nightly schedule, which declares no input) means patch, so the
+          # scheduled path is behaviourally identical to before this change.
+          _level="${RELEASE_LEVEL:-patch}"
+          case "$_level" in
+            patch) version="${_maj}.${_min}.$(( _pat + 1 ))" ;;
+            minor) version="${_maj}.$(( _min + 1 )).0" ;;
+            major) version="$(( _maj + 1 )).0.0" ;;
+            *) echo "::error::RELEASE_LEVEL='${_level}' is not patch|minor|major — refusing to guess which component to move."; exit 1 ;;
+          esac
+          # The floor/incumbent base is the highest version ALREADY CLAIMED, so a successor
+          # that does not sort strictly above it would re-issue a number against a different
+          # tree (DIVE-2118). patch cannot fail this; a wrong minor/major arithmetic can, and
+          # this is the arm that catches it before a tag exists rather than after.
+          if [[ "$(printf '%s\n%s\n' "$base" "$version" | sort -V | tail -1)" != "$version" || "$version" == "$base" ]]; then
+            echo "::error::derived ${version} does not sort strictly above the claimed base ${base} at level '${_level}' — refusing to cut (DIVE-2118)."
+            exit 1
+          fi
           tag="v${version}"
           echo "cut-time assignment: floor ${floor}, incumbent ${incumbent:-<none>} -> ${tag} (DIVE-2247)"
 

--- a/tests/release_cut_assign_unit.sh
+++ b/tests/release_cut_assign_unit.sh
@@ -160,5 +160,52 @@ grep -q 'PROCEEDED' <<<"$out" \
   && ok_t 'no incumbent tag at all -> proceeds (first cut is not blocked)' \
   || bad_t 'the very first cut must not be blocked by a missing incumbent' "$out"
 
+echo "-- DIVE-2539: WHICH COMPONENT MOVES. patch-only was invisible for its whole life"
+# Every cut since DIVE-2247 has been a patch, so a patch-only derivation and a correct one
+# were indistinguishable until an epoch completed and 0.18.0 turned out to be unreachable.
+# The arm that matters most is the DEFAULT one: the nightly schedule passes no input, so if
+# an unset RELEASE_LEVEL ever stopped meaning patch, every scheduled cut would change shape.
+
+out=$(run_block '0.17.8' v0.17.1 v0.17.11); rc=$?
+grep -q '^DERIVED=v0\.17\.12$' <<<"$out" \
+  && ok_t 'RELEASE_LEVEL UNSET (the scheduled path) still derives a PATCH — v0.17.11 -> v0.17.12' \
+  || bad_t 'the default changed; the nightly cut is no longer patch' "rc=$rc out=$out"
+
+out=$(RELEASE_LEVEL=patch run_block '0.17.8' v0.17.1 v0.17.11); rc=$?
+grep -q '^DERIVED=v0\.17\.12$' <<<"$out" \
+  && ok_t 'RELEASE_LEVEL=patch agrees with unset (explicit and default are the same path)' \
+  || bad_t 'explicit patch disagrees with the default' "rc=$rc out=$out"
+
+# THE LIVE CASE this ticket exists for: floor 0.17.8, incumbent v0.17.11, v0.18 code merged.
+out=$(RELEASE_LEVEL=minor run_block '0.17.8' v0.17.1 v0.17.11); rc=$?
+grep -q '^DERIVED=v0\.18\.0$' <<<"$out" \
+  && ok_t 'RELEASE_LEVEL=minor -> v0.18.0, and the PATCH RESETS TO 0 rather than carrying 11' \
+  || bad_t 'a minor is still unreachable, which is the whole defect' "rc=$rc out=$out"
+
+out=$(RELEASE_LEVEL=major run_block '0.17.8' v0.17.1 v0.17.11); rc=$?
+grep -q '^DERIVED=v1\.0\.0$' <<<"$out" \
+  && ok_t 'RELEASE_LEVEL=major -> v1.0.0 (minor AND patch both reset)' \
+  || bad_t 'major does not reset both lower components' "rc=$rc out=$out"
+
+echo "-- a minor must still obey the floor, or it re-issues a hand-assigned number"
+# The floor is the only thing between a fresh cut and a version already installed on a live
+# box. A new level arm is exactly where that invariant would get dropped by accident.
+out=$(RELEASE_LEVEL=minor run_block '0.19.3' v0.17.1 v0.17.11); rc=$?
+grep -q '^DERIVED=v0\.20\.0$' <<<"$out" \
+  && ok_t 'floor 0.19.3 above the incumbent -> minor derives v0.20.0, not v0.18.0' \
+  || bad_t 'the minor path ignored the floor and would re-issue a claimed number' "rc=$rc out=$out"
+
+echo "-- an unknown level REFUSES rather than guessing which component to move"
+out=$(RELEASE_LEVEL=mnior run_block '0.17.8' v0.17.11); rc=$?
+[[ $rc -ne 0 ]] && ok_t 'a typo\u2019d level refuses (never silently falls back to patch)' \
+               || bad_t 'an unknown level must refuse; falling back to patch would silently not cut the epoch asked for' "rc=$rc out=$out"
+
+echo "-- and the derived version must sort STRICTLY ABOVE the claimed base"
+# patch cannot fail this; a wrong minor/major arithmetic can, and this assert is what
+# catches it BEFORE a tag exists rather than after (DIVE-2118).
+grep -q 'does not sort strictly above the claimed base' "$WF" \
+  && ok_t 'the sorts-strictly-above assertion is present in the shipped workflow' \
+  || bad_t 'the sorts-above guard is missing; a bad level arithmetic could re-issue a number' ""
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Blocks the v0.18 epic (DIVE-2515) on arithmetic while the code is finished — whoami (DIVE-2517, e00d4e0) and the collapse (DIVE-2518, b6af46f) are both merged.

`release-cut.yml` is the only version writer in the repo and copied major/minor verbatim, so the next cut was v0.17.12 whether fired nightly or by hand. Adds a `level` input (default patch) via env so the fenced derivation stays pure bash and the harness keeps running the shipped bytes rather than a copy.

Harness 13 -> 21 arms. The load-bearing arm is that an unset RELEASE_LEVEL still derives a patch — the scheduled path must not change shape. Also: minor resets the patch to 0, major resets both, a minor still obeys a higher floor, and an unknown level refuses rather than silently falling back to patch.