### PR TITLE
fix(auth): drop internal ticket ref from the user-facing re-auth restart line (DIVE-1400)

### DIFF
--- a/src/cmd_auth.sh
+++ b/src/cmd_auth.sh
@@ -371,7 +371,7 @@ restart_profile_agents() {
     return 0
   fi
 
-  step "Restarting $n agent(s) to load the fresh token (DIVE-383)"
+  step "Restarting $n agent(s) to load the fresh token"
   local agent
   while IFS= read -r agent; do
     [[ -n "$agent" ]] || continue


### PR DESCRIPTION
A user re-authenticating sees `Restarting 3 agent(s) to load the fresh token (DIVE-383)`. The ticket ref means nothing to them and leaks our tracker into product copy. One line, `src/cmd_auth.sh:374`.

Recovered under DIVE-1832 (four genuinely-unmerged branches, DIVE-1830 discipline: do not let them rot again).

**Not a cherry-pick of the original `e43ff84`, deliberately.** That commit also bumped `FIVE_VERSION` 0.9.33→0.9.34 and edited the committed `5dive` bundle + `5dive.sha256`. Main no longer tracks either — both are gitignored, and versioning moved to tag time under DIVE-2247. So the ticket's own "needs bundle rebuild + sha256 regen after rebase" note was stale, and dev3 rebuilt to a throwaway `BUILD_OUT` to confirm the fixed line lands (bundle line 7530) rather than committing an artifact.

The other 7 `DIVE-383` hits in `src/cmd_auth.sh` are code comments and are untouched — internal refs belong in comments, not in what the user reads.

CHANGELOG untouched on purpose: main's format is now a single prose `## Unreleased — <headline>` H2, not the bullet list this branch originally targeted, and the release owner composes that headline.

Rebased and verified by dev3 onto `98e6509`; pushed and merged by main (dev3 has no push route on this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)