### PR TITLE
fix(tests): pin broker_surface_unit's differential baseline to 84ed56c^ (DIVE-2549)

### DIFF
--- a/tests/broker_surface_unit.sh
+++ b/tests/broker_surface_unit.sh
@@ -31,6 +31,15 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+# DIVE-2549: the differential baseline is PINNED, not branch-named. See the
+# block at "the baseline" below for why. Unlike grading_tree.sh this helper is
+# load-bearing — without it there is no baseline at all — so a missing copy
+# refuses rather than warning.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/pinned_baseline.sh" || {
+  echo "REFUSING: tests/lib/pinned_baseline.sh is not reachable — the differential arms have no baseline resolver."
+  exit 1
+}
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PASS=0; FAIL=0
 want() { local n="$1"; shift; if eval "$@"; then echo "  ok   $n"; PASS=$((PASS+1)); else echo "  FAIL $n"; FAIL=$((FAIL+1)); fi; }
@@ -42,20 +51,49 @@ same() { # <name> <expected> <actual>
 TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
 
 # ---------------------------------------------------------------- the baseline
-# origin/main's copies, renamed so both live in one shell. If the baseline ref
-# is unreachable the arms would silently become "compare new against nothing",
-# which is the vacuous pass this file exists to avoid — so refuse instead.
-BASE="${BROKER_BASELINE_REF:-origin/main}"
-if ! git -C "$ROOT" cat-file -e "${BASE}:src/cmd_push.sh" 2>/dev/null; then
+# The pre-INST-5 copies of these functions, renamed so both live in one shell.
+#
+# WHY A PINNED SHA AND NOT `origin/main` (DIVE-2549). This file originally read
+# its "before" from origin/main, which was correct for exactly as long as INST-5
+# was unmerged. The moment #363 landed, origin/main WAS the refactored tree, the
+# guard below fired on every run, and the harness went red on main and on every
+# branch cut from it — green once, red forever after. That is the anchor-baseline
+# class tests/lib/pinned_baseline.sh was written for (DIVE-2229): a baseline named
+# by a BRANCH moves out from under the claim. The fix is to name the commit.
+#
+# cd29fa5 is the tip of main immediately BEFORE #363 (84ed56c^) — the last commit
+# that carries the pre-refactor bodies of _push_gate_check / _push_bind_branch.
+#
+# WHAT PINNING MAKES THIS FILE, said out loud because it is a stronger claim than
+# the one it replaced: these arms are no longer a one-shot pre-merge safety check
+# that expires on merge, they are a STANDING fence that the push path's refusal
+# text and exit statuses have not moved since before the refactor. A deliberate
+# future change to push's refusals therefore reds here BY DESIGN; the response is
+# to move the pin in the same commit that changes the behaviour and say why, not
+# to loosen the comparison.
+#
+# WHY NOT "SKIP WHEN THE BASELINE ALREADY CARRIES THE REFACTOR". That was the
+# obvious cheaper fix and it is the wrong one: a skip is counted as green by every
+# reader of the tally, so the differential arms — the ones that decide whether the
+# push gate is still inert — would stop running while the file kept reporting
+# success. The refusal below is loud precisely because being unable to differ is
+# not the same as having differed and found nothing.
+PRE_INST5_REF="cd29fa54449f5740830cb8d5db1491ae0a98e5af"   # 84ed56c^ — full sha: fetchable
+BASE="${BROKER_BASELINE_REF:-$PRE_INST5_REF}"
+# pinned_blob fetches the one commit at depth 1 if the checkout is shallow, and
+# returns non-zero having written nothing if it still cannot resolve it. A caller
+# must RED on that, never skip.
+if ! ( cd "$ROOT" && pinned_blob "$BASE" src/cmd_push.sh "$TMP/base_push.sh" ); then
   echo "REFUSING: baseline ${BASE}:src/cmd_push.sh is unreachable — the differential arms cannot run."
-  echo "  (fetch origin, or set BROKER_BASELINE_REF to a ref that predates INST-5)"
+  echo "  $(pinned_unavailable_msg "$BASE")"
   exit 1
 fi
-git -C "$ROOT" show "${BASE}:src/cmd_push.sh" > "$TMP/base_push.sh"
 # Guard the extraction itself: the baseline must actually still CONTAIN the
-# pre-refactor bodies. If someone re-runs this after INST-5 has landed on the
-# baseline ref, the "old" side becomes a wrapper too and every arm passes for
-# the wrong reason.
+# pre-refactor bodies. With the pin above this can no longer fire from ordinary
+# merges — it now fences the PIN: a ref that does not predate INST-5 (a hand-set
+# BROKER_BASELINE_REF, or a pin someone advanced without re-reading this block)
+# would make the "old" side a wrapper too and every arm would pass for the wrong
+# reason.
 grep -q 'gansweredat=\$(db' "$TMP/base_push.sh" \
   || { echo "REFUSING: ${BASE} already carries the refactored wrapper — nothing to differ against."; exit 1; }
 


### PR DESCRIPTION
Fixes DIVE-2549 — main is red on `tests/broker_surface_unit.sh` today, independent of any open PR.

## The defect
The harness is differential: it grades the refactored broker wrapper against `origin/main`'s copies of `_push_gate_check` / `_push_bind_branch`. INST-5 (#363) merged as `84ed56c`, so `origin/main` now IS the refactored tree and the harness refuses:

```
REFUSING: origin/main already carries the refactored wrapper — nothing to differ against.
```

Anchor-baseline class: a baseline named by a BRANCH moves out from under the claim, so the check is green exactly once (pre-merge) and red forever after.

## The fix, and the call the ticket asked for
Pin to `cd29fa54449f5740830cb8d5db1491ae0a98e5af` (`84ed56c^`) using `tests/lib/pinned_baseline.sh` — the helper written for exactly this class in DIVE-2229, which fetches the single commit at depth 1 when the checkout is shallow and returns non-zero having written nothing otherwise.

**Pin, not skip.** The ticket asked whoever took it to decide rather than default. A skip is counted green by every reader of the tally, so the differential arms — the ones that decide whether the push gate is still inert — would stop running while the file kept reporting success. The `already carries the refactored wrapper` refusal is kept and now fences the PIN (a hand-set `BROKER_BASELINE_REF`, or a pin advanced without re-reading the block) instead of ordinary merges.

Stated in the header because it is a stronger claim than the one it replaces: these arms are now a STANDING fence that push's refusal text and exit statuses have not moved since before the refactor. A deliberate future change to push's refusals reds here by design — move the pin in the same commit and say why.

## Evidence (mutation-graded)
| arm | result |
|---|---|
| unpatched harness, same worktree | REFUSES — reproduces the reported red |
| patched, at `84ed56c` | 36 passed / 0 failed |
| text change in `src/lib/broker.sh` | 1 differential arm FAIL, rc=1 |
| `_push_gate_check` stubbed `return 0` | 8 arms FAIL, rc=1 |
| `BROKER_BASELINE_REF=84ed56c` (post-INST-5) | refuses, rc=1 |
| `BROKER_BASELINE_REF=dead0…` (unresolvable) | refuses with PRECONDITION-NOT-MET, rc=1 — never a silent skip |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
