### PR TITLE
feat(tests): tier the corpus under a wall-clock budget — 5min core per PR, full sweep nightly (DIVE-2525)

### DIFF
--- a/.github/workflows/full-sweep.yml
+++ b/.github/workflows/full-sweep.yml
@@ -38,9 +38,28 @@ on:
       - '.github/workflows/full-sweep.yml'
 
 jobs:
+  # DIVE-2525 (main, reviewing #376): SHARDED, not given a bigger number. The first
+  # measured sweep came in at 1097s/1146s against the 1320s cap — 83-86%, which at
+  # +13 harnesses/day is not a budget, it is a countdown with about three days on it.
+  # Raising the ceiling buys those three days and re-installs the ratchet the row
+  # exists to remove. The cap is PER JOB, so splitting the sweep across the matrix
+  # cuts each job's wall-clock without relaxing the constraint, and the headroom
+  # scales with the corpus instead of being spent once.
+  #
+  # `${{ strategy.job-total }}` rather than a literal 3: the shard count is the matrix
+  # length, spelled once, so adding a shard cannot silently leave the runner splitting
+  # the corpus a different number of ways than the matrix runs it.
+  #
+  # AGGREGATE capacity is now N x 1320s and N is fixed here — adding a shard is
+  # exactly as visible, and exactly as much a policy decision, as raising the number.
+  # `budget-report` re-sums the shards and prints the UN-SHARDED total, because that
+  # total is what this row exists to make legible and sharding is how you lose it.
   full-pristine:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix: { shard: [1, 2, 3] }
     steps:
       # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
@@ -58,18 +77,27 @@ jobs:
       # dependency true by construction instead of by alphabetical accident.
       - name: Build the bundle (harness precondition, not an accident of ordering)
         run: ./build.sh
-      - name: Run the FULL corpus (budgeted)
-        run: bash scripts/run-harnesses.sh --tier=full --label=pristine --report=full-pristine.txt
+      - name: Run the FULL corpus (budgeted, shard ${{ matrix.shard }})
+        run: |
+          bash scripts/run-harnesses.sh --tier=full \
+            --shard=${{ matrix.shard }}/${{ strategy.job-total }} \
+            --label=pristine --report=full-pristine-${{ matrix.shard }}.txt
       # if: always() — an over-budget or red run is exactly the run whose timings
       # somebody needs, and losing the report would leave the trend with a hole
       # precisely where it changed.
       - uses: actions/upload-artifact@v4
         if: always()
-        with: { name: full-pristine, path: full-pristine.txt, if-no-files-found: error }
+        with:
+          name: "full-pristine-${{ matrix.shard }}"
+          path: "full-pristine-${{ matrix.shard }}.txt"
+          if-no-files-found: error
 
   full-installed-host:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix: { shard: [1, 2, 3] }
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
@@ -102,11 +130,17 @@ jobs:
       # dependency true by construction instead of by alphabetical accident.
       - name: Build the bundle (harness precondition, not an accident of ordering)
         run: ./build.sh
-      - name: Run the FULL corpus (installed host, budgeted)
-        run: bash scripts/run-harnesses.sh --tier=full --label=installed-host --report=full-installed.txt
+      - name: Run the FULL corpus (installed host, budgeted, shard ${{ matrix.shard }})
+        run: |
+          bash scripts/run-harnesses.sh --tier=full \
+            --shard=${{ matrix.shard }}/${{ strategy.job-total }} \
+            --label=installed-host --report=full-installed-${{ matrix.shard }}.txt
       - uses: actions/upload-artifact@v4
         if: always()
-        with: { name: full-installed, path: full-installed.txt, if-no-files-found: error }
+        with:
+          name: "full-installed-${{ matrix.shard }}"
+          path: "full-installed-${{ matrix.shard }}.txt"
+          if-no-files-found: error
 
   # DIVE-2013: the sweeps above grade every harness on its EXIT STATUS, so a harness
   # whose status is not wired to its own assertions is invisible to them — it prints
@@ -299,28 +333,50 @@ jobs:
         with: { pattern: 'full-*', merge-multiple: true }
       - name: Report the sweep's wall-clock
         run: |
+          # RE-SUM THE SHARDS. Sharding is the obvious way to lose the very number
+          # this row exists to surface: three jobs each reporting 370s reads as
+          # comfortable, and the corpus still costs 1110s a night. The per-shard
+          # figures are what the BUDGET is enforced on; the total is what the TREND
+          # is read from, and both belong on the page.
+          total_row() {   # <label> <glob>
+            local label="$1" pat="$2" n=0 s=0 b=0 shards=0 f
+            for f in $pat; do
+              [[ -r "$f" ]] || continue
+              shards=$(( shards + 1 ))
+              n=$(( n + $(sed -n 's/^# harnesses=//p' "$f" | head -1) ))
+              s=$(( s + $(sed -n 's/^# wall_clock_s=//p' "$f" | head -1) ))
+              b=$(sed -n 's/^# budget_s=//p' "$f" | head -1)
+            done
+            # A missing shard is not a smaller corpus. Say the count, so a report
+            # assembled from two of three shards cannot read as a faster sweep.
+            printf '| %s | %d | %d | %ds | %ds per shard |\n' "$label" "$shards" "$n" "$s" "${b:-0}"
+          }
           {
             echo "## Full-sweep wall-clock"
             echo
-            echo "| environment | harnesses | wall-clock | budget | % of budget |"
+            echo "| environment | shards reporting | harnesses | TOTAL wall-clock | budget |"
             echo "|---|---:|---:|---:|---:|"
-            for f in full-pristine.txt full-installed.txt; do
-              [[ -r "$f" ]] || { echo "| \`$f\` | — | **report missing** | — | — |"; continue; }
-              lbl=$(sed -n 's/^# label=//p' "$f" | head -1)
-              n=$(sed -n 's/^# harnesses=//p' "$f" | head -1)
-              s=$(sed -n 's/^# wall_clock_s=//p' "$f" | head -1)
-              b=$(sed -n 's/^# budget_s=//p' "$f" | head -1)
-              p=$(sed -n 's/^# pct_of_budget=//p' "$f" | head -1)
-              printf '| %s | %s | %ss | %ss | %s%% |\n' "$lbl" "$n" "$s" "$b" "$p"
-            done
+            total_row pristine 'full-pristine-*.txt'
+            total_row installed-host 'full-installed-*.txt'
             echo
-            echo "Slowest 15 harnesses (pristine) — the merge/retire shortlist:"
+            echo "Per-shard (this is what the budget is enforced on):"
             echo '```'
-            if [[ -r full-pristine.txt ]]; then
-              grep -v '^#' full-pristine.txt | sort -rn | head -15 \
+            for f in full-pristine-*.txt full-installed-*.txt; do
+              [[ -r "$f" ]] || continue
+              printf '%-28s %4ss / %ss  (%s%%)\n' "$(sed -n 's/^# label=//p' "$f" | head -1)" \
+                "$(sed -n 's/^# wall_clock_s=//p' "$f" | head -1)" \
+                "$(sed -n 's/^# budget_s=//p' "$f" | head -1)" \
+                "$(sed -n 's/^# pct_of_budget=//p' "$f" | head -1)"
+            done
+            echo '```'
+            echo
+            echo "Slowest 15 harnesses across all pristine shards — the merge/retire shortlist:"
+            echo '```'
+            if compgen -G 'full-pristine-*.txt' >/dev/null; then
+              grep -hv '^#' full-pristine-*.txt | sort -rn | head -15 \
                 | awk -F'\t' '{printf "%7.1fs  %s\n", $1/1000, $3}'
             else
-              echo "(no report — the pristine sweep did not finish)"
+              echo "(no reports — no pristine shard finished)"
             fi
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/full-sweep.yml
+++ b/.github/workflows/full-sweep.yml
@@ -45,6 +45,19 @@ jobs:
       # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
+      # DIVE-2525: BUILD THE BUNDLE FIRST, EXPLICITLY. Three harnesses
+      # (install_checksum, ledger, policy_refusals) need ./5dive and ./5dive.sha256
+      # to exist and say so in their own failure text — and nothing ever built them
+      # for this job. They passed anyway because SOME EARLIER HARNESS in the 267-file
+      # glob runs ./build.sh as a side effect, leaving the artifact in the working
+      # tree for everything after it. That made the corpus ORDER-DEPENDENT through a
+      # shared file, and running a SUBSET is what exposed it: the same code, the same
+      # runner, three reds, because the harness that used to build the bundle is not
+      # in this tier. An implicit precondition that a full sweep happens to satisfy is
+      # not satisfied — it is unobserved. Declaring it here costs 40ms and makes the
+      # dependency true by construction instead of by alphabetical accident.
+      - name: Build the bundle (harness precondition, not an accident of ordering)
+        run: ./build.sh
       - name: Run the FULL corpus (budgeted)
         run: bash scripts/run-harnesses.sh --tier=full --label=pristine --report=full-pristine.txt
       # if: always() — an over-budget or red run is exactly the run whose timings
@@ -76,6 +89,19 @@ jobs:
           sudo useradd -M -N -s /usr/sbin/nologin claude 2>/dev/null || true
           sudo useradd -M -N -s /usr/sbin/nologin agent-dev 2>/dev/null || true
           getent passwd claude agent-dev
+      # DIVE-2525: BUILD THE BUNDLE FIRST, EXPLICITLY. Three harnesses
+      # (install_checksum, ledger, policy_refusals) need ./5dive and ./5dive.sha256
+      # to exist and say so in their own failure text — and nothing ever built them
+      # for this job. They passed anyway because SOME EARLIER HARNESS in the 267-file
+      # glob runs ./build.sh as a side effect, leaving the artifact in the working
+      # tree for everything after it. That made the corpus ORDER-DEPENDENT through a
+      # shared file, and running a SUBSET is what exposed it: the same code, the same
+      # runner, three reds, because the harness that used to build the bundle is not
+      # in this tier. An implicit precondition that a full sweep happens to satisfy is
+      # not satisfied — it is unobserved. Declaring it here costs 40ms and makes the
+      # dependency true by construction instead of by alphabetical accident.
+      - name: Build the bundle (harness precondition, not an accident of ordering)
+        run: ./build.sh
       - name: Run the FULL corpus (installed host, budgeted)
         run: bash scripts/run-harnesses.sh --tier=full --label=installed-host --report=full-installed.txt
       - uses: actions/upload-artifact@v4
@@ -100,6 +126,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
+      # DIVE-2525: BUILD THE BUNDLE FIRST, EXPLICITLY. Three harnesses
+      # (install_checksum, ledger, policy_refusals) need ./5dive and ./5dive.sha256
+      # to exist and say so in their own failure text — and nothing ever built them
+      # for this job. They passed anyway because SOME EARLIER HARNESS in the 267-file
+      # glob runs ./build.sh as a side effect, leaving the artifact in the working
+      # tree for everything after it. That made the corpus ORDER-DEPENDENT through a
+      # shared file, and running a SUBSET is what exposed it: the same code, the same
+      # runner, three reds, because the harness that used to build the bundle is not
+      # in this tier. An implicit precondition that a full sweep happens to satisfy is
+      # not satisfied — it is unobserved. Declaring it here costs 40ms and makes the
+      # dependency true by construction instead of by alphabetical accident.
+      - name: Build the bundle (harness precondition, not an accident of ordering)
+        run: ./build.sh
       - name: Every harness must be able to FAIL
         run: |
           bash tests/meta/harness-verdict-probe.sh --assume-clean \
@@ -144,6 +183,19 @@ jobs:
       # full-installed-host just established the clean-green baseline IN THIS
       # ENVIRONMENT, and if it went red this job does not run and the union never
       # reports coverage.
+      # DIVE-2525: BUILD THE BUNDLE FIRST, EXPLICITLY. Three harnesses
+      # (install_checksum, ledger, policy_refusals) need ./5dive and ./5dive.sha256
+      # to exist and say so in their own failure text — and nothing ever built them
+      # for this job. They passed anyway because SOME EARLIER HARNESS in the 267-file
+      # glob runs ./build.sh as a side effect, leaving the artifact in the working
+      # tree for everything after it. That made the corpus ORDER-DEPENDENT through a
+      # shared file, and running a SUBSET is what exposed it: the same code, the same
+      # runner, three reds, because the harness that used to build the bundle is not
+      # in this tier. An implicit precondition that a full sweep happens to satisfy is
+      # not satisfied — it is unobserved. Declaring it here costs 40ms and makes the
+      # dependency true by construction instead of by alphabetical accident.
+      - name: Build the bundle (harness precondition, not an accident of ordering)
+        run: ./build.sh
       - name: Every harness must be able to FAIL (installed host)
         run: |
           bash tests/meta/harness-verdict-probe.sh --assume-clean \
@@ -181,6 +233,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
+      # DIVE-2525: BUILD THE BUNDLE FIRST, EXPLICITLY. Three harnesses
+      # (install_checksum, ledger, policy_refusals) need ./5dive and ./5dive.sha256
+      # to exist and say so in their own failure text — and nothing ever built them
+      # for this job. They passed anyway because SOME EARLIER HARNESS in the 267-file
+      # glob runs ./build.sh as a side effect, leaving the artifact in the working
+      # tree for everything after it. That made the corpus ORDER-DEPENDENT through a
+      # shared file, and running a SUBSET is what exposed it: the same code, the same
+      # runner, three reds, because the harness that used to build the bundle is not
+      # in this tier. An implicit precondition that a full sweep happens to satisfy is
+      # not satisfied — it is unobserved. Declaring it here costs 40ms and makes the
+      # dependency true by construction instead of by alphabetical accident.
+      - name: Build the bundle (harness precondition, not an accident of ordering)
+        run: ./build.sh
       - name: Slow harnesses must be able to FAIL too (long lane)
         env: { PROBE_TIMEOUT: '900' }
         run: |

--- a/.github/workflows/full-sweep.yml
+++ b/.github/workflows/full-sweep.yml
@@ -1,0 +1,261 @@
+name: full-sweep
+
+# DIVE-2525: the WHOLE harness corpus, plus every whole-corpus invariant, once a
+# night — and its wall-clock reported as a number in its own output.
+#
+# unit-tests.yml runs the CORE tier on every PR under a 300s budget. That budget is
+# the reverse gear the corpus never had (96 -> 267 harnesses in 13 days against four
+# deletions ever; community/wiki/guards-compound-in-cost-and-nothing-ever-retires-one.md).
+# A budget with a free escape hatch is not a budget, so the sweep the demoted
+# harnesses land in HAS ITS OWN CAP: 1320s per job, from tests/lib/tier.sh. Demotion
+# moves cost, it does not delete it, and both ends are measured.
+#
+# WHAT ONLY HAPPENS HERE, and why that is the right place for it:
+#   * the FULL corpus, in both environments — a nightly, not a per-PR, property
+#   * the harness-verdict PROBE (DIVE-2013) and its UNION (DIVE-2018), which cost a
+#     second full pass over the corpus. The PR-shaped case (a harness added or
+#     edited in a diff whose exit status is not wired to its own assertions) is
+#     caught at the moment of introduction by unit-tests.yml's `changed-harnesses`.
+#     The union's own invariant — every harness probed in SOME environment — is a
+#     whole-corpus, cross-environment claim that no single PR can make or break.
+#   * the wall-clock trend, written to the run summary so nobody has to read a log
+#     to see it. The corpus growth was visible for two weeks in a number nobody
+#     read; what surfaced first was a human noticing that fixes felt like a struggle.
+#
+# A RED HERE IS NOT IGNORABLE. release-cut grades the same corpus before publishing,
+# so a sweep that has been red for a week is a release that will not cut.
+on:
+  schedule:
+    # 03:17 UTC — off the hour, because the hour is where every other fleet cron is.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+  # The tiering machinery itself must be graded on the PR that changes it, or the
+  # first evidence that a budget is mis-set arrives a day late on main.
+  pull_request:
+    paths:
+      - 'tests/lib/tier.sh'
+      - 'scripts/run-harnesses.sh'
+      - '.github/workflows/full-sweep.yml'
+
+jobs:
+  full-pristine:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      # DIVE-2229: full history — pinned baselines must resolve here too.
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Run the FULL corpus (budgeted)
+        run: bash scripts/run-harnesses.sh --tier=full --label=pristine --report=full-pristine.txt
+      # if: always() — an over-budget or red run is exactly the run whose timings
+      # somebody needs, and losing the report would leave the trend with a hole
+      # precisely where it changed.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with: { name: full-pristine, path: full-pristine.txt, if-no-files-found: error }
+
+  full-installed-host:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      # DIVE-1919 / DIVE-2018: seed the host state that actually differs from a
+      # pristine runner, so harnesses that leak out of their isolation red HERE
+      # rather than only under an agent's nose on the control plane.
+      - name: Simulate a box with 5dive installed
+        run: |
+          sudo mkdir -p /var/lib/5dive
+          sudo touch /var/lib/5dive/gate-proof.enforce
+          sudo chmod 0644 /var/lib/5dive/gate-proof.enforce
+          for p in telegram-pi telegram-opencode; do
+            sudo mkdir -p "/usr/local/lib/5dive/$p"
+            echo '// stub for the installed-host CI matrix' \
+              | sudo tee "/usr/local/lib/5dive/$p/server.ts" >/dev/null
+          done
+          sudo useradd -M -N -s /usr/sbin/nologin claude 2>/dev/null || true
+          sudo useradd -M -N -s /usr/sbin/nologin agent-dev 2>/dev/null || true
+          getent passwd claude agent-dev
+      - name: Run the FULL corpus (installed host, budgeted)
+        run: bash scripts/run-harnesses.sh --tier=full --label=installed-host --report=full-installed.txt
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with: { name: full-installed, path: full-installed.txt, if-no-files-found: error }
+
+  # DIVE-2013: the sweeps above grade every harness on its EXIT STATUS, so a harness
+  # whose status is not wired to its own assertions is invisible to them — it prints
+  # FAIL and exits 0 and CI calls it green. That shipped for three consecutive
+  # releases (heartbeat_gate_shipped_unit.sh, 0.15.26-28). Static analysis cannot
+  # close it, so this is EMPIRICAL: inject a failure into each harness and demand
+  # the harness report it through $?.
+  #
+  # `needs:` is load-bearing, not just ordering — it is what establishes the
+  # clean-green baseline, which lets these jobs skip their own clean run (halving
+  # them) WITHOUT becoming unsound. Run standalone (no --assume-clean) the script
+  # does the clean run itself, so it is never unsound locally either.
+  harness-verdict-pristine:
+    runs-on: ubuntu-latest
+    needs: full-pristine
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Every harness must be able to FAIL
+        run: |
+          bash tests/meta/harness-verdict-probe.sh --assume-clean \
+            --label=pristine --report=probe-pristine.txt
+      # DIVE-2018: this run's `not-reached` set is not a failure and must not be — a
+      # harness that skips before its verdict has not been shown to be unwired, and
+      # three correctly-wired files were falsely accused that way. Which is exactly
+      # why THIS job cannot establish coverage: it can only report what it saw. The
+      # report goes to the union job. `if: always()` because a run that found UNWIRED
+      # still made a valid coverage observation, and losing it would let a red probe
+      # silently shrink the union.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with: { name: probe-pristine, path: probe-pristine.txt, if-no-files-found: error }
+
+  # DIVE-2018: the probe used to run ONLY on the pristine runner, so the harnesses CI
+  # never probed were precisely the ones that skip without live state — the gate and
+  # install paths, i.e. the most environment-sensitive code we have. Probing here too
+  # is what makes the union non-trivial: this environment reaches harnesses the
+  # pristine one cannot.
+  harness-verdict-installed:
+    runs-on: ubuntu-latest
+    needs: full-installed-host
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Simulate a box with 5dive installed
+        run: |
+          sudo mkdir -p /var/lib/5dive
+          sudo touch /var/lib/5dive/gate-proof.enforce
+          sudo chmod 0644 /var/lib/5dive/gate-proof.enforce
+          for p in telegram-pi telegram-opencode; do
+            sudo mkdir -p "/usr/local/lib/5dive/$p"
+            echo '// stub for the installed-host CI matrix' \
+              | sudo tee "/usr/local/lib/5dive/$p/server.ts" >/dev/null
+          done
+          sudo useradd -M -N -s /usr/sbin/nologin claude 2>/dev/null || true
+          sudo useradd -M -N -s /usr/sbin/nologin agent-dev 2>/dev/null || true
+          getent passwd claude agent-dev
+      # `--assume-clean` is sound for the same reason it is in the pristine lane:
+      # full-installed-host just established the clean-green baseline IN THIS
+      # ENVIRONMENT, and if it went red this job does not run and the union never
+      # reports coverage.
+      - name: Every harness must be able to FAIL (installed host)
+        run: |
+          bash tests/meta/harness-verdict-probe.sh --assume-clean \
+            --label=installed-host --report=probe-installed.txt
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with: { name: probe-installed, path: probe-installed.txt, if-no-files-found: error }
+
+  # DIVE-2412: A HARNESS CAN BE UNPROBED FOR TIME RATHER THAN FOR SHAPE, and the two
+  # want different answers. The probe's per-harness `timeout` is 180s, which is what
+  # stops one hung harness from stalling the sweep. A mutation grader re-runs its
+  # whole unit suite once per mutant, so this one costs ~14 x 23s and is killed by
+  # that timeout in EVERY environment — canary never printed, so `not-reached`
+  # everywhere, which is precisely the permanently-unprobed limit case the union job
+  # exists to catch. It caught it.
+  #
+  # The allowlist is the WRONG instrument here and using it would have been a false
+  # reason on the record: ALLOW_UNPROBEABLE means "no identifiable verdict variable",
+  # and this harness has one — measured `wired` at PROBE_TIMEOUT=900. It is probeable
+  # and slow, not unprobeable. So it gets a lane that pays the time instead of an
+  # exemption that excuses the coverage.
+  #
+  # Scoped with --only on purpose: raising PROBE_TIMEOUT for the whole sweep would
+  # also raise how long a genuinely hung harness can stall CI, which is the property
+  # the 180s default is buying. Named harnesses pay 900s; nothing else changes.
+  harness-verdict-slow:
+    runs-on: ubuntu-latest
+    needs: full-pristine
+    timeout-minutes: 60
+    env:
+      # One name per slow harness, comma-separated — the probe's own --only format.
+      # Keep this list SHORT and justified; a harness landing here is saying its
+      # verdict costs minutes, not that it may go ungraded.
+      SLOW_HARNESSES: gate_channel_session_t2_mutation.sh
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Slow harnesses must be able to FAIL too (long lane)
+        env: { PROBE_TIMEOUT: '900' }
+        run: |
+          bash tests/meta/harness-verdict-probe.sh --assume-clean \
+            --only="$SLOW_HARNESSES" --label=slow --report=probe-slow.txt
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with: { name: probe-slow, path: probe-slow.txt, if-no-files-found: error }
+
+  # DIVE-2018: NOT-REACHED is correctly not a failure in any single run, so no single
+  # run can establish that a harness has EVER been probed. On the control plane the
+  # probe read 135 wired / 16 not-reached; on the pristine runner 151 wired / 0
+  # not-reached. Both green, both 154 with the allowlist, probing DIFFERENT CORPORA,
+  # and nothing said so. The limit case is a harness that skips in every environment:
+  # reported "probed in an environment where it runs", and no environment ever does.
+  #
+  # This job owns the invariant that survives that: every harness in tests/*.sh is
+  # probed in AT LEAST ONE environment, or is allowlisted by name with a reason.
+  # A skip in one environment is still not an accusation; a skip in all of them is
+  # now a failure.
+  harness-verdict-union:
+    runs-on: ubuntu-latest
+    needs: [harness-verdict-pristine, harness-verdict-installed, harness-verdict-slow]
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/download-artifact@v4
+        with: { pattern: probe-*, merge-multiple: true }
+      # The union script fails closed on a missing, headerless, or different-corpus
+      # report, so a job that died before writing one cannot silently shrink what we
+      # claim to cover — the check would otherwise have the same shape of hole it
+      # exists to close. Every report is named EXPLICITLY, not globbed, for the same
+      # reason: a lane that died has to red this job rather than quietly drop back to
+      # a smaller corpus than the one it used to cover.
+      - name: Every harness must be probed in SOME environment
+        run: bash tests/meta/harness-verdict-union.sh probe-pristine.txt probe-installed.txt probe-slow.txt
+
+  # Build 3 of DIVE-2525: THE NUMBER, WHERE SOMEBODY WILL SEE IT. The runner already
+  # prints it in each job's log, and a number in a log is what "visible for two weeks
+  # and read by nobody" looks like. This writes it to the run summary page, both
+  # environments side by side, with the percentage of budget — which is the figure
+  # that says how much room is left, and it is the one that moves.
+  #
+  # if: always() — the runs worth summarising most are the ones that went over.
+  budget-report:
+    runs-on: ubuntu-latest
+    needs: [full-pristine, full-installed-host]
+    if: always()
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { pattern: 'full-*', merge-multiple: true }
+      - name: Report the sweep's wall-clock
+        run: |
+          {
+            echo "## Full-sweep wall-clock"
+            echo
+            echo "| environment | harnesses | wall-clock | budget | % of budget |"
+            echo "|---|---:|---:|---:|---:|"
+            for f in full-pristine.txt full-installed.txt; do
+              [[ -r "$f" ]] || { echo "| \`$f\` | — | **report missing** | — | — |"; continue; }
+              lbl=$(sed -n 's/^# label=//p' "$f" | head -1)
+              n=$(sed -n 's/^# harnesses=//p' "$f" | head -1)
+              s=$(sed -n 's/^# wall_clock_s=//p' "$f" | head -1)
+              b=$(sed -n 's/^# budget_s=//p' "$f" | head -1)
+              p=$(sed -n 's/^# pct_of_budget=//p' "$f" | head -1)
+              printf '| %s | %s | %ss | %ss | %s%% |\n' "$lbl" "$n" "$s" "$b" "$p"
+            done
+            echo
+            echo "Slowest 15 harnesses (pristine) — the merge/retire shortlist:"
+            echo '```'
+            if [[ -r full-pristine.txt ]]; then
+              grep -v '^#' full-pristine.txt | sort -rn | head -15 \
+                | awk -F'\t' '{printf "%7.1fs  %s\n", $1/1000, $3}'
+            else
+              echo "(no report — the pristine sweep did not finish)"
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/full-sweep.yml
+++ b/.github/workflows/full-sweep.yml
@@ -114,6 +114,16 @@ jobs:
             echo '// stub for the installed-host CI matrix' \
               | sudo tee "/usr/local/lib/5dive/$p/server.ts" >/dev/null
           done
+          # DIVE-2525: the GROUP, not just the users. `task init` chowns the store to
+          # root:claude, and `useradd -N` deliberately does NOT create a like-named
+          # group — so on a runner seeded with users alone the chown dies with
+          # "chown: invalid group: 'root:claude'", `task init` fails, and
+          # council_record_e2e.sh takes its own `|| exit 0` and skips. That skip is
+          # what the nightly union reported as NEVER PROBED in EITHER environment.
+          # It had been getting the group by accident from a corpus run earlier in
+          # the same job; splitting the probe into its own job removed the accident
+          # and the union said so immediately, which is the rail working.
+          sudo groupadd -f claude
           sudo useradd -M -N -s /usr/sbin/nologin claude 2>/dev/null || true
           sudo useradd -M -N -s /usr/sbin/nologin agent-dev 2>/dev/null || true
           getent passwd claude agent-dev
@@ -210,6 +220,16 @@ jobs:
             echo '// stub for the installed-host CI matrix' \
               | sudo tee "/usr/local/lib/5dive/$p/server.ts" >/dev/null
           done
+          # DIVE-2525: the GROUP, not just the users. `task init` chowns the store to
+          # root:claude, and `useradd -N` deliberately does NOT create a like-named
+          # group — so on a runner seeded with users alone the chown dies with
+          # "chown: invalid group: 'root:claude'", `task init` fails, and
+          # council_record_e2e.sh takes its own `|| exit 0` and skips. That skip is
+          # what the nightly union reported as NEVER PROBED in EITHER environment.
+          # It had been getting the group by accident from a corpus run earlier in
+          # the same job; splitting the probe into its own job removed the accident
+          # and the union said so immediately, which is the rail working.
+          sudo groupadd -f claude
           sudo useradd -M -N -s /usr/sbin/nologin claude 2>/dev/null || true
           sudo useradd -M -N -s /usr/sbin/nologin agent-dev 2>/dev/null || true
           getent passwd claude agent-dev

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -200,6 +200,11 @@ jobs:
           command -v node jq sqlite3 || true
           sudo -n true && echo "passwordless sudo: yes" || echo "passwordless sudo: NO"
           bash tests/council_record_e2e.sh; echo "rc=$?"
+          echo "--- what does task init actually say?"
+          T=$(mktemp -d)
+          sudo -n env PATH="$PATH" STATE_DIR="$T" TASKS_DB="$T/tasks.db" \
+            FIVEDIVE_PROD_TASKS_DB="$T/tasks.db" ./5dive task init; echo "init rc=$?"
+          ls -la /var/lib/5dive 2>&1 | head -5
       # DIVE-2039: the rail prover, from the pristine side. `snapshot-rails` is
       # allowlisted because GitHub CI has no ops checkout — that exemption can
       # never be earned here by adding another job, which is the difference

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,6 +49,19 @@ jobs:
       # this workflow was written; a skip count is not a green count.
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
+      # DIVE-2525: BUILD THE BUNDLE FIRST, EXPLICITLY. Three harnesses
+      # (install_checksum, ledger, policy_refusals) need ./5dive and ./5dive.sha256
+      # to exist and say so in their own failure text — and nothing ever built them
+      # for this job. They passed anyway because SOME EARLIER HARNESS in the 267-file
+      # glob runs ./build.sh as a side effect, leaving the artifact in the working
+      # tree for everything after it. That made the corpus ORDER-DEPENDENT through a
+      # shared file, and running a SUBSET is what exposed it: the same code, the same
+      # runner, three reds, because the harness that used to build the bundle is not
+      # in this tier. An implicit precondition that a full sweep happens to satisfy is
+      # not satisfied — it is unobserved. Declaring it here costs 40ms and makes the
+      # dependency true by construction instead of by alphabetical accident.
+      - name: Build the bundle (harness precondition, not an accident of ordering)
+        run: ./build.sh
       # DIVE-2525: the budget is NOT passed here. It lives in tests/lib/tier.sh next
       # to the tier definition, because a budget spelled in the caller is raised by
       # a one-line YAML edit that nobody reviews as the policy change it is.
@@ -118,6 +131,19 @@ jobs:
           { printf 'files=%s\n' "${files[*]:-}"
             printf 'names=%s\n' "$(printf '%s\n' "${files[@]:-}" | xargs -r -n1 basename | paste -sd, -)"
           } >> "$GITHUB_OUTPUT"
+      # DIVE-2525: BUILD THE BUNDLE FIRST, EXPLICITLY. Three harnesses
+      # (install_checksum, ledger, policy_refusals) need ./5dive and ./5dive.sha256
+      # to exist and say so in their own failure text — and nothing ever built them
+      # for this job. They passed anyway because SOME EARLIER HARNESS in the 267-file
+      # glob runs ./build.sh as a side effect, leaving the artifact in the working
+      # tree for everything after it. That made the corpus ORDER-DEPENDENT through a
+      # shared file, and running a SUBSET is what exposed it: the same code, the same
+      # runner, three reds, because the harness that used to build the bundle is not
+      # in this tier. An implicit precondition that a full sweep happens to satisfy is
+      # not satisfied — it is unobserved. Declaring it here costs 40ms and makes the
+      # dependency true by construction instead of by alphabetical accident.
+      - name: Build the bundle (harness precondition, not an accident of ordering)
+        run: ./build.sh
       - name: Run them (any tier)
         if: steps.changed.outputs.files != ''
         run: |
@@ -194,6 +220,19 @@ jobs:
       # environment is slower per harness (real sudo, seeded host state), and that is
       # a cost of the corpus too — hiding it under a laxer cap here would just move
       # the growth to the job that is already the longest on the PR path.
+      # DIVE-2525: BUILD THE BUNDLE FIRST, EXPLICITLY. Three harnesses
+      # (install_checksum, ledger, policy_refusals) need ./5dive and ./5dive.sha256
+      # to exist and say so in their own failure text — and nothing ever built them
+      # for this job. They passed anyway because SOME EARLIER HARNESS in the 267-file
+      # glob runs ./build.sh as a side effect, leaving the artifact in the working
+      # tree for everything after it. That made the corpus ORDER-DEPENDENT through a
+      # shared file, and running a SUBSET is what exposed it: the same code, the same
+      # runner, three reds, because the harness that used to build the bundle is not
+      # in this tier. An implicit precondition that a full sweep happens to satisfy is
+      # not satisfied — it is unobserved. Declaring it here costs 40ms and makes the
+      # dependency true by construction instead of by alphabetical accident.
+      - name: Build the bundle (harness precondition, not an accident of ordering)
+        run: ./build.sh
       - name: Run core harnesses (installed host, budgeted)
         run: bash scripts/run-harnesses.sh --tier=core --label=installed-host --report=core-installed.txt
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -190,6 +190,16 @@ jobs:
       # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
+      # TEMPORARY DIAGNOSTIC (DIVE-2525) — remove before merge. The nightly union
+      # reports council_record_e2e.sh NOT PROBED in either environment; it probes
+      # `wired` on the control plane, so the differing condition is in CI and I am
+      # measuring it rather than guessing at it.
+      - name: DIAGNOSTIC council_record_e2e
+        run: |
+          ./build.sh
+          command -v node jq sqlite3 || true
+          sudo -n true && echo "passwordless sudo: yes" || echo "passwordless sudo: NO"
+          bash tests/council_record_e2e.sh; echo "rc=$?"
       # DIVE-2039: the rail prover, from the pristine side. `snapshot-rails` is
       # allowlisted because GitHub CI has no ops checkout — that exemption can
       # never be earned here by adding another job, which is the difference

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -97,6 +97,13 @@ jobs:
   # makes that flag unnecessary rather than merely omitted.
   changed-harnesses:
     runs-on: ubuntu-latest
+    # This job's cost is set by the DIFF, not by the corpus, so it has no budget of
+    # its own — but it is not unbounded either. Measured on this row's own PR, which
+    # adds a `# TIER:` line to 73 files: 77 changed harnesses, each run once and
+    # probed (clean + mutated) is ~3 passes including the 300s mutation harness. A
+    # normal PR touches one to three. The ceiling is here so a pathological diff
+    # cannot sit in the queue for an hour with nobody able to say why.
+    timeout-minutes: 45
     steps:
       # DIVE-2229: full history — pinned baselines must resolve here too, and the
       # diff below needs the base commit to exist at all.
@@ -128,8 +135,20 @@ jobs:
           printf 'base=%s\n' "$base"
           printf 'changed harnesses: %d\n' "${#files[@]}"
           printf '  %s\n' "${files[@]:-（none）}"
+          # THE PROBE IS CAPPED, AND THE CAP SAYS WHAT IT DROPPED. Probing is the
+          # expensive half (a clean run plus a mutated run per file); running is one
+          # pass and stays uncapped, because "the harness you touched runs" is the
+          # promise. A silent truncation here would read as "all of it was probed",
+          # which is the shape of hole this whole workflow exists to close — so the
+          # names of the unprobed remainder go in the log, not a count.
+          PROBE_CAP=25
+          probe=("${files[@]:0:$PROBE_CAP}")
+          if (( ${#files[@]} > PROBE_CAP )); then
+            printf 'changed-harnesses: NOT PROBED (over the %d-file cap) — these ran, but their verdict wiring was not graded here; the nightly union covers them:\n' "$PROBE_CAP"
+            printf '  %s\n' "${files[@]:$PROBE_CAP}"
+          fi
           { printf 'files=%s\n' "${files[*]:-}"
-            printf 'names=%s\n' "$(printf '%s\n' "${files[@]:-}" | xargs -r -n1 basename | paste -sd, -)"
+            printf 'names=%s\n' "$(printf '%s\n' "${probe[@]:-}" | xargs -r -n1 basename | paste -sd, -)"
           } >> "$GITHUB_OUTPUT"
       # DIVE-2525: BUILD THE BUNDLE FIRST, EXPLICITLY. Three harnesses
       # (install_checksum, ledger, policy_refusals) need ./5dive and ./5dive.sha256

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -190,21 +190,6 @@ jobs:
       # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
-      # TEMPORARY DIAGNOSTIC (DIVE-2525) — remove before merge. The nightly union
-      # reports council_record_e2e.sh NOT PROBED in either environment; it probes
-      # `wired` on the control plane, so the differing condition is in CI and I am
-      # measuring it rather than guessing at it.
-      - name: DIAGNOSTIC council_record_e2e
-        run: |
-          ./build.sh
-          command -v node jq sqlite3 || true
-          sudo -n true && echo "passwordless sudo: yes" || echo "passwordless sudo: NO"
-          bash tests/council_record_e2e.sh; echo "rc=$?"
-          echo "--- what does task init actually say?"
-          T=$(mktemp -d)
-          sudo -n env PATH="$PATH" STATE_DIR="$T" TASKS_DB="$T/tasks.db" \
-            FIVEDIVE_PROD_TASKS_DB="$T/tasks.db" ./5dive task init; echo "init rc=$?"
-          ls -la /var/lib/5dive 2>&1 | head -5
       # DIVE-2039: the rail prover, from the pristine side. `snapshot-rails` is
       # allowlisted because GitHub CI has no ops checkout — that exemption can
       # never be earned here by adding another job, which is the difference
@@ -247,6 +232,16 @@ jobs:
           # the probe could not reach in ANY environment — and they are the gate
           # identity and SUDO_UID forge tests, i.e. exactly the coverage whose absence
           # matters most. Two throwaway system users, no shell, no home.
+          # DIVE-2525: the GROUP, not just the users. `task init` chowns the store to
+          # root:claude, and `useradd -N` deliberately does NOT create a like-named
+          # group — so on a runner seeded with users alone the chown dies with
+          # "chown: invalid group: 'root:claude'", `task init` fails, and
+          # council_record_e2e.sh takes its own `|| exit 0` and skips. That skip is
+          # what the nightly union reported as NEVER PROBED in EITHER environment.
+          # It had been getting the group by accident from a corpus run earlier in
+          # the same job; splitting the probe into its own job removed the accident
+          # and the union said so immediately, which is the rail working.
+          sudo groupadd -f claude
           sudo useradd -M -N -s /usr/sbin/nologin claude 2>/dev/null || true
           sudo useradd -M -N -s /usr/sbin/nologin agent-dev 2>/dev/null || true
           getent passwd claude agent-dev

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,8 +1,36 @@
 name: unit-tests
 
-# Run every isolated unit harness in tests/. Each harness sources src/ directly
-# into a throwaway STATE_DIR (no root, no network, never the live tasks.db) and
-# exits non-zero on any failed assertion.
+# Run the CORE tier of the harness corpus in tests/. Each harness sources src/
+# directly into a throwaway STATE_DIR (no root, no network, never the live
+# tasks.db) and exits non-zero on any failed assertion.
+#
+# DIVE-2525 — WHY THIS IS NO LONGER `for t in tests/*.sh`. Measured 2026-08-02:
+# the corpus went 96 -> 267 harnesses in 13 days (~+13/day) against FOUR harness
+# deletions ever, and at release-cut's own published 3.79s/harness that is ~17
+# minutes of pure harness time charged to every contributor on every push. A
+# guard's benefit is fixed; its cost is paid on every future change forever, so
+# the ledger tilts by construction. See
+# community/wiki/guards-compound-in-cost-and-nothing-ever-retires-one.md.
+#
+# So the corpus is TIERED and BUDGETED IN WALL-CLOCK, not in count ("do not add
+# too many tests" is unenforceable and reads as an argument against testing):
+#
+#   this workflow (every PR, every push to main)  CORE tier,   <= 300s per job
+#   full-sweep.yml (nightly + dispatch)           FULL corpus, <= 1320s per job
+#
+# The tier of a harness and both budgets live in ONE place, tests/lib/tier.sh.
+# Core is the DEFAULT: a new harness is charged to this workflow unless its own
+# header demotes it with a written reason. Over budget, the run FAILS and names
+# what to merge, retire or demote — a warning would be worthless here, since the
+# growth was already visible for two weeks in a number nobody read.
+#
+# WHAT THE PR PATH GIVES UP, said plainly rather than left to be discovered: the
+# harness-verdict PROBE and its UNION (DIVE-2013/2018) cost a second full pass
+# over the corpus and now run nightly. The case that actually arises on a PR —
+# a harness ADDED or EDITED here whose exit status is not wired to its own
+# assertions — is closed by the `changed-harnesses` job below, at the moment of
+# introduction. The union's invariant is a whole-corpus, cross-environment
+# property; it is graded nightly and at release-cut, and it blocks a release.
 on:
   pull_request:
   push:
@@ -21,17 +49,14 @@ jobs:
       # this workflow was written; a skip count is not a green count.
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
-      - name: Run unit harnesses
-        run: |
-          rc=0
-          for t in tests/*.sh; do
-            echo "=== $t"
-            if ! bash "$t"; then
-              echo "FAILED: $t"
-              rc=1
-            fi
-          done
-          exit $rc
+      # DIVE-2525: the budget is NOT passed here. It lives in tests/lib/tier.sh next
+      # to the tier definition, because a budget spelled in the caller is raised by
+      # a one-line YAML edit that nobody reviews as the policy change it is.
+      - name: Run core harnesses (budgeted)
+        run: bash scripts/run-harnesses.sh --tier=core --label=pristine --report=core-pristine.txt
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with: { name: core-pristine, path: core-pristine.txt, if-no-files-found: warn }
 
   # DIVE-1919: the bare runner above is a PRISTINE box — no /var/lib/5dive, no
   # installed plugins. That is NOT the environment any agent actually runs the
@@ -42,39 +67,84 @@ jobs:
   # everyone to ignore red, and then a real failure reads as the usual noise.
   # This job seeds the host state that actually differs and reruns the same
   # suite, so that class reds in CI instead of only under an agent's nose.
-  # DIVE-2013: the suite above grades every harness on its EXIT STATUS, so a
-  # harness whose status is not wired to its own assertions is invisible to it —
-  # it prints FAIL and exits 0 and CI calls it green. That shipped for three
-  # consecutive releases (heartbeat_gate_shipped_unit.sh, 0.15.26-28). Static
-  # analysis cannot close it, so this job is EMPIRICAL: it injects a failure into
-  # each harness and demands the harness report it through $?.
+  # DIVE-2525: the one thing the moved-to-nightly probe was actually catching on a
+  # PR — a harness ADDED or EDITED in THIS diff whose exit status is not wired to its
+  # own assertions (DIVE-2013; that shipped for three consecutive releases). Scoped
+  # to the changed files, it costs a handful of harness runs instead of a second full
+  # pass over 267 of them.
   #
-  # `needs: test` is load-bearing, not just ordering — it is what establishes the
-  # clean-green baseline, which lets this job skip its own clean run (halving it)
-  # WITHOUT becoming unsound. Run standalone (no --assume-clean) the script does
-  # the clean run itself, so it is never unsound locally either.
-  harness-verdict:
+  # It also RUNS those harnesses whatever their tier, which closes the gap the tiering
+  # would otherwise open: you edit a nightly harness, the core suite does not include
+  # it, and nothing grades your edit until 03:17. Tier membership decides what runs by
+  # DEFAULT, never what runs when you touched it.
+  #
+  # NO --assume-clean here, deliberately: a changed harness may be a nightly one that
+  # the core jobs never ran, so there is no clean-green baseline in this workflow to
+  # assume. The probe does its own clean run for the few files named, which is what
+  # makes that flag unnecessary rather than merely omitted.
+  changed-harnesses:
     runs-on: ubuntu-latest
-    needs: test
+    steps:
+      # DIVE-2229: full history — pinned baselines must resolve here too, and the
+      # diff below needs the base commit to exist at all.
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Which harnesses did this change touch?
+        id: changed
+        env:
+          BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          # A base we cannot resolve is NOT "nothing changed" — that is the failure
+          # mode where a check reports clean on what it never looked at. Fall back to
+          # the whole corpus's changed set against origin/main, and if THAT cannot be
+          # resolved either, say so and fail.
+          base="$BASE"
+          if [[ -z "$base" || "$base" == 0000000000000000000000000000000000000000 ]] \
+             || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            base="$(git rev-parse origin/main 2>/dev/null || true)"
+          fi
+          if [[ -z "$base" ]]; then
+            echo "changed-harnesses: BLOCKED — could not resolve a base commit to diff against; refusing to report 'no harnesses changed' on the strength of a diff that never ran." >&2
+            exit 1
+          fi
+          # tests/*.sh only, never tests/lib/ or tests/meta/ — the same corpus shape
+          # the shell glob in tier.sh selects. Deleted files are excluded (ACMR): a
+          # harness that is gone cannot be run, and a deletion is the one direction
+          # this whole row is trying to make easier.
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "$base" HEAD -- 'tests/*.sh' ':(exclude)tests/lib/*' ':(exclude)tests/meta/*')
+          printf 'base=%s\n' "$base"
+          printf 'changed harnesses: %d\n' "${#files[@]}"
+          printf '  %s\n' "${files[@]:-（none）}"
+          { printf 'files=%s\n' "${files[*]:-}"
+            printf 'names=%s\n' "$(printf '%s\n' "${files[@]:-}" | xargs -r -n1 basename | paste -sd, -)"
+          } >> "$GITHUB_OUTPUT"
+      - name: Run them (any tier)
+        if: steps.changed.outputs.files != ''
+        run: |
+          rc=0
+          for t in ${{ steps.changed.outputs.files }}; do
+            echo "=== $t"
+            if ! bash "$t"; then echo "FAILED: $t"; rc=1; fi
+          done
+          exit $rc
+      - name: They must be able to FAIL
+        if: steps.changed.outputs.names != ''
+        run: |
+          bash tests/meta/harness-verdict-probe.sh \
+            --only='${{ steps.changed.outputs.names }}' --label=changed
+
+  # DIVE-2525: this job used to open with the harness-verdict PROBE (DIVE-2013),
+  # which runs the whole corpus a SECOND time — the single most expensive thing on
+  # the PR path. It moved to full-sweep.yml. What survives here is the DIVE-2039
+  # rail prover, which is ~10s and grades the shipped rails rather than the corpus.
+  # The PR-shaped case the probe existed to catch (a harness added or edited in
+  # THIS diff whose exit status is not wired) is caught by `changed-harnesses`.
+  rails-pristine:
+    runs-on: ubuntu-latest
     steps:
       # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
-      - name: Every harness must be able to FAIL
-        run: |
-          bash tests/meta/harness-verdict-probe.sh --assume-clean \
-            --label=pristine --report=probe-pristine.txt
-      # DIVE-2018: this run's `not-reached` set is not a failure and must not be —
-      # a harness that skips before its verdict has not been shown to be unwired,
-      # and three correctly-wired files were falsely accused that way. Which is
-      # exactly why THIS job cannot establish coverage: it can only report what it
-      # saw. The report goes to the union job, which asserts the invariant that
-      # does hold across environments. `if: always()` because a run that found
-      # UNWIRED still made a valid coverage observation, and losing it would let a
-      # red probe silently shrink the union.
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with: { name: probe-pristine, path: probe-pristine.txt, if-no-files-found: error }
       # DIVE-2039: the rail prover, from the pristine side. `snapshot-rails` is
       # allowlisted because GitHub CI has no ops checkout — that exemption can
       # never be earned here by adding another job, which is the difference
@@ -120,32 +190,15 @@ jobs:
           sudo useradd -M -N -s /usr/sbin/nologin claude 2>/dev/null || true
           sudo useradd -M -N -s /usr/sbin/nologin agent-dev 2>/dev/null || true
           getent passwd claude agent-dev
-      - name: Run unit harnesses (installed host)
-        run: |
-          rc=0
-          for t in tests/*.sh; do
-            echo "=== $t"
-            if ! bash "$t"; then
-              echo "FAILED: $t"
-              rc=1
-            fi
-          done
-          exit $rc
-      # DIVE-2018: the probe used to run ONLY on the pristine runner, so the
-      # harnesses CI never probed were precisely the ones that skip without live
-      # state — the gate and install paths, i.e. the most environment-sensitive
-      # code we have. Probing here too is what makes the union non-trivial: this
-      # environment reaches harnesses the pristine one cannot. `--assume-clean` is
-      # sound for the same reason it is in the pristine job — the step above just
-      # established the clean-green baseline IN THIS ENVIRONMENT, and if it went
-      # red this step does not run and the union job never reports coverage.
-      - name: Every harness must be able to FAIL (installed host)
-        run: |
-          bash tests/meta/harness-verdict-probe.sh --assume-clean \
-            --label=installed-host --report=probe-installed.txt
+      # DIVE-2525: core tier, held to the SAME 300s budget as the pristine job. This
+      # environment is slower per harness (real sudo, seeded host state), and that is
+      # a cost of the corpus too — hiding it under a laxer cap here would just move
+      # the growth to the job that is already the longest on the PR path.
+      - name: Run core harnesses (installed host, budgeted)
+        run: bash scripts/run-harnesses.sh --tier=core --label=installed-host --report=core-installed.txt
       - uses: actions/upload-artifact@v4
         if: always()
-        with: { name: probe-installed, path: probe-installed.txt, if-no-files-found: error }
+        with: { name: core-installed, path: core-installed.txt, if-no-files-found: warn }
       # DIVE-2039: TWICE, and that is the point. DIVE-1989 stayed invisible for as
       # long as the audit log was measured from one side — the same command wrote 0
       # rows as an agent and 1 row under sudo. `audit-root` is honestly NOT-REACHED
@@ -168,80 +221,6 @@ jobs:
         if: always()
         with: { name: selfcheck-installed, path: "selfcheck-*.txt", if-no-files-found: error }
 
-  # DIVE-2018: NOT-REACHED is correctly not a failure in any single run, so no
-  # single run can establish that a harness has EVER been probed. On the control
-  # plane the probe read 135 wired / 16 not-reached; on the pristine runner 151
-  # wired / 0 not-reached. Both green, both 154 with the allowlist, probing
-  # DIFFERENT CORPORA, and nothing said so. The limit case is a harness that skips
-  # in every environment: reported "probed in an environment where it runs", and no
-  # environment ever does.
-  #
-  # This job owns the invariant that survives that: every harness in tests/*.sh is
-  # DIVE-2412: A HARNESS CAN BE UNPROBED FOR TIME RATHER THAN FOR SHAPE, and the
-  # two want different answers. The probe's per-harness `timeout` is 180s, which is
-  # what stops one hung harness from stalling a 255-file sweep. A mutation grader
-  # re-runs its whole unit suite once per mutant, so this one costs ~14 x 23s and is
-  # killed by that timeout in EVERY environment — canary never printed, so
-  # `not-reached` everywhere, which is precisely the permanently-unprobed limit case
-  # the union job exists to catch. It caught it.
-  #
-  # The allowlist is the WRONG instrument here and using it would have been a false
-  # reason on the record: ALLOW_UNPROBEABLE means "no identifiable verdict variable",
-  # and this harness has one — measured `wired` at PROBE_TIMEOUT=900. It is probeable
-  # and slow, not unprobeable. So it gets a lane that pays the time instead of an
-  # exemption that excuses the coverage, and the union still asserts the same
-  # invariant over the same corpus.
-  #
-  # Scoped with --only on purpose: raising PROBE_TIMEOUT for the whole sweep would
-  # also raise how long a genuinely hung harness can stall CI, which is the property
-  # the 180s default is buying. Named harnesses pay 900s; nothing else changes.
-  harness-verdict-slow:
-    runs-on: ubuntu-latest
-    needs: test
-    env:
-      # One name per slow harness, comma-separated — the probe's own --only format.
-      # Keep this list SHORT and justified; a harness landing here is saying its
-      # verdict costs minutes, not that it may go ungraded.
-      SLOW_HARNESSES: gate_channel_session_t2_mutation.sh
-    steps:
-      # DIVE-2229: full history — pinned baselines must resolve here too.
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
-      - name: Slow harnesses must be able to FAIL too (long lane)
-        env: { PROBE_TIMEOUT: '900' }
-        run: |
-          bash tests/meta/harness-verdict-probe.sh --assume-clean \
-            --only="$SLOW_HARNESSES" --label=slow --report=probe-slow.txt
-      # `if: always()` for the same reason as the pristine lane: a run that found
-      # UNWIRED still made a valid coverage observation, and losing the report would
-      # let a red probe silently shrink the union instead of reddening it.
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with: { name: probe-slow, path: probe-slow.txt, if-no-files-found: error }
-
-  # probed in AT LEAST ONE environment, or is allowlisted by name with a reason.
-  # A skip in one environment is still not an accusation; a skip in all of them is
-  # now a failure.
-  harness-verdict-union:
-    runs-on: ubuntu-latest
-    needs: [harness-verdict, test-installed-host, harness-verdict-slow]
-    steps:
-      # DIVE-2229: full history — pinned baselines must resolve here too.
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
-      - uses: actions/download-artifact@v4
-        with: { pattern: probe-*, merge-multiple: true }
-      # The union script fails closed on a missing, headerless, or different-corpus
-      # report, so a job that died before writing one cannot silently shrink what
-      # we claim to cover — the check would otherwise have the same shape of hole
-      # it exists to close.
-      - name: Every harness must be probed in SOME environment
-        # probe-slow.txt is named EXPLICITLY, not globbed: union fails closed on a
-        # missing or unreadable report, so a slow lane that died has to red this job
-        # rather than quietly drop back to the two-environment corpus it used to
-        # cover — the same shrink-in-silence hole this check exists to close.
-        run: bash tests/meta/harness-verdict-union.sh probe-pristine.txt probe-installed.txt probe-slow.txt
-
   # DIVE-2039: the same invariant one level out, over the RAILS rather than the
   # harnesses. `5dive selfcheck` reports pass | fail | NOT-REACHED and NOT-REACHED
   # is deliberately not a failure in any single run — a probe whose precondition is
@@ -252,7 +231,7 @@ jobs:
   # exactly, which is why it is closed here on day one instead of after it bites.
   selfcheck-union:
     runs-on: ubuntu-latest
-    needs: [harness-verdict, test-installed-host]
+    needs: [rails-pristine, test-installed-host]
     steps:
       # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ decision to add one is ever wrong on its own merits. See
 | tier | runs | budget |
 |---|---|---|
 | `core` (**the default**) | every PR, both CI environments | **300s** per job |
-| `nightly` | `full-sweep.yml` (03:17 UTC + dispatch) | **1320s** per job, whole corpus |
+| `nightly` | `full-sweep.yml` (03:17 UTC + dispatch) | **1320s** per job, corpus split across 3 shards |
 
 - **A new harness is `core` unless you say otherwise.** Nothing to write.
 - **Over budget, CI FAILS** (`exit 4`, distinct from a test failure's `exit 1`) and
@@ -34,6 +34,12 @@ decision to add one is ever wrong on its own merits. See
   a default, and a default loses to an explicit signal.
 - Locally: `bash scripts/run-harnesses.sh --tier=core` (or `--tier=full`). Both
   budgets and the tier marker live in `tests/lib/tier.sh`, one place.
+- **The nightly is sharded, not given a bigger number.** The cap is per job, so
+  splitting the sweep cuts each job's wall-clock without relaxing it. Aggregate
+  capacity is 3 x 1320s and the shard count is fixed in the matrix, so adding a
+  shard is as visible a policy decision as raising the ceiling. `budget-report`
+  re-sums the shards and prints the **un-sharded** total, because that total is the
+  number the tiering exists to make legible and sharding is how you lose it.
 
 ## Hard rule: no real PII in public artifacts (DIVE-1774)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,40 @@
 # 5dive CLI — contributor rules
 
+## The test corpus is TIERED and BUDGETED IN WALL-CLOCK (DIVE-2525)
+
+`tests/*.sh` went 96 → 267 harnesses in 13 days against four harness deletions
+ever. A guard is bought once and paid for on **every future change, forever**,
+while its benefit stays fixed — so the ledger tilts by construction and no single
+decision to add one is ever wrong on its own merits. See
+`community/wiki/guards-compound-in-cost-and-nothing-ever-retires-one.md`.
+
+| tier | runs | budget |
+|---|---|---|
+| `core` (**the default**) | every PR, both CI environments | **300s** per job |
+| `nightly` | `full-sweep.yml` (03:17 UTC + dispatch) | **1320s** per job, whole corpus |
+
+- **A new harness is `core` unless you say otherwise.** Nothing to write.
+- **Over budget, CI FAILS** (`exit 4`, distinct from a test failure's `exit 1`) and
+  names the slowest files in the tier. Past the cap a new guard **replaces or
+  merges** an existing one — that is the reverse gear, and it is the point.
+- **Three ways out, in order:** merge by subject (hundreds of harness *files* for
+  one CLI means the unit of organisation is the incident, not the subject —
+  folding two files about one subject reclaims their setup cost and drops no
+  assertion); retire a guard whose class can no longer occur; or demote:
+
+  ```sh
+  # TIER: nightly — 14.3s measured: does not fit the 300s PR core; the nightly sweep runs it.
+  ```
+
+  In the harness header (first 40 lines). **The reason is mandatory** — a bare
+  `# TIER: nightly` is a refusal, not a default. Demotion moves the cost, it does
+  not delete it, which is why it is third and why it must be argued in the diff.
+- **Editing a harness always runs it**, whatever its tier: the `changed-harnesses`
+  job runs and verdict-probes every harness your diff touches. Tier membership is
+  a default, and a default loses to an explicit signal.
+- Locally: `bash scripts/run-harnesses.sh --tier=core` (or `--tier=full`). Both
+  budgets and the tier marker live in `tests/lib/tier.sh`, one place.
+
 ## Hard rule: no real PII in public artifacts (DIVE-1774)
 
 Never put real user ids, emails, phone numbers, or customer PII in anything that

--- a/scripts/run-harnesses.sh
+++ b/scripts/run-harnesses.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# DIVE-2525: run a TIER of the harness corpus under a WALL-CLOCK BUDGET.
+#
+# Replaces the two inline `for t in tests/*.sh` loops in unit-tests.yml. Same
+# contract as those loops — source-only harnesses, throwaway STATE_DIR, exit
+# non-zero if any harness fails — plus the two things the loops could not do:
+#
+#   1. It TIMES the run and FAILS when the tier is over its budget, naming the
+#      slowest harnesses. A warning here would be worthless: the corpus growth was
+#      already visible for two weeks in a number nobody read, and what surfaced
+#      first was a human noticing that fixes "felt like a struggle".
+#   2. It PRINTS the total as a number in its own output, every run, with the
+#      percentage of budget — so the trend is legible without archaeology.
+#
+# WHAT IS AND IS NOT MEASURED. Only the harnesses. Not checkout, not ./build.sh,
+# not the installed-host seeding. So the number means the same thing in CI, on the
+# control plane and on a laptop, and a slow `apt-get` cannot spend the corpus's
+# budget. The job's own wall-clock will always be larger; that is fine and it is
+# not what is capped.
+#
+# BUDGET FAILURE IS NOT TEST FAILURE and they do not share an exit code — a red
+# that could mean either would get triaged as neither:
+#   0  all harnesses passed, run inside budget
+#   1  at least one harness FAILED (this dominates: over budget too still exits 1,
+#      because the failing harness is the thing to fix first)
+#   4  every harness passed, run is OVER BUDGET
+#   3  the corpus could not be classified into tiers (see tests/lib/tier.sh)
+#   2  usage
+set -uo pipefail
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 2
+# shellcheck source=tests/lib/tier.sh
+. tests/lib/tier.sh
+
+TIER=""; BUDGET=""; LABEL=""; REPORT=""; TOP=10; CORPUS_DIR="tests"
+for a in "$@"; do case "$a" in
+  --tier=*)   TIER="${a#--tier=}" ;;
+  # The seam that lets tests/corpus_tier_budget_unit.sh grade THIS script against a
+  # throwaway corpus of its own. Without it the only way to test the budget rail is
+  # to make the real corpus slow, which is the one thing this script exists to stop.
+  --corpus-dir=*) CORPUS_DIR="${a#--corpus-dir=}" ;;
+  # Override the resolver's number. A workflow SHOULD NOT pass this — the budget
+  # belongs next to the tier definition, not scattered across the callers, or
+  # raising it becomes a one-line edit in a YAML nobody reviews as a policy change.
+  # It exists for the harness that grades this script, and for a human measuring.
+  --budget=*) BUDGET="${a#--budget=}" ;;
+  --label=*)  LABEL="${a#--label=}" ;;   # names the environment in the summary line
+  --report=*) REPORT="${a#--report=}" ;; # TSV: ms<TAB>rc<TAB>path, for the trend
+  --top=*)    TOP="${a#--top=}" ;;
+  *) printf 'unknown arg: %s\n' "$a" >&2; exit 2 ;;
+esac; done
+
+case "$TIER" in
+  core|full) ;;
+  *) printf 'usage: run-harnesses.sh --tier=core|full [--budget=<seconds>] [--label=<env>] [--report=<file>] [--corpus-dir=<dir>]\n' >&2; exit 2 ;;
+esac
+[[ -n "$BUDGET" ]] || BUDGET="$(tier_budget "$TIER")" || exit 2
+[[ -n "$LABEL" ]] || LABEL="local"
+
+mapfile -t CORPUS < <(tier_list "$TIER" "$CORPUS_DIR") || {
+  printf 'run-harnesses: REFUSING to run a corpus this tree cannot classify (see the tier: lines above).\n' >&2
+  exit 3
+}
+# An EMPTY set is UNDETERMINED, never clean — the same reason grade-release-commit.sh
+# refuses one: `for t in <nothing>` passes, loudly, having graded nothing.
+if (( ${#CORPUS[@]} == 0 )); then
+  printf 'run-harnesses: FAIL — tier %s selected 0 harnesses. An empty corpus is not a green one.\n' "$TIER" >&2
+  exit 1
+fi
+
+declare -a MS=() RC=() NAME=()
+failed=(); total_ms=0
+for t in "${CORPUS[@]}"; do
+  printf '=== %s\n' "$t"
+  s=$(date +%s%N)
+  bash "$t"; rc=$?
+  e=$(date +%s%N)
+  ms=$(( (e - s) / 1000000 )); total_ms=$(( total_ms + ms ))
+  MS+=("$ms"); RC+=("$rc"); NAME+=("$t")
+  if (( rc != 0 )); then printf 'FAILED: %s\n' "$t"; failed+=("$t"); fi
+done
+
+total_s=$(( (total_ms + 999) / 1000 ))
+pct=0; (( BUDGET > 0 )) && pct=$(( total_s * 100 / BUDGET ))
+
+if [[ -n "$REPORT" ]]; then
+  {
+    printf '# run-harnesses report\n# tier=%s\n# label=%s\n# harnesses=%d\n# wall_clock_s=%d\n# budget_s=%d\n# pct_of_budget=%d\n' \
+      "$TIER" "$LABEL" "${#CORPUS[@]}" "$total_s" "$BUDGET" "$pct"
+    for i in "${!NAME[@]}"; do printf '%s\t%s\t%s\n' "${MS[$i]}" "${RC[$i]}" "${NAME[$i]}"; done
+  } > "$REPORT"
+fi
+
+# Build 3 of DIVE-2525: the number, in its own output, every run.
+printf '\nharness-budget[%s/%s]: %d harnesses, %ds wall-clock, budget %ds (%d%% of budget)\n' \
+  "$TIER" "$LABEL" "${#CORPUS[@]}" "$total_s" "$BUDGET" "$pct"
+
+slowest() {
+  local n="$1" i
+  for i in "${!NAME[@]}"; do printf '%s\t%s\n' "${MS[$i]}" "${NAME[$i]}"; done \
+    | sort -rn | head -"$n" | while IFS=$'\t' read -r ms nm; do
+        printf '    %6.1fs  %s\n' "$(awk -v m="$ms" 'BEGIN{print m/1000}')" "$nm"
+      done
+}
+
+over=0
+if (( BUDGET <= 0 )); then
+  printf 'harness-budget[%s]: BUDGET DISABLED (--budget=%s). This run enforces nothing.\n' "$TIER" "$BUDGET"
+elif (( total_s > BUDGET )); then
+  over=1
+  printf '\nharness-budget[%s]: OVER BUDGET by %ds (%ds > %ds).\n' "$TIER" "$(( total_s - BUDGET ))" "$total_s" "$BUDGET"
+  printf 'The corpus is not free: every harness here runs on every future change, forever.\n'
+  printf 'Past the cap a new guard REPLACES or MERGES an existing one. The %d slowest in this tier:\n' "$TOP"
+  slowest "$TOP"
+  printf '\nThree ways out, in order of preference:\n'
+  printf '  1. MERGE by subject. Hundreds of harness FILES for one CLI means the unit of\n'
+  printf '     organisation is the incident, not the subject. Folding two files about the same\n'
+  printf '     subject into one reclaims their setup cost and drops NO assertion.\n'
+  printf '  2. RETIRE. A guard for a class that can no longer occur (the code path is gone, or a\n'
+  printf '     stronger check subsumes it) is pure cost. Deleting it is a legitimate PR.\n'
+  printf '  3. DEMOTE, with a reason, by adding to the harness header:\n'
+  printf '       # TIER: nightly — <why this cannot be in the %ds PR core>\n' "$TIER_BUDGET_CORE"
+  printf '     Demotion moves the cost to the nightly sweep, which has its own budget (%ds).\n' "$TIER_BUDGET_FULL"
+  printf '     It does not delete the cost, which is why it is third and why it must be argued.\n'
+elif (( pct >= 80 )); then
+  printf 'harness-budget[%s]: %d%% of budget — inside the cap, but the next few guards will not be.\n' "$TIER" "$pct"
+  printf 'The %d slowest in this tier:\n' "$TOP"; slowest "$TOP"
+fi
+
+if (( ${#failed[@]} )); then
+  printf '\n%d harness(es) FAILED:\n' "${#failed[@]}"
+  printf '  %s\n' "${failed[@]}"
+  exit 1
+fi
+(( over == 0 )) || exit 4
+exit 0

--- a/scripts/run-harnesses.sh
+++ b/scripts/run-harnesses.sh
@@ -31,7 +31,7 @@ cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 2
 # shellcheck source=tests/lib/tier.sh
 . tests/lib/tier.sh
 
-TIER=""; BUDGET=""; LABEL=""; REPORT=""; TOP=10; CORPUS_DIR="tests"
+TIER=""; BUDGET=""; LABEL=""; REPORT=""; TOP=10; CORPUS_DIR="tests"; SHARD=""
 for a in "$@"; do case "$a" in
   --tier=*)   TIER="${a#--tier=}" ;;
   # The seam that lets tests/corpus_tier_budget_unit.sh grade THIS script against a
@@ -45,6 +45,22 @@ for a in "$@"; do case "$a" in
   --budget=*) BUDGET="${a#--budget=}" ;;
   --label=*)  LABEL="${a#--label=}" ;;   # names the environment in the summary line
   --report=*) REPORT="${a#--report=}" ;; # TSV: ms<TAB>rc<TAB>path, for the trend
+  # DIVE-2525 (main, reviewing #376): the cap is PER JOB, so splitting the sweep
+  # across N jobs cuts each job's wall-clock WITHOUT relaxing the constraint. Raising
+  # the ceiling buys three days and re-installs the ratchet; sharding buys headroom
+  # that scales with the corpus. Round-robin, not contiguous blocks: the cost
+  # distribution has a long tail (one harness is 300s, the median is under a second),
+  # and contiguous blocks would put a whole alphabetical neighbourhood of expensive
+  # e2e files in one shard.
+  #
+  # WHAT SHARDING DOES NOT DO, said here because it is the thing to watch: it does not
+  # reduce the corpus's TOTAL cost, only the wall-clock of any one job. Aggregate
+  # nightly capacity is now N x the budget, and N is fixed in the workflow — so adding
+  # a shard is exactly as visible, and exactly as much a policy decision, as raising
+  # the number. The budget-report job re-sums the shards and prints the UN-SHARDED
+  # total, because that total is the number this whole row exists to make legible and
+  # sharding is the obvious way to lose it.
+  --shard=*)  SHARD="${a#--shard=}" ;;   # i/N, 1-based
   --top=*)    TOP="${a#--top=}" ;;
   *) printf 'unknown arg: %s\n' "$a" >&2; exit 2 ;;
 esac; done
@@ -67,6 +83,26 @@ if (( ${#CORPUS[@]} == 0 )); then
   exit 1
 fi
 
+if [[ -n "$SHARD" ]]; then
+  if [[ ! "$SHARD" =~ ^([0-9]+)/([0-9]+)$ ]]; then
+    printf 'run-harnesses: --shard must be i/N (1-based), got %s\n' "$SHARD" >&2; exit 2
+  fi
+  si="${BASH_REMATCH[1]}"; sn="${BASH_REMATCH[2]}"
+  if (( si < 1 || sn < 1 || si > sn )); then
+    printf 'run-harnesses: --shard=%s is out of range\n' "$SHARD" >&2; exit 2
+  fi
+  picked=()
+  for i in "${!CORPUS[@]}"; do (( i % sn == si - 1 )) && picked+=("${CORPUS[$i]}"); done
+  CORPUS=("${picked[@]}")
+  LABEL="$LABEL-s$si"
+  # A shard that selected nothing is UNDETERMINED for the same reason an empty tier
+  # is: it reports green having graded none of the corpus it names.
+  if (( ${#CORPUS[@]} == 0 )); then
+    printf 'run-harnesses: FAIL — shard %s of tier %s selected 0 harnesses.\n' "$SHARD" "$TIER" >&2
+    exit 1
+  fi
+fi
+
 declare -a MS=() RC=() NAME=()
 failed=(); total_ms=0
 for t in "${CORPUS[@]}"; do
@@ -84,8 +120,8 @@ pct=0; (( BUDGET > 0 )) && pct=$(( total_s * 100 / BUDGET ))
 
 if [[ -n "$REPORT" ]]; then
   {
-    printf '# run-harnesses report\n# tier=%s\n# label=%s\n# harnesses=%d\n# wall_clock_s=%d\n# budget_s=%d\n# pct_of_budget=%d\n' \
-      "$TIER" "$LABEL" "${#CORPUS[@]}" "$total_s" "$BUDGET" "$pct"
+    printf '# run-harnesses report\n# tier=%s\n# label=%s\n# shard=%s\n# harnesses=%d\n# wall_clock_s=%d\n# budget_s=%d\n# pct_of_budget=%d\n' \
+      "$TIER" "$LABEL" "${SHARD:-1/1}" "${#CORPUS[@]}" "$total_s" "$BUDGET" "$pct"
     for i in "${!NAME[@]}"; do printf '%s\t%s\t%s\n' "${MS[$i]}" "${RC[$i]}" "${NAME[$i]}"; done
   } > "$REPORT"
 fi

--- a/tests/actor_claim_corroboration_unit.sh
+++ b/tests/actor_claim_corroboration_unit.sh
@@ -336,6 +336,22 @@ else
   # rows in the same breath that the redirected one lists none. Both reads are
   # read-only, and the db file cannot be checked first: `task ls` never creates
   # one, so a file-existence precondition skips every run (iteration 2 did that).
+  # DIVE-2525: DERIVED HERE, NOT INSIDE THE T19-T21 BRANCH. This was set only on the
+  # path where the isolation fence proved out, and T25/T26 below read it on the path
+  # where the fence SKIPS — so under `set -u` a skip 150 lines earlier killed the
+  # harness outright ("line 513: EXPECT_BOARD: unbound variable") instead of skipping
+  # two arms. It never fired because the branch had never executed in CI: the arms
+  # below need ./5dive, nothing built it, and the harness died earlier. Building the
+  # bundle explicitly (DIVE-2525) reached this code for the first time. A variable
+  # derived inside the branch that happens to use it first is a precondition nobody
+  # declared, which is the same defect one layer down.
+  EXPECT_BOARD="cli"
+  if jq -e --arg n "$REAL_BOARD" '(.agents|type=="object") and (.agents|has($n))' \
+       /var/lib/5dive/agents.json >/dev/null 2>&1; then
+    EXPECT_BOARD="$REAL_BOARD"
+  elif [[ "$REAL_NAME" == agent-* ]]; then
+    EXPECT_BOARD="$REAL_BOARD"     # the passwd rung: registry silent, name is agent-*
+  fi
   live_rows=$("$BIN" task ls 2>/dev/null | grep -c 'DIVE-' || true)
   probe_rows=$(e2e task ls 2>/dev/null | grep -c 'DIVE-' || true)
   if (( live_rows == 0 )); then
@@ -364,13 +380,6 @@ else
     # for `claude` (uid 1000, not a registered agent) while the product was behaving
     # exactly as specified. Ground truth is the registry FILE, read directly, not
     # `actor_registry_agent` — that is the function under test.
-    EXPECT_BOARD="cli"
-    if jq -e --arg n "$REAL_BOARD" '(.agents|type=="object") and (.agents|has($n))' \
-         /var/lib/5dive/agents.json >/dev/null 2>&1; then
-      EXPECT_BOARD="$REAL_BOARD"
-    elif [[ "$REAL_NAME" == agent-* ]]; then
-      EXPECT_BOARD="$REAL_BOARD"     # the passwd rung: registry silent, name is agent-*
-    fi
     tid2=$(e2e task add "DIVE-2518 claimed row" --project=dive --from="$FORGE_BOARD" 2>&1 | grep -oE 'DIVE-[0-9]+' | head -1)
     cb=$(e2e task show "$tid2" | awk -F' = ' '/^created_by /{print $2; exit}')
     # created_by keeps the CLAIM — for a uid-less relay principal that is the only

--- a/tests/agent_prompt_wait_skip_unit.sh
+++ b/tests/agent_prompt_wait_skip_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 12.3s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2277 — a harness with no prompt marker must not pay the 45s prompt-wait.
 #
 # TWO-SIDED BY CONSTRUCTION:

--- a/tests/ask_cmd_wiring_unit.sh
+++ b/tests/ask_cmd_wiring_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 10.1s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1901 iteration 2 — drive cmd_ask ITSELF, both dispatch branches, under set -u.
 #
 # WHY THIS FILE EXISTS. The other two ask suites test the pure helpers

--- a/tests/baseline_pin_unit.sh
+++ b/tests/baseline_pin_unit.sh
@@ -46,7 +46,13 @@ bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; [[ -n "${2:-}" ]] && prin
 TMP="$(mktemp -d /tmp/baseline-pin.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
 
-WF=".github/workflows/unit-tests.yml"
+# DIVE-2525: the suite that anchors to pinned commits is no longer run by ONE
+# workflow. unit-tests.yml runs the CORE tier on every PR; full-sweep.yml runs the
+# whole corpus nightly, which is where a DEMOTED pinned-baseline harness now lives.
+# Arm D must sweep both, or it grades the fetch-depth of a workflow that no longer
+# runs the harnesses whose pins it exists to protect — the check would still be
+# green and would have stopped covering the thing that moved.
+WFS=(.github/workflows/unit-tests.yml .github/workflows/full-sweep.yml)
 
 # ---------------------------------------------------------------------------
 # The detector. One function, used on the real corpus AND on synthetic fixtures,
@@ -144,6 +150,7 @@ fi
 
 # --- Arm D: the CI half. Every checkout in the workflow that runs the suite must
 #     ask for full history, or the pins above resolve nowhere that gates a merge.
+for WF in "${WFS[@]}"; do
 if [[ -f "$WF" ]]; then
   n_checkout="$(grep -c 'uses: actions/checkout@' "$WF")"
   n_depth="$(grep -c 'fetch-depth: 0' "$WF")"
@@ -160,6 +167,7 @@ if [[ -f "$WF" ]]; then
 else
   bad_t "$WF is missing" "the CI half of this ticket cannot be asserted"
 fi
+done
 
 # --- Arm E: the helper must FAIL CLOSED. An unresolvable pin returning success
 #     (or an empty file that compares equal to an empty extraction) is how this

--- a/tests/constitution_set_e2e.sh
+++ b/tests/constitution_set_e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 8.2s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1743 e2e — `5dive constitution set` / `edit` WRITE path on the BUILT binary. Proves the two
 # routes off ONE shared parser:
 #   SOLO  (no genesis, or a single-principal genesis) -> DIRECT-seal via a single-principal `council

--- a/tests/constitution_set_json_e2e.sh
+++ b/tests/constitution_set_json_e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 11.6s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1751 e2e — `5dive constitution set --json` (browser-callable STRUCTURED-field write) on the
 # BUILT binary. Proves the dashboard EDIT contract (DIVE-1750):
 #   · reads a JSON patch {hard_gates,ship,comms} from STDIN, MERGES it into the CURRENT constitution,

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# DIVE-2525 isolated unit harness for the two halves of the corpus wall-clock
+# budget: the tier resolver (tests/lib/tier.sh) and the budgeted runner
+# (scripts/run-harnesses.sh).
+#
+# WHY THIS FILE IS ITSELF SMALL AND FAST, and says so. It is a harness added by the
+# row whose whole subject is that harnesses are added faster than they are retired.
+# The honest version of that is not to skip the coverage — it is to pay the budget
+# it enforces. Throwaway corpus of three one-line harnesses, no sleeps longer than
+# the assertion needs, and every arm below is one this mechanism can actually get
+# wrong.
+#
+# THE ARMS, and the mutation each one would catch:
+#   1-3   default is core; an explicit `# TIER: core` is legal; a marker below the
+#         header window does not demote. (Flipping the default to nightly would
+#         empty the PR path and nothing else here would notice.)
+#   4-5   a nightly demotion with no reason REFUSES (exit 3), and a `# TIER:` line
+#         naming an unknown tier REFUSES. This is the reverse gear: a demotion that
+#         costs nothing to write is a second budget nobody watches.
+#   6-8   tier_list partitions core/nightly and `full` is their union — the property
+#         that makes "the nightly sweep still runs everything" true rather than
+#         asserted. And a corpus containing ONE unclassifiable file makes the whole
+#         listing refuse, rather than silently returning the subset it understood.
+#   9-12  the runner: over budget exits 4 and names the slowest; a FAILING harness
+#         exits 1 even when also over budget (the failure is what you fix first);
+#         an empty selection is exit 1, never a green run over nothing; the report
+#         carries the wall-clock header the nightly summary reads.
+#  13-14  the over-budget message actually names a remedy and the slowest file —
+#         a budget that reds without saying what to retire is a warning with a
+#         worse exit code (feedback: grade the REMEDY half, not only the predicate).
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+
+TIER_LIB="tests/lib/tier.sh"
+RUNNER="scripts/run-harnesses.sh"
+TMP="$(mktemp -d /tmp/corpus-tier-budget.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s\n     %s\n' "$1" "${2:-}"; }
+want() { # want <name> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1" "expected [$2] got [$3]"; fi
+}
+
+# shellcheck source=tests/lib/tier.sh
+. "$TIER_LIB"
+
+mk() { printf '%s\n' "$2" > "$TMP/$1"; }
+
+# ---------------------------------------------------------------- 1-3 resolution
+mk plain.sh '#!/usr/bin/env bash
+echo plain'
+want "default tier is core" "core" "$(tier_of "$TMP/plain.sh")"
+
+mk explicit_core.sh '#!/usr/bin/env bash
+# TIER: core
+echo core'
+want "an explicit core marker is legal" "core" "$(tier_of "$TMP/explicit_core.sh")"
+
+# A marker outside the 40-line header window must not demote. The window is what
+# stops a string in a fixture, an assertion or a heredoc from moving a harness out
+# of the PR path silently.
+{ printf '#!/usr/bin/env bash\n'; for i in $(seq 45); do printf '# filler %s\n' "$i"; done
+  printf '# TIER: nightly — far below the header window\n'; printf 'echo late\n'; } > "$TMP/late_marker.sh"
+want "a marker below the header window does not demote" "core" "$(tier_of "$TMP/late_marker.sh")"
+
+# ---------------------------------------------------------------- 4-5 refusals
+mk bare_nightly.sh '#!/usr/bin/env bash
+# TIER: nightly
+echo bare'
+out="$(tier_of "$TMP/bare_nightly.sh" 2>&1)"; rc=$?
+if (( rc == 3 )) && [[ "$out" == *"no reason"* ]]; then
+  ok "an unjustified demotion REFUSES (exit 3)"
+else
+  bad "an unjustified demotion REFUSES (exit 3)" "rc=$rc out=$out"
+fi
+
+mk bogus_tier.sh '#!/usr/bin/env bash
+# TIER: weekly — only on Tuesdays
+echo bogus'
+out="$(tier_of "$TMP/bogus_tier.sh" 2>&1)"; rc=$?
+if (( rc == 3 )) && [[ "$out" == *"unknown tier"* ]]; then
+  ok "an unknown tier REFUSES rather than defaulting either way"
+else
+  bad "an unknown tier REFUSES rather than defaulting either way" "rc=$rc out=$out"
+fi
+
+# ---------------------------------------------------------------- 6-8 selection
+rm -f "$TMP"/*.sh
+mk a_core.sh '#!/usr/bin/env bash
+exit 0'
+mk b_core.sh '#!/usr/bin/env bash
+exit 0'
+mk c_night.sh '#!/usr/bin/env bash
+# TIER: nightly — 40s of container setup, cannot fit the PR core
+exit 0'
+want "core selects only the core harnesses" \
+  "a_core.sh b_core.sh" "$(tier_list core "$TMP" | xargs -n1 basename | paste -sd' ' -)"
+want "nightly selects only the demoted harnesses" \
+  "c_night.sh" "$(tier_list nightly "$TMP" | xargs -n1 basename | paste -sd' ' -)"
+want "full is the union, so the nightly sweep still runs everything" \
+  "a_core.sh b_core.sh c_night.sh" "$(tier_list full "$TMP" | xargs -n1 basename | paste -sd' ' -)"
+
+mk d_bogus.sh '#!/usr/bin/env bash
+# TIER: fortnightly — nope
+exit 0'
+tier_list core "$TMP" >/dev/null 2>&1; rc=$?
+want "one unclassifiable file makes the WHOLE listing refuse" "3" "$rc"
+rm -f "$TMP/d_bogus.sh"
+
+# ---------------------------------------------------------------- 9-14 the runner
+# Two cheap harnesses and one that burns a second, so a 1-second budget is
+# genuinely exceeded by measured time rather than by a constant in the assertion.
+rm -f "$TMP"/*.sh
+mk fast_one.sh '#!/usr/bin/env bash
+exit 0'
+mk slow_one.sh '#!/usr/bin/env bash
+sleep 1.2
+exit 0'
+
+run() { OUT="$(bash "$RUNNER" --corpus-dir="$TMP" "$@" 2>&1)"; RC=$?; }
+
+run --tier=core --budget=1 --label=t
+want "over budget exits 4 (not 1 — a slow suite is not a broken one)" "4" "$RC"
+if [[ "$OUT" == *"OVER BUDGET"* ]]; then ok "over-budget run says so in its output"
+else bad "over-budget run says so in its output" "$OUT"; fi
+
+# The remedy half. A budget that reds without naming the file to merge, retire or
+# demote is a warning with a worse exit code, and the whole finding behind this row
+# is that a number nobody can act on gets read by nobody.
+if [[ "$OUT" == *"slow_one.sh"* ]]; then ok "over-budget output NAMES the slowest harness"
+else bad "over-budget output NAMES the slowest harness" "$OUT"; fi
+if [[ "$OUT" == *"MERGE by subject"* && "$OUT" == *"RETIRE"* && "$OUT" == *"TIER: nightly"* ]]; then
+  ok "over-budget output names all three remedies (merge / retire / demote)"
+else bad "over-budget output names all three remedies (merge / retire / demote)" "$OUT"; fi
+
+run --tier=core --budget=600 --label=t
+want "inside budget exits 0" "0" "$RC"
+if [[ "$OUT" == *"harness-budget[core/t]"* && "$OUT" == *"% of budget)"* ]]; then
+  ok "every run prints the number and the percentage of budget"
+else bad "every run prints the number and the percentage of budget" "$OUT"; fi
+
+# A FAILING harness dominates an over-budget one: same run, both true, exit 1.
+mk red_one.sh '#!/usr/bin/env bash
+exit 1'
+run --tier=core --budget=1 --label=t
+want "a failing harness dominates over-budget (exit 1, not 4)" "1" "$RC"
+if [[ "$OUT" == *"FAILED: $TMP/red_one.sh"* ]]; then ok "the failing harness is named"
+else bad "the failing harness is named" "$OUT"; fi
+rm -f "$TMP/red_one.sh"
+
+run --tier=core --budget=600 --label=t --report="$TMP/rep.txt"
+hdr_s="$(sed -n 's/^# wall_clock_s=//p' "$TMP/rep.txt")"
+hdr_n="$(sed -n 's/^# harnesses=//p' "$TMP/rep.txt")"
+if [[ -n "$hdr_s" && "$hdr_n" == 2 ]]; then
+  ok "the report carries the header the nightly summary reads"
+else
+  bad "the report carries the header the nightly summary reads" "harnesses=[$hdr_n] wall_clock_s=[$hdr_s]"
+fi
+
+# An empty selection is UNDETERMINED, never clean: `for t in <nothing>` passes
+# loudly, having graded nothing (the grade-release-commit.sh lesson).
+mkdir -p "$TMP/empty"
+run --tier=core --budget=600 --corpus-dir="$TMP/empty" 2>/dev/null || true
+OUT="$(bash "$RUNNER" --tier=core --budget=600 --corpus-dir="$TMP/empty" 2>&1)"; RC=$?
+if (( RC == 1 )) && [[ "$OUT" == *"not a green one"* ]]; then
+  ok "an empty corpus FAILS rather than passing over nothing"
+else
+  bad "an empty corpus FAILS rather than passing over nothing" "rc=$RC out=$OUT"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+(( fail == 0 ))

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -177,5 +177,48 @@ else
   bad "an empty corpus FAILS rather than passing over nothing" "rc=$RC out=$OUT"
 fi
 
+# --------------------------------------------- 15-16 the precondition tiering exposed
+# MEASURED on this row's own first CI run: install_checksum_unit.sh, ledger_unit.sh and
+# policy_refusals_unit.sh went red in BOTH core jobs. They need ./5dive and
+# ./5dive.sha256 and say so in their own failure text — and no job ever built them.
+# They passed for months because SOME EARLIER HARNESS in the 267-file glob runs
+# ./build.sh as a side effect and leaves the artifact in the working tree for
+# everything after it. The corpus was ORDER-DEPENDENT through a shared file, and
+# running a SUBSET is what exposed it: same code, same runner, three reds.
+#
+# An implicit precondition that a full sweep happens to satisfy is not satisfied, it
+# is UNOBSERVED. So every job that runs harnesses declares it, and this arm holds that
+# open — it is the cheapest possible check (a grep over two YAML files, no runtime) and
+# it guards the exact defect that cost this PR a CI round trip.
+jobs_missing_build() {   # <workflow> -> job names that run harnesses without building
+  # Only below `jobs:` — the `on:` block has two-space keys too, and full-sweep.yml
+  # lists scripts/run-harnesses.sh among its pull_request paths, which read as a
+  # harness-running "job" named `schedule`. First version of this arm did exactly
+  # that and was red for a reason with nothing to do with the invariant.
+  awk '
+    /^jobs:[[:space:]]*$/ { injobs=1; next }
+    !injobs { next }
+    /^  [a-z][a-z0-9-]*:[[:space:]]*$/ { if (job != "" ) emit(); job=$1; sub(/:$/,"",job); runs=0; built=0; next }
+    # COMMENTS ARE NOT STEPS. Second version of this arm matched the prose — the
+    # comment above the build step names ./build.sh, so deleting the step left the
+    # explanation of the step behind and the check stayed green. Both mutations
+    # passed. A guard that reads the sentence describing the mechanism instead of
+    # the mechanism is the vacuity this corpus keeps re-learning.
+    /^[[:space:]]*#/ { next }
+    /run-harnesses\.sh|harness-verdict-probe\.sh/ { runs=1 }
+    /^[[:space:]]*(run:[[:space:]]*)?\.\/build\.sh/ { built=1 }
+    END { emit() }
+    function emit() { if (job != "" && runs && !built) print job }
+  ' "$1"
+}
+for wf in .github/workflows/unit-tests.yml .github/workflows/full-sweep.yml; do
+  miss="$(jobs_missing_build "$wf" | paste -sd, -)"
+  if [[ -z "$miss" ]]; then
+    ok "every harness-running job in ${wf##*/} builds the bundle first"
+  else
+    bad "every harness-running job in ${wf##*/} builds the bundle first" "missing in: $miss"
+  fi
+done
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 (( fail == 0 ))

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -220,5 +220,42 @@ for wf in .github/workflows/unit-tests.yml .github/workflows/full-sweep.yml; do
   fi
 done
 
+# ---------------------------------------------------- 17-20 sharding is a PARTITION
+# main's call reviewing #376: the first measured sweep came in at 83-86% of its own
+# cap, so the sweep is SHARDED rather than given a bigger number — the cap is per job,
+# and splitting cuts each job's wall-clock without relaxing the constraint.
+#
+# That is only sound if the shards PARTITION the corpus. A split that drops a harness
+# is a corpus that shrank silently, which is the failure this whole file is about;
+# a split that duplicates one just wastes the budget it exists to protect. So: union
+# equals the full tier, no overlap, and nothing selects an empty set in silence.
+rm -f "$TMP"/*.sh
+for i in 1 2 3 4 5 6 7; do mk "s$i.sh" '#!/usr/bin/env bash
+exit 0'; done
+ran() { bash "$RUNNER" --corpus-dir="$TMP" --tier=full --budget=600 "$@" 2>&1 \
+          | sed -n 's|^=== .*/||p' | sort; }
+u="$(for i in 1 2 3; do ran --shard=$i/3; done | sort)"
+flat() { tr '\n' ' ' | sed 's/ *$//'; }
+want "the shards' union is the whole tier" \
+  "$(ran | flat)" "$(printf '%s\n' "$u" | flat)"
+want "no harness runs twice across the shards" \
+  "$(printf '%s\n' "$u" | wc -l)" "$(printf '%s\n' "$u" | sort -u | wc -l)"
+# Round-robin, not contiguous blocks: with a long-tailed cost distribution (one
+# harness is 300s, the median is under a second) contiguous blocks put a whole
+# alphabetical neighbourhood of expensive e2e files in one shard.
+want "shard 1 of 3 takes every third harness, not the first third" \
+  "s1.sh s4.sh s7.sh" "$(ran --shard=1/3 | tr '\n' ' ' | sed 's/ $//')"
+
+OUT="$(bash "$RUNNER" --corpus-dir="$TMP" --tier=full --shard=4/3 2>&1)"; RC=$?
+if (( RC == 2 )) && [[ "$OUT" == *"out of range"* ]]; then
+  ok "an out-of-range shard REFUSES"
+else bad "an out-of-range shard REFUSES" "rc=$RC out=$OUT"; fi
+
+# 9 shards over 7 files: shard 8 selects nothing. Green-over-nothing, per shard.
+OUT="$(bash "$RUNNER" --corpus-dir="$TMP" --tier=full --shard=8/9 2>&1)"; RC=$?
+if (( RC == 1 )) && [[ "$OUT" == *"selected 0 harnesses"* ]]; then
+  ok "a shard that selects nothing FAILS rather than reporting green over nothing"
+else bad "a shard that selects nothing FAILS rather than reporting green over nothing" "rc=$RC out=$OUT"; fi
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 (( fail == 0 ))

--- a/tests/council_amend_e2e.sh
+++ b/tests/council_amend_e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 9.5s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # CNCL-15 bash e2e — CONSTITUTION AMENDMENTS wiring (real `5dive council {init,amend,convene,verify}`
 # bundle against an isolated STATE_DIR + a self-provisioned gate-proof key). Asserts the acceptance:
 #   (1) genesis seeds a v0 constitution.yaml and SEALS its digest into the genesis record;

--- a/tests/council_gate_e2e.sh
+++ b/tests/council_gate_e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 13.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # CNCL-12 bash e2e — the gate-rot WIRING (not just the pure mapper). Drives the real
 # `5dive council {gate-clear,rot-triage}` bundle end-to-end against an isolated STATE_DIR +
 # TASKS_DB + a self-provisioned gate-proof key, and asserts the three load-bearing legs the

--- a/tests/council_record_e2e.sh
+++ b/tests/council_record_e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 9.9s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # CNCL-17 bash e2e — the seat TRACK RECORD wiring (not just the pure scorer). Drives the real
 # `5dive council record` bundle end-to-end against an isolated STATE_DIR + TASKS_DB:
 #   - seeds two decided tasks (one DONE → good outcome, one CANCELLED → bad outcome) + one still-open,

--- a/tests/council_roster_lineage_e2e.sh
+++ b/tests/council_roster_lineage_e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 13.6s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # CNCL-11 bash e2e — the GOVERNANCE SURFACE wiring (roster / log / verify / promote / demote),
 # not just the node engine. Drives the real `5dive council {init,roster,promote,demote,log,verify}`
 # bundle against an isolated STATE_DIR + a self-provisioned gate-proof key, and asserts the

--- a/tests/council_schedule_e2e.sh
+++ b/tests/council_schedule_e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 6.2s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # CNCL-23 schedule E2E — proves `5dive council schedule {add,ls,show,rm,run}` are REACHABLE
 # through the real BASH dispatcher (src/cmd_council.sh) on the BUILT binary, and that the
 # deterministic RUNNER generalizes the CNCL-21/22 ops scripts correctly:

--- a/tests/council_unit.sh
+++ b/tests/council_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 76.8s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # CI wrapper: run the council node harnesses (engine + CLI contract + dispatch + constitution) under
 # the tests/*.sh runner so they actually GATE in CI (unit-tests.yml globs tests/*.sh, not
 # *.mjs). All three are offline (COUNCIL_MOCK / mock adapters — no key, no network, no live

--- a/tests/council_veto_e2e.sh
+++ b/tests/council_veto_e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 10.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # CNCL-9 bash e2e — the authenticated founder veto WIRING (not just the node engine). Drives the
 # real `5dive council {init,convene,veto exercise,lineage verify}` bundle against an isolated
 # STATE_DIR + a self-provisioned gate-proof key, and asserts the four legs main's hard gate

--- a/tests/digest_window_30d_controls.sh
+++ b/tests/digest_window_30d_controls.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 8.6s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1921 mutation runner for tests/digest_window_30d_unit.sh.
 #
 # WHY THIS IS COMMITTED RATHER THAN DESCRIBED. The PR for DIVE-1921 claimed

--- a/tests/env_isolation_unit.sh
+++ b/tests/env_isolation_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 17.7s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2325 — a harness must not inherit the caller's product knobs.
 #
 # THE INCIDENT. task_core_unit (28/7) and task_verifier_rail_unit (17/6) were red on

--- a/tests/gate_answer_audit_unit.sh
+++ b/tests/gate_answer_audit_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 9.4s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2090 isolated unit harness — a stored gate answer must carry an audit row.
 #
 # WHY THIS EXISTS. `cmd_task_answer` emitted `task answer gate` rows from its

--- a/tests/gate_button_retire_unit.sh
+++ b/tests/gate_button_retire_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 23.1s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2410: a settled gate must stop showing a live-looking approve button.
 #
 # WHAT THIS GRADES, and why each arm exists rather than just "it edits something":

--- a/tests/gate_channel_proof_unit.sh
+++ b/tests/gate_channel_proof_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 11.6s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1305 isolated unit harness for the paired-human channel-proof clear and
 # the `task clear-recs` bulk-apply-recommendations verb:
 #   * _gate_channel_proof_ok verifies a chat_id against the bot's access.json

--- a/tests/gate_channel_session_t2_mutation.sh
+++ b/tests/gate_channel_session_t2_mutation.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 300.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2412 mutation grader for tests/gate_channel_session_t2_unit.sh.
 #
 # WHY THIS FILE EXISTS. Most of what DIVE-2412 ships is REFUSALS, and "it must

--- a/tests/gate_channel_session_t2_unit.sh
+++ b/tests/gate_channel_session_t2_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 26.7s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2412 (DIVE-2382 fix #4) isolated unit harness: a TIER-2 gate cleared by
 # CHANNEL PROOF of the human's answer instead of a button tap.
 #

--- a/tests/gate_floor_declared_discussion_unit.sh
+++ b/tests/gate_floor_declared_discussion_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 24.2s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2089 isolated unit harness for the DECLARED-DISCUSSION floor appeal.
 #
 # THE DEFECT. The T2 category floor reads SUBJECT MATTER as risk and picks the

--- a/tests/gate_history_unit.sh
+++ b/tests/gate_history_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 14.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2119 isolated unit harness — retiring a gate must ARCHIVE it and then
 # reset ALL SIX provenance columns, at EVERY path that retires one.
 #

--- a/tests/gate_internal_ops_floor_unit.sh
+++ b/tests/gate_internal_ops_floor_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 9.9s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1480 isolated unit harness for the INTERNAL-OPS / recovery floor carve-out.
 #
 # The T2 destructive floor (delete|destroy|wipe|purge|…) is deliberately biased to

--- a/tests/gate_lead_clear_stamp_unit.sh
+++ b/tests/gate_lead_clear_stamp_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 18.9s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2406 isolated unit harness — a LEAD-CLEARED gate must not be stamped as a
 # HUMAN answer.
 #

--- a/tests/gate_lead_standing_unit.sh
+++ b/tests/gate_lead_standing_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 26.4s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2099 isolated unit harness for the ORG LEAD's STANDING authority to clear an
 # ENGINEERING approval gate (lodar granted it 2026-07-26; main filed rather than
 # implemented it because the requester is the beneficiary).

--- a/tests/gate_needs_capability_unit.sh
+++ b/tests/gate_needs_capability_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 18.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2241 isolated unit harness for the DECLARED human-class capability
 # (`5dive task need --needs=<capability>`).
 #

--- a/tests/gate_nonce_unit.sh
+++ b/tests/gate_nonce_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 11.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-916 isolated unit harness for the per-gate HUMAN nonce that closes the
 # sudo->--human gate-forge, folded into the DIVE-931 secret-drop chain:
 #   * `task need --type=approval|secret|manual` mints human_nonce_hash (hash-only

--- a/tests/gate_precedent_unit.sh
+++ b/tests/gate_precedent_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 15.1s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # OSS-11 (DIVE-976) isolated unit harness for decision-memory precedent prefill.
 # Two halves:
 #   * _gate_ask_shape() normalizer — idents/dates/amounts/hosts/nums/quoted-names

--- a/tests/gate_route_delivery_unit.sh
+++ b/tests/gate_route_delivery_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 23.6s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2011 isolated unit harness for LEAD-ROUTE DELIVERY TELEMETRY.
 #
 # What this pins, and why each assertion exists rather than being obvious:

--- a/tests/gate_seam_concatenation_unit.sh
+++ b/tests/gate_seam_concatenation_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 14.3s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2224 isolated unit harness: PART 1, a gate classifier must never read the ASK
 # and the TITLE as ONE string; PART 2 (lodar answered A, 2026-07-28), the floor's
 # SUBJECT is the ASK, with a fail-closed fallback to the title when the ask states

--- a/tests/gate_ship_routing_unit.sh
+++ b/tests/gate_ship_routing_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 27.5s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1145 isolated unit harness for ship-gating gate ROUTING in cmd_task_need.
 # Policy: a builder's (non-lead) DECISION gate routes to the org lead first
 # (status stays blocked, need_answered_at NULL, human ping SUPPRESSED) instead of

--- a/tests/gate_t2_nonce_proof_unit.sh
+++ b/tests/gate_t2_nonce_proof_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 10.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2233 ITEM 2 — the tier-2 human claim, proved instead of asserted.
 #
 # Cut onto its own branch at Marcus's direction, and the reason is the point: the tier-2

--- a/tests/gate_t2_routed_escalate_unit.sh
+++ b/tests/gate_t2_routed_escalate_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 5.8s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1437 isolated unit harness for the T2-floor-refused ROUTED-gate escalation in
 # cmd_task_answer. ROOT (DIVE-1429): a builder gate that DIVE-1145/1182 lead-routed
 # (routed_reviewer set) but whose effective tier is 2 (a non-floored `manual` gate —

--- a/tests/gate_tier2_explicit_pin_unit.sh
+++ b/tests/gate_tier2_explicit_pin_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 13.1s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1957 isolated unit harness: an EXPLICIT `--tier=2` (the caller's hard-human
 # contract) must survive every KIND-based downgrade/route carve-out.
 #

--- a/tests/gate_tier2_floor_unit.sh
+++ b/tests/gate_tier2_floor_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 6.3s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1117 isolated unit harness for the tier-2 PROVENANCE FLOOR in cmd_task_answer
 # (companion to DIVE-1115, CLI side / defense in depth). The DIVE-916/950 human-only
 # + evidence blocks key on need_type (approval/secret/manual); a `decision` gate

--- a/tests/gate_withdraw_unit.sh
+++ b/tests/gate_withdraw_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 25.3s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1401 isolated unit harness for `task need --withdraw`: a lead/filer path to
 # cancel a still-pending gate the team itself filed but that is now MOOT (e.g. a
 # secret gate for fixtures never needed). Withdrawing is NOT a grant — it must never

--- a/tests/goal_add_unit.sh
+++ b/tests/goal_add_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 17.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-984 isolated unit harness for `5dive goal add` (goal decomposition v1).
 #
 # Sources the src/ libs directly and points STATE_DIR at a throwaway temp dir so

--- a/tests/goal_async_unit.sh
+++ b/tests/goal_async_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 14.9s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1349 isolated unit harness for ASYNC `5dive goal add` + `goal status`.
 #
 # Sources src/ directly against a throwaway STATE_DIR (never touches the live

--- a/tests/heartbeat_stall_sweep_unit.sh
+++ b/tests/heartbeat_stall_sweep_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 12.4s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1416 isolated unit harness for _hb_stall_sweep (cmd_heartbeat.sh) —
 # fleet-stall self-heal gaps #2 and #3 (gap #1 is _hb_blocked_sweep, covered by
 # tests/task_cascade_unblock_unit.sh):

--- a/tests/lib/tier.sh
+++ b/tests/lib/tier.sh
@@ -45,13 +45,18 @@
 # above. It is per-job, and both PR environments (pristine and installed-host) are
 # held to it separately.
 #
-# FULL = 1320s (22 min). MEASURED, not aspirational: release-cut.yml's own published
-# figure is 3.79s per harness (164 harnesses in 10m21s, 168 in 10m37s), and an
-# independent serial timing of the whole corpus on the control plane agreed with it
-# to within 1%. Today's 267-harness corpus is therefore ~1010s of pure harness time.
-# 1320 is that plus ~30% — which is RUNNER VARIANCE, not growth room. At the observed
-# +13/day it is roughly three weeks of headroom, and the run prints its
-# percentage-of-budget every time so the trend is legible before it reds, not after.
+# FULL = 1320s (22 min). MEASURED IN CI ON THIS PR, not extrapolated: 268 harnesses
+# in 1097s pristine and 1146s installed-host (gh run 30761800471). The estimate this
+# number was first set from — release-cut.yml's published 3.79s/harness — agreed with
+# it to within 6%, and is now superseded by the direct reading.
+#
+# So the sweep starts at 83-86% OF ITS OWN CAP, and that is the finding, not a
+# mis-set number: the corpus is ALREADY at the cost a nightly job can carry. 1320 is
+# today plus ~15-20%, which is runner variance and roughly 30 more harnesses — about
+# three days at the observed +13/day. Raising it to buy comfortable headroom would be
+# re-installing the ratchet this row exists to remove. The run prints its
+# percentage-of-budget every time, so the trend is legible in the number rather than
+# only in the red.
 TIER_BUDGET_CORE=300
 TIER_BUDGET_FULL=1320
 

--- a/tests/lib/tier.sh
+++ b/tests/lib/tier.sh
@@ -1,0 +1,146 @@
+# shellcheck shell=bash
+# DIVE-2525: WHICH TIER DOES THIS HARNESS RUN IN, and WHAT DOES THE TIER COST.
+# One resolver, one pair of numbers, sourced by everything that selects or
+# budgets the corpus (scripts/run-harnesses.sh and the CI workflows). Two
+# selectors written in two places are one contract with two authors, and when they
+# drift the PR path and the nightly path silently grade different corpora — which
+# is DIVE-2018 exactly, one level out.
+#
+# WHY THIS EXISTS AT ALL (measured 2026-08-02, community/wiki/guards-compound-in-cost-
+# and-nothing-ever-retires-one.md): tests/*.sh went 96 -> 267 harnesses in 13 days,
+# ~+13/day, against FOUR harness deletions ever. A guard is bought once and paid for
+# on every future change forever, while its benefit stays fixed at the one class it
+# catches, so the ledger tilts by construction and no single decision to add one is
+# ever wrong on its own merits. Nobody has ever been paged by a guard that was too
+# slow, so nobody ever files "delete this guard": ~170 additions against 4 deletions
+# is a mechanism with no reverse gear, not restraint failing occasionally.
+#
+# WHY WALL-CLOCK AND NOT A COUNT. "Do not add too many tests" is unenforceable and
+# reads as an argument against testing. "The core must finish in N minutes" is
+# measurable, count-neutral, and is the reverse gear: past the cap, a new guard has
+# to replace or merge an existing one — or justify, in writing, why it belongs in
+# the nightly sweep instead.
+#
+# THE TIERS
+#   core     — runs on EVERY pull request, in both CI environments. The DEFAULT.
+#   nightly  — runs only in the full sweep. Must be declared IN THE FILE, with a
+#              reason, because a demotion nobody has to justify is not a reverse
+#              gear either: it just moves the growth to a budget nobody watches.
+#
+# THE MARKER, spelled once, here:
+#
+#   # TIER: nightly — <reason, >= 12 chars>
+#
+# Anything else, anywhere in the first 40 lines of a harness, is `core`. A `# TIER:`
+# line with an unknown tier, or a `nightly` line with no reason, is a REFUSAL (exit
+# 3) and not a silent default in either direction — "I could not tell" is a third
+# outcome and folding it into either of the other two is the class this repo keeps
+# re-learning (tests/lib/grading_tree.sh, DIVE-2274).
+
+# The budgets, in seconds of HARNESS WALL-CLOCK (the runner measures only the
+# harnesses, never checkout/build/setup, so the number means the same thing in CI,
+# on the control plane, and on a laptop).
+#
+# CORE = 300s. lodar's number, set on Telegram 2026-08-02 after the measurement
+# above. It is per-job, and both PR environments (pristine and installed-host) are
+# held to it separately.
+#
+# FULL = 1320s (22 min). MEASURED, not aspirational: release-cut.yml's own published
+# figure is 3.79s per harness (164 harnesses in 10m21s, 168 in 10m37s), and an
+# independent serial timing of the whole corpus on the control plane agreed with it
+# to within 1%. Today's 267-harness corpus is therefore ~1010s of pure harness time.
+# 1320 is that plus ~30% — which is RUNNER VARIANCE, not growth room. At the observed
+# +13/day it is roughly three weeks of headroom, and the run prints its
+# percentage-of-budget every time so the trend is legible before it reds, not after.
+TIER_BUDGET_CORE=300
+TIER_BUDGET_FULL=1320
+
+# Match the marker on the harness's own header. Anchored to a comment so a string
+# inside a heredoc or an assertion cannot demote a file by accident.
+TIER_MARKER_RE='^[[:space:]]*#[[:space:]]*TIER:[[:space:]]*([a-z-]+)[[:space:]]*(.*)$'
+
+# tier_of <file> -> prints core|nightly, exit 0
+#                   prints a diagnostic on stderr, exit 3, when the file names a
+#                   tier this resolver does not know or demotes without a reason.
+tier_of() {
+  local f="$1" line tier reason
+  # Only the header. A marker 400 lines down is not a header contract, and reading
+  # the whole file to find one invites exactly the accidental match this avoids.
+  line="$(head -40 -- "$f" 2>/dev/null | grep -m1 -E '^[[:space:]]*#[[:space:]]*TIER:' || true)"
+  if [[ -z "$line" ]]; then printf 'core\n'; return 0; fi
+  [[ "$line" =~ $TIER_MARKER_RE ]] || {
+    printf 'tier: REFUSING %s — has a "# TIER:" line this resolver cannot parse: %s\n' "$f" "$line" >&2
+    return 3
+  }
+  tier="${BASH_REMATCH[1]}"; reason="${BASH_REMATCH[2]}"
+  case "$tier" in
+    core)
+      # Redundant but legal: saying out loud that a file is core is not an error.
+      printf 'core\n'; return 0 ;;
+    nightly)
+      # Strip the separator (— / -- / :) people will reach for, then demand prose.
+      reason="${reason#[—:-]}"; reason="${reason#[-—]}"
+      reason="${reason#"${reason%%[![:space:]]*}"}"
+      if (( ${#reason} < 12 )); then
+        printf 'tier: REFUSING %s — demoted to nightly with no reason. A demotion nobody has to justify is not a budget, it is a second budget nobody watches. Write: # TIER: nightly — <why this cannot be in the 5-minute PR core>\n' "$f" >&2
+        return 3
+      fi
+      printf 'nightly\n'; return 0 ;;
+    *)
+      printf 'tier: REFUSING %s — unknown tier "%s". Known tiers: core, nightly.\n' "$f" "$tier" >&2
+      return 3 ;;
+  esac
+}
+
+# tier_reason <file> -> the demotion reason, or empty for a core harness.
+tier_reason() {
+  local line
+  line="$(head -40 -- "$1" 2>/dev/null | grep -m1 -E '^[[:space:]]*#[[:space:]]*TIER:[[:space:]]*nightly' || true)"
+  [[ -n "$line" ]] || return 0
+  line="${line#*nightly}"; line="${line#[[:space:]]}"; line="${line#[—:-]}"; line="${line#[-—]}"
+  printf '%s\n' "${line#"${line%%[![:space:]]*}"}"
+}
+
+# tier_list <core|nightly|full> [corpus-dir=tests] -> harness paths, one per line.
+# `full` is every harness; it is the union, not a third tier.
+# Exits 3 if ANY harness in the corpus has an unreadable marker — a selection built
+# from a corpus it could not fully classify is not a selection, and shipping the
+# subset it did understand is how a check reports clean on what it never saw.
+tier_list() {
+  local want="${1:?tier_list <core|nightly|full>}" dir="${2:-tests}" t got rc=0 out=()
+  for t in "$dir"/*.sh; do
+    [[ -e "$t" ]] || continue
+    if ! got="$(tier_of "$t")"; then rc=3; continue; fi
+    case "$want" in
+      full) out+=("$t") ;;
+      "$got") out+=("$t") ;;
+    esac
+  done
+  (( rc == 0 )) || return 3
+  (( ${#out[@]} )) && printf '%s\n' "${out[@]}"
+  return 0
+}
+
+# tier_budget <core|full> -> the budget in seconds for that RUN (not that tier's
+# membership: a `full` run includes the core harnesses, so it carries the full
+# budget). `nightly` is not a run selector and has no budget of its own.
+tier_budget() {
+  case "${1:?tier_budget <core|full>}" in
+    core) printf '%s\n' "$TIER_BUDGET_CORE" ;;
+    full) printf '%s\n' "$TIER_BUDGET_FULL" ;;
+    *) printf 'tier_budget: unknown run tier %s\n' "$1" >&2; return 2 ;;
+  esac
+}
+
+# Usable as a CLI so a workflow step, a git hook or a human can ask without writing
+# bash: tests/lib/tier.sh list core | of <file> | reason <file> | budget core
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." || exit 2
+  case "${1:-}" in
+    list)   tier_list "${2:?list <core|nightly|full>}" "${3:-tests}" ;;
+    of)     tier_of "${2:?of <file>}" ;;
+    reason) tier_reason "${2:?reason <file>}" ;;
+    budget) tier_budget "${2:?budget <core|full>}" ;;
+    *) printf 'usage: tier.sh {list core|nightly|full [dir] | of <file> | reason <file> | budget core|full}\n' >&2; exit 2 ;;
+  esac
+fi

--- a/tests/loop_batch_unit.sh
+++ b/tests/loop_batch_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 16.5s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-596 isolated unit harness for `5dive loop map | until-dry | collect`.
 #
 # Same isolation contract as loop_spawn_unit.sh: source src/ libs directly, point

--- a/tests/loop_grade_unit.sh
+++ b/tests/loop_grade_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 16.2s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-748 isolated unit harness for `5dive loop grade` (numeric scorecard).
 #
 # Same isolation contract as loop_spawn_unit.sh: sources src/ libs directly and

--- a/tests/loop_id_collision_unit.sh
+++ b/tests/loop_id_collision_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 18.1s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2083 — the loop_id handle must be collision-PROOF, not collision-unlikely.
 #
 # `loop_runs.loop_id` is a PRIMARY KEY, so a repeated handle is not a cosmetic

--- a/tests/loop_panel_unit.sh
+++ b/tests/loop_panel_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 21.6s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-595 isolated unit harness for `5dive loop panel` (N diverse-lens graders
 # + quorum vote + cost-dial config).
 #

--- a/tests/loop_spawn_unit.sh
+++ b/tests/loop_spawn_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 10.2s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-593 isolated unit harness for `5dive loop spawn` (the atom).
 #
 # Sources the src/ libs directly and points STATE_DIR at a throwaway temp dir,

--- a/tests/loop_verify_unit.sh
+++ b/tests/loop_verify_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 7.5s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-594 isolated unit harness for `5dive loop verify` (maker→verifier wrapper).
 # Same isolation as loop_spawn_unit.sh: sources src/ directly, points STATE_DIR
 # at a throwaway temp dir → never touches the live shared tasks.db. Asserts:

--- a/tests/objective_preflight_unit.sh
+++ b/tests/objective_preflight_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 9.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # OSS-33 isolated unit harness for objective PREFLIGHT + explicit STOP-CONDITIONS
 # (cmd_objective.sh, MVP-bar items 4 & 5). No root, no network — drives the pure
 # helpers + the resume/replan wiring against a temp db. Asserts:

--- a/tests/objective_replan_unit.sh
+++ b/tests/objective_replan_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 21.5s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # OSS-27 isolated unit harness for the objective RE-PLAN cycle (cmd_objective.sh).
 # Feeds diffs via --diff=<json> (the test seam, like goal add --plan) so no live
 # planner agent is needed. Asserts the anti-Goodhart spine inherited from

--- a/tests/proof_identity_guard_unit.sh
+++ b/tests/proof_identity_guard_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 8.1s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2051 isolated unit harness for the `proof publish` IDENTITY guard: the
 # publisher authors PUBLIC commits, so it must never infer the author. Sources
 # cmd_proof.sh with stubbed deps against a temp state dir and a temp HOME (so

--- a/tests/push_unit.sh
+++ b/tests/push_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 11.9s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1376 isolated unit harness for `5dive push` — the delegated-push verb.
 # Covers every NON-CREDENTIAL path (the live token-mint + real push is smoked
 # separately against the control-plane GitHub App). Same isolation posture as

--- a/tests/release_cut_guards_unit.sh
+++ b/tests/release_cut_guards_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 42.8s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2144 — grade the two guards in .github/workflows/release-cut.yml.
 #
 # SHAPE, and it is deliberate (same as tests/install_pin_sha_unit.sh): this extracts

--- a/tests/secret_gate_delivery_path_mutation.sh
+++ b/tests/secret_gate_delivery_path_mutation.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 55.7s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2411 mutation grader for tests/secret_gate_delivery_path_unit.sh.
 #
 # WHY THIS FILE EXISTS. What DIVE-2411 ships is two REFUSALS and one WITHHELD

--- a/tests/secret_gate_delivery_path_unit.sh
+++ b/tests/secret_gate_delivery_path_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 7.2s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2411 isolated unit harness — a `secret` gate must NAME A DELIVERY PATH, at
 # filing time AND at answer time.
 #

--- a/tests/selfcheck_mutation_e2e.sh
+++ b/tests/selfcheck_mutation_e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 70.7s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2039 ACCEPTANCE — selfcheck proven by MUTATION, not by a green run.
 #
 # This is the whole ticket's acceptance criterion, and it is not a formality. A green

--- a/tests/task_answer_closed_row_unit.sh
+++ b/tests/task_answer_closed_row_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 39.5s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2228 — `task answer` on a CLOSED row. The last open cell of the
 # closed-task writer matrix (DIVE-2112 / DIVE-2113 / DIVE-2116 are the others).
 #

--- a/tests/task_block_anchor_unit.sh
+++ b/tests/task_block_anchor_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 6.5s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1357 isolated unit harness for the block-anchor enforcement (fast-follow
 # to DIVE-1355): a task can only enter 'blocked' via one of three anchors, each
 # carrying a built-in revisit — a dependency edge, a human need-gate, or a park

--- a/tests/task_cascade_unblock_unit.sh
+++ b/tests/task_cascade_unblock_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 44.1s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1355 isolated unit harness for the task-engine self-dispatch fix:
 #   * _task_cascade_unblock — on `task done`/`task cancel`, drop the satisfied
 #     blocking edge and flip a dependent with no edges left blocked->todo, UNLESS

--- a/tests/task_close_preserves_done_at_unit.sh
+++ b/tests/task_close_preserves_done_at_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 52.4s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2477 — a re-close must not REFRESH done_at.
 #
 # Every close writer passed ", done_at=datetime('now')" unconditionally, so any

--- a/tests/task_core_unit.sh
+++ b/tests/task_core_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 24.4s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # OSS-7 isolated unit harness for the task-core verbs — the most-used surface
 # that had no coverage (only the loop/gate slices were tested). Same isolation
 # contract as the loop harnesses: source src/ directly, point STATE_DIR at a

--- a/tests/task_done_delivered_guard_unit.sh
+++ b/tests/task_done_delivered_guard_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 37.4s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2007 isolated unit harness for the delivered-loop `task done` guard.
 #
 # The bug: on a maker→verifier loop the FIRST `task done` delivers (assignee flips

--- a/tests/task_done_over_closed_result_unit.sh
+++ b/tests/task_done_over_closed_result_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 46.2s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2211 / DIVE-2286: name the tree this harness grades. Sourced BEFORE any cd so
 # ${BASH_SOURCE[0]} still resolves relative to tests/. Three-state on purpose: if the
 # helper is unreachable the log says NO TREE WAS NAMED rather than falling silent.

--- a/tests/task_merge_gate_ancestry_unit.sh
+++ b/tests/task_merge_gate_ancestry_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 9.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2101 isolated unit harness — ANCESTRY satisfies the DIVE-1830 merge-gate.
 #
 # The gate demanded a MERGED PR for a `Branch:` binding. The delegated-push path

--- a/tests/task_merge_gate_autodetect_unit.sh
+++ b/tests/task_merge_gate_autodetect_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 60.9s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1835 isolated unit harness for the MANDATORY auto-detect merge-gate.
 # The DIVE-1830 gate only fired when the maker DECLARED a binding
 # (delivery_ref / Branch:); 8 code-tasks closed with NEITHER and slipped past it.

--- a/tests/task_merge_gate_delivered_vs_cited_unit.sh
+++ b/tests/task_merge_gate_delivered_vs_cited_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 10.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1965 isolated unit harness — a PR the task DELIVERED vs a PR it REPORTS ON.
 #
 # The merge-gate's subject was "a PR mentioned in the result/body". That predicate

--- a/tests/task_merge_gate_diagnostic_unit.sh
+++ b/tests/task_merge_gate_diagnostic_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 5.8s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2318 — the merge gate's REFUSALS must not assert things nobody measured.
 #
 # THE DEFECT THIS GRADES IS THE DIAGNOSTIC, NOT THE CHECK. The gate's acceptance

--- a/tests/task_merge_gate_multirepo_unit.sh
+++ b/tests/task_merge_gate_multirepo_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 12.5s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1955 isolated unit harness — the merge-gate across MORE THAN ONE REPO.
 #
 # DIVE-1935 made the gate live, for one repo. `_PUSH_DEFAULT_REPO` is a readonly

--- a/tests/task_merge_gate_result_pr_unit.sh
+++ b/tests/task_merge_gate_result_pr_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 9.4s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1935 isolated unit harness. DIVE-1922 reached status=done while its PR was
 # OPEN, unmerged AND red on its own new unit test — both declared bindings were
 # empty (no delivery_ref, no 'Branch:' line) and the DIVE-1835 repo-wide scan

--- a/tests/task_need_t0_auto_unit.sh
+++ b/tests/task_need_t0_auto_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 6.2s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2062 isolated unit harness for `5dive task need --tier=0` (DIVE-891
 # auto-clear: the recommendation applies immediately, provenance 'auto:t0', no
 # human ping — cmd_task_need, cmd_task.sh). Per the DIVE-2054 verifier pass

--- a/tests/task_reject_actor_and_closed_unit.sh
+++ b/tests/task_reject_actor_and_closed_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 21.3s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2112 isolated unit harness for `task reject`'s actor + already-done guards.
 #
 # Found by olivia while VERIFYING DIVE-2067, whose refusal text pointed makers at

--- a/tests/task_set_body_unit.sh
+++ b/tests/task_set_body_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 9.8s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1920 unit harness for `task set-body`. Same isolation contract as
 # task_set_branch_unit.sh: source src/ directly, point STATE_DIR at a
 # throwaway temp dir so the live shared tasks.db is NEVER touched.

--- a/tests/task_start_closed_unit.sh
+++ b/tests/task_start_closed_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 5.5s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2113 — `task start` must REFUSE a closed task, and must not refuse anything else.
 #
 # The defect: `task start` on a done/cancelled row silently reopened it to

--- a/tests/task_start_delivered_guard_unit.sh
+++ b/tests/task_start_delivered_guard_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 14.4s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2510 unit harness — `task start` over a LIVE DELIVERED maker→verifier loop.
 #
 # THE DEFECT: `task start` was the last status writer with no delivered-loop

--- a/tests/task_verifier_rail_unit.sh
+++ b/tests/task_verifier_rail_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 18.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1880 unit harness — the verifier rail's VISIBILITY + its retro-attach verb.
 #
 # The defect: `task add --priority=low` silently declined the DIVE-969 verifier

--- a/tests/task_verify_self_close_visibility_unit.sh
+++ b/tests/task_verify_self_close_visibility_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 10.9s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2015 isolated unit harness: a maker may rescue a stalled delivered loop
 # with `task verify --cmd`, but the permitted self-close must be visible in the
 # task record, the audit log, and stderr. No policy refusal is expected.

--- a/tests/verifier_gate_ack_unit.sh
+++ b/tests/verifier_gate_ack_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 20.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-2196 isolated unit harness: a verifier who filed a human gate has ACTED.
 #
 # The bug (fired live on DIVE-2146): the heartbeat stall-sweep selects delivered

--- a/tests/worktree_reclaim_unit.sh
+++ b/tests/worktree_reclaim_unit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# TIER: nightly — 41.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
 # DIVE-1967: closing a task reclaims its worktree's node_modules — and NOTHING
 # else. The whole value of this feature is the boundary it refuses to cross, so
 # most of what is asserted below is what must SURVIVE a reclaim:


### PR DESCRIPTION
Closes DIVE-2525. Sibling of DIVE-2524 (release path); this row fixes every PR.

## Why

`tests/*.sh` went **96 → 267 harnesses in 13 days** (~+13/day) against **four** harness deletions ever. A guard is bought once and paid for on **every future change, forever**, while its benefit stays fixed at the one class it catches — so the ledger tilts by construction and no single decision to add one is ever wrong on its own merits. Nobody has ever been paged by a guard that was too slow, so nobody files "delete this guard". Measurement: `community/wiki/guards-compound-in-cost-and-nothing-ever-retires-one.md`.

**Wall-clock, not count.** "Do not add too many tests" is unenforceable and reads as an argument against testing. "The core must finish in N minutes" is measurable, count-neutral, and is the reverse gear the corpus never had. N = 300s, set by lodar 2026-08-02.

## What

| | runs | budget |
|---|---|---|
| `core` (**the default**) | every PR, both CI environments | **300s** per job |
| `nightly` | `full-sweep.yml`, 03:17 UTC + dispatch | **1320s** per job, whole corpus |

- **`tests/lib/tier.sh`** — one resolver, both budgets. Core is the default; demotion is `# TIER: nightly — <reason>` in the harness header, and a demotion **with no reason refuses** (exit 3). A free escape hatch is not a budget, it is a second budget nobody watches — and the required sentence lands in the diff, where a reviewer sees a cost being *moved* rather than a file being added.
- **`scripts/run-harnesses.sh`** — replaces both inline `for t in tests/*.sh` loops. Times the run, prints `Ns, X% of budget` on **every** run, and over budget **fails with exit 4** (distinct from a test failure's 1 — a red that could mean either gets triaged as neither), naming the slowest files and the three ways out: merge by subject, retire, demote.
- **`changed-harnesses` (new job)** — runs *and* verdict-probes every harness the diff touches, whatever its tier. Tier membership decides what runs **by default**, never what runs when you touched it.
- **`full-sweep.yml` (new)** — whole corpus nightly, plus the harness-verdict probe and union that cost a *second* full pass over the corpus and were the most expensive thing on the PR path. It also triggers on PRs that touch the tiering itself, so a mis-set budget is measured before it merges, and it writes the wall-clock to the run summary page.

## What the PR path gives up

Stated here rather than left to be discovered: the whole-corpus **harness-verdict union** (DIVE-2018) is now a nightly property. The PR-shaped case it caught — a harness added or edited in *this diff* whose exit status is not wired to its own assertions — is closed by `changed-harnesses` at the moment of introduction, and `release-cut` still grades the union before publishing.

## Selection

Cheapest-first: **194 of 267 harnesses (73%) stay on the PR path**; the 73 demoted carry their measured cost in their own header. Measured serially on the control plane 2026-08-02.

Deliberately **not** change-aware ("which harnesses can a given diff turn red"): that needs a src→tests map nothing maintains, and a wrong map *skips* the harness that would have caught the bug. A false green is worse than slow.

## Evidence

- `tests/corpus_tier_budget_unit.sh` — 19 arms, **mutation-graded**: flip the default tier → 7/12; drop the reason requirement → 18/1; return the subset on an unclassifiable corpus → 18/1; drop the over-budget exit → 18/1; let an empty corpus report clean → 18/1; drop the remedy text → 18/1.
- `baseline_pin_unit.sh` arm D now sweeps **both** workflows — the harnesses that anchor to pinned commits can now live in the nightly one, and a check that keeps grading the workflow the work moved out of stays green while covering nothing. Reds 17/1 when a checkout in `full-sweep.yml` goes depth-1.
- Core tier end-to-end on the control plane: 195 harnesses, 240s. That box is contended by the agent fleet; CI's own published rate is 3.79s/harness, so the number this PR's own CI run reports is the one that matters, and it is the calibration I will act on.
