### PR TITLE
fix(push): the workflow-scope probe fetched unauthenticated, so every private-repo push demanded workflows:write (DIVE-2547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased — fix(push): the workflow-scope probe fetched unauthenticated, so every private-repo push demanded `workflows:write` (DIVE-2547)
+
+`_push_touches_workflows` decides whether a delegated push needs `workflows:write`
+on top of `contents:write`. It ranged the branch by running `git fetch <repourl>`
+with **no credential**. Against a private repo that can never succeed, so the probe
+returned `unknown` and the caller escalated the token request — on every push, to
+every private repo, forever. A probe that never measures anything is not insurance;
+it is a permanently over-scoped token minted by a check that always abstains, which
+is the exact inversion of the one-permission scope DIVE-1460 exists to hold.
+
+It also did not degrade gracefully: the App is not granted `workflows:write`, so the
+defensive request **422s** and the push fails *after* a human already cleared the
+gate. Measured 2026-08-03, it blocked three agents across three repos — dev on
+`lodar/5dive-api` (DIVE-1999) and `lodar/5dive-frontend` (DIVE-2535), dev2 on
+`lodar/5dive-api` (DIVE-2033).
+
+The probe now degrades to the **cached** remote-tracking ref, exactly as the author
+scan one function over already did (DIVE-2161: *resolve the bound, degrade to a
+cached bound and say it may be stale, or refuse and name what is missing*). The same
+lesson was learned here and never applied.
+
+The staleness is safe in the direction that matters: `base...branch` reports what the
+branch *adds*, so an older base widens the range and can only over-report touched
+files. It can turn a `no` into a `yes` (request a scope we did not need) but never a
+`yes` into a `no` (push a workflow change under `contents:write` alone). Only when
+neither a live nor a cached bound resolves is the answer still `unknown`.
+
+`tests/push_unit.sh` 86 → 89 arms: the cached fallback measures `no` on a code-only
+branch, still catches a workflow-touching branch, and names its own staleness on
+stderr. The both-bounds-missing path still returns `unknown`.
+
 ## Unreleased — feat(actor): `5dive whoami`, one sealed actor derivation (DIVE-2517)
 
 The CLI had **six** actor derivations and they disagreed. Only one failed closed;

--- a/src/cmd_push.sh
+++ b/src/cmd_push.sh
@@ -273,6 +273,37 @@ _push_touches_workflows() { # <repopath> <repourl> <branch>
   for b in main master; do
     if "${g[@]}" fetch --quiet "$repourl" "$b" 2>/dev/null; then base="FETCH_HEAD"; break; fi
   done
+  # DIVE-2547: that fetch is UNAUTHENTICATED — it hands git a bare $repourl with no
+  # credential — so against a PRIVATE repo it can never succeed. The old code then
+  # returned "unknown" and the caller requested workflows:write defensively, on
+  # EVERY push to every private repo, forever. That is a permanently over-scoped
+  # token minted by a probe that never once measured anything, which is the exact
+  # inversion of what DIVE-1460's one-permission scope is for. Measured 2026-08-03:
+  # it blocked dev on lodar/5dive-api (DIVE-1999) and dev2 on the same repo
+  # (DIVE-2033), and the escalated request 422s because the App is not granted
+  # workflows:write — so the defensive branch does not even degrade gracefully, it
+  # fails the push outright after the human already cleared the gate.
+  #
+  # Degrade to the CACHED remote-tracking ref instead, exactly as the author scan
+  # one function over already does (DIVE-2161: "resolve the bound, degrade to a
+  # CACHED bound and SAY it may be stale, or refuse and name what is missing").
+  # The same lesson was learned here and never applied.
+  #
+  # A stale cached base is SAFE IN THE DIRECTION THAT MATTERS: base...branch shows
+  # what the branch adds relative to base, so an older base widens the range and can
+  # only report MORE files. It can therefore turn a "no" into a "yes" (request the
+  # scope we did not need) but never a "yes" into a "no" (push a workflow change
+  # under contents:write alone). Only when neither a live nor a cached bound exists
+  # is the answer genuinely unknown.
+  if [[ -z "$base" ]]; then
+    for b in main master; do
+      if "${g[@]}" rev-parse --verify --quiet "refs/remotes/origin/${b}" >/dev/null 2>&1; then
+        base="refs/remotes/origin/${b}"
+        echo "[5dive] could not fetch the remote default branch (unauthenticated probe); diffing '${branch}' against the cached ${base}, which may be stale — a stale base can only over-report touched files, never under-report them" >&2
+        break
+      fi
+    done
+  fi
   [[ -n "$base" ]] || { echo "unknown"; return; }
   files=$("${g[@]}" diff --name-only "${base}...refs/heads/${branch}" 2>/dev/null)     || { echo "unknown"; return; }
   if grep -qE '^\.github/workflows/' <<<"$files"; then echo "yes"; else echo "no"; fi

--- a/tests/push_unit.sh
+++ b/tests/push_unit.sh
@@ -771,12 +771,35 @@ wf() { ( _push_touches_workflows "$WFREPO" "$WFREPO" "$1" ) 2>/dev/null; }
 [[ "$(wf touches-ci)" == "yes" ]] \
   && ok_t "workflows scope: a branch touching .github/workflows/ needs workflows:write" \
   || bad_t "workflows scope: workflow-touching branch" "got '$(wf touches-ci)', want 'yes'"
-# No reachable default branch -> no range to diff. Must be 'unknown' (which the
-# caller treats as "include the permission and say so"), never a silent 'no' —
-# a false 'no' is a push that fails AFTER the human cleared the gate.
+# Neither a live NOR a cached bound -> no range to diff. Must be 'unknown' (which
+# the caller treats as "include the permission and say so"), never a silent 'no' —
+# a false 'no' is a push that fails AFTER the human cleared the gate. WFREPO has no
+# remote-tracking refs, so this arm exercises the both-bounds-missing path.
 [[ "$( ( _push_touches_workflows "$WFREPO" "/nonexistent/remote.git" touches-ci ) 2>/dev/null )" == "unknown" ]] \
-  && ok_t "workflows scope: unreachable remote -> unknown (fails open, loudly)" \
-  || bad_t "workflows scope: unreachable remote" "want 'unknown'"
+  && ok_t "workflows scope: no live AND no cached bound -> unknown (fails open, loudly)" \
+  || bad_t "workflows scope: no live and no cached bound" "want 'unknown'"
+
+# DIVE-2547: the live fetch is UNAUTHENTICATED, so on a PRIVATE repo it can never
+# succeed and the old code demanded workflows:write on every push forever. With a
+# cached remote-tracking ref present the probe must fall back to it and MEASURE,
+# rather than escalating the token. Same fixture, plus refs/remotes/origin/main.
+WFCACHED="$TMP/wfcached"
+cp -r "$WFREPO" "$WFCACHED" 2>/dev/null
+( cd "$WFCACHED" && git update-ref refs/remotes/origin/main refs/heads/main ) >/dev/null 2>&1
+wfc() { ( _push_touches_workflows "$WFCACHED" "/nonexistent/remote.git" "$1" ) 2>/dev/null; }
+
+[[ "$(wfc code-only)" == "no" ]] \
+  && ok_t "workflows scope: unreachable remote + cached ref -> measures 'no', does NOT escalate" \
+  || bad_t "workflows scope: cached-ref fallback on a code-only branch" "got '$(wfc code-only)', want 'no'"
+[[ "$(wfc touches-ci)" == "yes" ]] \
+  && ok_t "workflows scope: cached-ref fallback still catches a workflow-touching branch" \
+  || bad_t "workflows scope: cached-ref fallback on a ci branch" "got '$(wfc touches-ci)', want 'yes'"
+# The degradation must SAY it degraded (DIVE-2161: a cached bound that hides its
+# staleness is the failure this whole class is about).
+( _push_touches_workflows "$WFCACHED" "/nonexistent/remote.git" code-only ) 2>&1 >/dev/null \
+  | grep -q 'may be stale' \
+  && ok_t "workflows scope: the cached-bound fallback names its own staleness on stderr" \
+  || bad_t "workflows scope: cached fallback is silent" "no staleness warning emitted"
 # And the caller wires it: the wide body is reachable only when not 'no'.
 grep -q 'workflows:"write"' "$SRC/cmd_push.sh" \
   && ok_t "workflows scope: _push_do can request workflows:write" \


### PR DESCRIPTION
Fixes DIVE-2547. Unblocks DIVE-1999, DIVE-2033 and DIVE-2535.

`_push_touches_workflows` decides whether a delegated push needs `workflows:write` on top of `contents:write`. It ranged the branch with `git fetch <repourl>` and **no credential**. Against a private repo that can never succeed, so the probe returned `unknown` and the caller escalated the token request — on every push, to every private repo, forever. A probe that never measures is not insurance; it is a permanently over-scoped token minted by a check that always abstains.

It also does not degrade gracefully: the App is not granted `workflows:write`, so the defensive request **422s** and the push fails *after* a human already cleared the gate.

**Measured today, three agents across three repos:** dev on lodar/5dive-api (DIVE-1999) and lodar/5dive-frontend (DIVE-2535), dev2 on lodar/5dive-api (DIVE-2033). All three branches touch zero files under `.github/workflows/`.

## The fix

Degrade to the **cached** remote-tracking ref — exactly what the author scan one function over already does (DIVE-2161: *resolve the bound, degrade to a cached bound and say it may be stale, or refuse and name what is missing*). The same lesson was learned here and never applied.

Staleness is safe in the direction that matters: `base...branch` reports what the branch *adds*, so an older base widens the range and can only **over**-report touched files. It can turn a `no` into a `yes` (request a scope we did not need) but never a `yes` into a `no` (push a workflow change under `contents:write` alone). Both-bounds-missing is still `unknown`.

Deliberately **not** done: granting the App `workflows:write`. Widening a credential to route around a broken probe is the inversion of what the probe is for.

## Verification

- `tests/push_unit.sh` 86 → 89 arms, 89/0: cached fallback measures `no` on a code-only branch, still catches a workflow-touching branch, and names its own staleness on stderr; both-bounds-missing still returns `unknown`.
- **Real case, before/after:** run against lodar/5dive-api with dev2's actual branch `dive-2033-clerk-notfound-idempotent`, the probe now emits the staleness warning and returns `no` — narrow scope, no 422. Previously `unknown` → escalate → 422.