### PR TITLE
ci(workflows): actionlint over .github/workflows, and a canary that proves it fired (DIVE-2540)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,76 @@
+name: actionlint
+
+# DIVE-2540. Nothing in this repo could validate a workflow file. On 2026-08-02
+# an Actions expression delimiter inside a SHELL COMMENT made release-cut.yml —
+# the only writer of a version anywhere in this repo — unparseable for 45
+# minutes, and every instrument we had reported nothing: yaml.safe_load ACCEPTS
+# the file, shellcheck does not read `run:` blocks, and the run a broken workflow
+# produces has zero jobs and says only "This run likely failed because of a
+# workflow file issue". See DIVE-2539 and
+# community/wiki/an-actions-expression-is-parsed-inside-shell-comments.md
+#
+# WHAT THIS IS AND IS NOT. There WAS a pre-merge loop already — push the branch
+# and look for a zero-job failure run on that ref, which works even for a
+# workflow with no `push` trigger. It needs a human to remember to do it and it
+# returns a verdict that names nothing. This job is the two halves that were
+# genuinely missing: an instrument that NAMES the defect, and one that runs
+# whether or not anyone remembers.
+#
+# NO `paths:` FILTER, deliberately. A path-filtered required check is skipped
+# rather than green on PRs that do not touch it, which turns a merge gate into a
+# thing people learn to click past — and the whole scan is a few seconds.
+#
+# THE PIN IS THE SUPPLY CHAIN. A linter that gates merges is a binary that runs
+# with the repo checked out, so the version AND its sha256 are written down here
+# and verified before it executes. Upgrading is deliberate: bump both, and expect
+# the canary below to be re-measured.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    env:
+      ACTIONLINT_VERSION: 1.7.7
+      ACTIONLINT_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pinned actionlint
+        run: |
+          set -euo pipefail
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL --retry 3 -o /tmp/actionlint.tgz "$url"
+          echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tgz" | sha256sum -c -
+          tar -xzf /tmp/actionlint.tgz -C /tmp actionlint
+          /tmp/actionlint --version
+
+      # scripts/actionlint-scan.sh proves the binary FIRES before it trusts a
+      # clean scan: it runs the same binary with the same flags against a fixture
+      # carrying the DIVE-2539 defect (must be rejected, as an [expression]
+      # error) and a known-good fixture whose delimiter sits in a YAML-level
+      # comment (must be accepted). Either way round, it exits 2 and this job
+      # goes red rather than green-on-nothing. Every failure mode of a linter
+      # gate — missing binary, wrong flags, an empty target set, a checker that
+      # moved — presents as "no findings", so an unproven green is the default
+      # outcome unless something forces the instrument to speak.
+      - name: Lint every workflow file
+        env:
+          ACTIONLINT_BIN: /tmp/actionlint
+        run: |
+          # set +e is LOAD-BEARING: GitHub runs `run:` under `bash -e`, so a
+          # findings exit would abort the step before rc is read and the
+          # annotations below would never print. Same reason as
+          # supply-chain-guard.yml, which found this out by failing its own PR.
+          set +e
+          bash scripts/actionlint-scan.sh
+          rc=$?
+          set -e
+          case "$rc" in
+            0) echo "actionlint: clean, and the canary fired — the instrument was alive for this run." ;;
+            1) echo "::error::actionlint found problems in .github/workflows — see the findings above" ;;
+            *) echo "::error::actionlint-scan COULD NOT SCAN (exit $rc). This is not a pass: read the reason above." ;;
+          esac
+          exit "$rc"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,34 @@ decision to add one is ever wrong on its own merits. See
   re-sums the shards and prints the **un-sharded** total, because that total is the
   number the tiering exists to make legible and sharding is how you lose it.
 
+## Workflow files are linted, and the linter proves it fired (DIVE-2540)
+
+`yaml.safe_load` **accepts** a workflow file that GitHub cannot parse — expression
+substitution is a second layer on top of YAML, and it happens **before the shell
+exists**, so an Actions expression template inside a `#` comment in a `run:` block
+is still parsed.
+That made `release-cut.yml` — the only writer of a version in this repo —
+unparseable for 45 minutes on 2026-08-02 (DIVE-2539), and the run it produced said
+only *"This run likely failed because of a workflow file issue"*.
+
+- **`actionlint` is the only instrument that names it.** `.github/workflows/actionlint.yml`
+  runs it on every PR and every push to main; `scripts/git-hooks/pre-push` runs the
+  same script over the pushed revision when a push touches `.github/workflows`.
+- Locally: `bash scripts/actionlint-scan.sh` (exit **0** clean, **1** findings,
+  **2** *could not scan* — which is never a pass).
+- **The scan self-tests before it trusts a clean result.** Every way this gate can
+  break — missing binary, wrong flags, empty target set, a checker whose rule moved —
+  presents as "no findings", so the same binary with the same flags must first reject
+  `tests/fixtures/actionlint/canary-expression-in-run-comment.yml` *as an
+  `[expression]` error* and accept the known-good fixture next to it. If it does not,
+  the scan exits 2.
+- **shellcheck integration is off for now** (`--with-shellcheck` turns it on). The
+  tree emits three INFO findings today; a gate that is red on arrival gets disabled.
+- **Never write the expression delimiter literally inside a `run:` block**, including
+  in comments and error strings. At YAML level (`env:`, `with:`) it is a real comment
+  and harmless. Full write-up:
+  `community/wiki/an-actions-expression-is-parsed-inside-shell-comments.md`.
+
 ## Hard rule: no real PII in public artifacts (DIVE-1774)
 
 Never put real user ids, emails, phone numbers, or customer PII in anything that

--- a/scripts/actionlint-scan.sh
+++ b/scripts/actionlint-scan.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# DIVE-2540 — workflow-file scanner. ONE implementation, shared by CI
+# (.github/workflows/actionlint.yml) and the pre-push hook (scripts/git-hooks/
+# pre-push), so neither can drift from the other.
+#
+# WHAT IT CLOSES. On 2026-08-02 an Actions expression delimiter written inside a
+# SHELL COMMENT made release-cut.yml unparseable for 45 minutes (DIVE-2539).
+# release-cut.yml is the only writer of a version anywhere in this repo, so no
+# nightly cut could have fired, and nothing said so. Substitution is textual and
+# happens BEFORE the shell exists, so `#` means nothing to it — the comment
+# written to explain that the hazard had been avoided WAS the hazard. Full
+# write-up: community/wiki/an-actions-expression-is-parsed-inside-shell-comments.md
+#
+# WHY NOTHING CAUGHT IT. `yaml.safe_load` ACCEPTS that file — it is valid YAML,
+# and expression parsing is a second layer on top. shellcheck lints shell
+# scripts, not `run:` blocks. And the run a broken workflow produces names
+# nothing: zero jobs, 0s, and "This run likely failed because of a workflow file
+# issue", with the check-runs and annotations APIs empty. actionlint names it in
+# one run, with a byte offset that resolves to the comment.
+#
+# NARROWER THAN THE ROW WAS FILED, and this is main's own correction: a workflow
+# edit CAN be validated on a branch today — push it and look for a zero-job
+# failure run on that ref, which works even for a workflow with no `push`
+# trigger. What was missing is (a) an instrument that NAMES the defect instead of
+# a run that shrugs, and (b) anything that runs without a human remembering to
+# probe. This is (a) and (b), not "no check was possible".
+#
+#   Usage:  scripts/actionlint-scan.sh [--with-shellcheck] [--no-canary] [FILES...]
+#   Exit:   0 = clean   1 = findings   2 = COULD NOT SCAN
+#
+# THE CANARY IS THE POINT, not garnish. A green from a linter is worth exactly
+# what the proof that the linter FIRED is worth, and every failure mode here —
+# binary missing, wrong binary, arguments that silently lint nothing, a version
+# whose expression checker moved — presents as "no findings". So before the tree
+# is scanned, the same binary with the same flags is run against a fixture
+# carrying the DIVE-2539 defect and a fixture that is known-good, and it must
+# reject the first and accept the second. If it does not, this exits 2. A scanner
+# that reports clean when it could not look is the defect this repo spent
+# 2026-07-28 removing from six other controls, and an unproven instrument is that
+# defect wearing a linter's name.
+#
+# EXIT 2 IS A THIRD OUTCOME, deliberately: "I could not tell" is neither pass nor
+# fail, and folding it into either is the class this repo keeps re-learning
+# (tests/lib/grading_tree.sh, DIVE-2274). An empty target set is exit 2 for the
+# same reason — a rename of .github/workflows must not read as "clean".
+#
+# SHELLCHECK IS OFF BY DEFAULT, on purpose and only for now. actionlint shells
+# out to shellcheck for `run:` bodies when it is on PATH (it is, on
+# ubuntu-latest), and this tree emits three INFO findings today — SC2015 x2 in
+# release-cut.yml and SC2153 in unit-tests.yml. Landing a gate that is red on
+# arrival is how a gate gets disabled, and the class that BRICKS a workflow is
+# the syntax/expression class, which needs none of it. `--with-shellcheck` is the
+# whole tightening: fix the three, flip the flag.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || { echo "actionlint-scan: cannot resolve repo root" >&2; exit 2; }
+
+# The binary. ACTIONLINT_BIN lets CI point at a pinned download and lets the unit
+# harness point at a stub, so the harness never needs the real tool or a network.
+BIN="${ACTIONLINT_BIN:-actionlint}"
+
+CANARY_BAD="${ACTIONLINT_CANARY_BAD:-$ROOT/tests/fixtures/actionlint/canary-expression-in-run-comment.yml}"
+CANARY_GOOD="${ACTIONLINT_CANARY_GOOD:-$ROOT/tests/fixtures/actionlint/known-good-yaml-level-comment.yml}"
+
+# actionlint tags each finding with its rule kind in brackets. The DIVE-2539
+# class is [expression]. Matching the KIND rather than the prose means a reworded
+# message still satisfies the canary, while a version whose expression checker
+# has genuinely moved fails CLOSED (exit 2) and forces a re-measurement instead
+# of quietly scanning with a checker that no longer looks.
+CANARY_SIGNATURE='\[expression\]'
+
+WITH_SHELLCHECK=0
+RUN_CANARY=1
+TARGETS=()
+while (( $# )); do
+  case "$1" in
+    --with-shellcheck) WITH_SHELLCHECK=1 ;;
+    # ONLY for the harness arms that grade the canary machinery itself. There is
+    # no CI path that sets this, and there must not be one.
+    --no-canary)       RUN_CANARY=0 ;;
+    --help|-h)         sed -n '2,50p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    --*)               echo "actionlint-scan: unknown flag '$1'" >&2; exit 2 ;;
+    *)                 TARGETS+=("$1") ;;
+  esac
+  shift
+done
+
+# Flags, assembled ONCE so the canary and the tree scan are provably the same
+# invocation. A canary run under different flags proves nothing about the run
+# that matters.
+FLAGS=(-no-color -oneline)
+if (( ! WITH_SHELLCHECK )); then
+  FLAGS+=(-shellcheck= -pyflakes=)
+fi
+
+command -v "$BIN" >/dev/null 2>&1 || {
+  echo "actionlint-scan: actionlint not found (looked for '$BIN') — REFUSING to report clean" >&2
+  exit 2
+}
+
+# --- the canary: prove the instrument fires, and fires SPECIFICALLY ----------
+if (( RUN_CANARY )); then
+  for f in "$CANARY_BAD" "$CANARY_GOOD"; do
+    [[ -r "$f" ]] || { echo "actionlint-scan: canary fixture unreadable ($f) — REFUSING to report clean" >&2; exit 2; }
+  done
+
+  bad_out="$("$BIN" "${FLAGS[@]}" "$CANARY_BAD" 2>&1)"; bad_rc=$?
+  if (( bad_rc == 0 )); then
+    echo "actionlint-scan: CANARY DID NOT FIRE — '$BIN' accepted a file carrying the DIVE-2539 defect." >&2
+    echo "actionlint-scan: the instrument is dead or mis-invoked; a clean scan would mean nothing. REFUSING." >&2
+    exit 2
+  fi
+  if ! grep -qE "$CANARY_SIGNATURE" <<<"$bad_out"; then
+    echo "actionlint-scan: canary failed for the WRONG REASON — no [expression] finding in:" >&2
+    printf '%s\n' "$bad_out" >&2
+    echo "actionlint-scan: this binary rejects the fixture but not as an expression error. REFUSING." >&2
+    exit 2
+  fi
+
+  # The other half, and it is not symmetry for its own sake: a scanner that
+  # rejects EVERYTHING also passes the arm above. The known-good fixture carries
+  # the same delimiter at YAML level, where it is a real comment and genuinely
+  # harmless (pii-guard.yml has carried one for months). Rejecting it would mean
+  # the instrument is a grep for the delimiter, which would make every honest
+  # mention of the syntax unlandable — including this repo's own write-up of it.
+  if ! good_out="$("$BIN" "${FLAGS[@]}" "$CANARY_GOOD" 2>&1)"; then
+    echo "actionlint-scan: CANARY OVER-FIRES — '$BIN' rejected a known-good workflow:" >&2
+    printf '%s\n' "$good_out" >&2
+    echo "actionlint-scan: findings from this binary cannot be trusted. REFUSING." >&2
+    exit 2
+  fi
+fi
+
+# --- the actual scan ---------------------------------------------------------
+if (( ! ${#TARGETS[@]} )); then
+  shopt -s nullglob
+  TARGETS=("$ROOT"/.github/workflows/*.yml "$ROOT"/.github/workflows/*.yaml)
+  shopt -u nullglob
+fi
+
+if (( ! ${#TARGETS[@]} )); then
+  echo "actionlint-scan: no workflow files found under $ROOT/.github/workflows — REFUSING to report clean" >&2
+  echo "actionlint-scan: an empty target set is 'I scanned nothing', not 'nothing is wrong'." >&2
+  exit 2
+fi
+
+out="$("$BIN" "${FLAGS[@]}" "${TARGETS[@]}" 2>&1)"; rc=$?
+case "$rc" in
+  0) exit 0 ;;
+  1) printf '%s\n' "$out"; exit 1 ;;
+  *) printf '%s\n' "$out" >&2
+     echo "actionlint-scan: '$BIN' exited $rc (usage/internal error, not a verdict) — REFUSING to report clean" >&2
+     exit 2 ;;
+esac

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Fleet-wide pre-push guards: PII (DIVE-1797, enforcement follow-up to
-# DIVE-1774), release version-bump (DIVE-2065), and new-harness tree-naming
-# (DIVE-2286).
+# DIVE-1774), release version-bump (DIVE-2065), new-harness tree-naming
+# (DIVE-2286), and workflow-file parseability (DIVE-2540).
 #
 # WHY a local hook and not GitHub branch protection: our landing account is the
 # repo admin, so a required status check only gates EXTERNAL PRs, never our own
@@ -46,9 +46,18 @@
 # harness that later removes the line stays CI-only, which the contract test
 # already owns.
 #
+# WHAT the actionlint guard does (DIVE-2540): when the push touches
+# .github/workflows, runs scripts/actionlint-scan.sh over those files AS THEY
+# EXIST IN THE PUSHED REVISION. An Actions expression delimiter inside a shell
+# COMMENT made release-cut.yml unparseable for 45 minutes on 2026-08-02
+# (DIVE-2539) and yaml.safe_load accepted the file — expression parsing is a
+# second layer that only actionlint reads. Same script the CI job runs, so
+# neither can drift.
+#
 # DESIGN NOTES:
-#   - Calls scripts/pii-scan.sh, scripts/version-bump-guard.sh and
-#     scripts/harness-tree-guard.sh DIRECTLY. No forked scan logic here, so
+#   - Calls scripts/pii-scan.sh, scripts/version-bump-guard.sh,
+#     scripts/harness-tree-guard.sh and scripts/actionlint-scan.sh DIRECTLY.
+#     No forked scan logic here, so
 #     none can drift from its CI/README twin (DIVE-1797 requirement c;
 #     tests/names_the_tree_contract_unit.sh is the harness-tree guard's, over
 #     the whole corpus rather than just the push's added files).
@@ -60,19 +69,27 @@
 #     it fails closed if a bundle is ever committed to main again — but do
 #     NOT read its advice as current: nothing should bump FIVE_VERSION by
 #     hand any more (see CONTRIBUTING).
+#     DIVE-2540: the actionlint guard's CI twin is
+#     .github/workflows/actionlint.yml, which runs the same script — so the hook
+#     and the merge gate cannot disagree about what a valid workflow file is —
+#     and tests/actionlint_scan_unit.sh grades the script both call.
 #   - Installed fleet-wide via core.hooksPath=scripts/git-hooks, set once on the
 #     shared clone config so every linked worktree (and every future one)
 #     inherits it. See scripts/install-pii-push-guard.sh.
 #   - Threat model for PII is ACCIDENTAL fixture/log PII, not a malicious actor.
-#     Both guards fail OPEN with a warning if their script is missing (e.g. a
+#     Every guard here fails OPEN with a warning if its script is missing (e.g. a
 #     stale branch predating the guard) rather than blocking legitimate work;
 #     the matching CI job remains the post-hoc net for anything that slips past.
+#     The actionlint guard additionally fails open when the binary is not
+#     installed locally, which is the normal state of a fresh checkout — a guard
+#     that blocks every push on a tool nobody has is a guard that gets removed.
 set -uo pipefail
 
 TOP="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 SCAN="$TOP/scripts/pii-scan.sh"
 VERSION_GUARD="$TOP/scripts/version-bump-guard.sh"
 HARNESS_TREE_GUARD="$TOP/scripts/harness-tree-guard.sh"
+ACTIONLINT_SCAN="$TOP/scripts/actionlint-scan.sh"
 EMPTY_TREE=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 Z40=0000000000000000000000000000000000000000
 
@@ -131,6 +148,55 @@ while read -r local_ref local_oid remote_ref remote_oid; do
     echo "harness-tree-guard: script not found ($HARNESS_TREE_GUARD); skipping (the CI contract test is the net)." >&2
   fi
 
+  # DIVE-2540: workflow files, scanned FROM THE PUSHED REVISION rather than the
+  # working tree — a hook that grades whatever happens to be on disk is making a
+  # claim about a different artifact than the one being published
+  # (tests/lib/grading_tree.sh, one level out).
+  #
+  # WHY A LOCAL HOOK EARNS ITS KEEP HERE SPECIFICALLY, and it is not "defence in
+  # depth": this repo's landing account is the repo ADMIN, so a required status
+  # check gates external PRs and NOT our own pushes to main. The DIVE-2539
+  # breakage took exactly that route. .github/workflows/actionlint.yml does run
+  # on push to main, but it can only redden AFTER the unparseable file is on
+  # main, which is where the 45 minutes went. This is the only stage that runs
+  # BEFORE it lands on that path.
+  if [[ -f "$ACTIONLINT_SCAN" ]] \
+     && [[ -n "$(git diff --name-only "$base" "$local_oid" -- .github/workflows 2>/dev/null)" ]]; then
+    wf_tmp="$(mktemp -d)"
+    if git archive "$local_oid" .github/workflows tests/fixtures/actionlint 2>/dev/null \
+         | tar -x -C "$wf_tmp" 2>/dev/null; then
+      # Run FROM the extracted root so findings print `.github/workflows/x.yml`
+      # rather than a path relative to a temp dir the author has never seen —
+      # the file name is the only part of the message that tells them where to
+      # look. Subshell: the scanner's own ROOT is unused here (both the targets
+      # and the canary fixtures are named explicitly, all from the pushed rev).
+      (
+        cd "$wf_tmp" || exit 2
+        shopt -s nullglob
+        wf_files=(.github/workflows/*.yml .github/workflows/*.yaml)
+        shopt -u nullglob
+        (( ${#wf_files[@]} )) || exit 0
+        ACTIONLINT_CANARY_BAD="$wf_tmp/tests/fixtures/actionlint/canary-expression-in-run-comment.yml" \
+        ACTIONLINT_CANARY_GOOD="$wf_tmp/tests/fixtures/actionlint/known-good-yaml-level-comment.yml" \
+          bash "$ACTIONLINT_SCAN" "${wf_files[@]}"
+      )
+      al_rc=$?
+      case "$al_rc" in
+        0) ;;
+        1) echo "actionlint-push-guard: the workflow files in this push do not parse (findings above)." >&2; rc=1 ;;
+        # FAILS OPEN, deliberately and narrowly. Exit 2 here is overwhelmingly
+        # "actionlint is not installed on this box", which is the normal state of
+        # a fresh checkout; blocking every push on a tool nobody has installed is
+        # how a guard gets removed. Said out loud rather than silently, and the
+        # CI job — which installs a pinned copy — is the hard gate.
+        *) echo "actionlint-push-guard: could not scan (exit $al_rc); skipping. Install actionlint locally to gate this before it lands; the CI actionlint job is the net." >&2 ;;
+      esac
+    else
+      echo "actionlint-push-guard: could not materialise the pushed workflow files; skipping (CI actionlint is the net)." >&2
+    fi
+    rm -rf "$wf_tmp"
+  fi
+
   # DIVE-2065: only fires on a push to main with an EXISTING remote main
   # (skip branch deletion, already `continue`d above; skip first-ever-push of
   # a new branch — main always already exists so $remote_oid is never Z40 for
@@ -150,6 +216,7 @@ if [[ $rc -ne 0 ]]; then
   echo "  pii-push-guard: scrub the real id/email/phone (use placeholders like <user-id>, 1234567890) and re-commit." >&2
   echo "  version-bump-guard: this should be unreachable since DIVE-2247 — the bundle is not tracked on main and FIVE_VERSION is assigned at tag time. If you are seeing this, a bundle has been committed to main; remove it rather than bumping the version by hand." >&2
   echo "  harness-tree-guard: paste the printed source-line snippet into the named harness and recommit." >&2
+  echo "  actionlint-push-guard: the named workflow file does not parse. Run: bash scripts/actionlint-scan.sh" >&2
   echo "  Emergency override (discouraged; the matching CI job is still the net): git push --no-verify" >&2
   exit 1
 fi

--- a/tests/actionlint_scan_unit.sh
+++ b/tests/actionlint_scan_unit.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# DIVE-2540 — scripts/actionlint-scan.sh, the workflow-file gate.
+#
+# WHAT THIS GRADES, and why each arm can fail. The subject is a wrapper around an
+# external linter, and EVERY way that wrapper can be broken presents as "no
+# findings": binary missing, binary dead, flags that lint nothing, an empty
+# target set, a checker whose rule moved. So the arms below are almost entirely
+# about the difference between a clean scan and an UNPROVEN one.
+#
+#   the instrument must FIRE   arms 2-4. A stub that accepts the DIVE-2539
+#                              fixture, one that rejects it for the wrong reason,
+#                              and one that rejects EVERYTHING must all produce
+#                              exit 2, never 0 and never 1. Arm 4 is what stops
+#                              the canary from being satisfiable by a grep.
+#   absence is not clean       arms 1 and 8: no binary, and no workflow files.
+#                              Both exit 2. "I scanned nothing" is not a pass.
+#   the verdict is faithful    arms 5-7: clean tree -> 0, findings -> 1, and a
+#                              usage/internal error from the binary -> 2 rather
+#                              than 1, because a crash is not a finding.
+#   the canary is the SAME run arm 9 reads the stub's recorded argv: canary and
+#                              tree scan must carry identical flags, or the proof
+#                              is about an invocation that never happened.
+#   the fixture can still fail arm 10. The canary file must be ACCEPTED by
+#                              yaml.safe_load and must carry the delimiter inside
+#                              a `run:` block — the exact combination that made
+#                              DIVE-2539 invisible. A fixture edited into
+#                              harmless YAML would leave every arm above green
+#                              while grading nothing.
+#   CI cannot disarm it        arm 11: no workflow may pass --no-canary, and the
+#                              gate must actually call the shared scanner.
+#   the real binary            arm 12, SKIPPED unless actionlint is on PATH. The
+#                              stub arms grade our wrapper; only this one grades
+#                              the claim that actionlint names this defect at
+#                              all, and a skip is not a pass.
+#
+# NO NETWORK, NO ROOT, NO REAL BINARY REQUIRED: arms 1-11 run against a stub
+# actionlint whose behaviour is chosen per arm.
+#
+# Run: bash tests/actionlint_scan_unit.sh
+set -uo pipefail
+
+# DIVE-2211 / DIVE-2286: name the tree this harness grades. Sourced BEFORE the cd
+# so ${BASH_SOURCE[0]} still resolves relative to tests/.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+REPO="$PWD"
+SCAN="$REPO/scripts/actionlint-scan.sh"
+BAD="$REPO/tests/fixtures/actionlint/canary-expression-in-run-comment.yml"
+GOOD="$REPO/tests/fixtures/actionlint/known-good-yaml-level-comment.yml"
+
+PASS=0; FAIL=0; SKIP=0
+ok(){   PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+no(){   FAIL=$((FAIL+1)); printf 'NOT OK - %s\n' "$1"; }
+# A skip is NOT a pass. An unavailable precondition must never inflate a green log.
+skip(){ SKIP=$((SKIP+1)); printf 'skip - %s\n' "$1"; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+[[ -x "$SCAN" ]] || { no "scripts/actionlint-scan.sh is missing or not executable"; printf '\n%s passed, %s failed, %s skipped\n' "$PASS" "$FAIL" "$SKIP"; exit 1; }
+
+# --- the stub -----------------------------------------------------------------
+# Emulates actionlint's CONTRACT (exit 0 clean / 1 findings / 2 usage) and records
+# every invocation's argv, so the arms can grade both the verdict mapping and the
+# flags the wrapper actually used. STUB_MODE picks the behaviour per arm.
+STUB="$TMP/actionlint"
+ARGV_LOG="$TMP/argv.log"
+cat > "$STUB" <<'STUB_EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$ARGV_LOG"
+targets=(); for a in "$@"; do [[ "$a" == -* ]] || targets+=("$a"); done
+is_canary_bad=0; is_canary_good=0
+for t in "${targets[@]}"; do
+  case "$t" in
+    *canary-expression-in-run-comment.yml) is_canary_bad=1 ;;
+    *known-good-yaml-level-comment.yml)    is_canary_good=1 ;;
+  esac
+done
+case "${STUB_MODE:?}" in
+  dead)        exit 0 ;;                         # never fires, on anything
+  # Fires on EVERYTHING, and tagged [expression] on purpose: an over-firing
+  # binary that also failed the wrong-reason check would be rejected by the layer
+  # ABOVE the one arm 4 exists to isolate, and the arm would pass while the
+  # over-fire branch stayed unexercised. This is the witness row only that branch
+  # rejects. Shape: a grep for the delimiter, which is what a hand-rolled
+  # substitute for actionlint would be.
+  overfire)    echo "${targets[0]:-?}: unexpected end of input [expression]"; exit 1 ;;
+  wrong_reason)
+    if (( is_canary_bad )); then echo "canary: unrelated problem [syntax-check]"; exit 1; fi
+    exit 0 ;;
+  honest)      (( is_canary_bad )) && { echo "bad:10:61: unexpected end of input [expression]"; exit 1; }
+               exit 0 ;;
+  findings)    (( is_canary_bad )) && { echo "bad:10:61: unexpected end of input [expression]"; exit 1; }
+               (( is_canary_good )) && exit 0
+               echo ".github/workflows/x.yml:3:1: property not defined [syntax-check]"; exit 1 ;;
+  crash)       (( is_canary_bad )) && { echo "bad:10:61: unexpected end of input [expression]"; exit 1; }
+               (( is_canary_good )) && exit 0
+               echo "flag provided but not defined" >&2; exit 2 ;;
+esac
+STUB_EOF
+chmod +x "$STUB"
+
+# run_scan <mode> [args...] -> sets RC and OUT
+run_scan(){ local mode="$1"; shift
+  : > "$ARGV_LOG"
+  OUT="$(STUB_MODE="$mode" ARGV_LOG="$ARGV_LOG" ACTIONLINT_BIN="$STUB" bash "$SCAN" "$@" 2>&1)"; RC=$?
+}
+
+# --- arm 1: no binary is not a clean tree ------------------------------------
+OUT="$(ACTIONLINT_BIN="$TMP/definitely-not-installed" bash "$SCAN" 2>&1)"; RC=$?
+(( RC == 2 )) \
+  && ok "A1 a missing actionlint exits 2, not 0 (rc=$RC)" \
+  || no "A1 a missing actionlint must exit 2 — got rc=$RC: $OUT"
+grep -q 'REFUSING to report clean' <<<"$OUT" \
+  && ok "A1b it says it is refusing rather than reporting nothing" \
+  || no "A1b no refusal on stderr: $OUT"
+
+# --- arm 2: THE arm. A dead instrument must not produce a green ---------------
+# This is the failure mode a linter gate has by default: the binary runs, finds
+# nothing because it is looking at nothing, and the job goes green forever.
+run_scan dead
+(( RC == 2 )) \
+  && ok "A2 a binary that accepts the DIVE-2539 fixture exits 2 (rc=$RC)" \
+  || no "A2 a dead instrument must exit 2, never $RC — clean-on-nothing is the whole defect: $OUT"
+# A2b IS LOAD-BEARING, not message polish. Measured against a mutant that removes
+# the fire check: the dead stub's empty output then falls through to the signature
+# check, which refuses for its OWN reason — so A2 alone stays GREEN with the guard
+# it names deleted. The refusal STRING is the only thing that separates the two
+# layers here, which is the one case where asserting on a message is asserting on
+# the condition.
+grep -q 'CANARY DID NOT FIRE' <<<"$OUT" \
+  && ok "A2b the reason names the canary, not the adjacent guard" \
+  || no "A2b expected 'CANARY DID NOT FIRE': $OUT"
+
+# --- arm 3: fired, but not as an expression error ----------------------------
+run_scan wrong_reason
+(( RC == 2 )) \
+  && ok "A3 a canary rejected WITHOUT an [expression] finding exits 2 (rc=$RC)" \
+  || no "A3 rc!=0 alone must not satisfy the canary — got rc=$RC: $OUT"
+
+# --- arm 4: the isolating arm — a scanner that rejects everything ------------
+# Without this, arm 2 is satisfiable by `exit 1`, i.e. by a grep for the
+# delimiter — which would also reject this repo's own write-up of the hazard.
+run_scan overfire
+(( RC == 2 )) \
+  && ok "A4 a binary that also rejects the KNOWN-GOOD fixture exits 2 (rc=$RC)" \
+  || no "A4 over-firing must exit 2, not $RC — else the canary is a grep: $OUT"
+grep -q 'OVER-FIRES' <<<"$OUT" \
+  && ok "A4b the reason distinguishes over-firing from a real finding" \
+  || no "A4b expected 'OVER-FIRES': $OUT"
+
+# --- arms 5-7: the verdict mapping -------------------------------------------
+run_scan honest
+(( RC == 0 )) \
+  && ok "A5 canary fired + tree clean -> exit 0" \
+  || no "A5 expected 0, got $RC: $OUT"
+
+run_scan findings
+(( RC == 1 )) \
+  && ok "A6 canary fired + findings in the tree -> exit 1" \
+  || no "A6 expected 1, got $RC: $OUT"
+grep -q 'property not defined' <<<"$OUT" \
+  && ok "A6b the findings themselves reach stdout" \
+  || no "A6b findings were swallowed: $OUT"
+
+run_scan crash
+(( RC == 2 )) \
+  && ok "A7 a usage/internal error from the binary -> exit 2, not 1 (a crash is not a finding)" \
+  || no "A7 expected 2, got $RC: $OUT"
+
+# --- arm 8: an empty target set is not a clean tree --------------------------
+# Built as a real skeleton so the script's own ROOT resolution is what finds
+# nothing — asserting this through a flag would grade a path CI never takes.
+mkdir -p "$TMP/skel/scripts" "$TMP/skel/.github/workflows"
+cp "$SCAN" "$TMP/skel/scripts/"
+OUT="$(STUB_MODE=honest ARGV_LOG="$ARGV_LOG" ACTIONLINT_BIN="$STUB" \
+       ACTIONLINT_CANARY_BAD="$BAD" ACTIONLINT_CANARY_GOOD="$GOOD" \
+       bash "$TMP/skel/scripts/actionlint-scan.sh" 2>&1)"; RC=$?
+(( RC == 2 )) \
+  && ok "A8 an empty .github/workflows exits 2, not 0 (rc=$RC)" \
+  || no "A8 a renamed/emptied workflow dir must not read as clean — got rc=$RC: $OUT"
+
+# --- arm 9: the canary and the tree scan are the SAME invocation -------------
+run_scan honest
+canary_flags="$(awk '{f=""; for(i=1;i<=NF;i++) if ($i ~ /^-/) f=f" "$i; print f}' "$ARGV_LOG" | head -1)"
+tree_flags="$(awk '{f=""; for(i=1;i<=NF;i++) if ($i ~ /^-/) f=f" "$i; print f}' "$ARGV_LOG" | tail -1)"
+[[ -n "$canary_flags" && "$canary_flags" == "$tree_flags" ]] \
+  && ok "A9 canary and tree scan carry identical flags ($canary_flags)" \
+  || no "A9 flags differ — canary:'$canary_flags' tree:'$tree_flags'; the proof would be about another run"
+grep -q -- '-shellcheck=' <<<"$tree_flags" \
+  && ok "A9b shellcheck integration is OFF by default (three INFO findings in this tree today)" \
+  || no "A9b expected -shellcheck= in the default flags: $tree_flags"
+run_scan honest --with-shellcheck
+tree_flags="$(awk '{f=""; for(i=1;i<=NF;i++) if ($i ~ /^-/) f=f" "$i; print f}' "$ARGV_LOG" | tail -1)"
+grep -q -- '-shellcheck=' <<<"$tree_flags" \
+  && no "A9c --with-shellcheck must REMOVE the disabling flag: $tree_flags" \
+  || ok "A9c --with-shellcheck re-enables it — tightening is one flag, not a rewrite"
+
+# --- arm 10: the canary fixture must still be able to fail -------------------
+# The DIVE-2539 shape is precisely "valid YAML that Actions cannot parse". If the
+# fixture ever stops being valid YAML, or stops carrying the delimiter inside a
+# `run:` block, every arm above stays green while proving nothing.
+if python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$BAD" 2>/dev/null; then
+  ok "A10 the canary fixture is VALID YAML — it exercises the expression layer, not the YAML layer"
+else
+  no "A10 the canary fixture no longer parses as YAML; it would now fail for the wrong reason"
+fi
+# Inside a `run:` block scalar there are no comments as far as substitution is
+# concerned. Track block-scalar depth rather than grepping the whole file, so a
+# delimiter moved up to YAML level (where it is harmless) reds this arm.
+in_run_delim="$(awk '
+  /^[[:space:]]*run:[[:space:]]*[|>]/ { inrun=1; ind=match($0,/[^ ]/); next }
+  inrun && /[^[:space:]]/ { if (match($0,/[^ ]/) <= ind) inrun=0 }
+  inrun && /\$\{\{/ { n++ }
+  END { print n+0 }' "$BAD")"
+(( in_run_delim >= 1 )) \
+  && ok "A10b the canary carries an expression delimiter INSIDE a run: block ($in_run_delim)" \
+  || no "A10b the canary no longer carries the defect inside a run: block — it cannot fire"
+good_in_run="$(awk '
+  /^[[:space:]]*run:[[:space:]]*[|>]/ { inrun=1; ind=match($0,/[^ ]/); next }
+  inrun && /[^[:space:]]/ { if (match($0,/[^ ]/) <= ind) inrun=0 }
+  inrun && /\$\{\{/ { n++ }
+  END { print n+0 }' "$GOOD")"
+(( good_in_run == 0 )) && grep -q '\${{' "$GOOD" \
+  && ok "A10c the known-good fixture carries the delimiter only at YAML level — the discriminator holds" \
+  || no "A10c known-good fixture is not the discriminator it claims to be (in-run=$good_in_run)"
+
+# --- arm 11: the gate cannot be disarmed in CI -------------------------------
+if grep -rq -- '--no-canary' .github/workflows/; then
+  no "A11 a workflow passes --no-canary — that flag exists for this harness only and disarms the proof"
+else
+  ok "A11 no workflow passes --no-canary"
+fi
+if grep -rq 'scripts/actionlint-scan.sh' .github/workflows/; then
+  ok "A11b a workflow calls the shared scanner (no forked scan logic in CI)"
+else
+  no "A11b nothing in .github/workflows calls scripts/actionlint-scan.sh"
+fi
+
+# --- arm 12: the REAL binary, when there is one ------------------------------
+# The arms above grade our wrapper against a stub. Only this one grades the claim
+# the whole row rests on: that actionlint names THIS defect. Skipped, loudly,
+# where the binary is absent.
+REAL="${ACTIONLINT_REAL_BIN:-$(command -v actionlint 2>/dev/null || true)}"
+if [[ -x "$REAL" ]]; then
+  real_out="$("$REAL" -no-color -oneline -shellcheck= -pyflakes= "$BAD" 2>&1)"; real_rc=$?
+  { (( real_rc == 1 )) && grep -q '\[expression\]' <<<"$real_out"; } \
+    && ok "A12 real actionlint rejects the canary as an [expression] error" \
+    || no "A12 real actionlint did not name the defect (rc=$real_rc): $real_out"
+  "$REAL" -no-color -oneline -shellcheck= -pyflakes= "$GOOD" >/dev/null 2>&1 \
+    && ok "A12b real actionlint accepts the known-good fixture" \
+    || no "A12b real actionlint rejected a known-good workflow"
+  ACTIONLINT_BIN="$REAL" bash "$SCAN" >/dev/null 2>&1 \
+    && ok "A12c the tree in this checkout is clean under the real binary" \
+    || no "A12c the real scan is not clean on this tree"
+else
+  skip "A12 actionlint is not installed here — the real-binary arms did not run (CI installs a pinned copy)"
+fi
+
+printf '\n%s passed, %s failed, %s skipped\n' "$PASS" "$FAIL" "$SKIP"
+(( FAIL == 0 ))

--- a/tests/fixtures/actionlint/canary-expression-in-run-comment.yml
+++ b/tests/fixtures/actionlint/canary-expression-in-run-comment.yml
@@ -1,0 +1,12 @@
+name: actionlint-canary
+on: workflow_dispatch
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: The DIVE-2539 defect, preserved
+        env:
+          RELEASE_LEVEL: patch
+        run: |
+          # RELEASE_LEVEL comes from env, NOT from a ${{ }} template,
+          echo "$RELEASE_LEVEL"

--- a/tests/fixtures/actionlint/known-good-yaml-level-comment.yml
+++ b/tests/fixtures/actionlint/known-good-yaml-level-comment.yml
@@ -1,0 +1,15 @@
+name: actionlint-known-good
+on: workflow_dispatch
+jobs:
+  good:
+    runs-on: ubuntu-latest
+    steps:
+      - name: The SAFE half of the same distinction
+        env:
+          # a bare ${{ }} expansion inside `run:` is a script-injection site, so
+          # this value is passed through env instead. This `#` is a YAML comment:
+          # the YAML parser strips it before Actions is handed any value, so the
+          # delimiter above is never parsed as an expression.
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          printf '%s\n' "$EVENT_NAME"


### PR DESCRIPTION
Closes DIVE-2540.

## The hole

On 2026-08-02 an unparseable `release-cut.yml` sat on `main` for 45 minutes. `release-cut.yml` is the only writer of a version anywhere in the repo, so no nightly cut could have fired. Nothing objected:

- `python3 yaml.safe_load` **accepts** the file. It is valid YAML — Actions expression parsing is a second layer on top, and that is the layer that rejected it.
- Nothing in CI lints workflows. `shellcheck` runs over shell scripts, not over `run:` blocks.
- The failure names nothing: zero jobs, 0s, and `gh run view` says only "This run likely failed because of a workflow file issue." The check-runs and annotations APIs return nothing.

`actionlint` names it in one run: `unexpected end of input while parsing variable access, function call, null, bool, int, float or string [expression]`, with a byte offset resolving to the exact comment.

## What this adds

| file | what |
|---|---|
| `.github/workflows/actionlint.yml` | every PR + every push to `main`. actionlint 1.7.7 pinned by sha256, verified before it executes. No `paths:` filter — a path-filtered required check is *skipped*, not green. |
| `scripts/actionlint-scan.sh` | the one implementation, shared by CI and the pre-push hook so neither can drift. `0` clean / `1` findings / `2` could-not-scan. |
| `scripts/git-hooks/pre-push` | scans the **pushed revision** when a push touches `.github/workflows`. |
| `tests/actionlint_scan_unit.sh` | core tier, 0.23s. |
| `tests/fixtures/actionlint/` | the DIVE-2539 defect + a known-good YAML-level discriminator. |

## The design point: the canary

Every way this gate can break — missing binary, wrong binary, flags that lint nothing, an empty target set, a version whose expression rule moved — presents identically as **"no findings"**. So before the tree is scanned, the *same binary with the same flags* must **reject** the DIVE-2539 fixture as an `[expression]` error **and accept** the known-good fixture. Either way round is exit 2.

That second half is what stops the canary being satisfiable by a grep for the expression delimiter — which would have made our own write-up of the hazard unlandable.

## Why shellcheck integration is off by default

Baseline on a pristine tree: **0** findings with `-shellcheck=`; **3 INFO** findings with it on (`SC2015` ×2 in `release-cut.yml`, `SC2153` in `unit-tests.yml`). Landing red gets a gate disabled. `--with-shellcheck` tightens it later in one flag, not a rewrite.

## How it was checked

- Real actionlint on the fixture reproduces DIVE-2539 exactly (`10:61 [expression]`) while `yaml.safe_load` accepts the same file.
- Harness: **23 passed / 0 failed / 0 skipped** with a real actionlint on PATH; 20/0/1 without.
- **Mutation-graded, 7 mutants**, one per guard (canary-fire, over-fire, signature, empty-targets, missing-binary, default flags, crash mapping). Every one reds the harness. Notable: the canary-fire mutant left the exit-2 arm *green* because the next guard refused with the same code — so the refusal **string** is the only discriminator between two adjacent refusals.
- Pre-push hook proven end to end on a throwaway bare remote, with an isolating control: valid edit → pushed; one unparseable workflow → **blocked**, naming `:10:61 [expression]`; binary absent → loud fail-open skip; push touching no workflow file → guard never ran.

Wiki: `community/wiki/a-linter-gate-must-fire-in-the-run-you-trust.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
