### PR TITLE
fix(push): resolve the App installation per repo, not from one pinned id (DIVE-2563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased — fix(push): resolve the App installation PER REPO, not from one pinned id (DIVE-2562)
+## Unreleased — fix(push): resolve the App installation PER REPO, not from one pinned id (DIVE-2563)
 
 `_push_do` minted every installation token against a single `GITHUB_APP_INSTALLATION_ID`
 read from `github-app.env`. A GitHub App gets a **separate installation per account**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## Unreleased — fix(push): resolve the App installation PER REPO, not from one pinned id (DIVE-2562)
+
+`_push_do` minted every installation token against a single `GITHUB_APP_INSTALLATION_ID`
+read from `github-app.env`. A GitHub App gets a **separate installation per account**
+it is installed on, and the token exchange refuses any repository outside the
+installation it is addressed to — with a message that names the *repository*
+(`There is at least one repository that does not exist or is not accessible to the
+parent installation`), so it reads as a missing repo rather than a wrong installation.
+
+Measured 2026-08-03: the App's only installation is the **5dive-ai org** (20 repos, all
+`5dive-ai/*`), while `5dive-api` and `5dive-frontend` live under a **personal account**.
+So `5dive-ai/5dive` pushed fine and every customer-facing repo 422'd — and had since the
+rail was built. Pinning also means installing the App on the second account would *not*
+fix it alone: that mints a second installation id and the box would keep addressing the
+first.
+
+`_push_do` now asks `GET /repos/{owner}/{repo}/installation` which installation owns the
+target repo, and falls back to the pinned id when the lookup cannot answer — so a box
+with one installation behaves exactly as before.
+
+Two supporting fixes in the same block:
+
+- **The refusal carries GitHub's own words.** `curl -fsS` prints nothing on a 4xx, so the
+  mint failure rendered as a bare `installation token exchange failed` and the operator
+  had to re-run the call by hand to learn the cause (DIVE-2143). It now reports the API
+  `message` and names the owner the App is probably missing from.
+- **`slug` is assigned before the lookup reads it.** The first cut of this change
+  referenced it 40 lines above its assignment, which expands to empty and silently
+  queries `/repos//installation` — a lookup that cannot fail loudly. `push_unit` pins
+  the ordering, not just the presence.
+
+This is the **code** half. Pushing to a repo on another account still requires the App to
+be installed there; that is a human step, tracked separately.
+
+`tests/push_unit.sh` 89 → 92 arms.
+
 ## Unreleased — fix(push): the workflow-scope probe fetched unauthenticated, so every private-repo push demanded `workflows:write` (DIVE-2547)
 
 `_push_touches_workflows` decides whether a delegated push needs `workflows:write`

--- a/src/cmd_push.sh
+++ b/src/cmd_push.sh
@@ -568,8 +568,11 @@ cmd_push_do() {
   # Exchange for an installation token SCOPED to just the target repo +
   # contents:write (DIVE-1460 refinement 1) — a captured token can't touch other
   # org repos, and the scoped body caps the permission to the one op we need.
-  local reponame body tok
+  local reponame body tok slug
   reponame=$(_push_repo_name "$repourl")
+  # owner/repo, needed by the DIVE-2562 installation lookup below. Declared here
+  # rather than at the summary line further down, which ran AFTER the mint.
+  slug=$(_push_repo_slug "$repourl")
   # gh#250: contents:write alone CANNOT push .github/workflows/* — GitHub
   # refuses the push outright, and the error names the App's permissions rather
   # than this token's, so the operator chases the wrong thing. Ask for
@@ -588,14 +591,56 @@ cmd_push_do() {
       && echo "[5dive] cannot diff ${branch} against the remote default branch — requesting workflows:write defensively" >&2
     body=$(jq -cn --arg r "$reponame" '{repositories:[$r],permissions:{contents:"write",workflows:"write"}}')
   fi
-  tok=$(curl -fsS --max-time 15 -X POST \
+  # DIVE-2562: RESOLVE THE INSTALLATION FOR THIS REPO'S OWNER, don't mint against a
+  # single pinned id. GITHUB_APP_INSTALLATION_ID is one number in one env file, so
+  # every push on this box minted against whichever account was installed first.
+  # A GitHub App gets a SEPARATE installation per account it is installed on, and
+  # the token exchange refuses any repository outside the installation it is
+  # addressed to — with a message that names the repository rather than the
+  # installation ("There is at least one repository that does not exist or is not
+  # accessible to the parent installation"), which reads as a missing repo.
+  #
+  # Measured 2026-08-03: the App's only installation is the 5dive-ai ORG (20 repos,
+  # all 5dive-ai/*), while `5dive-api` and `5dive-frontend` are `lodar/*` on a
+  # PERSONAL account. So 5dive-ai/5dive pushed fine and every customer-facing repo
+  # 422'd, and had since the rail was built. Pinning also means that installing the
+  # App on the personal account does NOT fix it on its own: that mints a SECOND
+  # installation id and the box would keep addressing the first one.
+  #
+  # Ask GitHub which installation owns the repo. Fall back to the pinned id when the
+  # lookup cannot answer, so a box with one installation and no extra permission
+  # behaves exactly as before.
+  local _inst_for_repo
+  _inst_for_repo=$(curl -fsS --max-time 15 \
+        -H "Authorization: Bearer ${jwt}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/${slug}/installation" 2>/dev/null \
+        | jq -r '.id // empty')
+  if [[ -n "$_inst_for_repo" && "$_inst_for_repo" != "$inst" ]]; then
+    echo "[5dive] ${slug} belongs to installation ${_inst_for_repo}, not the pinned ${inst} — minting against the repo's own installation" >&2
+    inst="$_inst_for_repo"
+  elif [[ -z "$_inst_for_repo" ]]; then
+    echo "[5dive] could not resolve an installation for ${slug}; falling back to the pinned id ${inst}. If the exchange refuses, the App is probably not installed on $(printf '%s' "$slug" | cut -d/ -f1)." >&2
+  fi
+
+  # Keep the response body: `curl -fsS` prints nothing on a 4xx, so the old code
+  # turned GitHub's own explanation into "installation token exchange failed" and
+  # the operator had to re-run the call by hand to see the cause. A refusal must
+  # carry what the remote actually said (DIVE-2143).
+  local _tokresp _tokrc=0
+  _tokresp=$(curl -sS --max-time 15 -X POST \
         -H "Authorization: Bearer ${jwt}" \
         -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
         -d "$body" \
-        "https://api.github.com/app/installations/${inst}/access_tokens" \
-        | jq -r '.token // empty')
-  [[ -n "$tok" ]] || fail "$E_GENERIC" "installation token exchange failed"
+        "https://api.github.com/app/installations/${inst}/access_tokens" 2>&1) || _tokrc=$?
+  tok=$(printf '%s' "$_tokresp" | jq -r '.token // empty' 2>/dev/null)
+  if [[ -z "$tok" ]]; then
+    local _why; _why=$(printf '%s' "$_tokresp" | jq -r '.message // empty' 2>/dev/null)
+    [[ -n "$_why" ]] || _why="$(printf '%s' "$_tokresp" | head -c 300)"
+    fail "$E_GENERIC" "installation token exchange failed for ${slug} against installation ${inst}: ${_why:-no response body} — if that names an inaccessible repository, the App is not installed on '$(printf '%s' "$slug" | cut -d/ -f1)'."
+  fi
 
   # Push ONLY the named branch, token via extraheader so it never lands in argv
   # (no leak via ps/audit). Discard the token immediately after.
@@ -606,7 +651,7 @@ cmd_push_do() {
   tok=""; authhdr=""   # discard
 
   [[ $rc -eq 0 ]] || fail "$E_GENERIC" "push failed (branch ${branch}); see output above."
-  local slug sha; slug=$(_push_repo_slug "$repourl")
+  local sha
   sha=$("${G[@]}" rev-parse --short "refs/heads/${branch}")
   # DIVE-1923: ship ledger. After the push, never before — this records what
   # landed, so a failed push must leave no trace. Never fatal.

--- a/src/cmd_push.sh
+++ b/src/cmd_push.sh
@@ -570,7 +570,7 @@ cmd_push_do() {
   # org repos, and the scoped body caps the permission to the one op we need.
   local reponame body tok slug
   reponame=$(_push_repo_name "$repourl")
-  # owner/repo, needed by the DIVE-2562 installation lookup below. Declared here
+  # owner/repo, needed by the DIVE-2563 installation lookup below. Declared here
   # rather than at the summary line further down, which ran AFTER the mint.
   slug=$(_push_repo_slug "$repourl")
   # gh#250: contents:write alone CANNOT push .github/workflows/* — GitHub
@@ -591,7 +591,7 @@ cmd_push_do() {
       && echo "[5dive] cannot diff ${branch} against the remote default branch — requesting workflows:write defensively" >&2
     body=$(jq -cn --arg r "$reponame" '{repositories:[$r],permissions:{contents:"write",workflows:"write"}}')
   fi
-  # DIVE-2562: RESOLVE THE INSTALLATION FOR THIS REPO'S OWNER, don't mint against a
+  # DIVE-2563: RESOLVE THE INSTALLATION FOR THIS REPO'S OWNER, don't mint against a
   # single pinned id. GITHUB_APP_INSTALLATION_ID is one number in one env file, so
   # every push on this box minted against whichever account was installed first.
   # A GitHub App gets a SEPARATE installation per account it is installed on, and

--- a/tests/push_unit.sh
+++ b/tests/push_unit.sh
@@ -805,6 +805,35 @@ grep -q 'workflows:"write"' "$SRC/cmd_push.sh" \
   && ok_t "workflows scope: _push_do can request workflows:write" \
   || bad_t "workflows scope: _push_do can request workflows:write" "no workflows grant in the token body"
 
+# --- DIVE-2562: the installation is resolved PER REPO, not pinned -------------
+# A GitHub App gets one installation per ACCOUNT it is installed on, and the token
+# exchange refuses any repo outside the installation it is addressed to. A single
+# pinned GITHUB_APP_INSTALLATION_ID therefore works only while the whole fleet
+# lives in one account — which stopped being true the moment a repo sat under a
+# different owner. Measured 2026-08-03: 5dive-ai/5dive resolves to the pinned
+# installation; lodar/5dive-api and lodar/5dive-frontend resolve to none at all.
+grep -q 'repos/\${slug}/installation' "$SRC/cmd_push.sh" \
+  && ok_t "installation: _push_do asks GitHub which installation owns the repo" \
+  || bad_t "installation: per-repo lookup" "no /repos/<slug>/installation call before the mint"
+
+# The lookup needs the owner/repo slug, and it runs BEFORE the mint. The first cut
+# of this fix referenced \$slug 40 lines above its assignment, which expands to
+# empty and silently queries /repos//installation — a lookup that cannot fail
+# loudly. Pin the ordering, not just the presence.
+_slug_ln=$(grep -n '^  slug=\$(_push_repo_slug "\$repourl")' "$SRC/cmd_push.sh" | head -1 | cut -d: -f1)
+_inst_ln=$(grep -n 'repos/\${slug}/installation' "$SRC/cmd_push.sh" | head -1 | cut -d: -f1)
+[[ -n "$_slug_ln" && -n "$_inst_ln" && "$_slug_ln" -lt "$_inst_ln" ]] \
+  && ok_t "installation: slug is assigned BEFORE the installation lookup reads it" \
+  || bad_t "installation: slug assigned before use" "slug at line ${_slug_ln:-none}, lookup at ${_inst_ln:-none}"
+
+# A refusal must carry what GitHub actually said. `curl -fsS` prints nothing on a
+# 4xx, so the old code rendered "There is at least one repository that does not
+# exist or is not accessible to the parent installation" as "installation token
+# exchange failed" and the operator had to re-run the call by hand to find out.
+grep -q "message // empty" "$SRC/cmd_push.sh" \
+  && ok_t "installation: a failed mint surfaces GitHub's own message" \
+  || bad_t "installation: mint failure names the cause" "the API error body is discarded"
+
 echo "-----"
 printf 'push_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/tests/push_unit.sh
+++ b/tests/push_unit.sh
@@ -805,7 +805,7 @@ grep -q 'workflows:"write"' "$SRC/cmd_push.sh" \
   && ok_t "workflows scope: _push_do can request workflows:write" \
   || bad_t "workflows scope: _push_do can request workflows:write" "no workflows grant in the token body"
 
-# --- DIVE-2562: the installation is resolved PER REPO, not pinned -------------
+# --- DIVE-2563: the installation is resolved PER REPO, not pinned -------------
 # A GitHub App gets one installation per ACCOUNT it is installed on, and the token
 # exchange refuses any repo outside the installation it is addressed to. A single
 # pinned GITHUB_APP_INSTALLATION_ID therefore works only while the whole fleet


### PR DESCRIPTION
Found by dev underneath DIVE-2547. The scope probe fix was correct and landed; this is the **second refusal underneath it**.

A GitHub App gets a **separate installation per account** it is installed on, and the token exchange refuses any repository outside the installation it is addressed to. `_push_do` minted every token against one pinned `GITHUB_APP_INSTALLATION_ID`.

**Measured 2026-08-03**, querying `GET /repos/{owner}/{repo}/installation` with the App JWT:

| repo | result |
|---|---|
| `5dive-ai/5dive` | installation `147419836`, account `5dive-ai` (= the pinned id) |
| `lodar/5dive-api` | **no installation** |
| `lodar/5dive-frontend` | **no installation** |

So the CLI repo pushed fine and every customer-facing repo 422'd, and had since the rail was built. GitHub's message names the *repository* (`There is at least one repository that does not exist or is not accessible to the parent installation`), which reads as a missing repo rather than a wrong installation — that is why it went undiagnosed.

Pinning also means installing the App on the second account would **not** fix it alone: that mints a second installation id and the box would keep addressing the first.

## Changes

- Resolve the installation for the target repo's owner; fall back to the pinned id when the lookup cannot answer, so a single-installation box behaves exactly as before.
- **Surface GitHub's own error.** `curl -fsS` prints nothing on a 4xx, so a failed mint rendered as a bare `installation token exchange failed` and dev had to re-run the call by hand to find the cause (DIVE-2143). It now reports the API `message` and names the owner the App is probably missing from.
- **`slug` is assigned before the lookup reads it.** My first cut referenced it 40 lines above its assignment — expands to empty, silently queries `/repos//installation`, a lookup that cannot fail loudly. The harness pins the ordering, not just the presence.

## Scope

This is the **code** half only. Pushing to `lodar/*` still needs the App installed on that account — a human step, filed separately by dev. This change makes the box address the right installation the moment one exists, and makes the failure legible until then.

`tests/push_unit.sh` 89 → 92 arms, 92/0.