### PR TITLE
feat(whoami): --for=<subject> renders the RECORDED authority chain and exits 1 when it is unmeasurable (DIVE-2519)

### DIFF
--- a/changelog.d/DIVE-2519.md
+++ b/changelog.d/DIVE-2519.md
@@ -1,0 +1,40 @@
+## Unreleased — feat(whoami): `--for=<subject>` renders the RECORDED authority chain, and refuses when it cannot be measured (DIVE-2519)
+
+W1 sealed *who is acting, now*. This is the read half: **who did this, then** — and
+it is the half that can refuse.
+
+INST-4 already landed the recording layer (`lifecycle_events`: actor plus
+authority as `root` / `sudo:<who>` / `self`, the elevation the audit log never
+captured), and `trace` already read that table as a **timeline**. Nothing read it
+as a **chain**, and nothing refused when the chain could not be measured. A
+timeline that silently omits the row nobody recorded looks identical to a clean
+history.
+
+`5dive whoami --for=<id|DIVE-N> [--json]` resolves who created / started /
+delivered / answered-a-gate-on / closed a row and under whose authority, from the
+record, and **exits 1 when any link that happened cannot be measured**. Scope it
+with `--for=task:`, `gate:` or `action:`.
+
+The load-bearing distinction is `n/a` vs `unmeasurable`. "This transition never
+happened" and "it happened and nobody recorded who" are the absent-vs-forbidden
+conflation this codebase keeps paying for (DIVE-1989, DIVE-2318), and the ledger
+cannot testify to its own gaps — so the discriminator is the task row's own
+transition columns, never the ledger. Unmeasurable is named, never rendered green:
+`predates-ledger`, `ledger-start-unknown`, `no-recorded-event`, `actor-placeholder`
+(a `cli` or `unknown` in the actor column is a failed derivation wearing a name),
+`human-claim-undiscriminated` (no field separates an authorised human tap from an
+agent self-clear), `authority-absent`.
+
+DIVE-2518 reconciliation: where a `--from` claim disagreed with the derivation, W2
+folds the measured principal into `detail` as `derived_actor=`, leaving the claim
+in the `actor` column — so on those rows `actor` is the least reliable field. The
+chain renders the **derived** actor and keeps the claim beside it as `claimed_by`.
+That case is measured, not unmeasurable: we know exactly who ran it, and the
+disagreement is the thing W2 wrote down.
+
+**What it found on the live board the day it shipped:** 86 of the 96 rows started
+since the ledger opened have no `task.started` event at all. The emit exists and
+fires 10 times; the start path mostly does not reach it. That is a hole in the
+*recording* layer, filed separately — this row is the read half, and reading is
+how it became visible.
+

--- a/src/cmd_whoami.sh
+++ b/src/cmd_whoami.sh
@@ -17,12 +17,20 @@
 # it only works if the failure is in the status.
 
 cmd_whoami() {
-  local a
+  local a subject=""
   for a in "$@"; do
     case "$a" in
+      # DIVE-2519 (W3): the READ half. `--for` switches the verb from "who am I,
+      # now" to "who did this, then" — the same question asked of the RECORD.
+      # Parsed here rather than in a wrapper so `cmd_whoami` stays the single
+      # entry point the sealed harness already grades.
+      --for)   fail "$E_USAGE" "--for needs a subject: 5dive whoami --for=<id|DIVE-N>" ;;
+      --for=*) subject="${a#--for=}"
+               [[ -n "$subject" ]] || fail "$E_USAGE" "--for needs a subject: 5dive whoami --for=<id|DIVE-N>" ;;
       -h|--help)
         cat <<'EOF'
 5dive whoami [--json]
+5dive whoami --for=<id|DIVE-N> [--json]
 
 Print the actor, authority and tier of the CURRENT process, with the source of each.
 
@@ -39,11 +47,32 @@ and the last two resolve through the caller's own PATH.
 
 Exit status: 0 when the actor was measured, 6 (auth_required) when it was not.
 "Not an agent" is a MEASUREMENT and exits 0; "this uid resolves to nothing" is not.
+
+--for=<id|DIVE-N>   render the RECORDED authority chain for one board row —
+                    who created / started / delivered / answered-a-gate-on /
+                    closed it, and under whose authority — from the ledger.
+                    Scope it with --for=task:DIVE-N, gate:DIVE-N, action:DIVE-N.
+
+  Every link resolves to exactly one of three verdicts:
+    measured      an event of the right kind exists and names an identity.
+    n/a           the STATE row says the transition never happened. By design.
+    unmeasurable  the state row says it DID happen and the record cannot say
+                  who, or under what authority.
+
+  Exit status under --for: 0 when every link that happened is measured, 1 when
+  any is unmeasurable, 4 for no such subject. Distinct from the bare verb's 6 on
+  purpose: 6 means "I cannot measure YOU", 1 means "the record has a hole". A
+  hole is a finding about the ledger, not a failure to authenticate the caller.
 EOF
         return 0 ;;
       *) fail "$E_USAGE" "unknown flag: $a" ;;
     esac
   done
+
+  if [[ -n "$subject" ]]; then
+    _whoami_for "$subject"
+    return $?
+  fi
 
   local measured=1
   actor_derive || measured=0
@@ -137,5 +166,250 @@ EOF
   printf 'ignored for identity: %s\n' "${ignored:-<none set>}"
 
   (( measured )) || fail "$E_AUTH_REQUIRED" "actor is UNMEASURABLE ($ACTOR_REASON) — refusing to guess"
+  return 0
+}
+
+# -------- 5dive whoami --for=<subject> (DIVE-2519, v0.18 W3) --------
+#
+# The READ half of "proof of who". INST-4 landed the recording layer
+# (lifecycle_events: actor + authority, where authority is root | sudo:<who> |
+# self — the elevation the audit log never captured) and `trace` already reads
+# that table as a TIMELINE. Nothing read it as a CHAIN, and nothing REFUSED when
+# the chain could not be measured. A timeline that silently omits the row nobody
+# recorded looks identical to a clean history.
+#
+# The acceptance bar is DIVE-2224's: the event must be detectable FROM THE RECORD
+# ALONE, by a reader with no memory of the conversation. So every link resolves to
+# exactly one of three verdicts, and the third is the whole point:
+#
+#   measured      an event of the right kind exists and names an identity, under
+#                 a recorded authority.
+#   n/a           the STATE row says this transition never happened. Absent by
+#                 design — conflating "did not happen" with "happened,
+#                 unrecorded" is the absent-vs-forbidden bug this codebase has
+#                 paid for repeatedly (DIVE-1989, DIVE-2318).
+#   unmeasurable  the state row says the transition DID happen, and the record
+#                 cannot tell us who did it or under what authority.
+#
+# The discriminator between `n/a` and `unmeasurable` is the tasks row's own
+# transition columns (started_at, handoff_delivered_at, need_answered_at,
+# done_at). That is the only honest way to have one: the ledger cannot
+# distinguish its own silence from a thing that never occurred.
+#
+# UNMEASURABLE REASONS:
+#   predates-ledger      created before task_prefs.ledger_started. The great
+#                        majority of the board is in this bucket and always will
+#                        be. Not a bug, and not a pass either.
+#   ledger-start-unknown the start marker itself is missing, so we cannot even say
+#                        WHICH of the two an empty ledger means. Weaker than
+#                        predates-ledger; named separately on purpose.
+#                        REACHABILITY, stated because a check nobody can exercise
+#                        is a check nobody can trust (lib/audit.sh:154): through
+#                        THIS verb the branch is unreachable, since tasks_db_init
+#                        INSERT OR IGNOREs ledger_started and _whoami_for calls it
+#                        first. Kept because the reason to distrust an empty marker
+#                        does not depend on today's caller, and the harness reaches
+#                        it through the tasks_db_init seam rather than pretending
+#                        the verb can produce it.
+#   no-recorded-event    post-ledger, the transition happened, no row was written.
+#   actor-placeholder    the event exists and its actor is not an identity. The
+#                        live table carries `cli` (task_actor's literal
+#                        else-branch — resolution FAILED and recorded a value
+#                        anyway) and `unknown` (_actor_identity's genuine-failure
+#                        value, DIVE-2073). A placeholder in the actor column is a
+#                        failed derivation wearing a name.
+#   human-claim-undiscriminated  the actor is `human:<x>`. Per
+#                        community/wiki/gate-record-cannot-distinguish-tap-from-selfclear.md
+#                        NO field separates an authorized human tap from an agent
+#                        self-clear: `human=1` is a self-assertable flag any
+#                        root-capable agent may pass. Every `human:*` name on the
+#                        live board is an agent short-name. --for must SAY so
+#                        rather than render a green chain over it. UNMEASURABLE,
+#                        not FORGED — the claim may well be true, we cannot grade it.
+#   authority-absent     an actor with no recorded authority. Who, but not under
+#                        what powers — half a link.
+#
+# DIVE-2518 RECONCILIATION, and it is the one thing this verb could not have said
+# before W2. `--from` is now a CLAIM that is recorded beside the derivation rather
+# than replacing it: when the two DISAGREE, ledger_record folds the measured
+# principal into `detail` as `derived_actor=<name>` (tasks_db.sh:2110) and leaves
+# the claim in the `actor` column. So on those rows the `actor` column is the
+# LEAST reliable field in the row, and a reader that renders it as the answer
+# prints the claim while the measurement sits one column over.
+#
+# That case is MEASURED, not unmeasurable, and the distinction is load-bearing:
+# we know exactly who ran it. What we also know is that the row is attributed to
+# somebody else, so the chain renders the DERIVED actor and carries the claim
+# alongside it. Silently preferring either one would destroy the only record of
+# the disagreement — which is the whole reason W2 wrote both down.
+#
+# Read-only: touches the shared task DB only. No mutation, no lock, no audit line
+# of its own — same posture as trace/usage/digest.
+
+# Actor values that are NOT identities. Kept as one list so the reason string and
+# the test fixture cannot drift from the check.
+_WHOAMI_PLACEHOLDER_ACTORS=" cli unknown - none null "
+
+# _whoami_for <subject>
+# subject := [task:|gate:|action:]<id|DIVE-N>
+_whoami_for() {
+  tasks_db_init
+  local raw="$1" scope="all"
+  case "$raw" in
+    task:*)   scope="task";   raw="${raw#task:}" ;;
+    gate:*)   scope="gate";   raw="${raw#gate:}" ;;
+    action:*) scope="action"; raw="${raw#action:}" ;;
+  esac
+  [[ -n "$raw" ]] || fail "$E_USAGE" "--for needs a subject after the class prefix"
+
+  resolve_task_id "$raw"
+  local id="$RESOLVED_TASK_ID" ident="$RESOLVED_TASK_IDENT"
+
+  # ---- the STATE row: which transitions actually happened -----------------
+  # This is the discriminator between "n/a" and "unmeasurable". Read it from the
+  # tasks row, never from the ledger — the ledger cannot testify to its own gaps.
+  local srow
+  srow=$(db "SELECT COALESCE(created_at,'')||'|'||COALESCE(started_at,'')||'|'||
+                    COALESCE(handoff_delivered_at,'')||'|'||COALESCE(need_answered_at,'')||'|'||
+                    COALESCE(done_at,'')||'|'||COALESCE(status,'')
+               FROM tasks WHERE id=${id};")
+  local s_created s_started s_delivered s_answered s_done s_status
+  IFS='|' read -r s_created s_started s_delivered s_answered s_done s_status <<<"$srow"
+
+  # ---- the ledger start marker -------------------------------------------
+  local ledger_started
+  ledger_started=$(db "SELECT value FROM task_prefs WHERE key='ledger_started';" 2>/dev/null || true)
+  local predates=0 start_unknown=0
+  if [[ -z "$ledger_started" ]]; then
+    start_unknown=1
+  elif [[ -n "$s_created" && "$s_created" < "$ledger_started" ]]; then
+    predates=1
+  fi
+
+  # ---- link table: name | class | happened? | matching ledger kinds -------
+  # Each row is one link of the authority chain. `kinds` is a comma-separated SQL
+  # IN-list; a terminal close matches EITHER task.done or task.cancelled because
+  # the state column (done_at) cannot say which and both are the same link.
+  local -a L_NAME=(created started delivered answered closed)
+  local -a L_CLASS=(task task task gate action)
+  local -a L_WHEN=("$s_created" "$s_started" "$s_delivered" "$s_answered" "$s_done")
+  local -a L_KINDS=("'task.created'" "'task.started'" "'task.delivered'" "'gate.answered'" "'task.done','task.cancelled'")
+
+  local rows_json="" any_unmeasurable=0 n_measured=0 n_unmeasurable=0 n_na=0 n_divergent=0
+  local i
+  for i in "${!L_NAME[@]}"; do
+    local name="${L_NAME[$i]}" class="${L_CLASS[$i]}" when="${L_WHEN[$i]}" kinds="${L_KINDS[$i]}"
+    [[ "$scope" == "all" || "$scope" == "$class" ]] || continue
+
+    local verdict reason="" ev_ts="" ev_actor="" ev_auth="" ev_kind="" ev_detail=""
+    local eff_actor="" claimed=""
+    if [[ -z "$when" ]]; then
+      # The state row says this transition never occurred. Absent by design.
+      verdict="n/a"; reason="did-not-happen"; n_na=$(( n_na + 1 ))
+    else
+      local ev
+      # char(9), NOT a '\t' literal: SQLite's || concatenation does not interpret
+      # backslash escapes, so '\t' concatenates a BACKSLASH and a t and the
+      # IFS=$'\t' read below then finds no field separator at all — every field
+      # lands in $ev_ts and the actor reads EMPTY, which this verb would report as
+      # actor-placeholder. A measurement bug that fabricates the exact finding the
+      # verb exists to report is the worst possible failure here.
+      ev=$(db "SELECT ts||char(9)||kind||char(9)||actor||char(9)||authority||char(9)||COALESCE(detail,'')
+                 FROM lifecycle_events
+                WHERE ident=$(sqlq "$ident") AND kind IN (${kinds})
+                ORDER BY id LIMIT 1;" 2>/dev/null || true)
+      if [[ -z "$ev" ]]; then
+        verdict="unmeasurable"
+        if (( start_unknown )); then      reason="ledger-start-unknown"
+        elif (( predates )); then         reason="predates-ledger"
+        else                              reason="no-recorded-event"; fi
+      else
+        IFS=$'\t' read -r ev_ts ev_kind ev_actor ev_auth ev_detail <<<"$ev"
+        # DIVE-2518: `derived_actor=` in the detail means --from was a claim that
+        # DISAGREED with the measurement. The derived name is the measured one;
+        # the actor column holds the claim. Grade the derived name, keep the claim.
+        eff_actor="$ev_actor"
+        if [[ "$ev_detail" == *derived_actor=* ]]; then
+          local d="${ev_detail##*derived_actor=}"; d="${d%% *}"
+          if [[ -n "$d" ]]; then claimed="$ev_actor"; eff_actor="$d"; fi
+        fi
+        local a_lower="${eff_actor,,}"
+        if [[ -z "$eff_actor" || "$_WHOAMI_PLACEHOLDER_ACTORS" == *" $a_lower "* ]]; then
+          verdict="unmeasurable"; reason="actor-placeholder:${eff_actor:-<empty>}"
+        elif [[ "$a_lower" == human:* ]]; then
+          verdict="unmeasurable"; reason="human-claim-undiscriminated"
+        elif [[ -z "$ev_auth" ]]; then
+          verdict="unmeasurable"; reason="authority-absent"
+        else
+          verdict="measured"
+          if [[ -n "$claimed" ]]; then
+            reason="claim-divergent:${claimed}"; n_divergent=$(( n_divergent + 1 ))
+          fi
+        fi
+      fi
+      # $(( x + 1 )), never (( x++ )): a post-increment from 0 EVALUATES to 0, so
+      # the arithmetic command exits 1 and `set -e` kills the run mid-loop — the
+      # first unmeasurable link would abort the render and print nothing at all.
+      if [[ "$verdict" == "measured" ]]; then n_measured=$(( n_measured + 1 ))
+      else n_unmeasurable=$(( n_unmeasurable + 1 )); any_unmeasurable=1; fi
+    fi
+
+    rows_json+="$(jq -nc --arg link "$name" --arg class "$class" --arg verdict "$verdict" \
+                        --arg reason "$reason" --arg state_at "$when" --arg ts "$ev_ts" \
+                        --arg kind "$ev_kind" --arg actor "$eff_actor" --arg authority "$ev_auth" \
+                        --arg claimed "$claimed" \
+                  '{link:$link,class:$class,verdict:$verdict,reason:$reason,
+                    state_at:$state_at,
+                    event:{ts:$ts,kind:$kind,actor:$actor,authority:$authority,
+                           claimed_by:(if $claimed=="" then null else $claimed end)}}')"$'\n'
+  done
+
+  local links
+  links=$(printf '%s' "$rows_json" | jq -sc '.')
+  [[ -n "$links" ]] || links='[]'
+
+  local chain_verdict="measured"
+  (( any_unmeasurable )) && chain_verdict="unmeasurable"
+
+  if [[ "${JSON_MODE:-0}" == "1" ]]; then
+    jq -n --arg ident "$ident" --arg scope "$scope" --arg status "$s_status" \
+          --arg chain "$chain_verdict" --arg ledger_started "$ledger_started" \
+          --argjson predates "$predates" \
+          --argjson measured "$n_measured" --argjson unmeasurable "$n_unmeasurable" \
+          --argjson na "$n_na" --argjson divergent "$n_divergent" --argjson links "$links" \
+      '{ident:$ident,scope:$scope,status:$status,chain:$chain,
+        ledger_started:$ledger_started,predates_ledger:($predates==1),
+        counts:{measured:$measured,unmeasurable:$unmeasurable,na:$na,claim_divergent:$divergent},
+        links:$links}'
+  else
+    printf 'authority chain for %s  (scope: %s, status: %s)\n\n' "$ident" "$scope" "${s_status:-?}"
+    printf '  %-10s %-7s %-13s %-20s %-16s %s\n' LINK CLASS VERDICT ACTOR AUTHORITY WHEN/REASON
+    printf '%s' "$rows_json" | jq -r '
+      "  \(.link[0:10] | . + (" " * (10 - length)))"
+      + " \(.class[0:7] | . + (" " * (7 - length)))"
+      + " \(.verdict[0:13] | . + (" " * (13 - length)))"
+      + " \((if .verdict=="measured" then .event.actor else "-" end)[0:20] as $a | $a + (" " * (20 - ($a|length))))"
+      + " \((if .verdict=="measured" then .event.authority else "-" end)[0:16] as $x | $x + (" " * (16 - ($x|length))))"
+      + " \(if .verdict=="measured" and .reason=="" then .event.ts else .reason end)"'
+    printf '\n  chain: %s   (measured %d · unmeasurable %d · n/a %d)\n' \
+      "$chain_verdict" "$n_measured" "$n_unmeasurable" "$n_na"
+    if (( n_divergent )); then
+      printf '  note: %d link(s) carry a --from claim that DISAGREED with the derivation\n' "$n_divergent"
+      printf '        (DIVE-2518). The actor shown is the DERIVED one; claimed_by holds the claim.\n'
+    fi
+    if (( predates )); then
+      printf '  note: this row was created before the ledger opened (%s), so its early links\n' "$ledger_started"
+      printf '        were never recordable. Unmeasurable, not clean.\n'
+    fi
+    if (( start_unknown )); then
+      printf '  note: task_prefs.ledger_started is MISSING, so an empty ledger cannot be told\n'
+      printf '        apart from work that predates it. Weakest possible reading.\n'
+    fi
+    if [[ "$chain_verdict" == "unmeasurable" ]]; then
+      printf '\n  REFUSED: the chain cannot be measured from the record alone. Exit 1.\n'
+    fi
+  fi
+
+  if (( any_unmeasurable )); then return 1; fi
   return 0
 }

--- a/src/main.sh
+++ b/src/main.sh
@@ -283,7 +283,9 @@ Actor-routed gh (DIVE-2448):
   # (DIVE-2232). The PAT stays root-side in /etc/5dive/connectors/github-bot.env — the agent never holds it.
 
 Identity:
-  5dive whoami [--json]
+  5dive whoami [--json]                    # the CURRENT process: actor, authority, tier + the SOURCE of each; exit 6 if unmeasurable
+  5dive whoami --for=<id|DIVE-N> [--json]  # the RECORDED authority chain for one row; EXIT 1 when a link that HAPPENED is unmeasurable
+                                           # scope it: --for=task:DIVE-N | gate:DIVE-N | action:DIVE-N
     Who is acting, under whose authority, at what tier — and the SOURCE of each.
     Identity is uid-first: \$EUID (or sudo's \$SUDO_UID at real root) resolved
     against /etc/passwd in pure bash. Never argv/--from, \$USER, \$SUDO_USER or

--- a/tests/whoami_for_chain_unit.sh
+++ b/tests/whoami_for_chain_unit.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# DIVE-2519 (v0.18 W3) — `whoami --for=<subject>` renders the RECORDED authority
+# chain and EXITS NON-ZERO when a link that HAPPENED cannot be measured.
+#
+# The bar this harness has to clear is DIVE-2224's: the verdict must be
+# derivable FROM THE RECORD ALONE. So every arm constructs the record it grades
+# — a fixture DB with lifecycle_events rows written directly — rather than
+# asserting against whatever the live board happens to hold today.
+#
+# THE ARM THAT MATTERS MOST IS G, the exit-0 control. Without it, a verb that
+# returned "unmeasurable / exit 1" unconditionally would pass every other arm on
+# this page. That is the exact shape this epoch exists to refuse — a control
+# that reports a verdict while measuring nothing — and it would be absurd to
+# ship it inside the check for it.
+#
+# Arms:
+#   A  a happened-link with a real actor + authority        -> measured
+#   B  a link the STATE says never happened                 -> n/a, NOT counted
+#   C  post-ledger, transition happened, no event written   -> unmeasurable/no-recorded-event
+#   D  row created before ledger_started                    -> unmeasurable/predates-ledger
+#   E  actor is the literal placeholder 'cli' / 'unknown'   -> unmeasurable/actor-placeholder
+#   F  actor is 'human:<x>'                                 -> unmeasurable/human-claim-undiscriminated
+#   G  EVERY happened-link measured                         -> chain measured, EXIT 0   <-- the control
+#   H  ledger_started marker absent                         -> unmeasurable/ledger-start-unknown
+#   I  --for=gate:/task:/action: scopes the chain
+#   J  a bad subject is exit 4, not a green empty chain
+#   K  DIVE-2518 divergent --from claim  -> measured, DERIVED actor + claimed_by
+#   L  divergent claim onto a placeholder-> unmeasurable  <-- K's differential
+#
+# Run: bash tests/whoami_for_chain_unit.sh
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+cd "$(dirname "$0")/.."
+
+SRC=src
+TMP="$(mktemp -d /tmp/whoami-for-chain-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/disk.sh lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_whoami.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+mkdir -p "$TASKS_DIR"
+set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n       %s\n' "$1" "${2:-}"; }
+
+tasks_db_init
+
+LEDGER_START='2026-07-30 00:40:06'
+db "INSERT OR REPLACE INTO task_prefs(key,value) VALUES('ledger_started',$(sqlq "$LEDGER_START"));"
+
+# cmd_task_add is the REAL verb, so it emits its own task.created ledger row.
+# Every arm below is about the record, so the fixture has to OWN the record:
+# without this clear, the arm's hand-written event is the SECOND row for the
+# ident and the verb (ORDER BY id LIMIT 1) grades the harness's incidental one
+# instead. That silently turned the placeholder and predates-ledger arms green
+# on the wrong evidence the first time this file ran.
+add() {
+  local _i; _i=$(JSON_MODE=1 cmd_task_add "$@" 2>"$TMP"/err | jq -r '.data.ident // empty')
+  db "DELETE FROM lifecycle_events WHERE ident=$(sqlq "$_i");"
+  printf '%s' "$_i"
+}
+
+# Write the STATE row's transition columns directly. The state row is the
+# discriminator between n/a and unmeasurable, so each arm has to be able to say
+# "this transition DID happen" independently of whether an event exists.
+state() { # state <ident> <col> <value>
+  db "UPDATE tasks SET $2=$(sqlq "$3") WHERE ident=$(sqlq "$1");"
+}
+# Write a ledger event verbatim — actor and authority exactly as given.
+ev() { # ev <ident> <kind> <actor> <authority> <ts>
+  db "INSERT INTO lifecycle_events(ts,kind,ident,actor,authority,idem_key)
+      VALUES($(sqlq "$5"),$(sqlq "$2"),$(sqlq "$1"),$(sqlq "$3"),$(sqlq "$4"),
+             $(sqlq "$1-$2-$5-$RANDOM"));"
+}
+# Same, plus the DETAIL column. DIVE-2518 folds the MEASURED principal into
+# detail as `derived_actor=<name>` whenever a --from claim DISAGREED with the
+# derivation, leaving the claim in the `actor` column — so on those rows `actor`
+# is the least reliable field in the row. Arms K and L grade which one the verb
+# believes.
+ev_d() { # ev_d <ident> <kind> <actor-claim> <authority> <ts> <detail>
+  db "INSERT INTO lifecycle_events(ts,kind,ident,actor,authority,detail,idem_key)
+      VALUES($(sqlq "$5"),$(sqlq "$2"),$(sqlq "$1"),$(sqlq "$3"),$(sqlq "$4"),
+             $(sqlq "$6"),$(sqlq "$1-$2-$5-$RANDOM"));"
+}
+# Run the verb and capture BOTH the json and the exit code. JSON_MODE is set
+# per-call, never globally, so the human render stays exercised too.
+run_json() { JSON_MODE=1 cmd_whoami --for="$1" 2>"$TMP"/err; }
+rc_of()    { JSON_MODE=1 cmd_whoami --for="$1" >/dev/null 2>"$TMP"/err; printf '%s' "$?"; }
+v_of()     { printf '%s' "$1" | jq -r --arg l "$2" '.links[]|select(.link==$l)|.verdict'; }
+r_of()     { printf '%s' "$1" | jq -r --arg l "$2" '.links[]|select(.link==$l)|.reason'; }
+a_of()     { printf '%s' "$1" | jq -r --arg l "$2" '.links[]|select(.link==$l)|.event.actor'; }
+c_of()     { printf '%s' "$1" | jq -r --arg l "$2" '.links[]|select(.link==$l)|.event.claimed_by'; }
+
+# ── INSTRUMENT: the fixture writer actually lands rows ───────────────────────
+# Without this, every "unmeasurable" arm below would pass on an empty table for
+# the wrong reason — the verb would be reading a ledger the harness never wrote
+# to, and no arm would notice.
+I0=$(add "instrument row" --assignee=dev)
+[[ "$(db "SELECT COUNT(*) FROM lifecycle_events WHERE ident=$(sqlq "$I0");")" == "0" ]] \
+  && ok_t "INSTRUMENT: add() clears the real verb's own event, so arms grade the FIXTURE record" \
+  || bad_t "INSTRUMENT: stale events survive add()" "arms would grade cmd_task_add's row, not the fixture's"
+ev "$I0" task.created main self '2026-07-30 10:00:00'
+[[ "$(db "SELECT COUNT(*) FROM lifecycle_events WHERE ident=$(sqlq "$I0");")" == "1" ]] \
+  && ok_t "INSTRUMENT: the fixture writer lands lifecycle_events rows" \
+  || bad_t "INSTRUMENT: fixture writer wrote nothing" "every unmeasurable arm below would be vacuous"
+
+# ── A + B: measured, and n/a is not a failure ────────────────────────────────
+A=$(add "A measured created" --assignee=dev)
+state "$A" created_at '2026-07-30 10:00:00'
+ev "$A" task.created olivia 'sudo:agent-olivia' '2026-07-30 10:00:00'
+a=$(run_json "$A")
+[[ "$(v_of "$a" created)" == "measured" ]] \
+  && ok_t "A: a recorded event with a real actor+authority is 'measured'" \
+  || bad_t "A: expected measured" "got '$(v_of "$a" created)'"
+[[ "$(printf '%s' "$a" | jq -r '.links[]|select(.link=="created")|.event.authority')" == "sudo:agent-olivia" ]] \
+  && ok_t "A: the recorded AUTHORITY is rendered, not just the actor" \
+  || bad_t "A: authority not rendered" "$a"
+[[ "$(v_of "$a" delivered)" == "n/a" && "$(r_of "$a" delivered)" == "did-not-happen" ]] \
+  && ok_t "B: a transition the state row says never happened is n/a, not unmeasurable" \
+  || bad_t "B: expected n/a/did-not-happen" "got '$(v_of "$a" delivered)'/'$(r_of "$a" delivered)'"
+
+# ── C: post-ledger, it happened, nothing was recorded ────────────────────────
+# The live instance of this arm is DIVE-2519 itself: started 2026-08-02 07:30:12
+# with no task.started event on a row created after the ledger opened.
+C=$(add "C started but unrecorded" --assignee=dev)
+state "$C" created_at '2026-07-31 09:00:00'
+state "$C" started_at '2026-07-31 09:05:00'
+ev "$C" task.created main self '2026-07-31 09:00:00'
+c=$(run_json "$C")
+[[ "$(v_of "$c" started)" == "unmeasurable" && "$(r_of "$c" started)" == "no-recorded-event" ]] \
+  && ok_t "C: a transition that happened post-ledger with no event is unmeasurable/no-recorded-event" \
+  || bad_t "C: expected unmeasurable/no-recorded-event" "got '$(v_of "$c" started)'/'$(r_of "$c" started)'"
+[[ "$(rc_of "$C")" == "1" ]] \
+  && ok_t "C: exit 1 — a hole in the chain is a refusal, not a pass" \
+  || bad_t "C: expected exit 1" "got $(rc_of "$C")"
+
+# ── D: predates the ledger ───────────────────────────────────────────────────
+D=$(add "D predates the ledger" --assignee=dev)
+state "$D" created_at '2026-07-01 00:00:00'
+d=$(run_json "$D")
+[[ "$(r_of "$d" created)" == "predates-ledger" ]] \
+  && ok_t "D: a row created before ledger_started reads predates-ledger, not no-recorded-event" \
+  || bad_t "D: expected predates-ledger" "got '$(r_of "$d" created)'"
+[[ "$(printf '%s' "$d" | jq -r '.predates_ledger')" == "true" ]] \
+  && ok_t "D: --json exposes predates_ledger so a reader can tell the two silences apart" \
+  || bad_t "D: predates_ledger flag wrong" "$d"
+
+# ── E: placeholder actors ────────────────────────────────────────────────────
+# 'cli' is task_actor's literal else-branch: derivation FAILED and recorded a
+# value anyway. It is on the live board 2026-08-02 (DIVE-2457 et al).
+for ph in cli unknown; do
+  E=$(add "E placeholder $ph" --assignee=dev)
+  state "$E" created_at '2026-07-31 10:00:00'
+  ev "$E" task.created "$ph" self '2026-07-31 10:00:00'
+  e=$(run_json "$E")
+  [[ "$(v_of "$e" created)" == "unmeasurable" && "$(r_of "$e" created)" == "actor-placeholder:$ph" ]] \
+    && ok_t "E: actor '$ph' is a failed derivation, reported unmeasurable (not laundered green)" \
+    || bad_t "E[$ph]: expected unmeasurable/actor-placeholder:$ph" "got '$(v_of "$e" created)'/'$(r_of "$e" created)'"
+done
+
+# ── F: a human: claim carries no discriminator ───────────────────────────────
+# gate-record-cannot-distinguish-tap-from-selfclear: no field separates an
+# authorized human tap from an agent self-clear. UNMEASURABLE, not forged.
+F=$(add "F human claim" --assignee=dev)
+state "$F" created_at '2026-07-31 11:00:00'
+state "$F" need_answered_at '2026-07-31 11:30:00'
+ev "$F" task.created main self '2026-07-31 11:00:00'
+ev "$F" gate.answered 'human:main' self '2026-07-31 11:30:00'
+f=$(run_json "$F")
+[[ "$(v_of "$f" answered)" == "unmeasurable" && "$(r_of "$f" answered)" == "human-claim-undiscriminated" ]] \
+  && ok_t "F: a human:* actor is unmeasurable — the record cannot grade the claim" \
+  || bad_t "F: expected unmeasurable/human-claim-undiscriminated" "got '$(v_of "$f" answered)'/'$(r_of "$f" answered)'"
+
+# ── G: THE CONTROL — a fully measured chain must EXIT 0 ──────────────────────
+# If this arm ever fails, nothing else on this page means anything: a verb that
+# always says "unmeasurable" would satisfy every arm above it.
+G=$(add "G fully measured" --assignee=dev)
+state "$G" created_at   '2026-07-31 12:00:00'
+state "$G" started_at   '2026-07-31 12:01:00'
+state "$G" done_at      '2026-07-31 12:02:00'
+ev "$G" task.created main self          '2026-07-31 12:00:00'
+ev "$G" task.started dev  'sudo:agent-dev' '2026-07-31 12:01:00'
+ev "$G" task.done    dev  self          '2026-07-31 12:02:00'
+g=$(run_json "$G")
+[[ "$(printf '%s' "$g" | jq -r '.chain')" == "measured" ]] \
+  && ok_t "G/CONTROL: a chain whose every happened-link is recorded reads 'measured'" \
+  || bad_t "G/CONTROL: expected chain=measured" "$g"
+[[ "$(rc_of "$G")" == "0" ]] \
+  && ok_t "G/CONTROL: EXIT 0 — the verb is not a constant refusal" \
+  || bad_t "G/CONTROL: expected exit 0" "got $(rc_of "$G") — every arm above is now vacuous"
+[[ "$(printf '%s' "$g" | jq -r '.counts.na')" == "2" ]] \
+  && ok_t "G: the two n/a links do NOT count against the chain verdict" \
+  || bad_t "G: n/a count wrong" "$g"
+
+# ── H: the ledger start marker itself is missing ─────────────────────────────
+# REACHABILITY FIRST. Deleting the pref and calling cmd_whoami does NOT reach
+# this branch: cmd_whoami calls tasks_db_init, which INSERT OR IGNOREs the marker
+# straight back (tasks_db.sh:1456). The first cut of this arm did exactly that
+# and read 'predates-ledger' — it would have graded a branch it never entered.
+# So H is asserted TWICE: once that the marker self-heals through the verb, and
+# once on the branch itself, entered through the tasks_db_init seam.
+db "DELETE FROM task_prefs WHERE key='ledger_started';"
+h_healed=$(run_json "$D")
+[[ "$(r_of "$h_healed" created)" == "predates-ledger" ]] \
+  && ok_t "H/REACHABILITY: through the verb the marker SELF-HEALS (tasks_db_init) — the branch below is not reachable this way" \
+  || bad_t "H/REACHABILITY: marker did not self-heal" "got '$(r_of "$h_healed" created)'"
+db "DELETE FROM task_prefs WHERE key='ledger_started';"
+h=$( tasks_db_init() { :; }; JSON_MODE=1 _whoami_for "$D" 2>/dev/null )
+[[ "$(r_of "$h" created)" == "ledger-start-unknown" ]] \
+  && ok_t "H: with no start marker we say we cannot TELL, rather than guessing predates-ledger" \
+  || bad_t "H: expected ledger-start-unknown" "got '$(r_of "$h" created)'"
+db "INSERT OR REPLACE INTO task_prefs(key,value) VALUES('ledger_started',$(sqlq "$LEDGER_START"));"
+
+# ── I: class scoping ─────────────────────────────────────────────────────────
+i_gate=$(JSON_MODE=1 cmd_whoami --for="gate:$F" 2>/dev/null)
+[[ "$(printf '%s' "$i_gate" | jq -r '[.links[].link]|join(",")')" == "answered" ]] \
+  && ok_t "I: --for=gate:<ident> scopes the chain to the gate link" \
+  || bad_t "I: gate scope wrong" "$i_gate"
+i_task=$(JSON_MODE=1 cmd_whoami --for="task:$G" 2>/dev/null)
+[[ "$(printf '%s' "$i_task" | jq -r '[.links[].link]|join(",")')" == "created,started,delivered" ]] \
+  && ok_t "I: --for=task:<ident> scopes to the task-lifecycle links" \
+  || bad_t "I: task scope wrong" "$i_task"
+i_act=$(JSON_MODE=1 cmd_whoami --for="action:$G" 2>/dev/null)
+[[ "$(printf '%s' "$i_act" | jq -r '[.links[].link]|join(",")')" == "closed" ]] \
+  && ok_t "I: --for=action:<ident> scopes to the terminal action" \
+  || bad_t "I: action scope wrong" "$i_act"
+
+# ── J: an unknown subject must not read as a clean empty chain ───────────────
+( JSON_MODE=1 cmd_whoami --for=DIVE-99999 ) >/dev/null 2>&1; j_rc=$?
+[[ "$j_rc" != "0" ]] \
+  && ok_t "J: an unresolvable subject exits non-zero (rc=$j_rc), never a green empty chain" \
+  || bad_t "J: unknown subject exited 0" "an empty chain that exits 0 is the failure mode this verb exists to remove"
+
+# ── K: DIVE-2518 — a --from claim that DISAGREED with the derivation ─────────
+# W2 made `--from` a claim rather than an override: when it diverges,
+# ledger_record folds the MEASURED principal into detail as `derived_actor=<x>`
+# and leaves the CLAIM in the actor column (tasks_db.sh:2110). olivia's draft of
+# this verb predates W2 and would have rendered the claim as the answer.
+# The link is MEASURED — we know exactly who ran it — but the row is attributed
+# to somebody else, and both facts have to survive the render.
+K=$(add "K divergent claim" --assignee=dev)
+state "$K" created_at '2026-07-31 13:00:00'
+ev_d "$K" task.created olivia 'sudo:agent-dev' '2026-07-31 13:00:00' 'derived_actor=dev'
+k=$(run_json "$K")
+[[ "$(v_of "$k" created)" == "measured" ]] \
+  && ok_t "K: a divergent claim is MEASURED — we know who ran it; it is the attribution that disagrees" \
+  || bad_t "K: expected measured" "got '$(v_of "$k" created)'"
+[[ "$(a_of "$k" created)" == "dev" ]] \
+  && ok_t "K: the DERIVED actor is rendered, not the claim in the actor column" \
+  || bad_t "K: rendered the wrong principal" "got '$(a_of "$k" created)', want the derived 'dev'"
+[[ "$(c_of "$k" created)" == "olivia" ]] \
+  && ok_t "K: the claim survives as claimed_by — dropping it would destroy the only record of the disagreement" \
+  || bad_t "K: claimed_by lost" "got '$(c_of "$k" created)'"
+[[ "$(r_of "$k" created)" == "claim-divergent:olivia" && "$(printf '%s' "$k" | jq -r '.counts.claim_divergent')" == "1" ]] \
+  && ok_t "K: the divergence is COUNTED and named, not silently absorbed into a green" \
+  || bad_t "K: divergence not surfaced" "$k"
+
+# ── L: the DIFFERENTIAL arm for K ────────────────────────────────────────────
+# K alone passes for a verb that renders whichever principal happens to be the
+# derived one. L inverts the pair: the CLAIM is a real agent name and the DERIVED
+# actor is the `cli` placeholder. A verb that grades the actor column reads a
+# clean 'olivia' and returns measured/exit 0; the correct one grades the derived
+# value, finds a failed derivation wearing a name, and refuses.
+L=$(add "L divergent onto a placeholder" --assignee=dev)
+state "$L" created_at '2026-07-31 14:00:00'
+ev_d "$L" task.created olivia self '2026-07-31 14:00:00' 'derived_actor=cli'
+l=$(run_json "$L")
+[[ "$(v_of "$l" created)" == "unmeasurable" && "$(r_of "$l" created)" == "actor-placeholder:cli" ]] \
+  && ok_t "L/DIFFERENTIAL: grading the DERIVED value catches a placeholder the actor column hides" \
+  || bad_t "L/DIFFERENTIAL: expected unmeasurable/actor-placeholder:cli" "got '$(v_of "$l" created)'/'$(r_of "$l" created)' — the verb is reading the CLAIM"
+[[ "$(rc_of "$L")" == "1" ]] \
+  && ok_t "L/DIFFERENTIAL: exit 1 — a clean-looking claim over a failed derivation is still a hole" \
+  || bad_t "L/DIFFERENTIAL: expected exit 1" "got $(rc_of "$L")"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/whoami_for_chain_unit.sh
+++ b/tests/whoami_for_chain_unit.sh
@@ -26,6 +26,7 @@
 #   J  a bad subject is exit 4, not a green empty chain
 #   K  DIVE-2518 divergent --from claim  -> measured, DERIVED actor + claimed_by
 #   L  divergent claim onto a placeholder-> unmeasurable  <-- K's differential
+#   M  lead:<agent> vs human:<agent>     -> measured vs unmeasurable, as a PAIR
 #
 # Run: bash tests/whoami_for_chain_unit.sh
 set -uo pipefail
@@ -283,6 +284,46 @@ l=$(run_json "$L")
 [[ "$(rc_of "$L")" == "1" ]] \
   && ok_t "L/DIFFERENTIAL: exit 1 — a clean-looking claim over a failed derivation is still a hole" \
   || bad_t "L/DIFFERENTIAL: expected exit 1" "got $(rc_of "$L")"
+
+# ── M: `lead:<agent>` is MEASURED where `human:<agent>` is not ───────────────
+# This distinction is LIVE, not hypothetical: DIVE-2517's gate.answered row on
+# this very board carries actor `lead:olivia`. It is also entirely a judgement,
+# so it gets an arm rather than an inference from the placeholder list.
+#
+# WHY THEY DIFFER. `human:<x>` is unmeasurable because NO field separates an
+# authorised human tap from an agent self-clear — `human=1` is a self-assertable
+# flag (gate-record-cannot-distinguish-tap-from-selfclear.md), and every `human:*`
+# name on the live board is an agent short-name. `lead:<x>` claims something
+# weaker and checkable: an AGENT cleared this in a lead role. The principal named
+# is a real board agent, so the chain can attribute it. Nothing about the ROLE is
+# verified here and this arm does not claim otherwise — only that the ACTOR is an
+# identity, which is the question --for asks.
+#
+# Asserted as a PAIR on the same fixture shape. Alone, the lead arm passes for a
+# verb that grades nothing at all; the human arm is what proves the two names take
+# genuinely different paths through the same check.
+M=$(add "M lead vs human on the same link" --assignee=dev)
+state "$M" created_at       '2026-07-31 15:00:00'
+state "$M" need_answered_at '2026-07-31 15:30:00'
+ev "$M" task.created  main          self '2026-07-31 15:00:00'
+ev "$M" gate.answered 'lead:olivia' self '2026-07-31 15:30:00'
+m=$(run_json "$M")
+[[ "$(v_of "$m" answered)" == "measured" ]] \
+  && ok_t "M: lead:<agent> is MEASURED — the actor is a real board identity, whatever the role claims" \
+  || bad_t "M: expected measured for lead:olivia" "got '$(v_of "$m" answered)'/'$(r_of "$m" answered)'"
+[[ "$(a_of "$m" answered)" == "lead:olivia" ]] \
+  && ok_t "M: the lead: prefix is preserved in the render, not silently stripped to a bare agent name" \
+  || bad_t "M: lead prefix lost" "got '$(a_of "$m" answered)'"
+
+MH=$(add "M/pair human on the same link" --assignee=dev)
+state "$MH" created_at       '2026-07-31 15:00:00'
+state "$MH" need_answered_at '2026-07-31 15:30:00'
+ev "$MH" task.created  main           self '2026-07-31 15:00:00'
+ev "$MH" gate.answered 'human:olivia' self '2026-07-31 15:30:00'
+mh=$(run_json "$MH")
+[[ "$(v_of "$mh" answered)" == "unmeasurable" && "$(v_of "$m" answered)" == "measured" ]] \
+  && ok_t "M/PAIR: the SAME name under human: is unmeasurable and under lead: is measured — the prefix is what moves the verdict" \
+  || bad_t "M/PAIR: the two prefixes did not diverge" "lead='$(v_of "$m" answered)' human='$(v_of "$mh" answered)' — one of them is grading nothing"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## v0.18 W3 — the READ half of "proof of who" (DIVE-2519)

W1 (#368) sealed *who is acting, now*. W2 (b6af46f) collapsed the six derivations onto it. This is **who did this, then** — and it is the half that can refuse.

INST-4 landed the recording layer (`lifecycle_events`: actor + authority as `root|sudo:<who>|self`, the elevation the audit log never captured) and `trace` already read it as a **timeline**. Nothing read it as a **chain**, and nothing refused when the chain could not be measured. A timeline that silently omits the row nobody recorded looks identical to a clean history.

```
$ 5dive whoami --for=DIVE-2517
authority chain for DIVE-2517  (scope: all, status: done)

  LINK       CLASS   VERDICT       ACTOR                AUTHORITY        WHEN/REASON
  created    task    measured      main                 self             2026-08-02 05:02:35
  started    task    unmeasurable  -                    -                no-recorded-event
  delivered  task    measured      dev                  self             2026-08-02 09:47:42
  answered   gate    measured      lead:olivia          self             2026-08-02 05:43:21
  closed     action  measured      olivia               self             2026-08-02 11:16:30

  chain: unmeasurable   (measured 4 · unmeasurable 1 · n/a 0)

  REFUSED: the chain cannot be measured from the record alone. Exit 1.
$ echo $?
1
```

### The load-bearing distinction is `n/a` vs `unmeasurable`

"This transition never happened" and "it happened and nobody recorded who" are the absent-vs-forbidden conflation this codebase keeps paying for (DIVE-1989, DIVE-2318). **The ledger cannot testify to its own gaps**, so the discriminator is the task row's own transition columns (`started_at`, `handoff_delivered_at`, `need_answered_at`, `done_at`) — written by a different path than the ledger — never the ledger itself.

Unmeasurable is always **named**, never rendered green: `predates-ledger`, `ledger-start-unknown`, `no-recorded-event`, `actor-placeholder` (a `cli` or `unknown` in the actor column is a failed derivation wearing a name), `human-claim-undiscriminated` (per `gate-record-cannot-distinguish-tap-from-selfclear.md`, no field separates an authorised human tap from an agent self-clear), `authority-absent`.

### W1 is untouched, deliberately

`--for` is parsed **inside** `cmd_whoami` rather than behind a wrapper, so W1's entry point and its mutation-graded harness are unchanged. `tests/whoami_sealed_actor_unit.sh` still reports **21 passed / 0 failed / 0 skipped** against the built bundle — the exact baseline olivia verified on #368.

### DIVE-2518 reconciliation

Where a `--from` claim **disagreed** with the derivation, W2 folds the measured principal into `detail` as `derived_actor=` and leaves the **claim** in the `actor` column (`tasks_db.sh:2110`). So on exactly the rows where attribution is contested, `actor` is the least reliable field in the row. The chain renders the **derived** actor and keeps the claim beside it as `claimed_by`. That case is `measured`, not `unmeasurable` — we know exactly who ran it; it is the *attribution* that disagrees, and collapsing the two would destroy the distinction W2 was built to record.

### Testing

`tests/whoami_for_chain_unit.sh` — **30 passed / 0 failed**. Every arm builds the record it grades (a fixture DB with `lifecycle_events` rows written directly) rather than asserting against whatever the live board holds today.

- **Arm G is the exit-0 control.** Without it, a verb that returned "unmeasurable" unconditionally would pass every other arm on the page — the exact control-that-measures-nothing shape this epoch exists to refuse.
- **Arm L is K's differential**: the claim is a real agent name and the derived value is the `cli` placeholder, so a verb reading the `actor` column returns a clean green and the arm goes red.
- **Arm M is a PAIR, added from a pre-delivery self-audit.** The verb treats `lead:olivia` as `measured` and `human:olivia` as `unmeasurable`, and nothing pinned that — while DIVE-2517's own `gate.answered` row carries actor `lead:olivia`, so the branch was already running on real data with zero coverage. `human:<x>` is undiscriminated because `human=1` is self-assertable; `lead:<x>` claims something weaker and checkable — an *agent* cleared this in a lead role — so the actor is an identity. The role itself is not verified and the arm does not claim it is. Asserted as a pair because the lead half alone passes for a verb that grades nothing.
- **Arm H asserts reachability first**: deleting the ledger marker and calling the verb does *not* reach the `ledger-start-unknown` branch, because `tasks_db_init` re-inserts it. H asserts the self-heal, then enters the branch through the `tasks_db_init` seam.

**Mutation-graded, not asserted:**

| mutation | result |
|---|---|
| drop the `--for` dispatch | 4 pass / **23 fail** |
| grade the claim instead of the derived value | 22 pass / **5 fail** (K + L) |
| remove the non-zero exit | 25 pass / **2 fail** (C, L) |
| fold `lead:*` into the `human:*` branch | 28 pass / **2 fail** (M + pair) |
| delete the `human:*` branch outright | 28 pass / **2 fail** (F + pair) |

The last two are the same pair failing from opposite sides — the property a two-name arm is supposed to have.

Stated plainly: **zero live rows carry `derived_actor=` yet** (W2 landed hours ago), so K/L are fixture-built, not board-observed.

### Found on the live board — filed, not fixed here

**86 of the 96 rows started since the ledger opened carry no `task.started` event.** The emit exists and fires 10 times; the start path mostly does not reach it. That is a defect in the *recording* layer and belongs to the write path — this row is the read half, and reading is how it became visible. Compiled to `community/wiki/a-ledger-cannot-testify-to-its-own-gaps.md`.

### Release slot

DIVE-2519's body records lodar's tier-2 "narrow" decision: v0.18 = W1 + W2 only, **W3 ships in v0.19**. This PR does not bump `FIVE_VERSION` and should land on the v0.19 line, not be pulled into the v0.18 cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
