### PR TITLE
fix(digest): credit the MAKER, not whoever owned the row at close (DIVE-2556)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased — fix(digest): a completion was credited to whoever OWNED the row at close, which on a graded row is the verifier (DIVE-2556)
+
+On a maker/verifier loop the row's `assignee` moves to the verifier at delivery,
+and the verifier still owns it when it closes. Every read that attributes a
+completion to `assignee` therefore credits the grader and zeroes the builder.
+Measured 2026-08-03: of 28 rows closed in 24h, ten were built by `dev`; dev's
+credited count for the same window was **zero**, while it held 119 of 170 open
+todos and seven agents sat empty. The remedy that follows from that chart — move
+work off the idle-looking builder — is the exact inverse of what the board needs,
+and the bias is not noise: reassignment is *caused* by progress, so a per-owner
+count drops precisely the rows that completed and keeps the untouched ones
+(`community/wiki/counting-throughput-by-a-mutable-owner-field-hides-the-completed-work.md`).
+
+`5dive digest` now credits **`COALESCE(maker_agent, assignee)`** and reports the
+verifier as a **separate series**, never merged into the maker's:
+
+- `throughput.byMaker` / `throughput.byVerifier` in `--json`, plus `built by:` and
+  `verified by:` lines under Shipped in the text digest;
+- each `done` entry carries `maker` and `verifier` alongside the unchanged
+  `assignee` (still the current owner — no consumer's field changed meaning);
+- the Shipped line names the maker, with `(verified by <agent>)` beside it.
+
+The fallback is load-bearing and is not cosmetic: a bare swap to `maker_agent`
+would drop every row that never ran a loop, since `maker_agent` is NULL there.
+`tests/digest_maker_credit_unit.sh` pins that (arm E) and grades the whole seam
+end-to-end — real `task add/start/done` verbs, the real `task ls --json` producer
+(which had to start emitting `maker_agent`/`verifier` for the fix to reach the
+digest at all), the digest's own embedded python. Arm B is the control: on the
+same three rows the old by-assignee instrument still returns dev **0** / olivia
+**2**, so the green arms are graded against an instrument that fails.
+
+Sibling, same morning and same shape: DIVE-2554 (the human-ask counter reads only
+the live tasks table and renders 0 on days that had asks). Both attribute to the
+wrong party rather than losing data.
+
 ## Unreleased — feat(pack): export an agent as ONE AGENTS.md that codex and opencode read as-is (DIVE-2565)
 
 A tarball pack is a fine archive and a poor artefact: you cannot read it, diff it,

--- a/src/cmd_digest.sh
+++ b/src/cmd_digest.sh
@@ -289,13 +289,39 @@ for t in work:
 
 def line(t):
     who = t.get("assignee") or "unassigned"
+    # DIVE-2556: `assignee` is the row's CURRENT owner, and on a maker/verifier
+    # loop it moves to the VERIFIER at delivery — the verifier then closes the
+    # row, so it is still theirs at close. Crediting a completion to `assignee`
+    # therefore credits the grader and zeroes the builder: measured 2026-08-03,
+    # dev built 10 of the 28 rows closed in 24h and its credited count was 0.
+    # Fall back to `assignee` rather than swapping to maker_agent outright —
+    # maker_agent is NULL on every row that never ran a loop, and those rows
+    # would vanish from the count entirely.
+    maker = t.get("maker_agent") or who
+    ver = t.get("verifier") or ""
     return {"ident": t.get("ident"), "title": (t.get("title") or "").strip(),
-            "assignee": who, "ask": (t.get("ask") or "").strip(),
+            "assignee": who, "maker": maker, "verifier": ver,
+            "ask": (t.get("ask") or "").strip(),
             "need_type": t.get("need_type")}
 
 done_l = [line(t) for t in done]
 ip_l = [line(t) for t in in_progress]
 blk_l = [line(t) for t in blocked]
+
+# DIVE-2556: maker and verifier as two SEPARATE series, never one merged
+# per-owner tally. A row that was built by one agent and graded by another is a
+# unit of work for both, counted under each — summing byMaker gives the fleet's
+# build throughput, summing byVerifier its review load, and neither number is
+# the other's. Keyed on the same COALESCE(maker_agent, assignee) as the lines
+# above so a loopless row still lands on whoever holds it.
+def _tally(items, key):
+    d = {}
+    for x in items:
+        k = x.get(key)
+        if k:
+            d[k] = d.get(k, 0) + 1
+    return dict(sorted(d.items(), key=lambda kv: (-kv[1], kv[0])))
+throughput = {"byMaker": _tally(done_l, "maker"), "byVerifier": _tally(done_l, "verifier")}
 
 # DIVE-891: gates the tier system cleared without a ping (tier-0 immediate or
 # tier-1 48h TTL — need_answered_by 'auto:t0' / 'auto:ttl') inside the window.
@@ -560,6 +586,7 @@ if as_json:
         "pointInTime": point_in_time,
         "objectives": objectives,
         "done": done_l, "inProgress": ip_l, "blocked": blk_l, "autoCleared": auto_l,
+        "throughput": throughput,
         "zeroHuman": {"shipped": len(done_l), "humanTouches": len(ht_l), "gates": ht_l},
         "autonomy": autonomy,
         "precedentPrefill": {"count": len(prefilled), "accepted": len(accepted),
@@ -611,11 +638,22 @@ else:
     out.append("")
     out.append(f"✅ Shipped ({len(done_l)})")
     for t in done_l[:8]:
-        out.append(f"  • {t['ident']} {short(t['title'])} — {t['assignee']}")
+        # DIVE-2556: name the MAKER, and the verifier beside it when they differ.
+        # The old line printed `assignee`, which on a graded row is the verifier.
+        cred = t["maker"]
+        if t["verifier"] and t["verifier"] != t["maker"]:
+            cred += f" (verified by {t['verifier']})"
+        out.append(f"  • {t['ident']} {short(t['title'])} — {cred}")
     if not done_l:
         out.append("  (nothing closed)")
     if len(done_l) > 8:
         out.append(f"  … +{len(done_l) - 8} more")
+    if throughput["byMaker"]:
+        _bm = ", ".join(f"{k} {v}" for k, v in list(throughput["byMaker"].items())[:6])
+        out.append(f"  built by: {_bm}")
+    if throughput["byVerifier"]:
+        _bv = ", ".join(f"{k} {v}" for k, v in list(throughput["byVerifier"].items())[:6])
+        out.append(f"  verified by: {_bv}")
     out.append("")
     out.append(f"\U0001F501 In progress ({len(ip_l)})")
     for t in ip_l[:8]:

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -919,7 +919,7 @@ cmd_task_ls() {
     # the mark stands AND no verifier has since been assigned; the dashboard renders
     # it as an "Unverified" badge. NB: no inline SQL `--` comments in this string —
     # dbfmt flattens newlines, so a `--` would comment out the rest of the query.
-    rows=$(dbfmt -json "SELECT id, ident, title, status, priority, assignee, created_by, parent_id, created_at, done_at, body, result, need_type, ask, need_options, recommend, precedent_ref, precedent_kind, need_answer, need_answered_at, need_answered_by, tier, kind, schedule, last_fired_at, last_skipped_at, parked_at, park_reason, wake_at, project_key,
+    rows=$(dbfmt -json "SELECT id, ident, title, status, priority, assignee, created_by, parent_id, created_at, done_at, body, result, need_type, ask, need_options, recommend, precedent_ref, precedent_kind, need_answer, need_answered_at, need_answered_by, tier, kind, schedule, last_fired_at, last_skipped_at, parked_at, park_reason, wake_at, project_key, maker_agent, verifier,
              CASE WHEN maker_agent IS NOT NULL AND assignee=verifier AND status NOT IN ('done','cancelled')
                   THEN CASE WHEN handoff_ack_at IS NOT NULL THEN 'reviewing' ELSE 'delivered' END
                   ELSE NULL END AS handoff_state,

--- a/tests/digest_maker_credit_unit.sh
+++ b/tests/digest_maker_credit_unit.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# DIVE-2556 — completions must be credited to the MAKER, not to whoever happens
+# to own the row at close.
+#
+# The defect, measured 2026-08-03: on a maker/verifier loop the row's `assignee`
+# moves to the verifier at delivery, and the verifier is still the owner when it
+# closes. Every per-assignee throughput read therefore credits the grader and
+# zeroes the builder — dev built 10 of the 28 rows closed in 24h and its
+# credited done count was 0, which reads as an idle agent holding 119 open todos.
+#
+# This harness grades the WHOLE seam, not a fixture: it drives the real
+# `task add/start/done/verify` verbs against a throwaway DB, runs the real
+# `task ls --all --json` (the exact producer `5dive digest` shells out to), and
+# feeds that JSON into the digest's own embedded python. A fix that lands in the
+# digest but never reaches it — because the ls projection does not emit
+# maker_agent — fails here rather than passing on hand-built input.
+#
+# Arms:
+#   A  precondition — the loop actually formed (maker_agent=dev, assignee=olivia)
+#   B  the OLD instrument, on this same data, credits dev 0 and olivia 2
+#      (non-vacuity: the arms below are graded against a control that fails)
+#   C  byMaker credits the builder: dev 2
+#   D  byVerifier is a SEPARATE series: olivia 2 — never merged into byMaker
+#   E  a loopless row (maker_agent NULL) does NOT vanish: it lands on its assignee
+#   F  the rendered Shipped line names the maker, with the verifier beside it
+#
+# Same isolation contract as tests/task_verifier_rail_unit.sh: source src/
+# directly, STATE_DIR at a temp dir, live tasks.db never touched.
+# Run: bash tests/digest_maker_credit_unit.sh   (no root, no network).
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# NOTE the absence of `2>/dev/null` — the helper's stderr line IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
+SRC=src
+TMP="$(mktemp -d /tmp/digest-maker-credit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"
+TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DB="$TASKS_DIR/tasks.db"
+mkdir -p "$TASKS_DIR"
+set +e   # header.sh enabled `set -e`; tests expect non-zero exits
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+eq_t()  { # eq_t <label> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then ok_t "$1"; else bad_t "$1 (expected '$2', got '$3')"; fi
+}
+
+# --- build the board: two graded rows built by dev, one loopless row by dev2 ---
+mk_graded() { # mk_graded <title>
+  local id
+  ( actor_seam_as main; cmd_task_add "$1" --assignee=dev --verifier=olivia ) >/dev/null 2>&1
+  id=$(db "SELECT MAX(id) FROM tasks;")
+  ( actor_seam_as dev;    cmd_task_start "$id" )                >/dev/null 2>&1
+  ( actor_seam_as dev;    cmd_task_done  "$id" --result="built" )>/dev/null 2>&1
+  # the verifier's ACK *is* the close (a second `task done`, run as olivia)
+  ( actor_seam_as olivia; cmd_task_done "$id" --result="graded ok" ) >/dev/null 2>&1
+  printf '%s' "$id"
+}
+G1=$(mk_graded "graded row one")
+G2=$(mk_graded "graded row two")
+( actor_seam_as main; cmd_task_add "loopless row" --assignee=dev2 --no-verify ) >/dev/null 2>&1
+L1=$(db "SELECT MAX(id) FROM tasks;")
+( actor_seam_as dev2; cmd_task_start "$L1" )                 >/dev/null 2>&1
+( actor_seam_as dev2; cmd_task_done  "$L1" --result="built" )>/dev/null 2>&1
+
+# Arm A — precondition. If the loop never formed, every arm below is vacuous:
+# the row would carry assignee=dev and "credit the maker" would be trivially
+# true for the wrong reason.
+eq_t "A1 graded row closed" "done" "$(db "SELECT status FROM tasks WHERE id=${G1};")"
+eq_t "A2 maker_agent stamped to the builder" "dev" \
+     "$(db "SELECT COALESCE(maker_agent,'') FROM tasks WHERE id=${G1};")"
+eq_t "A3 assignee MOVED to the verifier at close" "olivia" \
+     "$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=${G1};")"
+eq_t "A4 loopless row has NO maker_agent" "" \
+     "$(db "SELECT COALESCE(maker_agent,'') FROM tasks WHERE id=${L1};")"
+eq_t "A5 loopless row closed under its builder" "done|dev2" \
+     "$(db "SELECT status||'|'||COALESCE(assignee,'') FROM tasks WHERE id=${L1};")"
+
+# --- run the REAL producer, then the REAL digest python over its output -------
+# `--json` is a GLOBAL flag consumed by main(); the verb itself refuses it, so
+# the producer is driven the way main() drives it: JSON_MODE=1 + the bare verb.
+# Subshell because cmd_task_ls exits the shell on its own success path.
+( JSON_MODE=1 cmd_task_ls --all ) >"$TMP/ls.json" 2>/dev/null
+python3 -c "import json,sys; d=json.load(open('$TMP/ls.json'))['data']; json.dump(d,open('$TMP/tasks.json','w'))" \
+  || { echo "FAIL - task ls --json did not parse"; exit 1; }
+
+awk "/python3 - >.*<<'PY'/{f=1;next} f&&/^PY\$/{f=0} f" src/cmd_digest.sh > "$TMP/digest.py"
+[[ -s "$TMP/digest.py" ]] || { echo "FAIL - could not extract digest python"; exit 1; }
+echo '{"agents":[],"tasks":[]}' > "$TMP/usage.json"; : > "$TMP/hb.txt"
+echo '{"loops":[]}' > "$TMP/loops.json"
+
+run_digest() { # run_digest [json|text]
+  DIGEST_TASKS_F="$TMP/tasks.json" DIGEST_USAGE_F="$TMP/usage.json" \
+  DIGEST_HB_F="$TMP/hb.txt" DIGEST_LOOPS_F="$TMP/loops.json" \
+  DIGEST_WINDOW=604800 DIGEST_JSON="${2:-1}" python3 "$TMP/digest.py" 2>/dev/null
+}
+run_digest json 1 >"$TMP/out.json"
+pick() { python3 -c "import json,sys; print($1)" <"$TMP/out.json"; }
+
+eq_t "shipped 3 rows in window" "3" "$(pick "len(json.load(sys.stdin)['done'])")"
+
+# Arm B — the control. Counting the SAME closed rows by the owner column is the
+# instrument that produced the zero. It must fail here; if it ever agrees with
+# byMaker, this harness has stopped discriminating and arms C/D prove nothing.
+OLD_DEV=$(pick "sum(1 for t in json.load(sys.stdin)['done'] if t['assignee']=='dev')")
+OLD_OLI=$(pick "sum(1 for t in json.load(sys.stdin)['done'] if t['assignee']=='olivia')")
+eq_t "B1 CONTROL: by-assignee credits the builder 0" "0" "$OLD_DEV"
+eq_t "B2 CONTROL: by-assignee credits the grader 2"  "2" "$OLD_OLI"
+
+# Arm C — the fix. Same rows, credited to whoever built them.
+eq_t "C1 byMaker credits the builder 2" "2" \
+     "$(pick "json.load(sys.stdin)['throughput']['byMaker'].get('dev',0)")"
+eq_t "C2 byMaker does NOT credit the grader" "0" \
+     "$(pick "json.load(sys.stdin)['throughput']['byMaker'].get('olivia',0)")"
+
+# Arm D — two series, not one. Review load is real work and is reported, but it
+# is reported SEPARATELY; merging the two is how the builder's count got eaten.
+eq_t "D1 byVerifier credits the grader 2" "2" \
+     "$(pick "json.load(sys.stdin)['throughput']['byVerifier'].get('olivia',0)")"
+eq_t "D2 byVerifier does not carry the loopless row" "0" \
+     "$(pick "json.load(sys.stdin)['throughput']['byVerifier'].get('dev2',0)")"
+
+# Arm E — the trap in the prescribed fix. A bare swap to maker_agent drops every
+# row that never ran a loop (maker_agent NULL), which is most of the board.
+eq_t "E1 loopless row still counted, under its own builder" "1" \
+     "$(pick "json.load(sys.stdin)['throughput']['byMaker'].get('dev2',0)")"
+eq_t "E2 byMaker total == rows closed" "3" \
+     "$(pick "sum(json.load(sys.stdin)['throughput']['byMaker'].values())")"
+
+# Arm F — the human-facing line. The digest text is what lodar actually reads.
+run_digest text 0 >"$TMP/out.txt"
+if grep -qE '^  • .* — dev \(verified by olivia\)$' "$TMP/out.txt"; then
+  ok_t "F1 Shipped line names the maker, verifier beside it"
+else
+  bad_t "F1 Shipped line names the maker, verifier beside it (got: $(grep -m1 '  • ' "$TMP/out.txt"))"
+fi
+if grep -q 'built by: dev 2' "$TMP/out.txt"; then
+  ok_t "F2 per-maker rollup rendered"
+else
+  bad_t "F2 per-maker rollup rendered (got: $(grep -m1 'built by' "$TMP/out.txt"))"
+fi
+if grep -q 'verified by: olivia 2' "$TMP/out.txt"; then
+  ok_t "F3 per-verifier rollup rendered as its own line"
+else
+  bad_t "F3 per-verifier rollup rendered as its own line"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
lodar noticed this himself: *"im surprised dev done so little tasks past 24h."* dev was the most productive builder that day and the board credited them with **zero**.

On a verifier-graded row the `assignee` flips to the **verifier** at close, so by the time anything counts it, the builder's name is gone. dev built 10 of the 28 rows closed in 24h — INST-5, DIVE-1999, 2025, 2506, 1975, 2524, 2517, 2518, 2525, 2528 — and was credited on none. Counting throughput by a mutable owner field hides exactly the rows that *completed*, so the better a lane performs, the worse it measures.

**Fix:** the digest resolves the maker rather than reading the field that gets overwritten.

**Measured on the live board with the patched binary:**
```
built by: dev 11, main 5, marketing 5, dev3 4, codex 3, dev2 3
  • DIVE-2517 …  — dev (verified by olivia)
  • DIVE-2524 …  — dev (verified by olivia)
```
`digest_maker_credit_unit.sh` 17 passed / 0 failed.

**Why this PR exists at all, and it is the more useful finding.** DIVE-2556 was verified by olivia and marked **done at 06:01** — but the branch was never pushed, so the fix was never in `main`. The board read "fixed" for five hours while the counter stayed broken in prod. It slipped because the `done=merged-to-main` gate only fires when a PR exists to notice, and the close landed in the window *before* one was filed. Confirmed before writing this: `origin/main` had 0 hits for `byMaker` and no test file.

That ordering hole is being filed separately. The lesson is narrow and worth stating: **the maker should push before the verifier closes, not after.**

Rebased by main onto `1cc1ce1`; dev2 cut this at an older base and has no push route. CHANGELOG conflict resolved keeping both Unreleased sections, newest first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)