### PR TITLE
fix(agent): the post-create self-check never probed whether the credential reached the agent (DIVE-2025)

### DIFF
--- a/src/cmd_agent_create.sh
+++ b/src/cmd_agent_create.sh
@@ -1157,6 +1157,92 @@ _resolve_inherit_sources() {
   done
 }
 
+# DIVE-2025: can the agent actually READ its credential?
+#
+# The self-check used to answer this by reading `defer_auth` — a flag recording
+# what the OPERATOR CHOSE, not what the agent GOT. On the completed-login path
+# nothing was checked at all (not even an ok entry), so a credential that
+# silently never reached the agent still printed "self-check PASS — reachable &
+# autonomous". That is the DIVE-1900 shape: every status surface agrees and
+# every one is wrong.
+#
+# THE PROBE MUST BE GROUNDED IN THE AGENT'S UID. `agent create` runs as root,
+# and root reads every credential on the box, so a readability test run from
+# here would pass unconditionally and prove nothing — it would replace a lie
+# with a vacuous truth. Presence is answered as root (root traverses every
+# 0700 dir, so its `-e` is the only trustworthy ABSENT verdict); readability is
+# answered as agent-<name>. Two different questions, two different uids.
+#
+# ABSENT and UNREADABLE stay distinct because they take different fixes:
+# absence is "go log in", unreadability is "the credential is fine, the perms
+# are not" (and presents as `invalid_grant "Malformed auth code"`, which reads
+# as an EXPIRED token, so the intuitive fix — a re-tap — changes nothing).
+#
+# The single seam where the agent-uid read happens, so a harness can stub it
+# without needing a real agent user, real sudo, or root.
+cred_readable_by_agent() { # <agent-user> <path>
+  sudo -n -u "$1" test -r "$2" 2>/dev/null
+}
+
+# selfcheck_cred_reached_agent <name> <type> <profile> <byo_provider>
+# Emits zero or more `ok:<text>` / `issue:<text>` lines on stdout. Never fails.
+# Kept as a named function (rather than inlined in the self-check) so the
+# agent-list health-badge rail (DIVE-1219) can call the same probe and re-check
+# continuously instead of only once at creation.
+selfcheck_cred_reached_agent() { # <name> <type> <profile> <byo_provider>
+  local name="$1" type="$2" profile="$3" byo="${4:-}"
+  local user="agent-${name}"
+
+  # Witness 1: the boot seed's own breadcrumb. 5dive-agent-start runs AS the
+  # agent and records a failed seed at ~/.5dive-cred-seed-failed (removing it
+  # on success), with ABSENT vs UNREADABLE already resolved by cred_seed_why.
+  # Until now that verdict only reached the unit's journal, where nobody looks.
+  # Reading it here costs nothing and duplicates no path knowledge.
+  # AGENT_HOME_ROOT is a test seam (default /home, as everywhere else in this
+  # file); a harness cannot create /home/agent-<name> without root.
+  local bc="${AGENT_HOME_ROOT:-/home}/${user}/.5dive-cred-seed-failed" why=""
+  if [[ -s "$bc" ]]; then
+    why=$(tr -d '\n' < "$bc" 2>/dev/null | cut -c1-400)
+    printf 'issue:credential did NOT reach the agent (it is UNAUTHED despite a completed login) — the boot seed recorded: %s. Re-seed as root: sudo 5dive agent restart %s\n' \
+      "$why" "$name"
+    return 0
+  fi
+
+  # Witness 2: the source the seed reads from, probed as the agent. Catches
+  # what the breadcrumb cannot — a seed that never ran because the unit had not
+  # reached it yet, and the no-seed types that never write a breadcrumb at all.
+  local src=""
+  if [[ -n "$byo" ]]; then
+    # BYO writes an API key into combined.env, not the type's OAuth sentinel;
+    # probing the sentinel would report a false ABSENT.
+    [[ -n "$profile" ]] && src="${AUTH_PROFILES_DIR}/${profile}/combined.env"
+  elif [[ -n "$profile" && -s "${AUTH_PROFILES_DIR}/${profile}/combined.env" ]]; then
+    # api-key / claude-OAuth path: create's own auth gate accepts combined.env
+    # in place of the per-type file, so the probe has to accept it too.
+    src="${AUTH_PROFILES_DIR}/${profile}/combined.env"
+  else
+    src=$(profile_type_auth_path "$profile" "$type" 2>/dev/null) || src=""
+    # `claude` is the one type whose shared sentinel is a `path:jsonkey` pair
+    # (DIVE-1803); every other type's is a bare path.
+    src="${src%%:*}"
+  fi
+  [[ -n "$src" ]] || return 0        # opencode/pi/devin: no credential sentinel
+
+  if [[ ! -e "$src" ]]; then
+    printf 'issue:no auth credential at %s (agent is UNAUTHED — it cannot think until you log in): sudo 5dive agent auth login %s%s\n' \
+      "$src" "$type" "${profile:+ --auth-profile=$profile}"
+  elif [[ ! -s "$src" ]]; then
+    printf 'issue:auth credential at %s is EMPTY (a login was started but never finalized) — re-run: sudo 5dive agent auth login %s%s\n' \
+      "$src" "$type" "${profile:+ --auth-profile=$profile}"
+  elif cred_readable_by_agent "$user" "$src"; then
+    printf 'ok:auth credential readable by %s\n' "$user"
+  else
+    printf 'issue:auth credential EXISTS at %s but is NOT readable by %s — a perms fault, NOT an expired token (the agent will fail token exchange with '"'"'Malformed auth code'"'"'; re-tapping the login changes nothing). Re-normalize perms as root: sudo 5dive agent restart %s\n' \
+      "$src" "$user" "$name"
+  fi
+  return 0
+}
+
 # Top-level seeding (root): builds the target store, seeds every resolved
 # source, rebuilds the index, and hands the whole tree to the agent user.
 seed_inherited_memory() {
@@ -2061,6 +2147,18 @@ cmd_create() {
   # auth: deferred login still pending, so the first turn will stall.
   if (( defer_auth )); then
     _hc_issues+=("auth was deferred (agent is UNAUTHED — can't think until you log in): sudo 5dive agent auth login $type${profile:+ --auth-profile=$profile}")
+  else
+    # DIVE-2025: a completed login used to be checked by NOTHING — not even an
+    # ok entry — so a credential that never reached the agent still printed
+    # "self-check PASS". Probe the credential itself, as the agent's own uid.
+    local _cred_line
+    while IFS= read -r _cred_line; do
+      [[ -n "$_cred_line" ]] || continue
+      case "$_cred_line" in
+        ok:*)    _hc_ok+=("${_cred_line#ok:}") ;;
+        issue:*) _hc_issues+=("${_cred_line#issue:}") ;;
+      esac
+    done < <(selfcheck_cred_reached_agent "$name" "$type" "$profile" "$byo_provider")
   fi
   if (( ${#_hc_issues[@]} == 0 )); then
     warn "self-check PASS for '$name' — reachable & autonomous (${_hc_ok[*]})."

--- a/tests/selfcheck_cred_reached_unit.sh
+++ b/tests/selfcheck_cred_reached_unit.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# DIVE-2025 unit harness: does the post-create self-check probe whether the
+# credential actually REACHED the agent?
+#
+# The defect this pins: the self-check answered "is this agent authed?" by
+# reading `defer_auth` — a flag recording what the OPERATOR CHOSE. Deferred
+# login raised an issue (correct); a COMPLETED login was checked by nothing at
+# all, not even an `_hc_ok` entry. So a credential that silently never reached
+# the agent still printed "self-check PASS — reachable & autonomous".
+#
+# WHY THE UID MATTERS, AND WHY THIS HARNESS IS BUILT AROUND IT. `agent create`
+# runs as root, and root can read every credential on the box. A readability
+# probe run from create's own uid therefore passes unconditionally: it would
+# swap a lie for a vacuous truth and this harness would go green on both. So
+# the assertions below are written in terms of TWO uids — presence answered as
+# root (whose `-e` is the only trustworthy ABSENT verdict, since it traverses
+# 0700 profile dirs), readability answered as the agent. `cred_readable_by_agent`
+# is the single seam where the agent-uid read happens, and it is stubbed here:
+# a harness that shelled out to real `sudo -u` would grade the runner's sudo
+# policy, not the code, and would be unrunnable in CI.
+#
+# The UNREADABLE row is the one that has to survive: it is the shape of
+# DIVE-1900 / gh#214, where a present-but-unreadable credential presents as an
+# EXPIRED token (`invalid_grant "Malformed auth code"`) so the intuitive fix — a
+# re-tap — changes nothing. It must never collapse into ABSENT.
+#
+# Run: bash tests/selfcheck_cred_reached_unit.sh
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades. NOTE the absence of
+# `2>/dev/null` — redirecting here would swallow the helper's own stderr line,
+# which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/selfcheck-cred-reached.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/state.sh lib/audit.sh lib/registry.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+# shellcheck source=/dev/null
+source "$SRC/cmd_auth.sh"          # profile_type_auth_path
+# shellcheck source=/dev/null
+source "$SRC/cmd_agent_create.sh"
+
+set +e   # header.sh enabled `set -e`; this harness asserts on values, not exits
+
+# --- degrade, do not crash ----------------------------------------------------
+# Against a tree WITHOUT the fix the probe is undefined, and a
+# command-not-found abort proves nothing about behaviour. This shim makes the
+# pre-fix tree fail through the ASSERTIONS instead — emitting nothing, which is
+# exactly what origin/main's self-check contributes on the completed-login path.
+# It never fires on a tree that has the feature, so it cannot mask a regression.
+command -v selfcheck_cred_reached_agent >/dev/null || selfcheck_cred_reached_agent() { :; }
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n     want: %s\n     got:  %s\n' "$1" "$2" "$3"; }
+has()  { [[ "$2" == *"$3"* ]] && ok "$1" || bad "$1" "contains: $3" "$2"; }
+hasnt(){ [[ "$2" != *"$3"* ]] && ok "$1" || bad "$1" "does NOT contain: $3" "$2"; }
+
+# --- fixtures -----------------------------------------------------------------
+export AUTH_PROFILES_DIR="$TMP/profiles"
+export AGENT_HOME_ROOT="$TMP/home"
+NAME=probe
+mkdir -p "$AGENT_HOME_ROOT/agent-$NAME"
+
+# The seam. AGENT_CAN_READ selects what the agent's uid would have answered;
+# READ_CALLS records that the probe actually consulted it, which is what keeps
+# the "readable" row from passing for the wrong reason (see section 5).
+READ_CALLS="$TMP/read-calls"; : > "$READ_CALLS"
+AGENT_CAN_READ=1
+cred_readable_by_agent() { printf '%s %s\n' "$1" "$2" >> "$READ_CALLS"; (( AGENT_CAN_READ )); }
+
+# A grok profile credential: HOME-redirect type, so the path exercises
+# profile_type_auth_path's per-type branch rather than a bare default.
+prof=p1
+cred="$AUTH_PROFILES_DIR/$prof/grok/.grok/auth.json"
+mkdir -p "$(dirname "$cred")"
+reset_fixture() {
+  rm -f "$AGENT_HOME_ROOT/agent-$NAME/.5dive-cred-seed-failed"
+  mkdir -p "$(dirname "$cred")"; printf '{"token":"t"}\n' > "$cred"
+  AGENT_CAN_READ=1; : > "$READ_CALLS"
+}
+
+echo "== 1. completed login, credential readable by the agent =="
+reset_fixture
+out=$(selfcheck_cred_reached_agent "$NAME" grok "$prof" "")
+has "readable credential yields an ok: entry" "$out" "ok:auth credential readable by agent-probe"
+hasnt "readable credential raises no issue" "$out" "issue:"
+
+echo "== 2. present but UNREADABLE by the agent — the DIVE-1900 shape =="
+reset_fixture
+AGENT_CAN_READ=0
+out=$(selfcheck_cred_reached_agent "$NAME" grok "$prof" "")
+has "unreadable raises an issue"            "$out" "issue:"
+has "issue names it a perms fault"          "$out" "perms fault"
+has "issue names the misleading symptom"    "$out" "Malformed auth code"
+has "issue gives the root-only remedy"      "$out" "5dive agent restart"
+hasnt "unreadable is NOT reported as absent" "$out" "no auth credential"
+hasnt "unreadable does not also report ok"   "$out" "ok:"
+
+echo "== 3. genuinely ABSENT stays distinct from unreadable =="
+reset_fixture
+rm -f "$cred"
+out=$(selfcheck_cred_reached_agent "$NAME" grok "$prof" "")
+has "absent raises an issue"            "$out" "issue:no auth credential"
+has "absent says GO LOG IN"             "$out" "5dive agent auth login grok"
+hasnt "absent is not a perms fault"     "$out" "perms fault"
+# The empty-file case: a login that started and never finalized (DIVE-1803's
+# antigravity onboarding shape) leaves a readable 0-byte token behind.
+reset_fixture
+: > "$cred"
+out=$(selfcheck_cred_reached_agent "$NAME" grok "$prof" "")
+has "empty credential is called EMPTY"  "$out" "EMPTY"
+hasnt "empty credential is not an ok"   "$out" "ok:"
+
+echo "== 4. the boot seed's breadcrumb wins, and carries its own reason =="
+reset_fixture
+printf 'could not seed grok auth.json from /x (source present but UNREADABLE by agent-probe)\n' \
+  > "$AGENT_HOME_ROOT/agent-$NAME/.5dive-cred-seed-failed"
+out=$(selfcheck_cred_reached_agent "$NAME" grok "$prof" "")
+has "breadcrumb raises an issue"              "$out" "issue:credential did NOT reach the agent"
+has "breadcrumb's own reason is carried through" "$out" "source present but UNREADABLE"
+hasnt "breadcrumb suppresses the ok entry"    "$out" "ok:"
+# A readable source with a FAILED seed is the whole point: the source being
+# fine says nothing about whether the copy landed. Without the breadcrumb arm
+# this row reports a clean PASS.
+has "breadcrumb outranks a readable source"   "$out" "did NOT reach"
+
+echo "== 5. the probe consults the AGENT's uid, not create's =="
+reset_fixture
+out=$(selfcheck_cred_reached_agent "$NAME" grok "$prof" "")
+seam=$(cat "$READ_CALLS")
+has "readability was asked of agent-probe" "$seam" "agent-probe"
+has "...about the credential path"         "$seam" "$cred"
+# Liveness for the negative assertions above: prove the seam can say NO and
+# that the code routes that answer somewhere. A stub that always returned true
+# would make section 2 unreachable and this whole harness vacuous.
+AGENT_CAN_READ=0
+out=$(selfcheck_cred_reached_agent "$NAME" grok "$prof" "")
+has "a NO from the seam changes the verdict" "$out" "NOT readable"
+
+echo "== 6. types and paths the probe must NOT invent a verdict for =="
+reset_fixture
+# opencode has no credential sentinel: profile_type_auth_path returns 1.
+out=$(selfcheck_cred_reached_agent "$NAME" opencode "$prof" "")
+hasnt "no-sentinel type raises no issue" "$out" "issue:"
+hasnt "no-sentinel type claims no ok"    "$out" "ok:"
+# BYO writes an API key to combined.env, not the type's OAuth sentinel —
+# probing the sentinel would report a false ABSENT for a working agent.
+rm -f "$cred"
+mkdir -p "$AUTH_PROFILES_DIR/$prof"; printf 'OPENAI_API_KEY=k\n' > "$AUTH_PROFILES_DIR/$prof/combined.env"
+out=$(selfcheck_cred_reached_agent "$NAME" grok "$prof" openrouter)
+hasnt "BYO does not report a false ABSENT" "$out" "no auth credential"
+has   "BYO probes combined.env instead"    "$(cat "$READ_CALLS")" "combined.env"
+
+echo "== 7. the probe is WIRED into the self-check, not merely defined =="
+# A function nobody calls fixes nothing. Grade the call site: the completed-
+# login arm of the defer_auth branch must reach the probe. Static, because the
+# self-check lives mid-way through a ~900-line create and cannot be invoked
+# without a real box.
+blk=$(awk '/auth: deferred login still pending/,/^  if \(\( \$\{#_hc_issues\[@\]\} == 0 \)\)/' "$SRC/cmd_agent_create.sh")
+has "completed-login arm exists (an else on defer_auth)" "$blk" "else"
+has "self-check calls the probe"                          "$blk" "selfcheck_cred_reached_agent"
+has "issue: lines reach _hc_issues"                       "$blk" "_hc_issues+="
+has "ok: lines reach _hc_ok"                              "$blk" "_hc_ok+="
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+(( FAIL == 0 ))


### PR DESCRIPTION
## The bug

The post-create self-check exists to stop an agent looking healthy while being broken — deaf, mute, blind, asleep, unauthed. For auth it asked `if (( defer_auth ))`.

That flag records **what the operator chose**, not **what the agent got**:

- deferred login → `UNAUTHED` issue raised. Correct.
- login completed → **nothing was checked at all.** There was not even an `_hc_ok+=("auth ok")` entry on the success path.

So on the next agy seat: the human taps Google consent, `defer_auth` is 0, no issue is appended, and create prints `self-check PASS for <name> — reachable & autonomous`. If the credential silently never reached the agent, PASS is a lie — the DIVE-1900 shape, where every status surface agrees and every one is wrong.

`assert_cred_seeded` does catch this, but it runs in `5dive-agent-start` at **boot** and writes to stderr only, so the verdict lands in that unit's journal where nobody looks, while `agent list` still reads ACTIVE.

## The trap in the obvious fix

"So probe the credential file" passes for every agent, forever, including the broken ones.

**`agent create` runs as root, and root reads every credential on the box.** A `test -r` evaluated from create's own uid is not a weak probe, it is a constant function — it would have replaced the lie with a vacuous truth, which is worse, because a vacuous truth *looks* checked and a harness written around it goes green on the broken tree too.

The bug being hunted is specifically that `agent-<name>` **cannot** read what `root` and `claude` can (0600 credentials, 0700 profile dirs, vendor CLIs creating their own `0700 owner=claude` dot-dirs under a profile — DIVE-1900 / gh#214). The privilege difference between prober and subject *is the subject*.

So presence and readability are answered by **two different uids**, because neither can answer both:

| question | correct uid | why the other lies |
|---|---|---|
| does the credential EXIST? | **root** | the agent's `-e` is false on an untraversable 0700 parent → a present credential reads ABSENT |
| can the agent READ it? | **agent-\<name\>** | root's `-r` is true unconditionally |

## What this does

`selfcheck_cred_reached_agent`, consulted on the completed-login arm, with two witnesses in order:

1. **The boot seed's breadcrumb.** `5dive-agent-start` runs *as* the agent and already records a failed seed at `~/.5dive-cred-seed-failed` (removing it on success), with ABSENT vs UNREADABLE already resolved by `cred_seed_why`. That verdict was correct and complete and went only to the journal — nothing needed computing, it needed **routing to a surface someone reads**. Duplicates no path knowledge, needs no new privilege, authored by exactly the uid whose opinion counts.
2. **The seed source**, via `profile_type_auth_path` (the same helper `cmd_auth.sh` resolves with), for what the breadcrumb cannot cover: a seed that had not run yet, and the types that never write one. A readable source says nothing about whether the copy landed, so the breadcrumb outranks it.

ABSENT and UNREADABLE stay distinct because the fixes are opposite. Absence is "go log in." Unreadability surfaces as `invalid_grant "Malformed auth code"`, which **reads as an expired token**, so the intuitive re-tap changes nothing and the real remedy (`sudo 5dive agent restart <name>`, re-normalizing perms as root) is never tried. That misdiagnosis cost two days once.

Kept as a **named function** rather than inlined, so the agent-list health-badge rail (DIVE-1219) can call the same probe and re-check continuously instead of only once at creation — the cheaper alternative floated on the task, now available without a second implementation.

Also handled: BYO (`combined.env`, not the type's OAuth sentinel — probing the sentinel would report a false ABSENT for a working agent), `claude`'s `path:jsonkey` sentinel (DIVE-1803, the one type that has one), and the no-sentinel types (opencode/pi/devin), which get no verdict at all rather than an invented one.

## How it was checked

`tests/selfcheck_cred_reached_unit.sh` — **28 pass / 0 fail** on this branch.

**RED against a pinned control worktree at `bb6e371`** (this PR's merge base) with only the harness copied in: **10 pass / 18 fail**, rc=1. The sha is cited rather than `origin/main` deliberately — that ref moves, and once this lands, re-running the same sentence gives 28/28 and the differential becomes unreproducible for anyone reading the row later.

- The agent-uid read sits behind **one seam** (`cred_readable_by_agent`) and is stubbed. A harness shelling out to real `sudo -u` would grade the runner's sudo policy rather than the code, and would be unrunnable in CI.
- Every `hasnt` is paired with a **liveness arm** proving the stub can say NO *and* that the NO reaches the verdict — otherwise the negative assertions pass on a tree with no probe at all.
- Section 7 grades the **wiring**, not just the definition: a function nobody calls fixes nothing.
- `tests/meta/harness-verdict-probe.sh --only=…` → **wired** (the harness reports its own assertions through `$?`).
- 0.82s, so `core` tier per CONTRIBUTING; all 27 harnesses sourcing `cmd_agent_create.sh` / `cmd_auth.sh` green; `scripts/pii-scan.sh` clean.

### Local reds, all three, none from this diff

An earlier revision of this section named only the first of these, which read as a complete accounting when it was not. Full list:

1. **`broker_surface_unit.sh`** — ~~fails identically on the unmodified `bb6e371` control~~ **WRONG, retracted.** Corrected by main, re-measured by me: at `bb6e371` it is **36 passed, 0 failed, rc=0**. `bb6e371` IS the DIVE-2549 pin fix — the commit that *cured* this failure. My claim was a measurement taken at **`84ed56c`** (the control's sha from 01:59:43 to 02:12:45, per its reflog) and carried across the rebase onto `bb6e371` as though it still described the new base. Two defects in one line: **wrong sha**, and `bash "$t" 2>&1 | tail -4; echo $?` reports **`tail`'s** rc, not the harness's — so the `rc=0` I printed measured nothing. Nothing was actually red here at this PR's base.
2. **`gate_tier2_decision_nonce_unit.sh`** — exits **6 while reporting 10 ok / 0 fail**. Reproduced 3/3 on an unmodified `bb6e371` worktree, passes on this branch, and CI's `test` + `test-installed-host` are green on `f92bfe1` — so it is host-state-coupled, not diff-coupled. It is the DIVE-2013 class inverted: exit status not wired to the harness's own assertions, in the direction that reads as a failure rather than a false green. Worth its own row; not filed here.
3. **`gate_channel_session_t2_mutation.sh`** — **my measurement, not the harness.** My local sweep wrapped every harness in `timeout 300`, and this one is `# TIER: nightly — 300.0s measured`. Re-run untimed it is **rc=0, 14 mutants killed, 0 ungraded, in 5m35s**. Worth noting for DIVE-2525: its header measurement of 300.0s is ~35s optimistic against current control-plane load, so a nightly shard budgeted from that number is tighter than it reads. It is nightly-tier, so it does not gate this PR either way.

## Disclosure: the VM smoke cannot grade this diff

`5dive/CLAUDE.md` asks for `./scripts/test-vm.sh smoke` before pushing anything on the agent-create path. Recording why that debt is **not** discharged here, so the next reader of this row sees it without hunting:

`test-vm.sh` takes **no branch or ref option**. `smoke` is `provision → agent matrix → update.sh refresh check → purge`, and `update.sh refresh` installs whatever the **release channel currently serves**. On an unmerged branch it therefore grades `origin/main`'s released bundle, not this change — a green there would say nothing about this diff, by construction.

The convention's real bite is at **release-cut / host-roll**, once `FIVE_VERSION` is stamped and the bundle is published. Accepted on the same grounds for INST-5. Everything gradeable offline was graded offline and is listed above.

Knowledge compiled to `community/wiki/a-permission-probe-run-as-root-answers-a-different-question.md`.

Closes DIVE-2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


