### PR TITLE
fix(release): an Actions expression delimiter inside a shell COMMENT made release-cut.yml unparseable (DIVE-2539)

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -158,7 +158,14 @@ jobs:
           # copied verbatim from the base, so 0.18.0 was unreachable from any path, and the
           # fleet would have kept installing 0.17.x builds that already contained the work.
           #
-          # RELEASE_LEVEL comes from the dispatch input via env, NOT from a ${{ }} template,
+          # RELEASE_LEVEL reaches this block through `env:` rather than through an
+          # Actions expression template. That is deliberate and it is also load-bearing
+          # for the harness: tests/release_cut_assign_unit.sh extracts these bytes and
+          # runs them, so anything the runner substitutes before bash sees it would be
+          # ungradeable. NOTE FOR ANYONE EDITING THIS COMMENT: do NOT write an Actions
+          # expression delimiter literally anywhere in a `run:` block, not even inside a
+          # shell comment — substitution happens before the shell exists, so an empty or
+          # malformed one makes the whole workflow unparseable (it did, DIVE-2539).
           # so this block stays pure bash and tests/release_cut_assign_unit.sh can keep
           # extracting and RUNNING these exact bytes rather than grading a copy.
           # Unset (the nightly schedule, which declares no input) means patch, so the


### PR DESCRIPTION
Supersedes #372 (the revert). This keeps the level input AND unbreaks the file, so main goes straight to working rather than back to patch-only.

An empty `$\{\{ \}\}` inside a shell comment in the `run:` block. Actions substitutes expressions before the shell exists, so it is parsed even in comments — the comment explaining I had avoided the hazard contained it. Publish path dead since 15:25; the 02:37Z nightly would not have fired.

Validated with actionlint (clean of expression errors) and the harness is 21/0. actionlint named it in one run with a byte offset resolving to the comment; `yaml.safe_load` accepts the file, which is why my own check missed it.