### PR TITLE
fix(heartbeat): don't reclaim a delivery sitting with its own verifier (DIVE-2560)

### DIFF
--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -1140,19 +1140,42 @@ _hb_reclaim_to_todo() {
 # (a)/(b)/(c) all reclaim the work (it still needs doing); (c) additionally
 # escalates a repeat offender. Nothing is ever cancelled here. Echoes
 # "<reclaimed> <escalated>". Uses started_at (falls back to created_at).
+#
+# DIVE-2560: (b) and (c) both read claim age as evidence of stall, but a row
+# the CURRENT holder is verifying — delivered by its maker, assignee flipped to
+# the verifier, handoff_ack_at still NULL — is not stalled at all: the maker's
+# job is done and the age on the claim is verifier think-time, not neglect.
+# Before this fix that state was indistinguishable from ordinary abandoned
+# work, so a verifier who claimed a delivery and sat with it (reading, or just
+# between heartbeat ticks) got it yanked back to todo and re-nudged on a loop —
+# the exact "claimed then went idle" churn _hb_stall_sweep already has a
+# correct, slower-cadence nag for. Rows in that state now skip (b) and (c)
+# entirely; (a) still fires, because a truly gone session is a real reason to
+# re-present the row fresh regardless of handoff state.
 _hb_reclaim() {
   local name="$1" everyMin="$2"
   local budget=$(( everyMin * _HB_STALE_MULT ))
   (( budget < _HB_STALE_MIN_MINUTES )) && budget=$_HB_STALE_MIN_MINUTES
   local proc_start; proc_start=$(_hb_claude_started "$name" 2>/dev/null || true)
-  local reclaimed=0 escalated=0 id started_epoch age_min
-  while IFS='|' read -r id started_epoch age_min; do
+  local reclaimed=0 escalated=0 id started_epoch age_min awaiting_verifier
+  while IFS='|' read -r id started_epoch age_min awaiting_verifier; do
     [[ -n "$id" ]] || continue
     # (a) the claiming session is gone — process is newer than the claim.
     if [[ -n "$proc_start" && -n "$started_epoch" ]] \
        && (( proc_start > started_epoch + _HB_PROC_SKEW_SEC )); then
       _hb_reclaim_to_todo "$name" "$id" "claiming session gone (claude restarted $(( (proc_start - started_epoch) / 60 ))m after the claim)"
       reclaimed=$((reclaimed + 1)); continue
+    fi
+    # DIVE-2560: a row currently held by its own VERIFIER, delivered but not yet
+    # ACKed (same predicate _hb_stall_sweep already uses to nag the verifier
+    # instead), is not stalled — it is sitting in the reviewer's queue, and the
+    # clock that matters is the verifier's latency, not this claim's age. Neither
+    # the hard-cap nor the idle-stall arm below may reclaim it; only rule (a)
+    # above (the holder's session is actually gone) still applies. A row bounced
+    # BACK to the maker by a reject is NOT this state — assignee != verifier once
+    # that happens — so ordinary rework still reclaims normally.
+    if (( awaiting_verifier )); then
+      continue
     fi
     # (c) hard cap before stall: in_progress past the budget but rule (a) didn't
     # fire (the claiming process did NOT restart — e.g. an in-process /clear or
@@ -1186,7 +1209,10 @@ _hb_reclaim() {
     fi
   done < <(db "SELECT id || '|' ||
                  strftime('%s', COALESCE(started_at, created_at)) || '|' ||
-                 CAST((julianday('now') - julianday(COALESCE(started_at, created_at))) * 1440 AS INTEGER)
+                 CAST((julianday('now') - julianday(COALESCE(started_at, created_at))) * 1440 AS INTEGER) || '|' ||
+                 CASE WHEN verifier IS NOT NULL AND verifier = assignee
+                           AND handoff_delivered_at IS NOT NULL AND handoff_ack_at IS NULL
+                      THEN 1 ELSE 0 END
                FROM tasks
                WHERE assignee=$(sqlq "$name") AND status='in_progress';" 2>/dev/null || true)
   printf '%s %s\n' "$reclaimed" "$escalated"

--- a/tests/heartbeat_reclaim_verifier_handoff_unit.sh
+++ b/tests/heartbeat_reclaim_verifier_handoff_unit.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# DIVE-2560 — isolated unit harness for the _hb_reclaim guard against
+# reclaiming a row that is sitting DELIVERED and awaiting its verifier's ACK.
+#
+# THE BUG. _hb_reclaim's idle-stall (b) and hard-cap (c) arms read only claim
+# age + the idle probe. Once the dispatcher claims a nudge on the VERIFIER's
+# behalf (status -> in_progress, assignee already flipped to the verifier by
+# _task_route_to_verifier on delivery), a verifier who is legitimately reading
+# / thinking about a delivery — not stalled — reads identically to an agent
+# that abandoned real work. Reclaimed rows sat in the SAME state
+# _hb_stall_sweep already has a correct, slower nag for (DIVE-1416 gap#2), so
+# the two mechanisms fought: the sweep waited, the reclaim didn't.
+#
+# WHAT THIS PROVES, arm by arm:
+#   1  an unacked verifier-held delivery, aged past the idle-stall grace AND
+#      read as idle, is NOT reclaimed (rule b suppressed);
+#   2  the same row, aged past the hard-cap budget, is NOT reclaimed either
+#      (rule c suppressed) — neither arm fires just because the other didn't;
+#   3  CONTROL — once the verifier explicitly ACKs (handoff_ack_at set), the
+#      SAME row aged the SAME way IS reclaimed normally: the guard is scoped to
+#      the unacked state, not a blanket exemption for verifier-owned rows;
+#   4  CONTROL — a row bounced back to its MAKER by a reject (assignee no
+#      longer equals the row's verifier, even though handoff_delivered_at is
+#      still set from the original delivery) reclaims normally: ordinary
+#      rework is not mistaken for an open handoff;
+#   5  rule (a) — the claiming session actually gone — still fires on an
+#      unacked verifier-held row; only (b)/(c) are guarded, never (a).
+#
+# Same isolation contract as tests/heartbeat_dispatcher_claim_unit.sh: source
+# src/ directly, throwaway tasks.db, no tmux/network/root.
+# Run: bash tests/heartbeat_reclaim_verifier_handoff_unit.sh
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/hb-reclaim-verifier-handoff.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh cmd_heartbeat.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"
+TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"
+set +e
+
+tasks_db_init
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+addt() { ( cmd_task_add "$@" ) 2>/dev/null | jq -r '.data.id'; }
+row()  { db "SELECT status||'|'||COALESCE(started_at,'NULL') FROM tasks WHERE id=$1;"; }
+reset_all() { db "DELETE FROM tasks;"; }
+
+# Boundaries: no tmux/registry/network. _hb_agent_idle and _hb_claude_started
+# are steerable per-arm below.
+REGISTRY="$TMP/registry.json"; printf '{"agents":{}}' >"$REGISTRY"
+registry_read()       { cat "$REGISTRY"; }
+registry_write()      { cat > "$REGISTRY"; }
+_hb_send_line()      { return 0; }
+_hb_pane_fingerprint() { echo "fp"; }
+cmd_send()            { :; }
+cmd_task_escalate()   { :; }
+with_registry_lock()  { local fn="$1"; shift; "$fn" "$@"; }
+_hb_claude_started()  { echo ""; }   # no proc time by default -> rule (a) never fires
+_hb_agent_idle()      { return 0; }  # confident idle by default
+
+# --- fixture: a real delivery through the real routing path ------------------
+# addt --assignee=dev --verifier=olivia, then cmd_task_done routes it exactly
+# like tests/heartbeat_stall_sweep_unit.sh's A1: assignee -> olivia, status ->
+# todo, handoff_delivered_at stamped, handoff_ack_at NULL. The dispatcher claim
+# is simulated the same way the real tick would do it on olivia's next nudge.
+mk_delivered_unacked() {
+  local id
+  id=$(addt --assignee=dev --verifier=olivia -- "ship the widget")
+  ( cmd_task_done "$id" ) >/dev/null 2>&1
+  _hb_claim_task olivia "$id" >/dev/null 2>&1
+  printf '%s' "$id"
+}
+
+# =============================================================================
+# 1) idle-stall (b) suppressed on an unacked verifier-held delivery
+# =============================================================================
+reset_all
+T1=$(mk_delivered_unacked)
+[[ "$(row "$T1")" == in_progress\|* ]] \
+  && ok_t "fixture: dispatcher claim landed (in_progress)" \
+  || bad_t "fixture: dispatcher claim landed" "got $(row "$T1")"
+db "UPDATE tasks SET started_at=datetime('now','-25 minutes') WHERE id=${T1};"
+read -r RC1_N _ < <(_hb_reclaim olivia 30)
+[[ "$(row "$T1")" == in_progress\|* ]] && (( ${RC1_N:-1} == 0 )) \
+  && ok_t "unacked verifier delivery, past idle-stall grace + idle probe -> NOT reclaimed" \
+  || bad_t "idle-stall arm reclaimed an unacked delivery" "reclaimed=${RC1_N:-?} row=$(row "$T1")"
+
+# =============================================================================
+# 2) hard cap (c) suppressed on the same state, aged well past the budget
+# =============================================================================
+reset_all
+T2=$(mk_delivered_unacked)
+db "UPDATE tasks SET started_at=datetime('now','-200 minutes') WHERE id=${T2};"
+read -r RC2_N _ < <(_hb_reclaim olivia 30)
+[[ "$(row "$T2")" == in_progress\|* ]] && (( ${RC2_N:-1} == 0 )) \
+  && ok_t "unacked verifier delivery, past the hard-cap budget -> NOT reclaimed" \
+  || bad_t "hard-cap arm reclaimed an unacked delivery" "reclaimed=${RC2_N:-?} row=$(row "$T2")"
+
+# =============================================================================
+# 3) CONTROL — once ACKed, the same aging reclaims normally (guard is narrow)
+# =============================================================================
+reset_all
+T3=$(mk_delivered_unacked)
+db "UPDATE tasks SET started_at=datetime('now','-200 minutes'),
+       handoff_ack_at=datetime('now') WHERE id=${T3};"
+read -r RC3_N _ < <(_hb_reclaim olivia 30)
+[[ "$(row "$T3")" == "todo|NULL" ]] && (( ${RC3_N:-0} == 1 )) \
+  && ok_t "[control] an ACKed handoff is not exempt — hard cap reclaims it normally" \
+  || bad_t "[control] ACKed handoff was not reclaimed" "reclaimed=${RC3_N:-?} row=$(row "$T3")"
+
+# =============================================================================
+# 4) CONTROL — a reject bounced back to the MAKER reclaims normally
+# =============================================================================
+# Shape a reject by hand (same fields _task_route_to_verifier's counterpart in
+# cmd_task_reject writes): assignee back to the maker, verifier column
+# unchanged (so verifier != assignee), handoff_delivered_at still set from the
+# original delivery, handoff_ack_at cleared. The predicate this fix adds is
+# `verifier = assignee` — a rejected row fails that on purpose.
+reset_all
+T4=$(mk_delivered_unacked)
+db "UPDATE tasks SET assignee='dev', handoff_ack_at=NULL WHERE id=${T4};"
+_hb_claim_task dev "$T4" >/dev/null 2>&1
+db "UPDATE tasks SET started_at=datetime('now','-200 minutes') WHERE id=${T4};"
+read -r RC4_N _ < <(_hb_reclaim dev 30)
+[[ "$(row "$T4")" == "todo|NULL" ]] && (( ${RC4_N:-0} == 1 )) \
+  && ok_t "[control] rework bounced back to the maker is not exempt — reclaims normally" \
+  || bad_t "[control] rejected/rework row was not reclaimed" "reclaimed=${RC4_N:-?} row=$(row "$T4")"
+
+# =============================================================================
+# 5) rule (a) — claiming session gone — still fires on an unacked delivery
+# =============================================================================
+reset_all
+T5=$(mk_delivered_unacked)
+CLAIM_EPOCH=$(db "SELECT strftime('%s', started_at) FROM tasks WHERE id=${T5};")
+# proc started well AFTER the claim -> rule (a)'s restart condition.
+_hb_claude_started() { echo "$(( ${CLAIM_EPOCH} + 3600 ))"; }
+read -r RC5_N _ < <(_hb_reclaim olivia 30)
+_hb_claude_started() { echo ""; }   # restore
+[[ "$(row "$T5")" == "todo|NULL" ]] && (( ${RC5_N:-0} == 1 )) \
+  && ok_t "rule (a) still reclaims an unacked delivery when the claiming session is actually gone" \
+  || bad_t "rule (a) did not fire on a gone session" "reclaimed=${RC5_N:-?} row=$(row "$T5")"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
The reclaim loop reads claim age as evidence of a stall. A row the **current holder is verifying** — delivered by its maker, assignee flipped to the verifier, `handoff_ack_at` still NULL — is not stalled: the maker's job is done, and the age on that claim is verifier think-time, not neglect.

Before this, that state was indistinguishable from ordinary abandoned work, so a verifier who claimed a delivery and sat with it got the row yanked back to `todo` and re-nudged, on a loop.

**Measured on the live board (2026-08-03).** dev shows 145 reclaims. Worked examples: DIVE-2506 reclaimed 4x in 75 minutes, DIVE-2517 5x — both rows dev had *successfully delivered*, both since closed. DIVE-2506 was reclaimed 10x under `main`, who is that row's verifier: exactly the state this exempts. So the loop was punishing makers for using the verifier rail, and the punishment was to interrupt them.

**Change.** The reclaim query now computes `awaiting_verifier` (`verifier = assignee AND handoff_delivered_at IS NOT NULL AND handoff_ack_at IS NULL` — the same predicate `_hb_stall_sweep` already uses to nag the verifier instead). Rows in that state skip the hard-cap and idle-stall arms.

Rule (a) still fires: a genuinely gone session is a real reason to re-present a row regardless of handoff state. And a row bounced **back** to the maker by a reject is not this state — `assignee != verifier` once that happens — so ordinary rework still reclaims normally.

**Verification.** Built by dev2, verified independently by olivia: 6/6 new unit tests with real controls, 19 regression suites green, and she reproduced the exempted state against the live log evidence above rather than only against fixtures.

Rebased by main: dev2's branch was cut at `bf0fbc1` and cherry-picked clean onto current `main` (`d0af108`). Author preserved.

**Explicitly out of scope**, and worth its own row if wanted: the 45-minute overrun cap mis-firing on genuine multi-hour builds (it reaped DIVE-2517, 1975, 2524, 2525, and a reap sends `/goal clear`, killing the thread too). Untouched here by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)