### PR TITLE
fix(tests): a timeout KILL is not a verdict, and a header's measurement is graded by the clock (DIVE-2555)

### DIFF
--- a/.github/workflows/full-sweep.yml
+++ b/.github/workflows/full-sweep.yml
@@ -275,6 +275,21 @@ jobs:
   # Scoped with --only on purpose: raising PROBE_TIMEOUT for the whole sweep would
   # also raise how long a genuinely hung harness can stall CI, which is the property
   # the 180s default is buying. Named harnesses pay 900s; nothing else changes.
+  #
+  # DIVE-2555: THE KILL NOW HAS ITS OWN NAME. `not-reached` was the right verdict to
+  # act on and the wrong sentence to read — it says the harness "skips before its
+  # verdict here", which this one never did; it was killed. The probe reports
+  # `timed-out` for a kill in either position now, and — this is the half that
+  # mattered — a mutant killed AFTER its canary printed used to be counted `wired`,
+  # because the non-zero exit `timeout` produces is indistinguishable from a harness
+  # reporting its own failure. That is a false PASS in the coverage direction, in the
+  # one check that exists to find harnesses which cannot fail CI. `timed-out` is not
+  # in the union's probed set, so a harness killed in every lane reds the union as
+  # NEVER PROBED, which is what it is. If that fires, the remedy is this list, not an
+  # allowlist entry: it is probeable and slow, not unprobeable.
+  #
+  # This harness measures 378s (control plane, 2026-08-03), not the 300.0s its header
+  # claimed — so the 900s here is ~2.4x the slowest reading we have, not 3x.
   harness-verdict-slow:
     runs-on: ubuntu-latest
     needs: full-pristine

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,13 @@ decision to add one is ever wrong on its own merits. See
   In the harness header (first 40 lines). **The reason is mandatory** — a bare
   `# TIER: nightly` is a refusal, not a default. Demotion moves the cost, it does
   not delete it, which is why it is third and why it must be argued in the diff.
+- **Say WHERE you measured, and expect the number to be graded** (DIVE-2555). The
+  runner compares every `Ns measured` claim against the clock in the run it is
+  already doing: 10% under is reported with the replacement line, 50%-and-3s under
+  is `exit 5` (its own code — the remedy is "correct a number", not "fix a test" or
+  "retire a guard"). A figure with no environment on it cannot be refuted by the
+  next reading, only silently disagreed with: one header claimed `300.0s` while
+  the same file measured 335s and 378s on the control plane.
 - **Editing a harness always runs it**, whatever its tier: the `changed-harnesses`
   job runs and verdict-probes every harness your diff touches. Tier membership is
   a default, and a default loses to an explicit signal.

--- a/scripts/run-harnesses.sh
+++ b/scripts/run-harnesses.sh
@@ -25,6 +25,9 @@
 #      because the failing harness is the thing to fix first)
 #   4  every harness passed, run is OVER BUDGET
 #   3  the corpus could not be classified into tiers (see tests/lib/tier.sh)
+#   5  every harness passed and the run is inside budget, but a harness HEADER
+#      claims a measured time the clock just refuted by >= 50% (DIVE-2555). Same
+#      reason 4 is not 1: the remedy is different, so the code is different.
 #   2  usage
 set -uo pipefail
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 2
@@ -118,10 +121,42 @@ done
 total_s=$(( (total_ms + 999) / 1000 ))
 pct=0; (( BUDGET > 0 )) && pct=$(( total_s * 100 / BUDGET ))
 
+# DIVE-2555: GRADE EACH HEADER'S OWN NUMBER AGAINST THE CLOCK THAT JUST RAN IT.
+#
+# `# TIER: nightly — 14.3s measured` is the entire argument a reviewer gets that a
+# cost was MOVED rather than hidden, and nothing has ever re-read it: it is a
+# comment, written once, in a file whose runtime nobody measures again. Measured
+# 2026-08-03, gate_channel_session_t2_mutation.sh claimed 300.0s and ran 335s on the
+# control plane, and neither figure carried an environment or a date, so no reading
+# could refute another.
+#
+# This costs nothing: MS[] is already the measurement, taken in the run that had to
+# happen anyway. It is the same principle as the budget itself (enforce on the number
+# you MEASURE, never on a table of per-file costs) turned on the table.
+#
+# A harness that FAILED is skipped — an aborted run's wall-clock is not a measurement
+# of what the harness costs, and accusing its header of drift on that evidence is the
+# same error, inverted.
+drift=(); drift_fatal=0
+for i in "${!NAME[@]}"; do
+  (( RC[i] == 0 )) || continue
+  claim="$(tier_claim "${NAME[$i]}")"
+  [[ -n "$claim" ]] || continue
+  claim_ms=$(awk -v c="$claim" 'BEGIN{printf "%d", c*1000 + 0.5}')
+  (( claim_ms > 0 && MS[i] > claim_ms )) || continue
+  gap_ms=$(( MS[i] - claim_ms )); over_pct=$(( gap_ms * 100 / claim_ms ))
+  (( gap_ms >= TIER_CLAIM_DRIFT_WARN_S * 1000 && over_pct >= TIER_CLAIM_DRIFT_WARN_PCT )) || continue
+  sev="stale"
+  if (( over_pct >= TIER_CLAIM_DRIFT_FAIL_PCT && gap_ms >= TIER_CLAIM_DRIFT_FAIL_S * 1000 )); then
+    sev="WRONG"; drift_fatal=1
+  fi
+  drift+=("$(printf '%s\t%s\t%s\t%s' "$sev" "${NAME[$i]}" "$claim" "${MS[$i]}")")
+done
+
 if [[ -n "$REPORT" ]]; then
   {
-    printf '# run-harnesses report\n# tier=%s\n# label=%s\n# shard=%s\n# harnesses=%d\n# wall_clock_s=%d\n# budget_s=%d\n# pct_of_budget=%d\n' \
-      "$TIER" "$LABEL" "${SHARD:-1/1}" "${#CORPUS[@]}" "$total_s" "$BUDGET" "$pct"
+    printf '# run-harnesses report\n# tier=%s\n# label=%s\n# shard=%s\n# harnesses=%d\n# wall_clock_s=%d\n# budget_s=%d\n# pct_of_budget=%d\n# header_drift=%d\n' \
+      "$TIER" "$LABEL" "${SHARD:-1/1}" "${#CORPUS[@]}" "$total_s" "$BUDGET" "$pct" "${#drift[@]}"
     for i in "${!NAME[@]}"; do printf '%s\t%s\t%s\n' "${MS[$i]}" "${RC[$i]}" "${NAME[$i]}"; done
   } > "$REPORT"
 fi
@@ -162,10 +197,35 @@ elif (( pct >= 80 )); then
   printf 'The %d slowest in this tier:\n' "$TOP"; slowest "$TOP"
 fi
 
+# DIVE-2555. Printed whatever else happened, because a header that no longer matches
+# the clock is exactly as wrong in a run that went red for another reason.
+if (( ${#drift[@]} )); then
+  printf '\nharness-budget[%s/%s]: %d HEADER MEASUREMENT(S) THE CLOCK JUST REFUTED.\n' \
+    "$TIER" "$LABEL" "${#drift[@]}"
+  printf 'A demotion is argued in the diff with its own number, and that number is the only\n'
+  printf 'evidence a reviewer has that a cost was MOVED rather than hidden. An optimistic one\n'
+  printf 'is a demotion argued on a figure nobody grades. Replace the header line with the\n'
+  printf 'measurement below, and say WHERE it was taken — a figure with no environment on it\n'
+  printf 'cannot be refuted by the next reading, only silently disagreed with:\n'
+  for d in "${drift[@]}"; do
+    IFS=$'\t' read -r sev nm claim ms <<<"$d"
+    printf '  %-5s %s\n' "$sev" "$nm"
+    printf '        claims %ss measured, ran %.1fs here (+%d%%) on %s\n' \
+      "$claim" "$(awk -v m="$ms" 'BEGIN{print m/1000}')" \
+      "$(( ( ms - $(awk -v c="$claim" 'BEGIN{printf "%d", c*1000 + 0.5}') ) * 100 / $(awk -v c="$claim" 'BEGIN{printf "%d", c*1000 + 0.5}') ))" \
+      "$LABEL"
+    printf '        # TIER: nightly — %.1fs measured (%s, <date>): <why this cannot be in the %ds PR core>\n' \
+      "$(awk -v m="$ms" 'BEGIN{print m/1000}')" "$LABEL" "$TIER_BUDGET_CORE"
+  done
+  (( drift_fatal )) && printf 'At least one is marked WRONG (>= %d%% and >= %ds under): that is not runner variance.\n' \
+    "$TIER_CLAIM_DRIFT_FAIL_PCT" "$TIER_CLAIM_DRIFT_FAIL_S"
+fi
+
 if (( ${#failed[@]} )); then
   printf '\n%d harness(es) FAILED:\n' "${#failed[@]}"
   printf '  %s\n' "${failed[@]}"
   exit 1
 fi
 (( over == 0 )) || exit 4
+(( drift_fatal == 0 )) || exit 5
 exit 0

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -257,5 +257,104 @@ if (( RC == 1 )) && [[ "$OUT" == *"selected 0 harnesses"* ]]; then
   ok "a shard that selects nothing FAILS rather than reporting green over nothing"
 else bad "a shard that selects nothing FAILS rather than reporting green over nothing" "rc=$RC out=$OUT"; fi
 
+
+# ------------------------------------------- 17-22 DIVE-2555: the CLOCK vs the CLAIM
+# MERGED HERE, NOT GIVEN A NEW FILE. This row's own rule is that past the cap a new
+# guard replaces or merges an existing one, and the subject is the same subject: what
+# the corpus's clock is allowed to be reported as. Two claims about a reading of it —
+# a HEADER's "Ns measured" and the probe's TIMEOUT KILL — and neither may be reported
+# as something it is not.
+#
+# WHY THIS EXISTS (DIVE-2555, measured 2026-08-03): a demotion is argued in the diff
+# with a number, and gate_channel_session_t2_mutation.sh claimed 300.0s while running
+# 335s on the control plane. Nothing had ever re-read that number. The runner already
+# times every harness, so grading the claim against the measurement is free.
+rm -f "$TMP"/*.sh
+mk truthful.sh '#!/usr/bin/env bash
+# TIER: nightly — 10.0s measured (DIVE-2555): does not fit the 300s PR core; the nightly sweep runs it.
+exit 0'
+mk stale_claim.sh '#!/usr/bin/env bash
+# TIER: nightly — 0.5s measured (DIVE-2555): does not fit the 300s PR core; the nightly sweep runs it.
+sleep 2
+exit 0'
+run --tier=full --budget=600 --label=t
+want "a header the clock only mildly refutes is REPORTED, not red (that band is runner variance)" "0" "$RC"
+if [[ "$OUT" == *"HEADER MEASUREMENT"* && "$OUT" == *"stale"* && "$OUT" == *"stale_claim.sh"* ]]; then
+  ok "the drifted header is named, with its severity"
+else bad "the drifted header is named, with its severity" "$OUT"; fi
+# The remedy half again: a drift report that does not print the replacement line is a
+# number nobody can act on, which is the finding this whole row descends from.
+if [[ "$OUT" == *"# TIER: nightly —"* && "$OUT" == *"measured (t,"* ]]; then
+  ok "the drift report prints the REPLACEMENT header line, with the environment in it"
+else bad "the drift report prints the REPLACEMENT header line, with the environment in it" "$OUT"; fi
+# Scoped to the DRIFT BLOCK, not to the whole output: the runner echoes every harness
+# path as it runs it, so "truthful.sh appears somewhere in stdout" is true of every
+# run and asserting on it grades nothing. First version of this arm did exactly that.
+DRIFT_BLOCK="$(printf '%s\n' "$OUT" | sed -n '/HEADER MEASUREMENT/,$p')"
+if [[ -n "$DRIFT_BLOCK" && "$DRIFT_BLOCK" != *"truthful.sh"* ]]; then
+  ok "a header the clock AGREES with is not accused"
+else bad "a header the clock AGREES with is not accused" "$DRIFT_BLOCK"; fi
+
+# >= 50% AND >= 3s under is not variance: exit 5, its own code, because the remedy is
+# neither "fix a test" (1) nor "retire a guard" (4) but "correct a number in a header".
+mk wrong_claim.sh '#!/usr/bin/env bash
+# TIER: nightly — 0.5s measured (DIVE-2555): does not fit the 300s PR core; the nightly sweep runs it.
+sleep 4
+exit 0'
+rm -f "$TMP/stale_claim.sh"
+run --tier=full --budget=600 --label=t
+want "a header the clock flatly refutes exits 5 (not 1, not 4)" "5" "$RC"
+if [[ "$OUT" == *"WRONG"* && "$OUT" == *"not runner variance"* ]]; then
+  ok "the refuted header is called WRONG and the message says why it is not variance"
+else bad "the refuted header is called WRONG and the message says why it is not variance" "$OUT"; fi
+
+# A harness that FAILED is not accused of drift: an aborted run's wall-clock is not a
+# measurement of what it costs, and the failure is the thing to fix first (exit 1).
+rm -f "$TMP/wrong_claim.sh"
+mk red_claim.sh '#!/usr/bin/env bash
+# TIER: nightly — 0.5s measured (DIVE-2555): does not fit the 300s PR core; the nightly sweep runs it.
+sleep 4
+exit 1'
+run --tier=full --budget=600 --label=t
+if (( RC == 1 )) && [[ "$OUT" != *"red_claim.sh"*"claims"* ]]; then
+  ok "a FAILING harness is not also accused of header drift"
+else bad "a FAILING harness is not also accused of header drift" "rc=$RC out=$OUT"; fi
+
+# ------------------------------------ 23-25 DIVE-2555: a TIMEOUT KILL is not a verdict
+# tests/meta/harness-verdict-probe.sh runs every harness under `timeout`. A kill used
+# to be laundered into two verdicts that are about the harness rather than the clock:
+# a killed CLEAN run became `already-red` ("failed its own clean run" — an accusation
+# about assertions, on evidence entirely about time), and a killed MUTANT became
+# `wired` whenever the canary had already printed, which is a FALSE PASS in the
+# coverage direction: the non-zero exit came from the KILL, not from the harness's
+# verdict. DIVE-2412 paid for this once already — 300s of mutation grader killed at
+# the 180s cap in every environment, reported as `not-reached`, i.e. "skips early
+# here", which it never did.
+#
+# Graded with a 1s cap against ONE real harness (`--only`), because the probe globs
+# tests/*.sh and has no --corpus-dir seam. Cost: two kills, ~2s.
+# LIMIT, stated rather than implied: this forces the kill BEFORE the canary prints.
+# The killed-after-the-canary shape (the false `wired`) shares the same guard — it is
+# placed ahead of the canary grep precisely so both land in one class — but forcing it
+# live would need a harness that hangs after its verdict line, and inventing one is a
+# corpus file added by a row about not adding corpus files.
+PROBE="tests/meta/harness-verdict-probe.sh"
+VICTIM="gate_nonce_unit.sh"
+if [[ -r "$PROBE" && -r "tests/$VICTIM" ]]; then
+  POUT="$(PROBE_TIMEOUT=1 bash "$PROBE" --only="$VICTIM" --label=cap1 --report="$TMP/probe.txt" 2>/dev/null)"; PRC=$?
+  want "a harness killed by the cap does not fail the probe (a kill is not a verdict)" "0" "$PRC"
+  if [[ "$POUT" == *"timed-out"* && "$POUT" == *"$VICTIM"* && "$POUT" != *"ALREADY-RED"* ]]; then
+    ok "the kill is reported as timed-out, NOT as a harness that failed its own clean run"
+  else bad "the kill is reported as timed-out, NOT as a harness that failed its own clean run" "$POUT"; fi
+  # The report is what the union reads, and `timed-out` is deliberately absent from
+  # its probed set: a harness killed in EVERY environment must red the union as NEVER
+  # PROBED rather than bank coverage it never earned.
+  if grep -q "^timed-out	$VICTIM$" "$TMP/probe.txt" && ! grep -qE "^(wired|UNWIRED)	$VICTIM$" "$TMP/probe.txt"; then
+    ok "the report row is timed-out and is NOT in the union's probed set"
+  else bad "the report row is timed-out and is NOT in the union's probed set" "$(cat "$TMP/probe.txt")"; fi
+else
+  bad "probe timeout arms" "NOT REACHED: $PROBE or tests/$VICTIM missing — arms 23-25 graded nothing"
+fi
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 (( fail == 0 ))

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -320,7 +320,7 @@ if (( RC == 1 )) && [[ "$OUT" != *"red_claim.sh"*"claims"* ]]; then
   ok "a FAILING harness is not also accused of header drift"
 else bad "a FAILING harness is not also accused of header drift" "rc=$RC out=$OUT"; fi
 
-# ------------------------------------ 23-25 DIVE-2555: a TIMEOUT KILL is not a verdict
+# ------------------------------------ 23-26 DIVE-2555: a TIMEOUT KILL is not a verdict
 # tests/meta/harness-verdict-probe.sh runs every harness under `timeout`. A kill used
 # to be laundered into two verdicts that are about the harness rather than the clock:
 # a killed CLEAN run became `already-red` ("failed its own clean run" — an accusation
@@ -331,29 +331,87 @@ else bad "a FAILING harness is not also accused of header drift" "rc=$RC out=$OU
 # the 180s cap in every environment, reported as `not-reached`, i.e. "skips early
 # here", which it never did.
 #
-# Graded with a 1s cap against ONE real harness (`--only`), because the probe globs
-# tests/*.sh and has no --corpus-dir seam. Cost: two kills, ~2s.
 # These arms force the kill BEFORE the canary prints. The killed-AFTER-the-canary
-# shape — the false `wired`, and the half that matters — is arms 26-29 below.
+# shape — the false `wired`, and the half that matters — is arms 27-30 below.
+#
+# GRADED AGAINST A STUB, NOT A REAL HARNESS, and iteration 2 is why. This arm used
+# to point a 1s cap at tests/gate_nonce_unit.sh (11.3s on the control plane, so
+# reliably killed HERE) and it was green locally in two trees and RED in CI. The
+# split was never in the probe: gate_nonce_unit.sh opens with a skip guard —
+# "no agent-* user on this host to source a real agent uid", then `exit 0` — and a
+# GitHub runner has no agent-* user. So on CI the clean run finished in
+# milliseconds, NOTHING was killed, the mutant exited before the canary, and the
+# row was `not-reached`. The arm's premise was "this victim is slower than the cap
+# here", which is a property of the HOST POPULATION, not of the code under test.
+# That is the same lesson as the header measurements above, one layer out: a
+# duration read off one box is not a constant. So the victim is now a stub whose
+# runtime is written down rather than measured, via the same fake-repo seam arms
+# 27-30 already proved — the claim that this needed a real harness ("no
+# --corpus-dir seam") was retired the moment that seam was found.
+# Cost: one kill at a 1s cap plus an instant control, ~1s.
 PROBE="tests/meta/harness-verdict-probe.sh"
-VICTIM="gate_nonce_unit.sh"
-if [[ -r "$PROBE" && -r "tests/$VICTIM" ]]; then
-  POUT="$(PROBE_TIMEOUT=1 bash "$PROBE" --only="$VICTIM" --label=cap1 --report="$TMP/probe.txt" 2>/dev/null)"; PRC=$?
+FAKE="$TMP/fakerepo"
+mkdir -p "$FAKE/tests/meta"
+# THE SEAM (shared with arms 27-30). The probe roots itself at
+# `dirname "$BASH_SOURCE"/../..` and globs `tests/*.sh` from there, so a throwaway
+# tree with a SYMLINK to the probe in tests/meta/ becomes a corpus of exactly the
+# stubs written below — no file added to tests/, per this row's own rule. Symlink
+# and not a copy, deliberately: the arms grade the probe in THIS checkout, so
+# deleting either kill classification reds it here.
+# Both stubs live in one fake corpus, so every probe run below passes `--only`:
+# without it each run would probe the other stub too, and the kill counts these
+# arms assert are counts over the whole run.
+FAKE_PROBE="$FAKE/tests/meta/$(basename "$PROBE")"
+SEAM=0
+[[ -r "$PROBE" ]] && ln -s "$PWD/$PROBE" "$FAKE_PROBE" 2>/dev/null && SEAM=1
+CSTUB=hang_before_verdict.sh
+if (( SEAM )); then
+  # Hangs on its CLEAN run, before any verdict, in every environment — the kill is
+  # written into the stub instead of hoped for from the host. STUB_HANG=0 turns the
+  # hang off for the control.
+  cat > "$FAKE/tests/$CSTUB" <<'STUBEOF'
+#!/usr/bin/env bash
+# Stub corpus for DIVE-2555: green and instant with STUB_HANG=0, otherwise it
+# sleeps past any sane cap before reaching its verdict line.
+fail=0
+sleep "${STUB_HANG:-20}"
+(( fail == 0 ))
+STUBEOF
+  # CONTROL FIRST, and it is what makes the kill arm non-vacuous. Same stub, same
+  # cap, hang switched off: the probe runs it clean, mutates it, and earns `wired`.
+  # So a `timed-out` verdict below cannot be this stub being unprobeable, missing
+  # from the corpus, or red on its own assertions — the only thing that changed is
+  # the CLOCK.
+  CCOUT="$(STUB_HANG=0 PROBE_TIMEOUT=20 bash "$FAKE_PROBE" --only="$CSTUB" --label=ctl1 --report="$TMP/probe-ctl1.txt" 2>/dev/null)"; CCRC=$?
+  if (( CCRC == 0 )) && grep -q "^wired	$CSTUB$" "$TMP/probe-ctl1.txt"; then
+    ok "control: this stub is probeable and earns 'wired' when nothing kills it"
+  else bad "control: this stub is probeable and earns 'wired' when nothing kills it" "rc=$CCRC $(cat "$TMP/probe-ctl1.txt" 2>&1)"; fi
+
+  POUT="$(PROBE_TIMEOUT=1 bash "$FAKE_PROBE" --only="$CSTUB" --label=cap1 --report="$TMP/probe.txt" 2>/dev/null)"; PRC=$?
   want "a harness killed by the cap does not fail the probe (a kill is not a verdict)" "0" "$PRC"
-  if [[ "$POUT" == *"timed-out"* && "$POUT" == *"$VICTIM"* && "$POUT" != *"ALREADY-RED"* ]]; then
+  # SCOPED TO THE VERDICT LINES, because the previous form was vacuous: the summary
+  # always contains the literal "timed-out (cap 1s)" whatever the count is, and the
+  # victim's name appears in whichever per-harness row it landed in. `*timed-out*`
+  # and `*$VICTIM*` over the whole transcript therefore passed on the CI run where
+  # the classification was `not-reached` — the arm that mattered was the report grep
+  # below, alone. Assert the COUNT off the summary and the CLEAN-RUN wording off the
+  # row: only a clean-phase kill produces both.
+  PSUM="$(grep -m1 '^harness-verdict-probe:' <<<"$POUT")"
+  if [[ "$PSUM" == *"1 timed-out (cap 1s)"* && "$PSUM" == *"0 already-red"* \
+     && "$POUT" == *"timed-out    $CSTUB (clean run killed at 1s"* ]]; then
     ok "the kill is reported as timed-out, NOT as a harness that failed its own clean run"
   else bad "the kill is reported as timed-out, NOT as a harness that failed its own clean run" "$POUT"; fi
   # The report is what the union reads, and `timed-out` is deliberately absent from
   # its probed set: a harness killed in EVERY environment must red the union as NEVER
   # PROBED rather than bank coverage it never earned.
-  if grep -q "^timed-out	$VICTIM$" "$TMP/probe.txt" && ! grep -qE "^(wired|UNWIRED)	$VICTIM$" "$TMP/probe.txt"; then
+  if grep -q "^timed-out	$CSTUB$" "$TMP/probe.txt" && ! grep -qE "^(wired|UNWIRED|not-reached)	$CSTUB$" "$TMP/probe.txt"; then
     ok "the report row is timed-out and is NOT in the union's probed set"
   else bad "the report row is timed-out and is NOT in the union's probed set" "$(cat "$TMP/probe.txt")"; fi
 else
-  bad "probe timeout arms" "NOT REACHED: $PROBE or tests/$VICTIM missing — arms 23-25 graded nothing"
+  bad "probe timeout arms" "NOT REACHED: could not symlink $PROBE into $FAKE — arms 23-26 graded nothing"
 fi
 
-# --------------- 26-29 DIVE-2555: the kill that arrives AFTER the canary has printed
+# --------------- 27-30 DIVE-2555: the kill that arrives AFTER the canary has printed
 # THE HALF THAT MATTERS, and the one nothing in tests/*.sh can reach:
 # `grep -rln '__PROBE_REACHED__' tests/*.sh` is empty, so no real harness exercises
 # the mutant phase's kill at all. The arms above force the kill BEFORE the canary
@@ -364,20 +422,15 @@ fi
 # cannot fail CI then reports that they can. The two halves fail in opposite
 # directions and neither subsumes the other (DIVE-2464), so both need an arm.
 #
-# THE SEAM. The probe roots itself at `dirname "$BASH_SOURCE"/../..` and globs
-# `tests/*.sh` from there, so a throwaway tree with a SYMLINK to the probe in
-# tests/meta/ becomes a corpus of exactly one stub — no file added to tests/, per
-# this row's own rule. Symlink and not a copy, deliberately: the arm grades the probe
-# in THIS checkout, so deleting the mutant-phase kill classification reds it here.
+# THE SEAM is the fake repo built for arms 23-26 above — same throwaway tree, same
+# symlinked probe, one more stub in its corpus.
 #
 # THE STUB is green and instant on its clean run and hangs only once MUTATED: the
 # injected `fail=$((fail+1))` lands after the canary and before the verdict, and the
 # sleep is downstream of the verdict and gated on `fail`. `STUB_HANG` makes the hang
 # itself a variable, which buys the control below. Cost: one kill, ~2s.
-FAKE="$TMP/fakerepo"
-mkdir -p "$FAKE/tests/meta"
 STUB=hang_after_verdict.sh
-if ln -s "$PWD/$PROBE" "$FAKE/tests/meta/$(basename "$PROBE")" 2>/dev/null; then
+if (( SEAM )); then
   cat > "$FAKE/tests/$STUB" <<'STUBEOF'
 #!/usr/bin/env bash
 # Stub corpus for DIVE-2555. Its exit status IS wired to its counter; the probe
@@ -390,7 +443,6 @@ rc=$?
 if (( fail != 0 )); then sleep "${STUB_HANG:-20}"; fi
 exit "$rc"
 STUBEOF
-  FAKE_PROBE="$FAKE/tests/meta/$(basename "$PROBE")"
   # CONTROL FIRST, and it is what makes the arm below non-vacuous. Same stub, same
   # mutation, hang switched off: the canary prints, the mutant exits non-zero on its
   # own, and the probe correctly says `wired`. That is the exact shape the kill
@@ -398,14 +450,14 @@ STUBEOF
   # (that would be `not-reached`), and `wired` is demonstrably what this stub earns
   # when the CLOCK does not intervene. Without this, arm 28 passes just as well
   # against a stub that never reached its verdict line at all.
-  COUT="$(STUB_HANG=0 PROBE_TIMEOUT=20 bash "$FAKE_PROBE" --label=ctl --report="$TMP/probe-ctl.txt" 2>/dev/null)"; CRC=$?
+  COUT="$(STUB_HANG=0 PROBE_TIMEOUT=20 bash "$FAKE_PROBE" --only="$STUB" --label=ctl --report="$TMP/probe-ctl.txt" 2>/dev/null)"; CRC=$?
   if (( CRC == 0 )) && grep -q "^wired	$STUB$" "$TMP/probe-ctl.txt"; then
     ok "control: the canary IS reached and this stub earns 'wired' when nothing kills it"
   else bad "control: the canary IS reached and this stub earns 'wired' when nothing kills it" "rc=$CRC $(cat "$TMP/probe-ctl.txt" 2>&1)"; fi
 
   # Now the same stub, killed after the canary. rc is non-zero and the canary is in
   # the output — every precondition the old code read as `wired`.
-  KOUT="$(PROBE_TIMEOUT=2 bash "$FAKE_PROBE" --label=cap2 --report="$TMP/probe-kill.txt" 2>/dev/null)"; KRC=$?
+  KOUT="$(PROBE_TIMEOUT=2 bash "$FAKE_PROBE" --only="$STUB" --label=cap2 --report="$TMP/probe-kill.txt" 2>/dev/null)"; KRC=$?
   want "a mutant killed after the canary does not fail the probe" "0" "$KRC"
   if [[ "$KOUT" == *"0 wired"* && "$KOUT" == *"1 timed-out (cap 2s)"* ]]; then
     ok "the kill is classified timed-out and is NOT counted wired (the false PASS)"
@@ -414,7 +466,7 @@ STUBEOF
     ok "the killed mutant is absent from the union's probed set, so coverage is not banked"
   else bad "the killed mutant is absent from the union's probed set, so coverage is not banked" "$(cat "$TMP/probe-kill.txt" 2>&1)"; fi
 else
-  bad "probe mutant-kill arms" "NOT REACHED: could not symlink $PROBE into $FAKE — arms 26-29 graded nothing"
+  bad "probe mutant-kill arms" "NOT REACHED: could not symlink $PROBE into $FAKE — arms 27-30 graded nothing"
 fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -333,11 +333,8 @@ else bad "a FAILING harness is not also accused of header drift" "rc=$RC out=$OU
 #
 # Graded with a 1s cap against ONE real harness (`--only`), because the probe globs
 # tests/*.sh and has no --corpus-dir seam. Cost: two kills, ~2s.
-# LIMIT, stated rather than implied: this forces the kill BEFORE the canary prints.
-# The killed-after-the-canary shape (the false `wired`) shares the same guard — it is
-# placed ahead of the canary grep precisely so both land in one class — but forcing it
-# live would need a harness that hangs after its verdict line, and inventing one is a
-# corpus file added by a row about not adding corpus files.
+# These arms force the kill BEFORE the canary prints. The killed-AFTER-the-canary
+# shape — the false `wired`, and the half that matters — is arms 26-29 below.
 PROBE="tests/meta/harness-verdict-probe.sh"
 VICTIM="gate_nonce_unit.sh"
 if [[ -r "$PROBE" && -r "tests/$VICTIM" ]]; then
@@ -354,6 +351,70 @@ if [[ -r "$PROBE" && -r "tests/$VICTIM" ]]; then
   else bad "the report row is timed-out and is NOT in the union's probed set" "$(cat "$TMP/probe.txt")"; fi
 else
   bad "probe timeout arms" "NOT REACHED: $PROBE or tests/$VICTIM missing — arms 23-25 graded nothing"
+fi
+
+# --------------- 26-29 DIVE-2555: the kill that arrives AFTER the canary has printed
+# THE HALF THAT MATTERS, and the one nothing in tests/*.sh can reach:
+# `grep -rln '__PROBE_REACHED__' tests/*.sh` is empty, so no real harness exercises
+# the mutant phase's kill at all. The arms above force the kill BEFORE the canary
+# (the old false `not-reached`). This forces it AFTER, which is the FALSE PASS: the
+# canary has printed, so the probe believes the mutation executed, and `timeout`
+# hands it a non-zero exit for free — so an UNWIRED harness banks a `wired` row and
+# the union counts it as probed. The one check that exists to find harnesses which
+# cannot fail CI then reports that they can. The two halves fail in opposite
+# directions and neither subsumes the other (DIVE-2464), so both need an arm.
+#
+# THE SEAM. The probe roots itself at `dirname "$BASH_SOURCE"/../..` and globs
+# `tests/*.sh` from there, so a throwaway tree with a SYMLINK to the probe in
+# tests/meta/ becomes a corpus of exactly one stub — no file added to tests/, per
+# this row's own rule. Symlink and not a copy, deliberately: the arm grades the probe
+# in THIS checkout, so deleting the mutant-phase kill classification reds it here.
+#
+# THE STUB is green and instant on its clean run and hangs only once MUTATED: the
+# injected `fail=$((fail+1))` lands after the canary and before the verdict, and the
+# sleep is downstream of the verdict and gated on `fail`. `STUB_HANG` makes the hang
+# itself a variable, which buys the control below. Cost: one kill, ~2s.
+FAKE="$TMP/fakerepo"
+mkdir -p "$FAKE/tests/meta"
+STUB=hang_after_verdict.sh
+if ln -s "$PWD/$PROBE" "$FAKE/tests/meta/$(basename "$PROBE")" 2>/dev/null; then
+  cat > "$FAKE/tests/$STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+# Stub corpus for DIVE-2555. Its exit status IS wired to its counter; the probe
+# injects its canary and `fail=$((fail+1))` immediately before the verdict line.
+fail=0
+(( fail == 0 ))
+rc=$?
+# Downstream of the verdict and gated on the MUTATED counter: the clean run never
+# sleeps, the mutant always does. STUB_HANG=0 turns the hang off for the control.
+if (( fail != 0 )); then sleep "${STUB_HANG:-20}"; fi
+exit "$rc"
+STUBEOF
+  FAKE_PROBE="$FAKE/tests/meta/$(basename "$PROBE")"
+  # CONTROL FIRST, and it is what makes the arm below non-vacuous. Same stub, same
+  # mutation, hang switched off: the canary prints, the mutant exits non-zero on its
+  # own, and the probe correctly says `wired`. That is the exact shape the kill
+  # arrives in — so a `timed-out` verdict below cannot be the canary going unreached
+  # (that would be `not-reached`), and `wired` is demonstrably what this stub earns
+  # when the CLOCK does not intervene. Without this, arm 28 passes just as well
+  # against a stub that never reached its verdict line at all.
+  COUT="$(STUB_HANG=0 PROBE_TIMEOUT=20 bash "$FAKE_PROBE" --label=ctl --report="$TMP/probe-ctl.txt" 2>/dev/null)"; CRC=$?
+  if (( CRC == 0 )) && grep -q "^wired	$STUB$" "$TMP/probe-ctl.txt"; then
+    ok "control: the canary IS reached and this stub earns 'wired' when nothing kills it"
+  else bad "control: the canary IS reached and this stub earns 'wired' when nothing kills it" "rc=$CRC $(cat "$TMP/probe-ctl.txt" 2>&1)"; fi
+
+  # Now the same stub, killed after the canary. rc is non-zero and the canary is in
+  # the output — every precondition the old code read as `wired`.
+  KOUT="$(PROBE_TIMEOUT=2 bash "$FAKE_PROBE" --label=cap2 --report="$TMP/probe-kill.txt" 2>/dev/null)"; KRC=$?
+  want "a mutant killed after the canary does not fail the probe" "0" "$KRC"
+  if [[ "$KOUT" == *"0 wired"* && "$KOUT" == *"1 timed-out (cap 2s)"* ]]; then
+    ok "the kill is classified timed-out and is NOT counted wired (the false PASS)"
+  else bad "the kill is classified timed-out and is NOT counted wired (the false PASS)" "$KOUT"; fi
+  if grep -q "^timed-out	$STUB$" "$TMP/probe-kill.txt" && ! grep -qE "^(wired|UNWIRED)	$STUB$" "$TMP/probe-kill.txt"; then
+    ok "the killed mutant is absent from the union's probed set, so coverage is not banked"
+  else bad "the killed mutant is absent from the union's probed set, so coverage is not banked" "$(cat "$TMP/probe-kill.txt" 2>&1)"; fi
+else
+  bad "probe mutant-kill arms" "NOT REACHED: could not symlink $PROBE into $FAKE — arms 26-29 graded nothing"
 fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/tests/gate_channel_session_t2_mutation.sh
+++ b/tests/gate_channel_session_t2_mutation.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-# TIER: nightly — 300.0s measured (DIVE-2525): does not fit the 300s PR core; the nightly sweep runs it.
+# TIER: nightly — 378s measured (control plane, 2026-08-03, DIVE-2555): does not fit the 300s PR core; the nightly sweep runs it.
+# The 300.0s this file shipped with named NO environment and NO date, so neither later
+# reading could refute it, only disagree: 335s (main, control plane) and 378s (dev3,
+# same box, `time bash tests/gate_channel_session_t2_mutation.sh` -> rc 0, 14 mutants
+# killed). scripts/run-harnesses.sh now grades this number against its own clock every
+# time the sweep runs it, so the next reading refutes it in the log instead of in a
+# ticket. Quote the environment when you replace it.
 # DIVE-2412 mutation grader for tests/gate_channel_session_t2_unit.sh.
 #
 # WHY THIS FILE EXISTS. Most of what DIVE-2412 ships is REFUSALS, and "it must

--- a/tests/lib/tier.sh
+++ b/tests/lib/tier.sh
@@ -60,6 +60,36 @@
 TIER_BUDGET_CORE=300
 TIER_BUDGET_FULL=1320
 
+# DIVE-2555: HOW FAR A HEADER'S OWN MEASUREMENT MAY DRIFT FROM THE CLOCK.
+#
+# A demotion is argued in the diff with a number — `14.3s measured: does not fit
+# the 300s PR core`. That number is the whole evidence a reviewer has that a cost
+# was moved rather than hidden, and NOTHING GRADED IT: it is free text in a comment,
+# written once, never re-read. Measured 2026-08-03 on the control plane,
+# gate_channel_session_t2_mutation.sh claimed 300.0s and ran 335s (+12%), and the
+# claim had no environment and no date on it, so neither reading could refute the
+# other.
+#
+# The fix costs nothing to run, because the runner already times every harness in
+# the run it was doing anyway (property 2: enforce on the number you MEASURE, never
+# on a table of per-file costs — this grades the table AGAINST the measurement
+# instead of trusting it). Two thresholds, not one:
+#
+#   WARN  measured exceeds the claim by >= 10% AND by >= 1s. Printed with the exact
+#         replacement line. This is the band a busier host or a slower runner can
+#         produce, and the honest remedy is to update the number, not to red a build.
+#   FAIL  >= 50% AND >= 3s over  ->  exit 5. Runner variance does not double a
+#         harness that is already several seconds long. A claim that far under is
+#         not a stale measurement, it is a wrong one, and it was load-bearing
+#         evidence in a review that already happened.
+#
+# Exit 5 is its OWN code for the same reason over-budget is 4 and a red harness is
+# 1: a red that could mean either gets triaged as neither.
+TIER_CLAIM_DRIFT_WARN_PCT=10
+TIER_CLAIM_DRIFT_WARN_S=1
+TIER_CLAIM_DRIFT_FAIL_PCT=50
+TIER_CLAIM_DRIFT_FAIL_S=3
+
 # Match the marker on the harness's own header. Anchored to a comment so a string
 # inside a heredoc or an assertion cannot demote a file by accident.
 TIER_MARKER_RE='^[[:space:]]*#[[:space:]]*TIER:[[:space:]]*([a-z-]+)[[:space:]]*(.*)$'
@@ -106,6 +136,17 @@ tier_reason() {
   printf '%s\n' "${line#"${line%%[![:space:]]*}"}"
 }
 
+# tier_claim <file> -> the number of SECONDS the header claims was MEASURED for this
+# harness ("14.3s measured"), or nothing when the demotion reason argues from
+# something other than a clock ("40s of container setup" is prose, not a claim this
+# can grade, and inventing a number from it would be worse than having none).
+tier_claim() {
+  local r re='([0-9]+(\.[0-9]+)?)s[[:space:]]+measured'
+  r="$(tier_reason "$1")" || return 0
+  [[ -n "$r" && "$r" =~ $re ]] || return 0
+  printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
 # tier_list <core|nightly|full> [corpus-dir=tests] -> harness paths, one per line.
 # `full` is every harness; it is the union, not a third tier.
 # Exits 3 if ANY harness in the corpus has an unreadable marker — a selection built
@@ -145,7 +186,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     list)   tier_list "${2:?list <core|nightly|full>}" "${3:-tests}" ;;
     of)     tier_of "${2:?of <file>}" ;;
     reason) tier_reason "${2:?reason <file>}" ;;
+    claim)  tier_claim  "${2:?claim <file>}" ;;
     budget) tier_budget "${2:?budget <core|full>}" ;;
-    *) printf 'usage: tier.sh {list core|nightly|full [dir] | of <file> | reason <file> | budget core|full}\n' >&2; exit 2 ;;
+    *) printf 'usage: tier.sh {list core|nightly|full [dir] | of <file> | reason <file> | claim <file> | budget core|full}\n' >&2; exit 2 ;;
   esac
 fi

--- a/tests/meta/harness-verdict-probe.sh
+++ b/tests/meta/harness-verdict-probe.sh
@@ -59,6 +59,11 @@ esac; done
 ALLOW_UNPROBEABLE="council_amend_e2e.sh council_roster_lineage_e2e.sh schema_sync_unit.sh"
 
 WIRED=(); UNWIRED=(); UNPROBEABLE=(); ALREADY_RED=(); ALLOWED=(); NOT_REACHED=()
+# DIVE-2555: killed by the time cap. Its own class, because it is neither of the two
+# it used to be folded into: not a failed assertion (already-red) and not an early
+# skip (not-reached), and above all not a verdict (a non-zero exit produced by the
+# KILL is not evidence that the harness's exit status is wired to anything).
+TIMED_OUT=()
 
 # Extract the verdict variable from a harness's last executable line.
 # Prints "<var>\t<lineno>" or nothing. Handles the shapes olivia's census found:
@@ -153,7 +158,21 @@ for t in tests/*.sh; do
   PROBED_N=$(( PROBED_N + 1 ))
   printf '  probing %d/%d %s\n' "$PROBED_N" "$CORPUS_N" "$b" >&2
   if (( ! ASSUME_CLEAN )); then
-    if ! timeout "$TIMEOUT" bash "$t" >/dev/null 2>&1; then ALREADY_RED+=("$b"); continue; fi
+    timeout "$TIMEOUT" bash "$t" >/dev/null 2>&1; rc=$?
+    # DIVE-2555: A KILL IS NOT A FAILURE. `timeout` exits 124 when it has to signal
+    # the child (137 when the child needed SIGKILL), and folding either into
+    # already-red publishes "failed its own clean run" — a statement about the
+    # harness's ASSERTIONS, made on evidence that is entirely about the CLOCK. The
+    # remedy the label implies (find the broken assertion) does not exist, and the
+    # one that does (the long lane, or a slower harness to merge or retire) is not
+    # named anywhere. Same shape as the exit-code split this corpus already carries:
+    # over-budget is exit 4 and a red test is exit 1, because a red that could mean
+    # either gets triaged as neither.
+    if (( rc == 124 || rc == 137 )); then
+      TIMED_OUT+=("$b (clean run killed at ${TIMEOUT}s — over the probe's time cap, NOT a failed assertion)")
+      continue
+    fi
+    if (( rc != 0 )); then ALREADY_RED+=("$b"); continue; fi
   fi
   if spec=$(counter_verdict "$t"); then
     IFS=$'\t' read -r var ln pos <<<"$spec"
@@ -190,6 +209,26 @@ if [[ " $ALLOW_UNPROBEABLE " == *" $b "* ]]; then ALLOWED+=("$b"); else UNPROBEA
   awk -v n="$ln" -v inj="$inject" 'NR==n{print "printf \x27__PROBE_REACHED__\\n\x27 >&2"; print inj} {print}' "$t" > "$mutant"
   out=$(timeout "$TIMEOUT" bash "$mutant" 2>&1 >/dev/null); rc=$?
   rm -f "$mutant"
+  # DIVE-2555: THE KILL MUST BE CLASSIFIED BEFORE THE VERDICT IS READ, because a
+  # killed mutant produces BOTH of this loop's outcomes for reasons that have
+  # nothing to do with wiring:
+  #   * killed after the canary printed -> rc 124, non-zero, counted WIRED. That is
+  #     a FALSE PASS in the coverage direction, and the worst one available here: an
+  #     unwired harness earns a `wired` row, the union counts it as probed, and the
+  #     one check that exists to find harnesses that cannot fail CI says it can.
+  #   * killed before the canary printed -> not-reached, whose message says the
+  #     harness "exits early in this environment". It did not exit; it was killed.
+  #     A true classification with a false explanation sends the reader to look for
+  #     a skip guard that is not there (DIVE-2412 spent exactly that trip before
+  #     landing the 900s lane).
+  # Neither is a failure and neither is coverage: `timed-out` is reported, carried
+  # into the report, and NOT in the union's probed set — so a harness timed out in
+  # EVERY environment reds the union as NEVER PROBED, which is true and is the
+  # signal that its lane needs the time.
+  if (( rc == 124 || rc == 137 )); then
+    TIMED_OUT+=("$b (mutant killed at ${TIMEOUT}s — no verdict was observed; raise PROBE_TIMEOUT for it or make it faster)")
+    continue
+  fi
   if ! grep -q '__PROBE_REACHED__' <<<"$out"; then
     NOT_REACHED+=("$b (verdict line $ln never executed — harness exits early in this environment)")
     continue
@@ -199,13 +238,14 @@ if [[ " $ALLOW_UNPROBEABLE " == *" $b "* ]]; then ALLOWED+=("$b"); else UNPROBEA
   else WIRED+=("$b"); fi
 done
 
-printf 'harness-verdict-probe: %d wired, %d UNWIRED, %d UNPROBEABLE, %d allowlisted, %d not-reached, %d already-red\n' \
-  "${#WIRED[@]}" "${#UNWIRED[@]}" "${#UNPROBEABLE[@]}" "${#ALLOWED[@]}" "${#NOT_REACHED[@]}" "${#ALREADY_RED[@]}"
+printf 'harness-verdict-probe: %d wired, %d UNWIRED, %d UNPROBEABLE, %d allowlisted, %d not-reached, %d already-red, %d timed-out (cap %ss)\n' \
+  "${#WIRED[@]}" "${#UNWIRED[@]}" "${#UNPROBEABLE[@]}" "${#ALLOWED[@]}" "${#NOT_REACHED[@]}" "${#ALREADY_RED[@]}" "${#TIMED_OUT[@]}" "$TIMEOUT"
 for x in "${UNWIRED[@]:-}";     do [[ -n "$x" ]] && printf 'UNWIRED      %s — exit status is NOT wired to its assertions; it cannot fail CI\n' "$x"; done
 for x in "${UNPROBEABLE[@]:-}"; do [[ -n "$x" ]] && printf 'UNPROBEABLE  %s — no identifiable verdict variable; NOT counted clean\n' "$x"; done
 for x in "${NOT_REACHED[@]:-}";  do [[ -n "$x" ]] && printf 'not-reached  %s — skipped before the verdict here; probed in an environment where it runs\n' "$x"; done
 for x in "${ALLOWED[@]:-}";     do [[ -n "$x" ]] && printf 'allowlisted  %s — unprobeable, permitted by name with a recorded reason\n' "$x"; done
 for x in "${ALREADY_RED[@]:-}"; do [[ -n "$x" ]] && printf 'ALREADY-RED  %s — failed its own clean run; reported, not probed\n' "$x"; done
+for x in "${TIMED_OUT[@]:-}";   do [[ -n "$x" ]] && printf 'timed-out    %s — the CLOCK ran out, not an assertion; not counted as probed, so the union will say so if every environment times it out\n' "$x"; done
 
 # DIVE-2018: the machine-readable half. `not-reached` is still not a failure HERE
 # — a skip is not an accusation — so this run cannot establish coverage on its own.
@@ -227,6 +267,7 @@ if [[ -n "$REPORT" ]]; then
     for x in "${ALLOWED[@]:-}";     do [[ -n "$x" ]] && printf 'allowlisted\t%s\n'  "${x%% *}"; done
     for x in "${NOT_REACHED[@]:-}"; do [[ -n "$x" ]] && printf 'not-reached\t%s\n'  "${x%% *}"; done
     for x in "${ALREADY_RED[@]:-}"; do [[ -n "$x" ]] && printf 'already-red\t%s\n'  "${x%% *}"; done
+    for x in "${TIMED_OUT[@]:-}";   do [[ -n "$x" ]] && printf 'timed-out\t%s\n'    "${x%% *}"; done
     # Terminating `:` is load-bearing. A brace group's status is its LAST command's,
     # and every loop above ends on `[[ -n "$x" ]] && printf` — which is FALSE, not an
     # error, whenever that category is empty. Without this the guard below fired on a
@@ -240,7 +281,7 @@ if [[ -n "$REPORT" ]]; then
   # (full disk) leaves a truncated file that the redirect status cannot see. The row
   # count must match what we classified, or the report is not usable as evidence.
   rows=$(grep -cv '^#' "$REPORT")
-  want=$(( ${#WIRED[@]} + ${#UNWIRED[@]} + ${#UNPROBEABLE[@]} + ${#ALLOWED[@]} + ${#NOT_REACHED[@]} + ${#ALREADY_RED[@]} ))
+  want=$(( ${#WIRED[@]} + ${#UNWIRED[@]} + ${#UNPROBEABLE[@]} + ${#ALLOWED[@]} + ${#NOT_REACHED[@]} + ${#ALREADY_RED[@]} + ${#TIMED_OUT[@]} ))
   if (( rows != want )); then
     printf 'probe: report %s has %d rows, classified %d — refusing to emit a partial report\n' "$REPORT" "$rows" "$want" >&2
     exit 1


### PR DESCRIPTION
Two defects in how the corpus reads its own results. Both are the same shape: **a time budget firing was treated as evidence about the work, when it is only evidence about the clock.**

**1. A timeout KILL was classified before the verdict was read.** `harness-verdict-probe.sh` looked at rc=124/137 first, so a killed *clean* run was reported "already-red" — an accusation about assertions, from evidence about the clock. Worse in the other direction: a killed *mutant* that had already printed its canary was counted "wired", a false PASS in the **coverage** direction, since a timeout supplies the non-zero exit for free. Kills are now their own class, `timed-out`, absent from the union's probed set — so a harness killed in every lane reds as NEVER PROBED instead of banking coverage it never earned.

**2. Nightly header measurements were ~12% optimistic and ungraded.** `run-harnesses.sh` now grades every `# TIER: nightly — Ns measured` claim against `MS[]`, the measurement it was already taking. ≥10%/1s over prints the exact replacement line; ≥50%/3s over exits 5 — its own code, because "correct a number" is neither "fix a test" (1) nor "retire a guard" (4). A FAILED harness is never accused. `gate_channel_session_t2_mutation.sh` restamped 300.0s → 378s **with its environment and date**, since a figure naming neither cannot be refuted, only disagreed with.

**Verification.** Built by dev2. olivia graded it independently with **five** separate mutations in a writable copy — and caught that her first four silently no-op'd against a read-only worktree, producing pristine runs she nearly read as mutant runs. All five reproduce and are killed: delete mutant-phase rc==124/137 → 38/2; delete clean-phase → 38/2; remove exit 5 → 39/1; `tier_claim` never yields → 35/5; write timed-out rows as wired → 38/2. Plus `corpus_tier_budget_unit.sh` 40/0, `harness_verdict_union_unit.sh` 17/0, `actionlint-scan.sh` rc=0, `bash -n` clean on all five changed scripts.

Rebased by main onto current `main` (`1cc1ce1`) — dev2 cut at `2a8f192` and cannot push `.github/workflows/`. Both suites **re-run through the rebased tree**, not inherited: 40/0 and 17/0.

**Disclosed behaviour change:** a harness counted "wired" today only because a kill produced its non-zero exit will now surface as NEVER PROBED. That red would be *true*, and the remedy is the `SLOW_HARNESSES` list, not an allowlist entry. Bounded rather than enumerated: the largest non-slow-lane header claim is 76.8s against the 180s cap, so only the 900s lane is near it.

**Not done, deliberately:** the other 72 nightly headers were not restamped. The budget binds in CI and these are control-plane numbers; the new drift report emits that list from the CI clock on the first nightly, which is the right reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)