### PR TITLE
feat(pack): export an agent as ONE AGENTS.md that codex/opencode read as-is (DIVE-2565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## Unreleased — feat(pack): export an agent as ONE AGENTS.md that codex and opencode read as-is (DIVE-2565)
+
+A tarball pack is a fine archive and a poor artefact: you cannot read it, diff it,
+paste it into a chat, or hand it to a harness that has never heard of 5dive. And
+every published pack hardcoded `config.type: "claude"` — the ONLY Claude-specific
+thing about the format. Memory is plain markdown and needs no porting at all.
+
+`5dive agent export <name> --format=agents-md [-o <path>]` renders the SAME staged
+pack as one markdown file that IS an AGENTS.md: YAML frontmatter carries the agent
+spec (type, model, effort, isolation, channels, skills, plugins), the body is the
+persona doc verbatim, and `--with-memory` adds fenced `## memory/<file>` sections.
+`5dive agent import <file.md>` splits it back. Since `AGENTS.md -> CLAUDE.md` is
+already the convention, the export degrades into something useful instead of a dead
+archive: drop it in a repo with no 5dive installed and codex or opencode reads it.
+
+**One renderer, not one adapter per harness.** Import explodes the file back into a
+v1 pack stage and re-tars it, so safe-extract, manifest validation, the DIVE-995
+disclosure, hook stripping, memory seeding and skill re-add all run on the identical
+path — one import flow, not two.
+
+**No new policy surface.** The renderer runs over the stage `cmd_export` already
+built, *after* the secret tripwire, so it inherits the deny-by-default
+{reference,project}-only memory scoping and the mandatory two-phase approve gate
+unchanged: `--format=agents-md --with-memory` still writes a draft and stops.
+
+Two things are deliberately not carried, and the file **says so** rather than
+dropping them silently — a silent drop was the failure mode to avoid:
+
+- **hooks**: arbitrary shell auto-run on tool events. A pasteable single file is the
+  worst possible carrier, and import strips hooks by default anyway (DIVE-995), so
+  carrying them would only ever be a trap. Export warns; frontmatter reads
+  `hooks: dropped`.
+- **avatar**: a PNG. A file whose whole value is being human-sized and pasteable
+  cannot carry it and base64 would defeat the point, so the frontmatter reads
+  `avatar: dropped` when there was one and `avatar: none` when there wasn't, and
+  export warns. `--format=pack` still carries the real `avatar.png`.
+- **skill bodies**: names travel as refs, exactly as the tarball manifest does.
+  Inlining bodies would balloon a file whose whole value is being human-sized. The
+  names stay visible in the frontmatter, are restated in a `## Skills` section that
+  states plainly that a harness with no skills directory installs none of them, and
+  import now warns **by name** for every skill it could not install.
+
+The memory-section filename is read off an HTML-comment sentinel and becomes a path,
+so it is validated against `^[A-Za-z0-9._-]+\.md$` — a traversal name is dropped
+while clean facts in the same file still land.
+
 ## Unreleased — fix(push): resolve the App installation PER REPO, not from one pinned id (DIVE-2563)
 
 `_push_do` minted every installation token against a single `GITHUB_APP_INSTALLATION_ID`

--- a/src/cmd_pack.sh
+++ b/src/cmd_pack.sh
@@ -774,8 +774,17 @@ _pack_usage() {
   cat <<USAGE
 5dive agent export / import — portable agent packs (DIVE-39)
 
-  5dive agent export <name> [--with-memory] [--approve-memory=<dir>] [--out=<path>]
-                                  # write a shareable pack (.tar.gz). Default = config only.
+  5dive agent export <name> [--format=pack|agents-md] [--with-memory]
+                            [--approve-memory=<dir>] [-o <path>|--out=<path>]
+                                  # write a shareable pack. Default = config only.
+                                  # --format=agents-md (DIVE-2565) writes ONE markdown
+                                  # file that IS an AGENTS.md: YAML frontmatter = the
+                                  # agent spec, body = the persona doc, memory as fenced
+                                  # '## memory/<file>' sections. Readable, diffable,
+                                  # pasteable — and codex/opencode read it as-is with no
+                                  # 5dive installed. Skills travel as NAMES not bodies and
+                                  # hooks are never carried; the file says both out loud.
+                                  # 'agent import <file.md>' splits it back.
                                   # --with-memory is a TWO-PHASE deny-by-default flow:
                                   #   1) export <name> --with-memory  -> writes a scoped persona
                                   #      DRAFT (only reference/project knowledge facts; private
@@ -889,20 +898,279 @@ _pack_scope_memory() {
   printf '%s %s\n' "$kept" "$excluded"
 }
 
+# -------- DIVE-2565: single-file agent export/import (AGENTS.md) -----------
+#
+# A tarball pack is a fine ARCHIVE and a poor ARTEFACT: you cannot read it, diff
+# it, paste it into a chat, or hand it to a harness that has never heard of
+# 5dive. This renders the very same staged pack as ONE markdown file that IS an
+# AGENTS.md — YAML frontmatter carrying the agent spec, the persona doc as the
+# body, and (opt-in) memory as fenced `## memory/<file>` sections.
+#
+# ONE RENDERER, NOT ONE ADAPTER PER HARNESS. Nothing in the format is
+# Claude-specific: `type` is a field, and memory is plain markdown that needs no
+# porting at all. `AGENTS.md -> CLAUDE.md` is already the convention, so codex or
+# opencode reads the export as-is with no 5dive installed — the file degrades
+# into something useful instead of a dead archive.
+#
+# SECURITY — this path invents NO new policy. It renders the stage cmd_export
+# already built, so it inherits, unchanged: the deny-by-default {reference,
+# project}-only memory scoping, the mandatory two-phase approve gate, and the
+# secret tripwire (which runs over the whole stage BEFORE we render). Two things
+# are deliberately NOT carried, and the file SAYS SO rather than dropping them
+# silently:
+#   - hooks: arbitrary shell auto-run on tool events. A pasteable single file is
+#     the worst possible carrier for it, and import already strips hooks by
+#     default anyway (DIVE-995), so carrying them would only ever be a trap.
+#   - skill BODIES: names travel as refs (exactly as the tarball manifest does).
+#     Inlining bodies would balloon a file whose whole value is being
+#     human-sized, and a harness with no skills directory still gets the NAMES —
+#     visible in the frontmatter, restated in a `## Skills` section, and warned
+#     about by name on import.
+AGENTS_MD_FORMAT_VERSION=1
+
+# Sentinels are HTML comments: invisible in every markdown renderer, ignored by
+# any harness reading the file as instructions, and exact for the parser — which
+# is what lets the persona body stay UNFENCED (codex must read it verbatim)
+# without its own `##` headings colliding with our section headings.
+AGENTS_MD_S_SKILLS='<!-- 5dive:skills -->'
+AGENTS_MD_S_MEMORY='<!-- 5dive:memory -->'
+
+# Longest tilde-fence in <file>, so we can open a longer one and contain content
+# that itself contains fences (memory facts routinely hold ``` code blocks).
+_agents_md_fence() {
+  local f="$1" n
+  n=$(grep -oE '^~{3,}' "$f" 2>/dev/null | awk '{ if (length($0) > m) m = length($0) } END { print m + 0 }')
+  (( n < 5 )) && n=5
+  printf '%*s\n' "$((n + 1))" '' | tr ' ' '~'
+}
+
+# Render a staged pack (the dir cmd_export builds) as one AGENTS.md on stdout.
+_agents_md_render() {
+  local stage="$1"
+  local mf="$stage/manifest.json"   # separate stmt: ${stage} aborts under set -u if same line
+  [[ -f "$mf" ]] || return 1
+
+  # Frontmatter. Every scalar goes through jq's @json: a JSON string is a valid
+  # YAML 1.2 double-quoted scalar, so this is exact quoting with no YAML emitter
+  # dependency — and it round-trips through `fromjson` on the parse side.
+  local hasav=false
+  [[ -f "$stage/avatar.png" ]] && hasav=true
+  jq -r --argjson amf "$AGENTS_MD_FORMAT_VERSION" --argjson hasav "$hasav" '
+    def s: if . == null or . == "" then "null" else (. | tostring | @json) end;
+    [ "---",
+      "agentsMdFormat: \($amf)",
+      "packFormat: \(.packFormat)",
+      "name: \(.agentName | s)",
+      "type: \(.config.type | s)",
+      "model: \(.config.model | s)",
+      "effort: \(.config.effort | s)",
+      "isolation: \(.config.isolation | s)",
+      "channels: \(.config.channels | s)",
+      "workdir: \(.config.workdir | s)",
+      "createdWith: \(.createdWith | s)",
+      "includesMemory: \(.includes.memory | if . == false then "false" else (. | @json) end)",
+      "hooks: dropped   # never carried by a single-file export (see Skills note)",
+      # The avatar is a PNG. A file whose whole value is being human-sized and
+      # pasteable cannot carry it, and base64 would defeat the point — but a
+      # QUIET drop is precisely the failure mode this format exists to avoid, so
+      # the absence is declared. Export --format=pack keeps the real avatar.png.
+      "avatar: \(if $hasav then "dropped   # binary; use --format=pack to carry avatar.png" else "none" end)"
+    ]
+    + (if ((.skills // []) | length) == 0 then ["skills: []"]
+       else ["skills:"] + ((.skills // []) | map("  - " + @json)) end)
+    + ["plugins: " + ((.plugins // []) | tojson), "---", ""]
+    | .[]' "$mf" || return 1
+
+  # Persona doc — verbatim and unfenced: this IS the AGENTS.md body a foreign
+  # harness reads as its instructions.
+  if [[ -f "$stage/CLAUDE.md" ]]; then
+    cat "$stage/CLAUDE.md"
+  else
+    printf '# %s\n\n(no persona document in this export)\n' "$(jq -r '.agentName // "agent"' "$mf")"
+  fi
+  printf '\n'
+
+  # Skills: names, never bodies — and say so, because a silent drop is the bad
+  # outcome for a harness that has no skills directory.
+  local nskills; nskills=$(jq -r '(.skills // []) | length' "$mf")
+  if (( nskills > 0 )); then
+    printf '%s\n' "$AGENTS_MD_S_SKILLS"
+    printf '## Skills\n\n'
+    printf 'This agent expects the skills below. They travel as NAMES, not bodies —\n'
+    printf 'the same refs the tarball pack records. `5dive agent import` re-installs\n'
+    printf 'them where it can and reports by name the ones it could not. On a harness\n'
+    printf 'with no skills directory (codex, opencode) NONE are installed: treat this\n'
+    printf 'list as the capabilities the agent was written to assume.\n\n'
+    jq -r '(.skills // [])[] | "- `" + . + "`"' "$mf"
+    printf '\n'
+  fi
+
+  # Memory: fenced, one section per fact, opt-in and already scoped upstream.
+  if [[ -d "$stage/memory" ]] && find "$stage/memory" -maxdepth 1 -name '*.md' 2>/dev/null | grep -q .; then
+    printf '%s\n' "$AGENTS_MD_S_MEMORY"
+    printf '# Memory\n\n'
+    printf 'Distilled persona memory, one fact per section. `5dive agent import`\n'
+    printf 'writes each back to `memory/<file>`; any other harness just reads them.\n\n'
+    local f base fence
+    while IFS= read -r f; do
+      base=$(basename "$f")
+      fence=$(_agents_md_fence "$f")
+      printf '<!-- 5dive:memory-file: %s -->\n' "$base"
+      printf '## memory/%s\n\n' "$base"
+      printf '%s\n' "$fence"
+      cat "$f"
+      # A fact not ending in a newline would swallow the closing fence.
+      [[ -n "$(tail -c1 "$f")" ]] && printf '\n'
+      printf '%s\n\n' "$fence"
+    done < <(find "$stage/memory" -maxdepth 1 -name '*.md' 2>/dev/null | sort)
+  fi
+}
+
+# Is <file> a 5dive single-file agent export? Anchored on the frontmatter key we
+# emit, so a persona.yaml or a plain hand-written AGENTS.md never misfires.
+_agents_md_is() {
+  local f="$1"
+  [[ -f "$f" ]] || return 1
+  [[ "$(head -c3 "$f" 2>/dev/null)" == "---" ]] || return 1
+  awk 'NR==1 && $0 != "---" { exit 1 }
+       NR>1 && /^---[[:space:]]*$/ { exit 1 }
+       NR>1 && /^agentsMdFormat:[[:space:]]*[0-9]+[[:space:]]*$/ { exit 0 }
+       NR>200 { exit 1 }' "$f"
+}
+
+# Explode a single-file export back into a pack STAGE at <outdir>: manifest.json,
+# CLAUDE.md, memory/*.md. Deliberately reconstructs a v1 pack rather than a
+# second import path, so everything downstream in cmd_import is untouched.
+_agents_md_explode() {
+  local file="$1" outdir="$2"
+  _agents_md_is "$file" || return 1
+  mkdir -p "$outdir" || return 1
+
+  # --- frontmatter -> manifest.json
+  local fm; fm=$(mktemp)
+  awk 'NR==1 { next } /^---[[:space:]]*$/ { exit } { print }' "$file" > "$fm"
+
+  local amf; amf=$(awk -F': *' '/^agentsMdFormat:/ { print $2; exit }' "$fm" | tr -d '[:space:]')
+  [[ "$amf" =~ ^[0-9]+$ ]] || { rm -f "$fm"; return 1; }
+  (( amf <= AGENTS_MD_FORMAT_VERSION )) || { rm -f "$fm"; return 1; }
+
+  # Scalars were emitted as JSON, so `fromjson` unquotes exactly; a human who
+  # hand-edited the file into a bare word still parses via the `// .` fallback.
+  _amd_get() {
+    awk -v k="$1" 'index($0, k ": ") == 1 { sub("^" k ": ", ""); sub(/[[:space:]]+#.*$/, ""); sub(/[[:space:]]+$/, ""); print; exit }' "$fm" \
+      | jq -r 'fromjson? // .' 2>/dev/null
+  }
+  local pf name type model effort iso channels workdir cwith meminc
+  pf=$(_amd_get packFormat);   [[ "$pf" =~ ^[0-9]+$ ]] || pf=1
+  name=$(_amd_get name); type=$(_amd_get type); model=$(_amd_get model)
+  effort=$(_amd_get effort); iso=$(_amd_get isolation); channels=$(_amd_get channels)
+  workdir=$(_amd_get workdir); cwith=$(_amd_get createdWith); meminc=$(_amd_get includesMemory)
+  local v; for v in name type model effort iso channels workdir cwith meminc; do
+    [[ "${!v}" == "null" ]] && printf -v "$v" '%s' ''
+  done
+  [[ -n "$name" && -n "$type" ]] || { rm -f "$fm"; unset -f _amd_get; return 1; }
+
+  # skills: block list OR inline `[]`.
+  local skills
+  skills=$(awk '/^skills:[[:space:]]*\[\][[:space:]]*$/ { exit }
+                /^skills:[[:space:]]*$/ { inl = 1; next }
+                inl && /^  - / { sub(/^  - /, ""); print; next }
+                inl { exit }' "$fm" | jq -Rc 'fromjson? // .' 2>/dev/null | jq -cs '.' 2>/dev/null)
+  [[ -n "$skills" ]] || skills='[]'
+  local plugins
+  plugins=$(awk 'index($0, "plugins: ") == 1 { sub(/^plugins: /, ""); print; exit }' "$fm")
+  # settings.json's enabledPlugins is an OBJECT map in the field
+  # ({"telegram@5dive-plugins":true}), not an array — an array-only check here
+  # silently DROPPED every real agent's plugins on round-trip. Accept either;
+  # cmd_import's `($plugins|length) > 0` works for both.
+  jq -e 'type == "array" or type == "object"' <<<"$plugins" >/dev/null 2>&1 || plugins='[]'
+  rm -f "$fm"; unset -f _amd_get
+
+  # A single-file export never carries hooks (see the header) — reconstruct an
+  # EMPTY hooks block rather than omitting the key, so the manifest stays v1-shaped.
+  jq -n --argjson fmt "$pf" --arg name "$name" --arg ver "$cwith" \
+        --arg type "$type" --arg iso "$iso" --arg ch "$channels" --arg wd "$workdir" \
+        --arg model "$model" --arg effort "$effort" --arg mem "$meminc" \
+        --argjson skills "$skills" --argjson plugins "$plugins" '
+    def n: if . == "" then null else . end;
+    { packFormat: $fmt, agentName: $name, createdWith: $ver,
+      includes: { memory: (if $mem == "" or $mem == "false" then false else $mem end), persona: false },
+      config: { type: $type, isolation: ($iso | n), channels: (if $ch == "" then "none" else $ch end),
+                workdir: ($wd | n), authProfile: null, model: ($model | n), effort: ($effort | n) },
+      plugins: $plugins, skills: $skills, hooks: {} }' > "$outdir/manifest.json" || return 1
+
+  # --- persona body: everything between the frontmatter and the first sentinel.
+  awk -v sk="$AGENTS_MD_S_SKILLS" -v me="$AGENTS_MD_S_MEMORY" '
+    NR == 1 { next }
+    !seen && /^---[[:space:]]*$/ { seen = 1; next }
+    !seen { next }
+    $0 == sk || $0 == me { exit }
+    # Drop the blank line the renderer puts after the closing "---" (and any
+    # others), so render->explode->render is byte-stable on the persona doc.
+    !started && /^[[:space:]]*$/ { next }
+    { started = 1; print }' "$file" > "$outdir/CLAUDE.md"
+  # Trim the blank lines the renderer padded with, so a render->parse->render
+  # round-trip is byte-stable.
+  awk 'BEGIN { RS = "\0" } { sub(/\n+$/, "\n"); printf "%s", $0 }' "$outdir/CLAUDE.md" > "$outdir/.cm" \
+    && mv "$outdir/.cm" "$outdir/CLAUDE.md"
+  [[ -s "$outdir/CLAUDE.md" ]] || rm -f "$outdir/CLAUDE.md"
+
+  # --- memory sections. The filename comes off the sentinel and is validated
+  # here: it becomes a path, and this file may have crossed a trust boundary.
+  if grep -qxF "$AGENTS_MD_S_MEMORY" "$file"; then
+    mkdir -p "$outdir/memory"
+    awk -v me="$AGENTS_MD_S_MEMORY" -v dir="$outdir/memory" '
+      $0 == me { inmem = 1; next }
+      !inmem { next }
+      /^<!-- 5dive:memory-file: .* -->$/ {
+        f = $0; sub(/^<!-- 5dive:memory-file: /, "", f); sub(/ -->$/, "", f)
+        # Reject anything that is not a plain <name>.md — no traversal, no path.
+        if (f !~ /^[A-Za-z0-9._-]+\.md$/ || f ~ /^\.\.?$/ || index(f, "..") > 0) { cur = ""; next }
+        cur = dir "/" f; printf "" > cur; body = 0; fence = ""; next
+      }
+      cur == "" { next }
+      fence == "" && /^~{3,}[[:space:]]*$/ { fence = $0; sub(/[[:space:]]+$/, "", fence); body = 1; next }
+      body && $0 == fence { cur = ""; fence = ""; body = 0; next }
+      body { print >> cur }' "$file"
+    find "$outdir/memory" -maxdepth 1 -name '*.md' 2>/dev/null | grep -q . || rm -rf "$outdir/memory"
+  fi
+  return 0
+}
+
+# Explode + re-tar into a v1 pack tarball; echoes the path. cmd_import then runs
+# its existing safe-extract / manifest-validation / disclosure path over it, so a
+# single-file import is graded by exactly the same gates as a tarball import.
+_agents_md_to_pack() {
+  local file="$1" stage tgz
+  stage=$(mktemp -d) || return 1
+  if ! _agents_md_explode "$file" "$stage"; then rm -rf "$stage"; return 1; fi
+  tgz=$(mktemp -u /tmp/5dive-agentsmd-XXXXXX.tar.gz)
+  if ! tar -czf "$tgz" -C "$stage" . 2>/dev/null; then rm -rf "$stage" "$tgz"; return 1; fi
+  rm -rf "$stage"
+  printf '%s\n' "$tgz"
+}
+
 cmd_export() {
   require_root
-  local name="" with_memory=0 out="" approve_memory=""
+  local name="" with_memory=0 out="" approve_memory="" format="pack"
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --with-memory)      with_memory=1 ;;
       --approve-memory=*) approve_memory="${1#--approve-memory=}"; with_memory=1 ;;
       --out=*)            out="${1#--out=}" ;;
+      # DIVE-2565: -o is the spelling the single-file flow is documented with.
+      -o)                 shift; [[ $# -gt 0 ]] || fail "$E_USAGE" "-o needs a path"; out="$1" ;;
+      --format=*)         format="${1#--format=}" ;;
       -*)                 fail "$E_USAGE" "unknown flag: $1" ;;
       *)                  [[ -z "$name" ]] && name="$1" || fail "$E_USAGE" "extra arg: $1" ;;
     esac
     shift
   done
-  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent export <name> [--with-memory] [--approve-memory=<dir>] [--out=<path>]"
+  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent export <name> [--format=pack|agents-md] [--with-memory] [--approve-memory=<dir>] [-o <path>]"
+  case "$format" in
+    pack|agents-md) ;;
+    *) fail "$E_USAGE" "unknown --format '$format' (known: pack, agents-md)" ;;
+  esac
   require_agent "$name"
   local user="agent-${name}" cdir="/home/agent-${name}/.claude"
 
@@ -1041,6 +1309,27 @@ cmd_export() {
     fail "$E_GENERIC" "refusing to export: a staged file looks like it contains a secret (safety tripwire). Nothing written."
   fi
 
+  # DIVE-2565: same stage, different container. Renders AFTER the tripwire above,
+  # so the single-file export can never carry something the tarball would refuse.
+  if [[ "$format" == "agents-md" ]]; then
+    [[ -n "$out" ]] || out="/tmp/${name}-AGENTS.md"
+    if ! _agents_md_render "$stage" > "$out"; then
+      rm -f "$out"; rm -rf "$stage" "$mem_tmp"
+      fail "$E_GENERIC" "failed to render the single-file export"
+    fi
+    chmod 644 "$out"
+    local n_hooks; n_hooks=$(jq -r '(.hooks // {}) | length' "$stage/manifest.json" 2>/dev/null || echo 0)
+    rm -rf "$stage"; [[ -n "$mem_tmp" ]] && rm -rf "$mem_tmp"
+    (( has_avatar )) && warn "dropped the avatar (binary): a single-file export carries no image — use --format=pack to keep avatar.png"
+    (( n_hooks > 0 )) && warn "dropped $n_hooks hook block(s): a single-file export never carries arbitrary shell (export --format=pack if you need them)"
+    local skill_n; skill_n=$(jq -r 'length' <<<"$skills" 2>/dev/null || echo 0)
+    (( skill_n > 0 )) && warn "skills travel as NAMES, not bodies ($skill_n listed in the file) — a harness with no skills directory installs none of them; the file says so"
+    ok "exported '$name' as a single-file AGENTS.md (memory: $mem_inc) -> $out" \
+       '{name:$n, file:$o, format:"agents-md", agentsMdFormat:$f, withMemory:($m != "false"), memory:$m, skills:$s, hooks:"dropped"}' \
+       --arg n "$name" --arg o "$out" --argjson f "$AGENTS_MD_FORMAT_VERSION" --arg m "$mem_inc" --argjson s "$skills"
+    return 0
+  fi
+
   [[ -n "$out" ]] || out="/tmp/${name}-pack-v${PACK_FORMAT_VERSION}.tar.gz"
   tar -czf "$out" -C "$stage" . 2>/dev/null || { rm -rf "$stage" "$mem_tmp"; fail "$E_GENERIC" "failed to write pack tarball"; }
   chmod 644 "$out"
@@ -1111,6 +1400,18 @@ cmd_import() {
   fi
   [[ -n "$pack" ]] || fail "$E_USAGE" "usage: 5dive agent import <pack>|--from-persona=<file.persona.yaml> --as=<name> [--type=claude] [--channels=...] [--telegram-token=...] [--discord-token=...] [--auth-profile=...] [--workdir=...]"
 
+  # DIVE-2565: a single-file AGENTS.md export is a pack too. Explode it back into
+  # a v1 stage and re-tar, so EVERYTHING below — safe-extract, manifest
+  # validation, the DIVE-995 disclosure, hook stripping, memory seeding, skill
+  # re-add — runs on the identical path. One import flow, not two.
+  local md_tmp=""
+  if [[ -f "$pack" ]] && _agents_md_is "$pack"; then
+    step "Reading single-file agent export '$pack' (AGENTS.md)"
+    md_tmp=$(_agents_md_to_pack "$pack") \
+      || fail "$E_VALIDATION" "could not parse '$pack' as a 5dive single-file agent export"
+    pack="$md_tmp"
+  fi
+
   # A bare slug (not a local file) → resolve from the character-pack git registry.
   local resolved_tmp=""
   if [[ ! -f "$pack" ]]; then
@@ -1132,11 +1433,12 @@ cmd_import() {
 
   # Unpack into an isolated stage and validate the manifest before touching anything.
   local stage; stage=$(mktemp -d)
-  _pack_safe_extract "$pack" "$stage" || { local rc=$?; rm -rf "$stage" "$resolved_tmp" "$persona_tmp"
+  _pack_safe_extract "$pack" "$stage" || { local rc=$?; rm -rf "$stage" "$resolved_tmp" "$persona_tmp" "$md_tmp"
     (( rc == 2 )) && fail "$E_VALIDATION" "pack rejected: contains unsafe members (path traversal, absolute paths, or sym/hardlinks), refusing to extract"
     fail "$E_GENERIC" "could not read pack (expected a .tar.gz from 'agent export')"; }
   [[ -n "$resolved_tmp" ]] && rm -f "$resolved_tmp"
   [[ -n "$persona_tmp" ]] && rm -f "$persona_tmp"
+  [[ -n "$md_tmp" ]] && rm -f "$md_tmp"
   [[ -f "$stage/manifest.json" ]] \
     || { rm -rf "$stage"; fail "$E_VALIDATION" "pack has no manifest.json — not a 5dive agent pack"; }
 
@@ -1423,6 +1725,12 @@ cmd_import() {
       skipped+=("$sk")
     fi
   done < <(jq -r '.skills[]? // empty' "$stage/manifest.json")
+
+  # DIVE-2565: a silent skill drop is the bad outcome the single-file format was
+  # explicitly not allowed to have. Name them, on every harness.
+  if (( ${#skipped[@]} > 0 )); then
+    warn "skills NOT installed on this '$type' agent: ${skipped[*]} — the agent's instructions still assume them"
+  fi
 
   rm -rf "$stage"
 

--- a/tests/pack_agents_md_unit.sh
+++ b/tests/pack_agents_md_unit.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# DIVE-2565 isolated unit harness for the single-file agent export (AGENTS.md).
+#
+# Sources src/ libs directly (no root, no network, no agent user) and grades the
+# two PURE halves of the feature against a hand-built pack stage:
+#   1. _agents_md_render  — stage -> one markdown file (frontmatter + persona
+#      body + skills note + fenced memory sections).
+#   2. _agents_md_explode — that file -> a v1 pack stage again.
+# The round-trip is the real assertion: import reuses cmd_import's existing path
+# on the re-tarred stage, so if explode reconstructs a faithful v1 stage the rest
+# of the import is already covered by the tarball tests.
+# Run: bash tests/pack_agents_md_unit.sh
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades. NOTE the absence of 2>/dev/null —
+# redirecting the source's stderr also swallows the helper's own stderr payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/agents-md-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+# cmd_pack.sh is function-defs-only at source time.
+# shellcheck source=/dev/null
+source "$SRC/cmd_pack.sh"
+
+JSON_MODE=1
+set +e   # header.sh enabled `set -e`; tests deliberately probe non-zero paths
+
+PASS=0; FAIL=0
+ok_()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad_()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+check() { if [[ "$2" == "$3" ]]; then ok_ "$1"; else bad_ "$1 (want [$3] got [$2])"; fi; }
+truthy(){ if (( $2 == 0 )); then ok_ "$1"; else bad_ "$1"; fi; }
+
+# ---------------------------------------------------------------- fixtures ---
+# Persona body deliberately contains markdown that could collide with the
+# format: a '## Skills' heading of its own, a '---' rule, and a fenced block.
+STAGE="$TMP/stage"; mkdir -p "$STAGE/memory"
+cat > "$STAGE/CLAUDE.md" <<'EOF'
+# Ada
+
+You are **Ada**, a research engineer.
+
+---
+
+## Skills
+
+She writes her own headings, and they must survive verbatim.
+
+```bash
+echo "a fenced block inside the persona doc"
+```
+EOF
+# A memory fact that itself holds BOTH fence styles — the renderer must open a
+# fence long enough to contain them.
+cat > "$STAGE/memory/reference_thing.md" <<'EOF'
+---
+name: reference_thing
+description: a reference fact
+metadata:
+  type: reference
+---
+
+Body with a fence:
+
+```
+inner backticks
+```
+
+~~~~~
+inner tildes
+~~~~~
+EOF
+cat > "$STAGE/memory/project_other.md" <<'EOF'
+---
+name: project_other
+description: a project fact
+metadata:
+  type: project
+---
+
+Second fact.
+EOF
+# Hooks are present in the source stage on purpose: the single-file format must
+# drop them, and the drop must be observable.
+printf 'not-really-a-png' > "$STAGE/avatar.png"   # presence is what the renderer reads
+jq -n '{
+  packFormat: 1, agentName: "ada", createdWith: "0.99.0",
+  includes: { memory: "distilled", persona: true },
+  config: { type: "claude", isolation: "standard", channels: "telegram",
+            workdir: "/home/claude/projects/x", authProfile: "ada",
+            model: "claude-opus-5", effort: "high" },
+  plugins: ["telegram"], skills: ["deep-research", "code-review"],
+  hooks: { PostToolUse: [{ command: "echo hi" }] }
+}' > "$STAGE/manifest.json"
+
+# ------------------------------------------------------------------ render ---
+MD="$TMP/AGENTS.md"
+_agents_md_render "$STAGE" > "$MD"; truthy "render exits 0" $?
+truthy "render produced a file" $([[ -s "$MD" ]]; echo $?)
+
+check "frontmatter opens on line 1" "$(head -1 "$MD")" "---"
+truthy "frontmatter carries agentsMdFormat" $(grep -qx 'agentsMdFormat: 1' "$MD"; echo $?)
+truthy "frontmatter carries the type (the ONE field that made packs claude-only)" \
+  $(grep -qx 'type: "claude"' "$MD"; echo $?)
+truthy "frontmatter carries the model"   $(grep -qx 'model: "claude-opus-5"' "$MD"; echo $?)
+truthy "frontmatter lists skills as a block list" $(grep -qx '  - "deep-research"' "$MD"; echo $?)
+truthy "hooks are declared dropped, not omitted" $(grep -q '^hooks: dropped' "$MD"; echo $?)
+# The avatar is a PNG this format cannot carry. Dropping it is fine; dropping it
+# SILENTLY is the one thing the format forbids, so grade the DECLARATION — with
+# both arms, or "says dropped" would also pass on a stage that has no avatar.
+truthy "an avatar present in the stage is declared dropped, not omitted" $(grep -q "^avatar: dropped" "$MD"; echo $?)
+truthy "the file STATES that skills are names not bodies" \
+  $(grep -q 'travel as NAMES, not bodies' "$MD"; echo $?)
+truthy "memory sections are human-readable headings" \
+  $(grep -qx '## memory/reference_thing.md' "$MD"; echo $?)
+# Non-vacuity for the tripwire below: the fixture really does hold both fences.
+truthy "fixture memory really contains an inner ~~~~~ fence" \
+  $(grep -qx '~~~~~' "$STAGE/memory/reference_thing.md"; echo $?)
+
+# ----------------------------------------------------------------- detect ----
+truthy "_agents_md_is accepts our own export" $(_agents_md_is "$MD"; echo $?)
+printf -- '---\nname: notmine\n---\n\nhello\n' > "$TMP/other.md"
+_agents_md_is "$TMP/other.md"; check "_agents_md_is rejects a foreign frontmatter doc" "$?" "1"
+printf '# plain\n\nno frontmatter\n' > "$TMP/plain.md"
+_agents_md_is "$TMP/plain.md"; check "_agents_md_is rejects a plain markdown file" "$?" "1"
+_agents_md_is "$TMP/nope.md"; check "_agents_md_is rejects a missing file" "$?" "1"
+
+# ---------------------------------------------------------------- explode ----
+OUT="$TMP/out"
+_agents_md_explode "$MD" "$OUT"; truthy "explode exits 0" $?
+truthy "explode wrote a manifest" $([[ -f "$OUT/manifest.json" ]]; echo $?)
+
+check "packFormat round-trips" "$(jq -r '.packFormat' "$OUT/manifest.json")" "1"
+check "agentName round-trips"  "$(jq -r '.agentName' "$OUT/manifest.json")" "ada"
+check "type round-trips"       "$(jq -r '.config.type' "$OUT/manifest.json")" "claude"
+check "model round-trips"      "$(jq -r '.config.model' "$OUT/manifest.json")" "claude-opus-5"
+check "effort round-trips"     "$(jq -r '.config.effort' "$OUT/manifest.json")" "high"
+check "isolation round-trips"  "$(jq -r '.config.isolation' "$OUT/manifest.json")" "standard"
+check "channels round-trips"   "$(jq -r '.config.channels' "$OUT/manifest.json")" "telegram"
+check "workdir round-trips"    "$(jq -r '.config.workdir' "$OUT/manifest.json")" "/home/claude/projects/x"
+check "memory mode round-trips as the value cmd_import accepts" \
+  "$(jq -r '.includes.memory' "$OUT/manifest.json")" "distilled"
+check "skills round-trip in order" \
+  "$(jq -rc '.skills' "$OUT/manifest.json")" '["deep-research","code-review"]'
+check "plugins round-trip" "$(jq -rc '.plugins' "$OUT/manifest.json")" '["telegram"]'
+# The security half: hooks were in the source stage and must NOT survive.
+check "hooks did NOT survive the single-file round-trip" \
+  "$(jq -rc '.hooks' "$OUT/manifest.json")" '{}'
+
+# The persona doc is what a foreign harness actually executes — byte-identical or
+# the format is a lossy rewrite, not an export.
+if diff -q "$STAGE/CLAUDE.md" "$OUT/CLAUDE.md" >/dev/null 2>&1; then
+  ok_ "persona doc is byte-identical through render->explode"
+else
+  bad_ "persona doc DIFFERS through render->explode"; diff "$STAGE/CLAUDE.md" "$OUT/CLAUDE.md" | head -20
+fi
+
+for m in reference_thing.md project_other.md; do
+  if diff -q "$STAGE/memory/$m" "$OUT/memory/$m" >/dev/null 2>&1; then
+    ok_ "memory/$m is byte-identical (fence containment holds)"
+  else
+    bad_ "memory/$m DIFFERS"; diff "$STAGE/memory/$m" "$OUT/memory/$m" | head -20
+  fi
+done
+
+# ------------------------------------------------------- traversal refusal ---
+# The memory filename comes off a sentinel in a file that may have crossed a
+# trust boundary, and it becomes a path. A hostile name must be refused — and the
+# arm is differential: a CLEAN name in the same file must still land, otherwise
+# "no file escaped" would also be true of a parser that simply did nothing.
+EVIL="$TMP/evil.md"
+{
+  printf -- '---\nagentsMdFormat: 1\npackFormat: 1\nname: "x"\ntype: "claude"\n'
+  printf 'includesMemory: "distilled"\nskills: []\nplugins: []\n---\n\nbody\n\n'
+  printf '%s\n# Memory\n\n' "$AGENTS_MD_S_MEMORY"
+  printf '<!-- 5dive:memory-file: ../../../../tmp/pwned-%s.md -->\n' "$$"
+  printf '## memory/evil\n\n~~~~~\nowned\n~~~~~\n\n'
+  printf '<!-- 5dive:memory-file: clean_fact.md -->\n'
+  printf '## memory/clean_fact.md\n\n~~~~~\nfine\n~~~~~\n'
+} > "$EVIL"
+EOUT="$TMP/eout"
+_agents_md_explode "$EVIL" "$EOUT"; truthy "explode of a hostile file still exits 0" $?
+truthy "traversal target was NOT written" $([[ ! -e "/tmp/pwned-$$.md" ]]; echo $?)
+truthy "LIVENESS: the clean fact in the SAME file WAS written" \
+  $([[ -f "$EOUT/memory/clean_fact.md" ]]; echo $?)
+truthy "hostile section body did not leak into the clean fact" \
+  $(! grep -q owned "$EOUT/memory/clean_fact.md" 2>/dev/null; echo $?)
+rm -f "/tmp/pwned-$$.md"
+
+# ------------------------------------------------------------ no-memory arm ---
+# A config-only export must produce a file with NO memory sections at all, and
+# explode must report memory:false so cmd_import takes its config-pack branch.
+S2="$TMP/stage2"; mkdir -p "$S2"
+cp "$STAGE/CLAUDE.md" "$S2/CLAUDE.md"
+jq -n '{ packFormat: 1, agentName: "bo", createdWith: "0.99.0",
+         includes: { memory: false, persona: false },
+         config: { type: "codex", isolation: "standard", channels: "none",
+                   workdir: null, authProfile: null, model: null, effort: null },
+         plugins: [], skills: [], hooks: {} }' > "$S2/manifest.json"
+MD2="$TMP/AGENTS2.md"; _agents_md_render "$S2" > "$MD2"
+truthy "config-only export has NO memory sentinel" \
+  $(! grep -qxF "$AGENTS_MD_S_MEMORY" "$MD2"; echo $?)
+truthy "config-only export has NO skills section (there are none)" \
+  $(! grep -qxF "$AGENTS_MD_S_SKILLS" "$MD2"; echo $?)
+truthy "skills: [] renders inline (valid YAML for an empty seq)" \
+  $(grep -qx 'skills: \[\]' "$MD2"; echo $?)
+truthy "a stage with NO avatar says none, not dropped (differential arm)" $(grep -qx "avatar: none" "$MD2"; echo $?)
+O2="$TMP/out2"; _agents_md_explode "$MD2" "$O2"
+check "a non-claude type survives (the whole point)" \
+  "$(jq -r '.config.type' "$O2/manifest.json")" "codex"
+check "config-only reports memory:false, so import takes the config-pack branch" \
+  "$(jq -r '.includes.memory' "$O2/manifest.json")" "false"
+check "null model stays null (not the string \"null\")" \
+  "$(jq -r '.config.model' "$O2/manifest.json")" "null"
+truthy "no memory dir materialised" $([[ ! -d "$O2/memory" ]]; echo $?)
+
+# ------------------------------------------------- plugins as an OBJECT map ---
+# The fixture above uses an array, which is the shape a hand-written manifest
+# takes. A REAL agent's settings.json carries enabledPlugins as an OBJECT
+# ({"telegram@5dive-plugins":true}) — an array-only parse dropped it silently,
+# and only a live export surfaced that. Grade the real shape.
+S3="$TMP/stage3"; mkdir -p "$S3"; printf '# Bo\n' > "$S3/CLAUDE.md"
+jq -n '{ packFormat: 1, agentName: "bo", createdWith: "0.99.0",
+         includes: { memory: false, persona: false },
+         config: { type: "claude", isolation: "admin", channels: "telegram",
+                   workdir: "/w", authProfile: null, model: "opus", effort: "xhigh" },
+         plugins: { "telegram@5dive-plugins": true }, skills: [], hooks: {} }' > "$S3/manifest.json"
+MD3="$TMP/AGENTS3.md"; _agents_md_render "$S3" > "$MD3"
+O3="$TMP/out3"; _agents_md_explode "$MD3" "$O3"
+check "an OBJECT-map plugins block survives the round-trip" \
+  "$(jq -rc '.plugins' "$O3/manifest.json")" '{"telegram@5dive-plugins":true}'
+check "and stays non-empty, so cmd_import's length>0 branch still fires" \
+  "$(jq -r '.plugins | length' "$O3/manifest.json")" "1"
+check "a bare model ALIAS survives verbatim (import resolves it, not us)" \
+  "$(jq -r '.config.model' "$O3/manifest.json")" "opus"
+
+# ------------------------------------------------------------------ to-pack ---
+TGZ=$(_agents_md_to_pack "$MD"); truthy "_agents_md_to_pack exits 0" $?
+truthy "to_pack wrote a tarball" $([[ -s "$TGZ" ]]; echo $?)
+# cmd_import always mktemp -d's the stage before calling this; tar -C needs it.
+mkdir -p "$TMP/x"
+truthy "the tarball is what _pack_safe_extract accepts" \
+  $(_pack_safe_extract "$TGZ" "$TMP/x" >/dev/null 2>&1; echo $?)
+check "extracted manifest is the same one" "$(jq -r '.agentName' "$TMP/x/manifest.json")" "ada"
+rm -f "$TGZ"
+
+printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$PASS" "$FAIL"
+(( FAIL == 0 ))


### PR DESCRIPTION
## What

`5dive agent export <name> --format=agents-md [-o <path>]` renders an agent as **one markdown file that IS an AGENTS.md**; `5dive agent import <file.md>` splits it back.

The gap this closes was one field and one renderer: every published pack hardcodes `config.type: "claude"`. Nothing else about packFormat 1 is Claude-specific — memory is plain markdown and needs no porting at all.

- **Frontmatter** = the agent spec (`type`, `model`, `effort`, `isolation`, `channels`, `workdir`, `skills`, `plugins`).
- **Body** = the persona doc, verbatim and unfenced, because that is what a foreign harness reads as its instructions.
- **Memory** = fenced `## memory/<file>` sections, opt-in via `--with-memory`.

Since `AGENTS.md -> CLAUDE.md` is already the convention, the export degrades into something useful instead of a dead archive: drop it in a repo with no 5dive installed and codex or opencode reads it as-is.

## One renderer, not one adapter per harness

Import explodes the file back into a **v1 pack stage** and re-tars it, so `_pack_safe_extract`, manifest validation, the DIVE-995 disclosure, hook stripping, memory seeding and skill re-add all run on the **identical** path. One import flow, not two.

## No new policy surface

The renderer runs over the stage `cmd_export` already built, **after** `_pack_secret_tripwire`, so it inherits unchanged: the deny-by-default `{reference,project}`-only memory scoping and the mandatory two-phase approve gate. `--format=agents-md --with-memory` still writes a draft and stops.

## Three things are deliberately not carried, and the file says so

A silent drop was the failure mode the row explicitly forbade.

| | why | what the file says |
|---|---|---|
| **hooks** | arbitrary shell auto-run on tool events; a pasteable single file is the worst carrier, and import strips hooks by default anyway | `hooks: dropped`, plus an export warning |
| **skill bodies** | inlining would balloon a file whose whole value is being human-sized | frontmatter lists the names; a `## Skills` section states that a harness with no skills directory installs **none** of them; import now warns **by name** per skill it could not install |
| **avatar** | a PNG; base64 would defeat the point | `avatar: dropped` when there was one, `avatar: none` when there wasn't, plus a warning |

## Security

The memory-section filename is read off an HTML-comment sentinel and **becomes a path**, so it is validated against `^[A-Za-z0-9._-]+\.md$`. The traversal arm is differential: a hostile name is dropped **while a clean fact in the same file still lands**, so "nothing escaped" cannot pass on a parser that simply did nothing.

## How it was checked

`tests/pack_agents_md_unit.sh` — **52 passed, 0 failed**, 0.92s (core tier). Round-trip equality on the persona doc and every memory fact, hooks-do-not-survive, traversal refusal + liveness, and a config-only arm on a **codex** type.

Live on this host, not just in the harness:
- Real export of a live agent; persona doc **byte-identical** to its `~/.claude/CLAUDE.md`.
- Real import onto a fresh agent: model alias `opus` resolved to `claude-opus-5`, object-map `enabledPlugins` landed in `settings.json`, skill-drop warning fired **by name**, `hooks: none`. Torn down after.
- The memory approve-gate fires on this path and refuses with *"Nothing written"*.

**A live export caught a bug the fixture hid:** `enabledPlugins` is an **object map** in real settings, not an array, and an array-only parse dropped it silently on round-trip. Fixed, with an arm at the real shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
