### PR TITLE
fix(tests): enable pipefail in graded harnesses so internal pipe failures aren't swallowed (DIVE-2559)

### DIFF
--- a/tests/compose_asleep_report_unit.sh
+++ b/tests/compose_asleep_report_unit.sh
@@ -23,7 +23,7 @@
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
-set +e
+set +e -o pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"

--- a/tests/constitution_init_e2e.sh
+++ b/tests/constitution_init_e2e.sh
@@ -8,7 +8,7 @@
 #     HARD-refused even with --force (route to council amend / constitution edit).
 # Needs NO gate-proof key (init never seals) so a hand-synthesized sealed lineage exercises the
 # refusal root-free — this GATES in CI. SKIPs green when node/jq missing or build fails. Exit 0 == green.
-set -u
+set -uo pipefail
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry

--- a/tests/constitution_legacy_migration_e2e.sh
+++ b/tests/constitution_legacy_migration_e2e.sh
@@ -6,7 +6,7 @@
 # revert to built-in defaults after upgrading to a post-rename build. Exercises the BUILT binary via
 # `constitution show --json` (the READ verb resolves the path the same way every reader does).
 # SKIPs green when node/jq missing or the build fails. Exit 0 == green.
-set -u
+set -uo pipefail
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry

--- a/tests/constitution_show_e2e.sh
+++ b/tests/constitution_show_e2e.sh
@@ -6,7 +6,7 @@
 # (sealedDigest + amendment receipts), and DRIFT detection. The READ path needs NO gate-proof key
 # (only WRITE/verify do), so a hand-synthesized lineage exercises the sealed case root-free — this
 # GATES in CI. SKIPs green when node/jq missing or the build fails. Exit 0 == green.
-set -u
+set -uo pipefail
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry

--- a/tests/council_ballot_e2e.sh
+++ b/tests/council_ballot_e2e.sh
@@ -8,7 +8,7 @@
 # unsealed receipt is a valid convene (exit 0), and a FAKE `5dive` at COUNCIL_5DIVE_BIN stands in
 # for the fleet (agent list / task add / task show / agent ask). SKIPs green when node/jq are
 # missing or the build fails. Exit 0 == green.
-set -u
+set -uo pipefail
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry

--- a/tests/council_ballot_tap_e2e.sh
+++ b/tests/council_ballot_tap_e2e.sh
@@ -8,7 +8,7 @@
 # FAKE `5dive` at COUNCIL_5DIVE_BIN stands in for the board: `task ls --json` returns one OPEN human
 # ballot whose body carries nonceDigest=sha256(NONCE); `task done` is logged. SKIPs green when node/
 # jq/sha256sum are missing or the build fails. Exit 0 == green.
-set -u
+set -uo pipefail
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry

--- a/tests/council_bashroute_e2e.sh
+++ b/tests/council_bashroute_e2e.sh
@@ -12,7 +12,7 @@
 # It builds a throwaway ./5dive to a temp dir (build.sh is pure-bash + fast, honours BUILD_OUT) so
 # it GATES in CI too (CI never builds ./5dive, and no root/sudo/seal is needed — these verbs are
 # pure). SKIPs green only when node/jq/openssl are missing or the build fails. Exit 0 == green.
-set -u
+set -uo pipefail
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry

--- a/tests/council_cosign_e2e.sh
+++ b/tests/council_cosign_e2e.sh
@@ -2,7 +2,7 @@
 # CNCL-10 co-signed-votes E2E — exercises the real `council sign-vote` / `verify-votes` CLI over
 # REAL on-disk Ed25519 keys and proves: keys are 0600 owner-only, the honest path verifies green,
 # and forged / cross-convene-replay / revoked-key votes are all rejected (non-zero exit). Exit 0 == green.
-set -u
+set -uo pipefail
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry

--- a/tests/council_init_wizard_unit.sh
+++ b/tests/council_init_wizard_unit.sh
@@ -4,7 +4,7 @@
 # SAME contract the non-interactive seal path already consumes. Drives the wizard
 # over piped stdin (its dumb-terminal numbered branch), so it gates in CI with no
 # TTY, no root, and no gate-proof key. Exit 0 == green.
-set -u
+set -uo pipefail
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry

--- a/tests/council_liveness_e2e.sh
+++ b/tests/council_liveness_e2e.sh
@@ -6,7 +6,7 @@
 # ordinary-class motion is NOT gated. A FAKE `5dive` at COUNCIL_5DIVE_BIN stands in for the fleet
 # (agent list health / agent send / task add|show). SKIPs green when node/jq missing or build fails.
 # Exit 0 == green.
-set -u
+set -uo pipefail
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry

--- a/tests/council_schedule_e2e.sh
+++ b/tests/council_schedule_e2e.sh
@@ -14,7 +14,7 @@
 # scripts' STANDUP_PARSE_TEST) so the runner is exercised offline with zero network / no seat
 # dispatch. Builds a throwaway ./5dive (BUILD_OUT) so it GATES in CI; SKIPs green if it can't
 # build or node/jq are missing. Exit 0 == green.
-set -u
+set -uo pipefail
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry

--- a/tests/gate_t2_nonce_proof_unit.sh
+++ b/tests/gate_t2_nonce_proof_unit.sh
@@ -26,6 +26,7 @@
 # the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+set -o pipefail
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-t2-nonce-proof.XXXXXX)"


### PR DESCRIPTION
Enables `pipefail` in the 12 `5dive-cli/tests/*.sh` graded harnesses that lacked it, so a failure inside an internal pipeline (`sha256sum ... | awk ...`) is no longer swallowed and reported as a green.

Maker: dev2. Verifier: olivia (DIVE-2559).

**Scope boundary (explicit):** this fixes pipes *inside* a harness. It does not and structurally cannot fix a grader typing `bash tests/x.sh 2>&1 | tail -3; echo rc=$?` in their own shell — no in-file setting reaches a pipeline built in the caller's shell after the harness has exited. Flagged as a separate follow-up, not silently claimed as covered.

**Verification (olivia, independent, in a clean detached worktree at this SHA):** all 12 changed harnesses run with rc captured unpiped — 12 green / 0 red.

Note for the record: dev2 reported `council_ballot_e2e.sh` as a pre-existing 7-passed/1-failed. That was an artifact of the dirty shared checkout it was run in (parked on a sibling task's branch). On pristine `origin/main` and on this branch in isolation it is 8/8 rc=0. The verdict "not caused by this diff" was right; the evidence for it was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)