### PR TITLE
fix(heartbeat): the dispatcher claims a task without telling the ledger (DIVE-2541)

### DIFF
--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -1081,6 +1081,30 @@ _hb_claim_task() {
   # as a claim.
   n=$(db "SELECT COUNT(*) FROM tasks WHERE id=${id} AND status='in_progress' AND started_at IS NOT NULL;" 2>/dev/null) || return 1
   [[ "$n" == "1" ]] || return 1
+  # DIVE-2541: THE CLAIM IS A START, SO IT GOES ON THE LEDGER.
+  #
+  # DIVE-2244 moved the authoritative start from `task start` to this function, and
+  # the ledger emit stayed behind on the verb. Measured 2026-08-02 over the ledger's
+  # whole life: the dispatcher claimed 94 distinct tasks and 85 of them carry NO
+  # task.started event, while the verb fired 13 times. The instrumentation was still
+  # attached to the path that had stopped being the main one, and it fired often
+  # enough to look alive — which is why nobody caught it for four days.
+  #
+  # authority=dispatcher, NOT self. The agent has not acted at this point; the
+  # dispatcher moved the row on its behalf. Writing `self` here would be a false
+  # claim of exactly the kind v0.18 exists to delete — actor keeps its meaning
+  # (whose queue this is) and authority says who actually moved it, so a reader can
+  # tell a dispatcher claim from an agent that ran the verb.
+  #
+  # The DEFAULT idem_key (kind|ident|task_id|hash(detail)) is deliberate: it is
+  # constant per task, so a task reclaimed to todo and re-claimed records its FIRST
+  # claim only. The chain reader asks "was this started, and under whose authority",
+  # not "how many times" — and a UNIQUE collision is a silent no-op, so this can
+  # never inflate the ledger. Losing re-claim COUNT is the safe direction; a
+  # per-claim key would let a nudge loop write unbounded rows.
+  ledger_emit "task.started" ident="$(_hb_ident "$id")" task_id="$id" \
+    actor="$name" authority="dispatcher" \
+    detail="heartbeat claim (DIVE-2244)" || true
   return 0
 }
 

--- a/tests/heartbeat_dispatcher_claim_unit.sh
+++ b/tests/heartbeat_dispatcher_claim_unit.sh
@@ -313,5 +313,41 @@ cmd_heartbeat_tick >/dev/null 2>&1
   && ok_t "[restore] claim reinstated => green again (the mutation was the cause)" \
   || bad_t "[restore] claim reinstated => green again" "got $(row "$G1")"
 
+# --- 8) DIVE-2541: the claim must reach the LEDGER, not just the row ---------
+# DIVE-2244 moved the authoritative start from `task start` to the dispatcher and
+# the ledger emit stayed on the verb. Measured on the live board over the ledger's
+# whole life: 94 distinct tasks claimed by the dispatcher, 85 with NO task.started
+# event, against 13 emitted by the verb. Every reader of that ledger — `trace`,
+# `whoami --for` — was therefore reading a ~90% empty chain while looking healthy,
+# because a timeline cannot render an absence.
+ev_count() { db "SELECT COUNT(*) FROM lifecycle_events WHERE kind='task.started' AND task_id=$1;"; }
+ev_auth()  { db "SELECT actor||'|'||authority FROM lifecycle_events WHERE kind='task.started' AND task_id=$1;"; }
+
+# G1 was claimed by the restore arm above, so it is a REAL dispatcher claim.
+(( $(ev_count "$G1") == 1 )) \
+  && ok_t "[2541] a dispatcher claim writes a task.started event" \
+  || bad_t "[2541] a dispatcher claim writes a task.started event" "count=$(ev_count "$G1")"
+
+# THE DISCRIMINATOR, and the reason the arm above is not enough. An emit that
+# recorded authority='self' would satisfy "an event exists" while asserting the
+# agent started its own task — which it did not; the dispatcher moved the row on
+# its behalf. That is the false-claim shape v0.18 exists to delete, so the arm
+# has to pin the authority and not merely the existence.
+[[ "$(ev_auth "$G1")" == "dev|dispatcher" ]] \
+  && ok_t "[2541] the event says actor=dev authority=DISPATCHER — not a self-start" \
+  || bad_t "[2541] claim must record authority=dispatcher, never self" "got $(ev_auth "$G1")"
+
+# NEGATIVE CONTROL: without it, "an event exists" passes for an emit that fires on
+# every tick regardless of whether anything was claimed. A tick that wakes NOBODY
+# must write nothing.
+db "DELETE FROM tasks;"; db "DELETE FROM lifecycle_events;"
+N1=$(mk "never claimed")
+seed_reg "$(date +%s)"          # just ran => not due => no wake, no claim
+WAKE_CALLS=0
+cmd_heartbeat_tick >/dev/null 2>&1
+(( $(ev_count "$N1") == 0 && WAKE_CALLS == 0 )) \
+  && ok_t "[2541] NEGATIVE CONTROL: a tick that claims nothing emits nothing" \
+  || bad_t "[2541] a tick that claims nothing must emit nothing" "count=$(ev_count "$N1") wakes=$WAKE_CALLS"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## The cause, measured

DIVE-2244 moved the authoritative start from `task start` to `_hb_claim_task`. **The ledger emit stayed behind on the verb.**

Corroborated against an **outside witness** rather than the ledger itself — `/var/log/5dive-heartbeat.log`, written by a different path — because a ledger cannot testify to its own gaps:

| | count |
|---|---|
| dispatcher claims logged since the ledger opened | **795** |
| distinct tasks claimed | **94** |
| ...of those carrying a `task.started` event | **9** |
| `task.started` events in total | 13 |

**85 of 94 dispatcher-started tasks left no ledger row.** The 13 that exist are the residue of agents who *also* ran the verb by hand — 4 of them on rows the dispatcher never touched.

That is why `whoami --for` reads UNMEASURABLE for ~90% of rows: correct by spec, empty as a product.

## Why nobody caught it for four days

The instrumentation was attached to **the path that had stopped being the main one**, and it fired often enough to look alive. A kind that never fires looks broken on inspection; a kind that fires *sometimes* looks like a working feature. Same shape as DIVE-1968 — *the rail we fixed is not the rail most gates take*.

Three explanations were open when this was filed (a writer that does not emit / a path that bypasses the ledger / starts predating the ledger). It is the second, and the log settles it: claims are spread across all four days and five actors, so it is neither a rollout nor an actor quirk.

## The fix

`ledger_emit "task.started"` at the point the claim is **confirmed from the row** — not from the UPDATE's exit code, reusing the existing confirmation.

**`authority=dispatcher`, not `self`.** The agent has not acted at that moment; the dispatcher moved the row on its behalf. Writing `self` would be a false claim of exactly the kind v0.18 exists to delete. `actor` keeps its meaning (whose queue this is), `authority` says who actually moved it.

**The default `idem_key` is deliberate** — constant per task, so a reclaim-then-re-claim records the first claim only. The chain reader asks *was this started, and under whose authority*, not *how many times*, and a UNIQUE collision is a silent no-op. Losing re-claim count is the safe direction; a per-claim key would let a nudge loop write unbounded rows.

## NOT backfilled

The 85 historical rows stay missing. A synthesised start event is the unfalsifiable record this epoch exists to delete.

## Verification

Harness **20 arms → 23**, mutation-graded with **distinct kill sets**:

| mutant | result | dies |
|---|---|---|
| drop the `ledger_emit` (the original defect) | 21 passed, **2** failed | existence + authority arms |
| emit with `authority=self` | 22 passed, **1** failed | the discriminator, **alone** |
| restored | 23 passed, 0 failed | — |

Mutant B killing exactly one arm is the load-bearing result: an emit that recorded `self` would satisfy *"an event exists"* while asserting the agent started its own task. The negative control (a tick that claims nothing emits nothing) survives both, correctly.

DIVE-2541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)