### PR TITLE
feat(pack): a marketplace pack imports onto codex and opencode, not only Claude (DIVE-2568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,54 @@ Still open on `deliver`, named in the source rather than implied to be covered: 
 deliver` with no `--result=` re-stamps `delivery_ref`/`delivered_at` on a closed row, and on a
 closed row with a distinct verifier it still routes. Both are the no-result population this guard
 cannot see.
+## Unreleased — feat(pack): a marketplace pack imports onto codex and opencode, not only Claude (DIVE-2568)
+
+All 19 packs in `character-packs` declare `config.type` `"claude"` and not one
+declares another harness, so "import from the marketplace" meant "import into
+Claude". Nothing in packFormat 1 was actually Claude-specific: `persona.yaml`,
+`card.md`, the manifest, the avatar and `memory/` are harness-neutral markdown
+and data. Only two questions were harness-bound — where the identity doc goes and
+where skills go — and both were already answered per type by `TYPE_PERSONA_FILE`
+and `SKILLS_INSTALL_DIR`.
+
+A pack is now **target-agnostic**, and the set of harnesses it lands on is
+**derived from the CLI rather than declared by the publisher**: every known type
+whose persona doc has a probe-verified home (DIVE-2223). The consequence is the
+point — **no pack has to be republished** to become importable onto codex or
+opencode, and a publisher cannot get compatibility wrong because a publisher does
+not state it. The optional manifest key `config.targets` **narrows** the set and
+can never widen it; `cmd_export` deliberately does not write it, because the set
+is a property of the CLI and baking it in would freeze it on the day the pack was
+packed.
+
+- **The set is stated everywhere an install decision is made**, from one source:
+  `agent inspect`, the import-time disclosure, `market show` and the `market`
+  footer all render `landsOn` out of `_pack_disclosure_json`. `type` in the
+  catalog is shown as *what it was packed as* — the import default, never a
+  ceiling.
+- **A silent drop is fixed.** `settings.json` is Claude Code's file and the only
+  sink for a pack's `model`, `effort`, `hooks` and `plugins`. Importing onto a
+  codex seat dropped all four with nothing on screen: the agent ran the harness
+  default while the manifest still read `model: opus`. Import now names each one
+  **by value**. It is a report, never a refusal — the persona, memory, avatar and
+  skills all land.
+- **An unhostable target is refused before provisioning.** `hermes` and
+  `openclaw` pass `is_known_type` but have no persona path, so an import created
+  a unix account, a home and a unit, then dropped the pack's entire payload and
+  reported success. The fence sits above `cmd_create` and names the harnesses the
+  pack *does* land on.
+- **Distilled memory is now in *effect* on a foreign seat, not merely present.**
+  Import seeds facts to `~/.claude/projects/<slug>/memory` — 5dive's own store,
+  which `5dive memory search` reads for any agent, so the facts were always
+  reachable. They were not *loaded*: it is the Claude Code harness that
+  auto-injects that store each session, and a codex seat reads `.codex/AGENTS.md`
+  and nothing else. The DIVE-2565 renderer is applied to the import direction to
+  inline the facts into the instruction file the target harness actually reads,
+  with the same fenced sections and sentinels the single-file export emits.
+  Claude is deliberately excluded — there the store *is* the loading mechanism,
+  and duplicating every fact into `CLAUDE.md` would double the system prompt to
+  fix a problem that harness does not have. The import envelope reports
+  `memoryInEffect` so the mechanism is stated rather than inferred from the type.
 
 ## Unreleased — fix(digest): a completion was credited to whoever OWNED the row at close, which on a graded row is the verifier (DIVE-2556)
 

--- a/src/cmd_pack.sh
+++ b/src/cmd_pack.sh
@@ -469,8 +469,14 @@ _market_usage() {
   --json                                # machine-readable (dashboard/agent feed)
 
   Then: 5dive hire <role> --from-market --dry-run   (preview a real hire, provisions nothing)
-        5dive agent inspect <slug>                  (full install-time disclosure)
+        5dive agent inspect <slug>                  (full install-time disclosure, incl. which harnesses it lands on)
         5dive agent import <slug> --as=<name>       (clone this exact persona)
+        5dive agent import <slug> --as=<name> --type=codex     (DIVE-2568: onto a non-Claude harness)
+
+  A pack is HARNESS-AGNOSTIC. `type` in the catalog is what it was packed as and
+  is only the import default — the persona, memory, avatar and skills are plain
+  markdown and data, and import renders the identity doc into whichever
+  instruction file the target harness actually reads.
 USAGE
 }
 
@@ -562,6 +568,16 @@ cmd_market() {
           ((complete|tostring) + "%") ]|@tsv)' <<<"$filtered" \
     | column -t -s $'\t' | sed 's/^/  /'
   echo
+  # DIVE-2568: nobody should hire something that will not run. The harness set is
+  # derived per pack, but it is IDENTICAL for every pack that does not narrow
+  # itself — so a per-row column would be the same string repeated N times, which
+  # reads as noise and gets skipped. State it once as a property of the catalog,
+  # and let `market show` carry the per-pack answer for the narrowed case.
+  local _agnostic; _agnostic=$(_pack_targets_from "" | paste -sd, - | sed 's/,/, /g')
+  local _narrowed; _narrowed=$(jq -r '[.[] | select(((.targets // []) | length) > 0) | .slug] | length' <<<"$filtered")
+  echo "  lands on: ${_agnostic:-(no hostable harness on this box)}  — every pack imports onto any of these (5dive agent import <slug> --as=<n> --type=<harness>)"
+  (( _narrowed > 0 )) && echo "  ${_narrowed} pack(s) here narrow that set — see 5dive market show <slug>"
+  echo
   echo "  preview: 5dive market show <slug>    ·    hire: 5dive hire <role> --from-market --dry-run"
 }
 
@@ -581,8 +597,13 @@ cmd_market_show() {
   base=$(_marketplace_base); path=$(jq -r '.path' <<<"$pack")
   card=$(curl -fsSL --max-time 15 "${base}/${path}/card.md" 2>/dev/null || true)
 
+  # DIVE-2568: the per-pack harness answer, derived from THIS CLI and narrowed
+  # only if the catalog entry says so. A pack's `type` in the index is what it was
+  # packed as — the import DEFAULT — never a ceiling, so it is rendered as such.
+  local lands_j; lands_j=$(_pack_targets_from "$(jq -r '(.targets // [])[]? | select(type=="string")' <<<"$pack")" | jq -R . | jq -cs 'map(select(. != ""))')
+
   if (( JSON_MODE )); then
-    ok "" '{pack:$p, card:$c}' --argjson p "$pack" --arg c "$card"
+    ok "" '{pack:$p, card:$c, landsOn:$lands}' --argjson p "$pack" --arg c "$card" --argjson lands "$lands_j"
     return
   fi
   # DIVE-2303: a pack stores the family ALIAS ("opus"), never a concrete id, so the
@@ -596,10 +617,13 @@ cmd_market_show() {
   if [[ -z "$_m" ]]; then _mdisp="-"
   elif [[ "$_mres" != "$_m" ]]; then _mdisp="$_m (currently $_mres)"
   else _mdisp="$_m"; fi
-  jq -r --arg mdisp "$_mdisp" "$_MARKET_JQ"'
+  jq -r --arg mdisp "$_mdisp" --argjson lands "$lands_j" "$_MARKET_JQ"'
     "\(.name)  —  \(.rarity // "unranked") · \(.character // "agent")   ·   completeness \(complete)%",
     "  \(.tagline // "")",
     "",
+    "  lands on: " + (if ($lands|length)>0 then ($lands|join(", ")) else "(no hostable harness on this box)" end)
+                  + (if ((.targets // [])|length) > 0 then "   [narrowed by the pack]" else "" end)
+                  + (if (.type // "") != "" then "   (packed as \(.type))" else "" end),
     "  model:   \($mdisp)    effort: \(.effort // "-")",
     "  memory:  " + (if .includesMemory then "seasoned — ships pre-trained (distilled lessons)" else "persona-only (no seeded memory)" end),
     "  skills:  " + (distinct | if length==0 then "(baseline only)" else join(", ") end),
@@ -611,7 +635,8 @@ cmd_market_show() {
   fi
   echo
   echo "  full disclosure:  5dive agent inspect ${slug}"
-  echo "  clone this one:   5dive agent import ${slug} --as=<name>"
+  echo "  clone this one:   5dive agent import ${slug} --as=<name>            (defaults to the harness it was packed as)"
+  echo "  onto a codex/opencode seat:  5dive agent import ${slug} --as=<name> --type=codex"
   echo "  hire by role:     5dive hire <role> --from-market --dry-run"
 }
 
@@ -623,9 +648,99 @@ cmd_market_show() {
 # new agent's tool events — the agentjacking/prompt-injection surface); the rest
 # (skills/plugins added, system-prompt render, seeded recall, adopted signing
 # key) are lower-risk but still material to an informed install decision.
+# DIVE-2568 — WHICH HARNESSES A PACK CAN LAND ON.
+#
+# Target-agnostic, and DERIVED rather than declared. Nothing in packFormat 1 is
+# Claude-specific: persona.yaml, card.md, the manifest, the avatar and memory/
+# are harness-neutral markdown and data. Exactly two questions are harness-bound
+# — WHERE the identity doc goes and WHERE skills go — and both are already
+# answered per type by TYPE_PERSONA_FILE and SKILLS_INSTALL_DIR. So the target
+# set is "every known type whose persona doc has a probe-verified home", which
+# is the DIVE-2223 invariant, nothing new.
+#
+# The consequence is the point of this row: all 19 shipped packs declare
+# config.type "claude" and not one of them has to be republished to become
+# importable onto codex or opencode. A publisher cannot get compatibility wrong
+# because a publisher does not state it.
+#
+# The optional manifest key config.targets NARROWS the set and can never widen
+# it — a pack that genuinely needs one harness may say so, but no pack may claim
+# a harness this CLI cannot render its persona into.
+#
+# DELIBERATELY NOT WRITTEN BY cmd_export. The set is a property of the CLI, not
+# of the pack; baking it in at pack time freezes it on the day it was packed and
+# recreates precisely the drift DIVE-2303 moved back out of index.json. A pack
+# packed today gets a harness added tomorrow for free.
+_pack_targets_from() {   # _pack_targets_from [<newline-separated declared narrowing>]
+  local declared="${1:-}" t
+  while IFS= read -r t; do
+    [[ -n "$t" ]] || continue
+    # An entry with no persona path (hermes, openclaw) is not a target: the
+    # create would succeed and the persona — the pack's whole payload — would
+    # never reach the model. That is a half-import, not an import.
+    [[ -n "${TYPE_PERSONA_FILE[$t]:-}" ]] || continue
+    is_known_type "$t" || continue
+    if [[ -n "$declared" ]] && ! grep -qxF -- "$t" <<<"$declared"; then continue; fi
+    printf '%s\n' "$t"
+  done < <(printf '%s\n' "${!TYPE_PERSONA_FILE[@]}" | sort -u)
+}
+
+# Same set, read through a pack manifest's optional config.targets narrowing.
+_pack_harness_targets() {   # _pack_harness_targets [<manifest.json>]
+  local mf="${1:-}" declared=""
+  if [[ -n "$mf" && -f "$mf" ]]; then
+    declared=$(jq -r '(.config.targets // [])[]? | select(type=="string")' "$mf" 2>/dev/null || true)
+  fi
+  _pack_targets_from "$declared"
+}
+
+# True when the manifest narrows its own target set (vs. the agnostic default).
+_pack_targets_declared() {   # _pack_targets_declared <manifest.json>
+  [[ -f "${1:-}" ]] || return 1
+  jq -e '((.config.targets // []) | length) > 0' "$1" >/dev/null 2>&1
+}
+
+# DIVE-2568 — WHAT A NON-CLAUDE SEAT CANNOT CARRY, named by value.
+#
+# settings.json is Claude Code's file and it is the ONLY sink 5dive has for a
+# pack's model, effort, hooks and plugins. On a codex or opencode seat those four
+# keys have nowhere to go. That is correct and it is not a reason to refuse the
+# import — the persona, memory, avatar and skills are the payload and they all
+# land. What was wrong is that the drop was SILENT: a pack whose manifest reads
+# model "opus" imported onto codex produced an agent running the harness default
+# while the manifest still read "opus", with nothing on screen either way. Same
+# rule DIVE-2565 set for the three things a text file cannot carry — the drop is
+# fine, the silence is not, and the report must name the VALUE (not just the key)
+# so the operator can set it in the harness's own config.
+#
+# Extracted from cmd_import so it is gradeable without root, a network or an
+# agent user: an assertion on the warn STRING grades the rendering, not the
+# condition, and would pass on a branch that never runs. Emits one item per line;
+# empty output means nothing was dropped. Never fails — a report, not a gate.
+# model/effort are the RESOLVED values the import would have written (manifest,
+# then any explicit --model/--effort override, then resolve_model_alias) — NOT
+# re-read from the manifest here. Reporting the manifest's value would name a
+# model the operator never asked for whenever they passed an override, which is
+# the same class of wrong-but-plausible the report exists to prevent.
+_pack_unapplied_on() {   # _pack_unapplied_on <type> <model> <effort> <hooks-present:0|1> <manifest.json>
+  local type="${1:-}" model="${2:-}" effort="${3:-}" hooks_present="${4:-0}" mf="${5:-}"
+  [[ "$type" == "claude" ]] && return 0
+  [[ -n "$model"  ]] && printf 'model=%s\n'  "$model"
+  [[ -n "$effort" ]] && printf 'effort=%s\n' "$effort"
+  (( hooks_present )) && printf 'hooks\n'
+  if [[ -f "$mf" ]] && jq -e '((.plugins // []) | length) > 0' "$mf" >/dev/null 2>&1; then
+    printf 'plugins\n'
+  fi
+  return 0
+}
+
 _pack_disclosure_json() {
   local stage="$1" mf="$1/manifest.json"
   [[ -f "$mf" ]] || { echo '{}'; return 1; }
+  # DIVE-2568: the harness set is part of the install-time disclosure, not a
+  # separate report — `agent inspect`, the import-time print and the market
+  # preview all read it from here, so there is one answer and three renders.
+  local lands_on; lands_on=$(_pack_harness_targets "$mf" | jq -R . | jq -cs .)
   # A persona.yaml is the canonical identity source, so its presence means the
   # pack (re)renders the agent's system prompt (CLAUDE.md). Pre-strip it may also
   # bundle a private signing key the imported agent would adopt (own its identity).
@@ -634,7 +749,8 @@ _pack_disclosure_json() {
     renders=true
     grep -qF "signing_key" "$stage/persona.yaml" && adopts=true
   fi
-  jq -n --argjson m "$(cat "$mf")" --argjson r "$renders" --argjson a "$adopts" '
+  jq -n --argjson m "$(cat "$mf")" --argjson r "$renders" --argjson a "$adopts" \
+        --argjson lands "$lands_on" '
     ($m.hooks // {}) as $h
     | ($m.plugins // []) as $p
     | [$h | .. | objects | .command? // empty] as $cmds
@@ -656,6 +772,12 @@ _pack_disclosure_json() {
                        present: (($pcmds | length) > 0 or ($pHookBlocks | length) > 0) },
         skills:  ($m.skills  // []),
         plugins: ($m.plugins // []),
+        # DIVE-2568. `landsOn` is DERIVED from this CLI; `declaredType` is what
+        # the pack itself was packed as and is only the import DEFAULT, never a
+        # ceiling. `narrowed` says the publisher restricted the set by hand.
+        landsOn:      $lands,
+        declaredType: ($m.config.type // null),
+        narrowed:     ((($m.config.targets // []) | length) > 0),
         rendersSystemPrompt: $r,
         seedsMemory: (($m.includes.memory // false) != false),
         adoptsSigningKey: $a
@@ -691,7 +813,15 @@ _pack_disclosure_print() {
          elif ($p|type)=="array"  then [$p[] | if type=="object" then (.name // "plugin") else tostring end]
          else [] end) as $names
       | if ($names|length)>0 then ($names|join(", ")) else "none" end' <<<"$d")"
-  echo "     system prompt (CLAUDE.md) re-rendered from persona: $(jq -r '.rendersSystemPrompt' <<<"$d")"
+  # DIVE-2568: state the harness set BEFORE the reader decides to install. "Which
+  # seats does this run on" is an install decision, so it belongs in the same
+  # disclosure as "what does it run", not in a separate command.
+  echo "     lands on: $(jq -r '
+      (.landsOn // []) as $l
+      | (if ($l|length)>0 then ($l|join(", ")) else "(no harness on this box can host it)" end)
+      + (if .narrowed then "   [narrowed by the pack]" else "" end)
+      + (if (.declaredType // "") != "" then "   (packed as \(.declaredType))" else "" end)' <<<"$d")"
+  echo "     system prompt re-rendered from persona: $(jq -r '.rendersSystemPrompt' <<<"$d")"
   echo "     seeds recall memory: $(jq -r '.seedsMemory' <<<"$d")"
   echo "     adopts a bundled signing key (owns identity): $(jq -r '.adoptsSigningKey' <<<"$d")"
   echo "  ─────────────────────────────────────────────────────────────"
@@ -1165,24 +1295,83 @@ _agents_md_render() {
   fi
 
   # Memory: fenced, one section per fact, opt-in and already scoped upstream.
-  if [[ -d "$stage/memory" ]] && find "$stage/memory" -maxdepth 1 -name '*.md' 2>/dev/null | grep -q .; then
-    printf '%s\n' "$AGENTS_MD_S_MEMORY"
-    printf '# Memory\n\n'
-    printf 'Distilled persona memory, one fact per section. `5dive agent import`\n'
-    printf 'writes each back to `memory/<file>`; any other harness just reads them.\n\n'
-    local f base fence
-    while IFS= read -r f; do
-      base=$(basename "$f")
-      fence=$(_agents_md_fence "$f")
-      printf '<!-- 5dive:memory-file: %s -->\n' "$base"
-      printf '## memory/%s\n\n' "$base"
-      printf '%s\n' "$fence"
-      cat "$f"
-      # A fact not ending in a newline would swallow the closing fence.
-      [[ -n "$(tail -c1 "$f")" ]] && printf '\n'
-      printf '%s\n\n' "$fence"
-    done < <(find "$stage/memory" -maxdepth 1 -name '*.md' 2>/dev/null | sort)
+  _agents_md_render_memory "$stage"
+}
+
+# The memory half of the render, extracted VERBATIM so cmd_import can reuse it
+# (DIVE-2568). Emits nothing when the stage carries no facts, so callers can call
+# it unconditionally. tests/pack_agents_md_unit.sh grades the export format and is
+# the check that this extraction changed no output — mutation-confirmed: breaking
+# the delegation below reds 3 of its arms.
+_agents_md_render_memory() {
+  local stage="$1"
+  [[ -d "$stage/memory" ]] || return 0
+  find "$stage/memory" -maxdepth 1 -name '*.md' 2>/dev/null | grep -q . || return 0
+  printf '%s\n' "$AGENTS_MD_S_MEMORY"
+  printf '# Memory\n\n'
+  printf 'Distilled persona memory, one fact per section. `5dive agent import`\n'
+  printf 'writes each back to `memory/<file>`; any other harness just reads them.\n\n'
+  local f base fence
+  while IFS= read -r f; do
+    base=$(basename "$f")
+    fence=$(_agents_md_fence "$f")
+    printf '<!-- 5dive:memory-file: %s -->\n' "$base"
+    printf '## memory/%s\n\n' "$base"
+    printf '%s\n' "$fence"
+    cat "$f"
+    # A fact not ending in a newline would swallow the closing fence.
+    [[ -n "$(tail -c1 "$f")" ]] && printf '\n'
+    printf '%s\n\n' "$fence"
+  done < <(find "$stage/memory" -maxdepth 1 -name '*.md' 2>/dev/null | sort)
+  return 0
+}
+
+# DIVE-2568 — MEMORY HAS TO BE IN EFFECT, NOT MERELY PRESENT.
+#
+# The row's acceptance criterion is that a pack hired onto a codex or opencode
+# seat comes up with the persona AND any distilled memory in effect. cmd_import
+# seeds facts to ~/.claude/projects/<slug>/memory — 5dive's own store, which
+# `5dive memory search` reads for ANY agent, so the facts are reachable. They are
+# not LOADED, though: it is the Claude Code harness that auto-injects that store's
+# index each session. A codex seat reads .codex/AGENTS.md and nothing else, so on
+# a foreign harness the memory would sit one command away from an agent with no
+# reason to run it — present, and not in effect. Same shape as the settings.json
+# drop, one layer up.
+#
+# This is what the DIVE-2565 renderer is FOR, applied to the import direction
+# rather than the export one: inline the facts into the instruction file the
+# target harness actually reads, using the same fenced sections and sentinels the
+# single-file export emits. Claude is deliberately excluded — there the store IS
+# auto-loaded, and duplicating every fact into CLAUDE.md would double the system
+# prompt to fix a problem that harness does not have.
+#
+# Rewrites $stage/CLAUDE.md IN PLACE, before persona_install_doc routes it to the
+# harness's own path. Returns 0 when it inlined, 1 when it did not (either not
+# wanted, or it failed and said so) — so the caller reports the mechanism rather
+# than inferring it. A separate function because the alternative is a branch
+# inside cmd_import that only a live root import can reach: an assertion on its
+# warn STRING grades the rendering, not the condition, and stays green on a
+# branch that never runs.
+_pack_inline_memory_into_doc() {   # _pack_inline_memory_into_doc <stage> <type> <mem_inc>
+  local stage="${1:-}" type="${2:-}" mem_inc="${3:-}"
+  local doc="$stage/CLAUDE.md"
+  [[ -f "$doc" ]] || return 1
+  [[ "$type" != "claude" && "$mem_inc" == "distilled" ]] || return 1
+  [[ -d "$stage/memory" ]] || return 1
+  find "$stage/memory" -maxdepth 1 -name '*.md' 2>/dev/null | grep -q . || return 1
+  local inl="$doc.inline.$$" n
+  n=$(find "$stage/memory" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l)
+  if { cat "$doc"; printf '\n'; _agents_md_render_memory "$stage"; } > "$inl" 2>/dev/null \
+     && [[ -s "$inl" ]]; then
+    mv "$inl" "$doc"
+    step "Inlined $n distilled memory fact(s) into the persona doc — a '$type' seat does not auto-load 5dive's memory store"
+    return 0
   fi
+  rm -f "$inl"
+  # NEVER a silent failure: the facts are still seeded and searchable, but this
+  # harness will not load them, and that difference is the whole point of the row.
+  warn "could not inline distilled memory into the persona doc for this '$type' seat — the facts are still seeded and reachable via '5dive memory search', but this harness will not load them automatically"
+  return 1
 }
 
 # Is <file> a 5dive single-file agent export? Anchored on the frontmatter key we
@@ -1714,6 +1903,23 @@ cmd_import() {
   [[ -n "$model" ]] && model=$(resolve_model_alias "$model")
   [[ -n "$type" ]] || { rm -rf "$stage"; fail "$E_VALIDATION" "manifest has no agent type"; }
   is_known_type "$type" || { rm -rf "$stage"; fail "$E_NOT_FOUND" "unknown --type '$type' (known: ${!TYPE_BIN[*]})"; }
+  # DIVE-2568: a pack is target-agnostic, but "agnostic" is not "unbounded" — the
+  # persona has to have somewhere to land. Refuse an unhostable target HERE,
+  # before cmd_create makes a unix account, a home and a systemd unit for an
+  # agent that would come up with none of the character it was hired for.
+  # is_known_type is not enough on its own: hermes and openclaw pass it and have
+  # no TYPE_PERSONA_FILE entry, so today they provision and then silently drop
+  # the entire payload (persona_install_doc warns and returns 1, import carries
+  # on and reports success).
+  local -a _lands=(); mapfile -t _lands < <(_pack_harness_targets "$stage/manifest.json")
+  if ! printf '%s\n' "${_lands[@]+"${_lands[@]}"}" | grep -qxF -- "$type"; then
+    local _why="this CLI has no probe-verified persona path for a '$type' seat, so the pack's identity doc would never reach the model (DIVE-2223)"
+    if _pack_targets_declared "$stage/manifest.json"; then
+      _why="the pack narrows itself to: $(jq -r '(.config.targets // []) | join(", ")' "$stage/manifest.json")"
+    fi
+    rm -rf "$stage"
+    fail "$E_VALIDATION" "this pack cannot be imported onto a '$type' agent — ${_why}. It lands on: ${_lands[*]:-(nothing on this box)}"
+  fi
   [[ -n "$workdir" ]] || workdir="$m_workdir"
   [[ -n "$profile" ]] || profile="$m_profile"
   # DIVE-620: a dashboard marketplace import passes no --auth-profile and packs
@@ -1773,6 +1979,14 @@ cmd_import() {
 
   local cdir="/home/agent-${as}/.claude"
 
+  # DIVE-2568: put distilled memory IN EFFECT for a harness that does not
+  # auto-load 5dive's store. Must run BEFORE the install below, which routes this
+  # same doc to the harness's own instruction path. See _pack_inline_memory_into_doc.
+  local mem_effect="none"
+  if _pack_inline_memory_into_doc "$stage" "$type" "$mem_inc"; then
+    mem_effect="inlined into the persona doc"
+  fi
+
   # Layer the identity doc into the file THIS harness actually reads (DIVE-2223).
   # persona.yaml / avatar.png / settings.json below stay under ~/.claude because
   # 5dive itself reads those; the persona DOC is the one that has to follow the
@@ -1822,6 +2036,17 @@ cmd_import() {
 
   # Layer model/effort/hooks/plugins into settings.json (claude-only keys; others
   # ignore them). settings.json may not exist until first boot.
+  # DIVE-2568 — THE SILENT DROP THIS ROW EXISTS TO REMOVE. See _pack_unapplied_on
+  # for the reasoning; the predicate lives there so it can be graded offline.
+  local cross_dropped='[]'
+  local _hp=0
+  if (( disc_hooks > 0 )) || [[ "$disc_hooks_nonempty" == "true" || "$disc_plugin_hooks" == "true" ]]; then _hp=1; fi
+  local -a _nc=()
+  mapfile -t _nc < <(_pack_unapplied_on "$type" "$model" "$effort" "$_hp" "$stage/manifest.json")
+  if (( ${#_nc[@]} > 0 )); then
+    warn "NOT applied on this '$type' seat (settings.json is Claude Code's file): ${_nc[*]} — set these in the harness's own config; the persona, memory and skills DID land"
+    cross_dropped=$(printf '%s\n' "${_nc[@]}" | jq -R . | jq -cs .)
+  fi
   if [[ "$type" == "claude" ]]; then
     local sfile="$cdir/settings.json" hooks plugins cur
     hooks=$(jq -c '.hooks // {}'     "$stage/manifest.json")
@@ -1883,6 +2108,11 @@ cmd_import() {
       cp "$stage"/memory/*.md "$mdir/" 2>/dev/null || true
       chown -R "agent-${as}:agent-${as}" "$cdir/projects" 2>/dev/null || true
       mem_seeded="$mdir"
+      # DIVE-2568: on a claude seat the store IS the loading mechanism; elsewhere
+      # it is only the searchable one, and the inline above is what puts the facts
+      # in front of the model. Say which happened rather than leaving the reader
+      # to infer it from the type.
+      [[ "$mem_effect" == "none" && "$type" == "claude" ]] && mem_effect="auto-loaded from $mdir"
     else
       mem_seeded="skipped (no workdir to resolve the memory slug)"
     fi
@@ -1935,13 +2165,21 @@ cmd_import() {
   added_j=$(printf '%s\n'   "${added[@]+"${added[@]}"}"   | jq -R . | jq -cs 'map(select(. != ""))')
   skipped_j=$(printf '%s\n' "${skipped[@]+"${skipped[@]}"}" | jq -R . | jq -cs 'map(select(. != ""))')
   local mem_note="no memory"
-  [[ "$mem_inc" == "distilled" ]] && mem_note="distilled memory -> $mem_seeded"
+  [[ "$mem_inc" == "distilled" ]] && mem_note="distilled memory -> $mem_seeded ($mem_effect)"
   local hooks_note="none"
   if (( disc_hooks > 0 )) || [[ "$disc_hooks_nonempty" == "true" || "$disc_plugin_hooks" == "true" ]]; then
     local _pn=""; [[ "$disc_plugin_hooks" == "true" ]] && _pn="+plugin"
     hooks_note="stripped($disc_hooks$_pn)"; (( allow_hooks )) && hooks_note="allowed($disc_hooks$_pn)"
   fi
-  ok "imported '$as' from pack ($mem_note). Skills added: ${#added[@]}, skipped: ${#skipped[@]}; template: $templated; avatar: $avatar_note; hooks: $hooks_note." \
-     '{name:$n, type:$t, memory:$mem, memorySeeded:$ms, skillsAdded:$a, skillsSkipped:$s, template:$tpl, avatar:$av, reported:$ri, hooks:$hk, disclosure:$disc}' \
-     --arg n "$as" --arg t "$type" --arg mem "$mem_inc" --arg ms "$mem_seeded" --argjson a "$added_j" --argjson s "$skipped_j" --arg tpl "$templated" --arg av "$avatar_note" --arg ri "$reported" --arg hk "$hooks_note" --argjson disc "$disclosure"
+  # DIVE-2568: `persona` is where the identity doc actually landed for THIS
+  # harness, and `notApplied` is the machine-readable half of the warn above —
+  # the dashboard renders a cross-harness hire from these two, so neither the
+  # human nor the UI has to infer "did the persona reach a codex seat" from the
+  # absence of an error.
+  local persona_at; persona_at=$(persona_target "$as" "$type" 2>/dev/null || echo "")
+  local lands_j; lands_j=$(printf '%s\n' "${_lands[@]+"${_lands[@]}"}" | jq -R . | jq -cs 'map(select(. != ""))')
+  ok "imported '$as' from pack onto a '$type' seat ($mem_note). Skills added: ${#added[@]}, skipped: ${#skipped[@]}; template: $templated; avatar: $avatar_note; hooks: $hooks_note." \
+     '{name:$n, type:$t, persona:$pa, landsOn:$lands, notApplied:$nap, memory:$mem, memorySeeded:$ms, memoryInEffect:$me, skillsAdded:$a, skillsSkipped:$s, template:$tpl, avatar:$av, reported:$ri, hooks:$hk, disclosure:$disc}' \
+     --arg n "$as" --arg t "$type" --arg pa "$persona_at" --argjson lands "$lands_j" --argjson nap "$cross_dropped" \
+     --arg mem "$mem_inc" --arg ms "$mem_seeded" --arg me "$mem_effect" --argjson a "$added_j" --argjson s "$skipped_j" --arg tpl "$templated" --arg av "$avatar_note" --arg ri "$reported" --arg hk "$hooks_note" --argjson disc "$disclosure"
 }

--- a/tests/pack_cross_harness_unit.sh
+++ b/tests/pack_cross_harness_unit.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+# DIVE-2568 isolated unit harness — a marketplace pack lands on codex and
+# opencode, not only Claude.
+#
+# Grades the PURE half of the row (no root, no network, no agent user):
+#   1. _pack_targets_from / _pack_harness_targets — the DERIVED harness set, its
+#      TYPE_PERSONA_FILE floor, and the manifest's narrow-only override.
+#   2. _pack_disclosure_json / _pack_disclosure_print — the set reaching the
+#      install-time disclosure that `agent inspect`, import and market all render.
+#   3. _pack_unapplied_on / _pack_inline_memory_into_doc — the two things that
+#      differ on a foreign seat: the claude-only settings.json keys (named, not
+#      dropped) and distilled memory (inlined into the instruction file the
+#      harness actually reads, since only Claude Code auto-loads 5dive's store).
+#
+# Sections 3 and 4 are BEHAVIOURAL by design. The first cut of both grepped
+# cmd_import for the branch text, and mutation-grading showed a branch disabled
+# outright (condition -> false) killed NOTHING — a string survives dead code. Both
+# predicates are extracted so the arms execute the shipped path. Same lesson a
+# third time in T7g: a file-wide grep for a call passed on the OTHER call site, so
+# an assertion about one caller is now evaluated inside that caller's body.
+#
+# The impure half (cmd_import provisioning a real codex seat) is graded by the
+# DIVE-2223 persona-routing arms and by the VM smoke matrix; what this file can
+# grade offline is that the SET is right and that nothing drops silently.
+# Run: bash tests/pack_cross_harness_unit.sh
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades. No 2>/dev/null — redirecting the
+# source's stderr also swallows the helper's own stderr payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/cross-harness-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+# cmd_pack.sh is function-defs-only at source time.
+# shellcheck source=/dev/null
+source "$SRC/cmd_pack.sh"
+
+JSON_MODE=1
+set +e   # header.sh enabled `set -e`; tests deliberately probe non-zero paths
+
+PASS=0; FAIL=0
+ok_()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad_()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+check() { if [[ "$2" == "$3" ]]; then ok_ "$1"; else bad_ "$1 (want [$3] got [$2])"; fi; }
+has()   { if grep -qF -- "$2" <<<"$1"; then ok_ "$3"; else bad_ "$3 (missing [$2])"; fi; }
+hasnt() { if grep -qF -- "$2" <<<"$1"; then bad_ "$3 (unexpectedly present: [$2])"; else ok_ "$3"; fi; }
+
+# ---------------------------------------------------------------- fixtures ---
+# A pack that declares itself claude — the shape ALL 19 published packs have.
+# Reserved fakes only (host CLAUDE.md rule): no real slug, no real identifier.
+mk_manifest() {  # mk_manifest <dir> [<targets-json-or-empty>] [<model>] [<effort>]
+  local dir="$1" targets="${2:-}" model="${3:-opus}" effort="${4:-high}"
+  mkdir -p "$dir"
+  jq -n --arg m "$model" --arg e "$effort" \
+        --argjson t "$( [[ -n "$targets" ]] && echo "$targets" || echo 'null' )" '
+    { packFormat: 1, agentName: "testpack", createdWith: "0.0.0-test",
+      includes: { memory: false, persona: false },
+      config: ({ type: "claude", isolation: "standard", model: $m, effort: $e }
+               + (if $t == null then {} else { targets: $t } end)),
+      plugins: [], skills: [], hooks: {} }' > "$dir/manifest.json"
+}
+
+echo "== DIVE-2568 cross-harness import =="
+
+# ---------------------------------------------------- 1. the derived set ------
+# The row's decision: TARGET-AGNOSTIC. A pack packed as "claude" must land on the
+# non-Claude harnesses too, WITHOUT being republished — that is the entire ask.
+AGN=$(_pack_targets_from "")
+check "T1a codex is a target"        "$(grep -cxF codex    <<<"$AGN")" "1"
+check "T1b opencode is a target"     "$(grep -cxF opencode <<<"$AGN")" "1"
+check "T1c claude is still a target" "$(grep -cxF claude   <<<"$AGN")" "1"
+
+# THE FLOOR, and the reason this is derived rather than declared. hermes and
+# openclaw pass is_known_type (they are in TYPE_BIN) but are deliberately absent
+# from TYPE_PERSONA_FILE because neither was ever probe-verified on a live seat
+# (DIVE-2223). Import onto one would create a unix account, a home and a unit,
+# then drop the persona — the pack's whole payload — and report success. A
+# membership assertion alone would pass on any non-empty list, so grade the
+# EXCLUSION explicitly; it is the half that can regress silently.
+check "T1d hermes is NOT a target (no persona path)"   "$(grep -cxF hermes   <<<"$AGN")" "0"
+check "T1e openclaw is NOT a target (no persona path)" "$(grep -cxF openclaw <<<"$AGN")" "0"
+# ...and prove the exclusion is caused by the persona map, not by an empty list:
+# hermes IS a known type, so is_known_type cannot be what filtered it.
+if is_known_type hermes; then ok_ "T1f hermes IS a known type — so the persona map is what excluded it"
+else bad_ "T1f hermes unexpectedly not a known type — T1d proves nothing"; fi
+
+# Every emitted target must have a persona path. This is the invariant, stated
+# as a property rather than as a list, so adding a harness cannot quietly break it.
+_bad=0
+while IFS= read -r t; do [[ -n "${TYPE_PERSONA_FILE[$t]:-}" ]] || _bad=$((_bad+1)); done <<<"$AGN"
+check "T1g every target has a TYPE_PERSONA_FILE entry" "$_bad" "0"
+
+# T1d/T1e/T1g above are satisfied by the ITERATION SOURCE alone — _pack_targets_from
+# walks ${!TYPE_PERSONA_FILE[@]}, so an absent key can never be emitted and the
+# non-empty guard inside the loop is never what excluded hermes. Mutation-graded
+# and confirmed: deleting that guard kills none of them. The guard is not dead,
+# though — it catches the OTHER way a harness can be unmapped, which is a key
+# present with an EMPTY value. header.sh documents hermes/openclaw as
+# "deliberately unmapped"; today that is by absence, and the natural way to make
+# the intent explicit later is `[hermes]=""`, which the iteration source alone
+# would then happily emit. Inject exactly that shape so the guard is load-bearing
+# for a defect no other arm can see.
+TYPE_PERSONA_FILE[t2568empty]=""
+TYPE_BIN[t2568empty]="/nonexistent/t2568"
+TYPE_PERSONA_FILE[t2568mapped]=".t2568/AGENTS.md"
+TYPE_BIN[t2568mapped]="/nonexistent/t2568m"
+INJ=$(_pack_targets_from "")
+# DIFFERENTIAL: the empty-valued key is dropped WHILE a mapped key injected the
+# same way lands. Without the second half, "dropped" also passes on a function
+# that emits nothing at all.
+check "T1h a key mapped to an EMPTY persona path is not a target" "$(grep -cxF t2568empty  <<<"$INJ")" "0"
+check "T1i ...while a mapped injected key IS a target"            "$(grep -cxF t2568mapped <<<"$INJ")" "1"
+unset 'TYPE_PERSONA_FILE[t2568empty]' 'TYPE_BIN[t2568empty]'
+unset 'TYPE_PERSONA_FILE[t2568mapped]' 'TYPE_BIN[t2568mapped]'
+# is_known_type is the other filter and it too must be load-bearing: a persona
+# path for a type with no binary is not a hostable seat.
+TYPE_PERSONA_FILE[t2568nobin]=".t2568/AGENTS.md"
+check "T1j persona path without a TYPE_BIN entry is not a target" \
+      "$(grep -cxF t2568nobin <<<"$(_pack_targets_from "")")" "0"
+unset 'TYPE_PERSONA_FILE[t2568nobin]'
+
+# ------------------------------------------- 2. narrow-only manifest override --
+mk_manifest "$TMP/agnostic"
+mk_manifest "$TMP/narrow" '["claude","codex"]'
+mk_manifest "$TMP/widen"  '["hermes","openclaw"]'
+
+A=$(_pack_harness_targets "$TMP/agnostic/manifest.json")
+N=$(_pack_harness_targets "$TMP/narrow/manifest.json")
+W=$(_pack_harness_targets "$TMP/widen/manifest.json")
+
+check "T2a no targets key -> full agnostic set" "$A" "$AGN"
+check "T2b narrowed set has exactly 2"          "$(grep -c . <<<"$N")" "2"
+check "T2c narrowed keeps codex"                "$(grep -cxF codex    <<<"$N")" "1"
+check "T2d narrowed drops opencode"             "$(grep -cxF opencode <<<"$N")" "0"
+# CANNOT WIDEN: a pack asking for harnesses this CLI has no persona path for
+# gets an EMPTY set, not those harnesses. Without this a publisher could assert
+# compatibility the box cannot honour, and the import would half-land.
+check "T2e cannot widen past the persona map"   "$(grep -c . <<<"$W")" "0"
+check "T2f declared-narrowing is detected"      "$(_pack_targets_declared "$TMP/narrow/manifest.json"; echo $?)"   "0"
+check "T2g absent targets is NOT declared"      "$(_pack_targets_declared "$TMP/agnostic/manifest.json"; echo $?)" "1"
+
+# A malformed targets value must not widen either, and must not crash the render.
+mk_manifest "$TMP/junk" '["codex",7,null]'
+J=$(_pack_harness_targets "$TMP/junk/manifest.json")
+check "T2h non-string targets entries ignored, codex survives" "$J" "codex"
+
+# --------------------------------------------- 3. disclosure carries the set --
+# One answer, three renders (inspect / import / market). Grade the JSON and the
+# human print separately — a field present in the object and missing from the
+# print is exactly the "silently dropped" shape this row is about.
+D=$(_pack_disclosure_json "$TMP/agnostic")
+check "T3a disclosure landsOn has codex"    "$(jq -r '[.landsOn[]|select(.=="codex")]|length'    <<<"$D")" "1"
+check "T3b disclosure landsOn has opencode" "$(jq -r '[.landsOn[]|select(.=="opencode")]|length' <<<"$D")" "1"
+check "T3c declaredType is reported"        "$(jq -r '.declaredType' <<<"$D")" "claude"
+check "T3d agnostic pack is not narrowed"   "$(jq -r '.narrowed'     <<<"$D")" "false"
+
+DN=$(_pack_disclosure_json "$TMP/narrow")
+check "T3e narrowed pack reports narrowed"  "$(jq -r '.narrowed' <<<"$DN")" "true"
+check "T3f narrowed disclosure drops opencode" "$(jq -r '[.landsOn[]|select(.=="opencode")]|length' <<<"$DN")" "0"
+
+P=$(_pack_disclosure_print "$D" 2>&1)
+has  "$P" "lands on:" "T3g the human disclosure states the harness set"
+has  "$P" "codex"     "T3h ...and names codex in it"
+PN=$(_pack_disclosure_print "$DN" 2>&1)
+has  "$PN" "narrowed by the pack" "T3i a narrowed pack says so in the print"
+hasnt "$PN" "opencode"            "T3j ...and does not offer opencode"
+
+# DIFFERENTIAL, not just "says claude": the print must show the packed type as
+# context WITHOUT it reading as the only option. Both facts in one render.
+has "$P" "packed as claude" "T3k print names the packed type as context"
+
+# ---------------------------------------- 4. the model/effort silent drop ------
+# The bug this row removes. settings.json is Claude Code's file and the ONLY sink
+# for a pack's model/effort/hooks/plugins; on a codex seat they have nowhere to
+# go. That is fine — the SILENCE was not. cmd_import's warn is the fix, and the
+# branch is graded here by replaying its exact predicate over a real manifest, so
+# the assertion moves if the manifest keys move.
+#
+# NOT a message-only assertion (feedback: a message assertion grades the
+# rendering, not the condition): each arm asserts the CONDITION that produced the
+# message — the manifest genuinely carries the value that has no sink.
+mf="$TMP/agnostic/manifest.json"
+check "T4a fixture pack really pins a model"  "$(jq -r '.config.model'  "$mf")" "opus"
+check "T4b fixture pack really pins effort"   "$(jq -r '.config.effort' "$mf")" "high"
+# The claude branch is the ONLY writer of these keys — prove it by grepping the
+# one sink rather than by trusting the comment above it. If a second sink ever
+# appears, the premise of the whole report changes and this arm says so.
+SINK=$(grep -c 'effortLevel:\$effort' "$SRC/cmd_pack.sh")
+check "T4c exactly one settings.json sink for effort" "$SINK" "1"
+
+# BEHAVIOURAL, not textual. An earlier cut of these arms grepped cmd_import for
+# the warn string; mutation-grading showed that disabling the branch outright
+# (condition -> false) killed NOTHING, because the text survives a dead branch.
+# The predicate is extracted for exactly this reason and is executed here.
+U_CODEX=$(_pack_unapplied_on codex opus high 0 "$mf")
+U_CLAUDE=$(_pack_unapplied_on claude opus high 0 "$mf")
+check "T4d codex seat reports the model by VALUE"  "$(grep -cxF 'model=opus'  <<<"$U_CODEX")" "1"
+check "T4e codex seat reports the effort by VALUE" "$(grep -cxF 'effort=high' <<<"$U_CODEX")" "1"
+# DIFFERENTIAL: a claude seat reports NOTHING, because on claude the keys DO
+# land. Without this arm, a function that reports everything always would pass.
+check "T4f claude seat reports nothing (the keys land there)" "$(grep -c . <<<"$U_CLAUDE")" "0"
+check "T4g opencode behaves like codex" \
+      "$(_pack_unapplied_on opencode opus high 0 "$mf" | grep -cxF 'model=opus')" "1"
+# The RESOLVED value is reported, not the manifest's — an operator who passed
+# --model=sonnet must be told sonnet is unapplied, not opus. This is the arm
+# that pins the signature to resolved inputs.
+check "T4h an overridden model is reported as the OVERRIDE" \
+      "$(_pack_unapplied_on codex sonnet "" 0 "$mf" | grep -cxF 'model=sonnet')" "1"
+# hooks and plugins are the other two claude-only keys.
+check "T4i hooks reported when present"     "$(_pack_unapplied_on codex "" "" 1 "$mf" | grep -cxF hooks)" "1"
+check "T4j hooks NOT reported when absent"  "$(_pack_unapplied_on codex "" "" 0 "$mf" | grep -cxF hooks)" "0"
+mk_manifest "$TMP/plug"; jq '.plugins=["p@mkt"]' "$TMP/plug/manifest.json" > "$TMP/plug/m2" && mv "$TMP/plug/m2" "$TMP/plug/manifest.json"
+check "T4k plugins reported when the pack ships them" \
+      "$(_pack_unapplied_on codex "" "" 0 "$TMP/plug/manifest.json" | grep -cxF plugins)" "1"
+check "T4l plugins NOT reported for a plugin-less pack" \
+      "$(_pack_unapplied_on codex "" "" 0 "$mf" | grep -cxF plugins)" "0"
+# A pack with nothing claude-only in it produces an EMPTY report on codex — the
+# warn must not fire on a pack that loses nothing.
+mk_manifest "$TMP/bare" '' '' ''
+check "T4m a pack with no claude-only keys drops nothing" \
+      "$(_pack_unapplied_on codex "" "" 0 "$TMP/bare/manifest.json" | grep -c .)" "0"
+# It is a REPORT, never a refusal: the persona, memory, avatar and skills are the
+# payload and they all land on a codex seat. Grade the rc, not the prose.
+_pack_unapplied_on codex opus high 1 "$mf" >/dev/null
+check "T4n the report exits 0 — it never gates the import" "$?" "0"
+# ...and cmd_import consumes it rather than re-implementing it (the extraction is
+# only worth anything if the shipped path is the graded path).
+if grep -q 'mapfile -t _nc < <(_pack_unapplied_on "\$type"' "$SRC/cmd_pack.sh"; then
+  ok_ "T4o cmd_import calls the graded predicate (no second copy)"
+else bad_ "T4o cmd_import does not call _pack_unapplied_on — this file grades dead code"; fi
+
+# ------------------------------------------- 5. the import-time target fence ---
+# cmd_import must refuse an unhostable target BEFORE cmd_create makes an account.
+# Grade the ORDER, not just the presence — a fence below the create is not a
+# fence. Line numbers, because "both strings appear" passes on either order.
+L_FENCE=$(grep -n 'this pack cannot be imported onto a' "$SRC/cmd_pack.sh" | head -1 | cut -d: -f1)
+L_CREATE=$(grep -n 'cmd_create "\${cargs\[@\]}"' "$SRC/cmd_pack.sh" | head -1 | cut -d: -f1)
+if [[ -n "$L_FENCE" && -n "$L_CREATE" ]] && (( L_FENCE < L_CREATE )); then
+  ok_ "T5a target fence sits ABOVE the create call ($L_FENCE < $L_CREATE)"
+else bad_ "T5a target fence not proven above cmd_create (fence=$L_FENCE create=$L_CREATE)"; fi
+# The refusal must name the set it WILL land on — a bare "unsupported" leaves the
+# operator with no next step, and the next step is the whole point of the row.
+if grep -q 'It lands on: \${_lands\[\*\]' "$SRC/cmd_pack.sh"; then
+  ok_ "T5b the refusal names the harnesses it DOES land on"
+else bad_ "T5b the refusal does not name the landable set"; fi
+
+# ------------------------------------------------- 6. the envelope contract ----
+# A dashboard renders a cross-harness hire from these; assert they are wired to
+# the derived values and not to a hardcoded string.
+if grep -q 'persona_target "\$as" "\$type"' "$SRC/cmd_pack.sh"; then
+  ok_ "T6a import reports where the persona ACTUALLY landed for this type"
+else bad_ "T6a import does not resolve the per-type persona path for its envelope"; fi
+if grep -q 'notApplied:\$nap' "$SRC/cmd_pack.sh"; then
+  ok_ "T6b the not-applied list is machine-readable in the ok envelope"
+else bad_ "T6b notApplied missing from the import envelope"; fi
+
+# ------------------------------------- 7. memory IN EFFECT on a foreign seat --
+# The row's acceptance criterion is that a pack hired onto codex/opencode comes up
+# with the persona AND any distilled memory IN EFFECT. Import seeds facts into
+# ~/.claude/projects/<slug>/memory — reachable by `5dive memory search` on any
+# harness, but only Claude Code AUTO-LOADS that store. On a codex seat the facts
+# would be present and not in effect, which is the settings.json drop one layer
+# up. The fix reuses the DIVE-2565 renderer on the import direction.
+MSTAGE="$TMP/mem"; mk_manifest "$MSTAGE"; mkdir -p "$MSTAGE/memory"
+printf '# Ada\n\nYou are Ada.\n' > "$MSTAGE/CLAUDE.md"
+cat > "$MSTAGE/memory/a-fact.md" <<'EOF'
+---
+name: a-fact
+metadata:
+  type: reference
+---
+The build runs green only after the index is rebuilt.
+EOF
+printf 'second fact, no trailing newline' > "$MSTAGE/memory/b-fact.md"
+
+MEMOUT=$(_agents_md_render_memory "$MSTAGE")
+has "$MEMOUT" "a-fact.md"   "T7a the extracted memory renderer emits fact one"
+has "$MEMOUT" "b-fact.md"   "T7b ...and fact two"
+has "$MEMOUT" "The build runs green" "T7c ...with the fact BODY, not just the filename"
+# A fact with no trailing newline must not swallow its closing fence — the
+# renderer's own guard, now exercised through the extracted entry point.
+check "T7d fence count is balanced across both facts" \
+      "$(( $(grep -c '^~~~' <<<"$MEMOUT") % 2 ))" "0"
+# EMPTY-STAGE LIVENESS: emits nothing (so callers may call it unconditionally),
+# and rc is still 0 — a non-zero here would abort cmd_import under set -e.
+EMPTY=$(_agents_md_render_memory "$TMP/agnostic"); _rc=$?
+check "T7e no memory dir -> empty output" "$(grep -c . <<<"$EMPTY")" "0"
+check "T7f ...and rc 0 (never aborts the import)" "$_rc" "0"
+
+# The EXPORT format must be unchanged by the extraction. pack_agents_md_unit.sh
+# grades that across 52 arms and is the real check (mutation-confirmed: breaking
+# the delegation reds 3 of its arms). This arm only pins that the export path
+# still routes THROUGH the shared function rather than growing a second copy.
+#
+# SCOPED TO THE FUNCTION BODY ON PURPOSE. A file-wide grep for the call passes on
+# cmd_import's call site — the string occurs twice — so the first cut of this arm
+# stayed green through a mutation that removed the export delegation entirely.
+# An assertion about one caller has to be evaluated inside that caller.
+RENDER_FN=$(awk '/^_agents_md_render\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$SRC/cmd_pack.sh")
+if [[ $(grep -c . <<<"$RENDER_FN") -gt 20 ]]; then
+  ok_ "T7g-live _agents_md_render body extracted ($(grep -c . <<<"$RENDER_FN") lines)"
+else bad_ "T7g-live could not extract _agents_md_render — T7g would grade nothing"; fi
+has "$RENDER_FN" '_agents_md_render_memory "$stage"' \
+    "T7g _agents_md_render itself delegates to the shared memory emitter"
+# ...and the two call sites are genuinely distinct, which is what made the
+# file-wide grep unsound. Count them rather than assert "at least one".
+check "T7g2 exactly two call sites (export + import)" \
+      "$(grep -c '_agents_md_render_memory "\$stage"' "$SRC/cmd_pack.sh")" "2"
+
+# THE DECISION AND THE REWRITE, both BEHAVIOURAL. An earlier cut replayed the
+# guard in the test and grepped cmd_import for the branch text; a mutant that
+# stopped inlining altogether killed only a call-site count. The rewrite is
+# extracted so these arms execute the shipped code path on a real stage.
+# The stage dir comes back in a global, not on stdout: the function under test
+# writes step/warn to stderr and the rc is the verdict, so multiplexing both onto
+# one captured line is how the first cut of this helper silently mis-split.
+INL_ST=""; _inl_n=0
+inl() {  # inl <type> <mem_inc> — fresh stage each call; rewrites $INL_ST/CLAUDE.md in place
+  local t="$1" mi="$2"
+  _inl_n=$((_inl_n+1)); INL_ST="$TMP/inl.$_inl_n"
+  mkdir -p "$INL_ST/memory"
+  cp "$MSTAGE/manifest.json" "$MSTAGE/CLAUDE.md" "$INL_ST/"
+  cp "$MSTAGE"/memory/*.md "$INL_ST/memory/"
+  _pack_inline_memory_into_doc "$INL_ST" "$t" "$mi" >/dev/null 2>&1
+}
+inl codex distilled
+check "T7h codex + distilled memory -> inlined (rc 0)" "$?" "0"
+has "$(cat "$INL_ST/CLAUDE.md")" "The build runs green" "T7h2 ...the FACT BODY is now in the persona doc"
+has "$(cat "$INL_ST/CLAUDE.md")" "You are Ada"          "T7h3 ...and the original persona survived"
+has "$(cat "$INL_ST/CLAUDE.md")" "5dive:memory-file: a-fact.md" \
+    "T7h4 ...carried by the DIVE-2565 sentinels, not a bespoke format"
+inl opencode distilled
+check "T7i opencode + distilled memory -> inlined" "$?" "0"
+# CLAUDE IS EXCLUDED, and differentially: rc says no AND the doc is UNCHANGED.
+# rc alone would pass on a function that rewrote the file and then returned 1.
+inl claude distilled
+check "T7j claude is EXCLUDED (store is auto-loaded)" "$?" "1"
+check "T7j2 ...and claude's persona doc is byte-identical" \
+      "$(cmp -s "$INL_ST/CLAUDE.md" "$MSTAGE/CLAUDE.md" && echo same || echo CHANGED)" "same"
+inl codex false
+check "T7k no distilled memory -> no inline" "$?" "1"
+# A memory-less pack: same type, same mem_inc, no facts.
+STMP="$TMP/nomem"; mkdir -p "$STMP"; cp "$MSTAGE/manifest.json" "$STMP/"; cp "$MSTAGE/CLAUDE.md" "$STMP/"
+_pack_inline_memory_into_doc "$STMP" codex distilled >/dev/null 2>&1
+check "T7l memory-less pack -> no inline" "$?" "1"
+# IDEMPOTENCE is not claimed and must not be assumed: import runs this once, on a
+# fresh stage. Pin that the doc grows exactly one Memory section per call so a
+# future second caller is a visible change rather than a silent duplication.
+inl codex distilled
+check "T7m exactly one Memory section per inline" \
+      "$(grep -c '^# Memory$' "$INL_ST/CLAUDE.md")" "1"
+# ...and cmd_import consumes the graded function rather than a second copy.
+if grep -q 'if _pack_inline_memory_into_doc "\$stage" "\$type" "\$mem_inc"' "$SRC/cmd_pack.sh"; then
+  ok_ "T7m2 cmd_import calls the graded inline (no second copy)"
+else bad_ "T7m2 cmd_import does not call _pack_inline_memory_into_doc"; fi
+if grep -q 'memoryInEffect:\$me' "$SRC/cmd_pack.sh"; then
+  ok_ "T7n the envelope reports WHICH mechanism put memory in effect"
+else bad_ "T7n memoryInEffect missing from the import envelope"; fi
+
+echo
+echo "  pass=$PASS fail=$FAIL"
+(( FAIL == 0 )) || exit 1


### PR DESCRIPTION
## The row

All 19 packs in `character-packs` declare `config.type` `"claude"` and not one declares another harness, so **"import from the marketplace" meant "import into Claude"**.

Nothing in packFormat 1 was actually Claude-specific. `persona.yaml`, `card.md`, the manifest, the avatar and `memory/` are harness-neutral markdown and data. Only two questions were harness-bound — where the identity doc goes and where skills go — and both were already answered per type by `TYPE_PERSONA_FILE` and `SKILLS_INSTALL_DIR`.

## The decision: target-agnostic, and derived rather than declared

A pack's harness set is now **derived from the CLI**: every known type whose persona doc has a probe-verified home (the DIVE-2223 invariant).

The consequence is the point — **no pack has to be re-released** to become importable onto codex or opencode, and a publisher cannot get compatibility wrong because a publisher does not state it. `config.targets` **narrows** the set and can never widen it.

`cmd_export` deliberately does **not** write it. The set is a property of the CLI; baking it in freezes it on the day the pack was packed and recreates the drift DIVE-2303 moved back out of `index.json`. A pack packed today gets a harness added tomorrow for free.

One source, four renders: `agent inspect`, the import-time disclosure, `market show` and the `market` footer all read `landsOn` out of `_pack_disclosure_json`. The catalog's `type` renders as *what it was packed as* — the import default, never a ceiling.

## Three silent failures removed

All the shape DIVE-2565 refused: **the drop is fine, the silence is not.**

1. **`settings.json` is Claude Code's file** and the only sink for a pack's `model`, `effort`, `hooks` and `plugins`. Importing onto a codex seat dropped all four with nothing on screen — the agent ran the harness default while the manifest still read `model: opus`. Now named **by value**. A report, never a refusal.
2. **`hermes` and `openclaw` pass `is_known_type` but have no persona path**, so an import created a unix account, a home and a systemd unit, then dropped the pack's entire payload and reported success. Fenced above `cmd_create`, naming what it *does* land on.
3. **Distilled memory was present but not in effect.** Import seeds facts to `~/.claude/projects/<slug>/memory`, which `5dive memory search` reads for any agent — but it is the Claude Code harness that **auto-loads** that store, and a codex seat reads `.codex/AGENTS.md` and nothing else. So the DIVE-2565 renderer runs on the **import** direction: facts are inlined into the instruction file the target harness actually reads, same fenced sections and sentinels as the single-file export. Claude is excluded on purpose — there the store *is* the loading mechanism, and duplicating every fact into `CLAUDE.md` would double the system prompt to fix a problem that harness does not have.

That third one is the row's acceptance criterion ("persona **and** distilled memory in effect"), and it is why this row is not just a manifest field.

## Testing

`tests/pack_cross_harness_unit.sh` — **69 arms, 0 fail, 0.5s, core tier.**

The not-applied and inline arms are **behavioural**, and that was learned the hard way three times in this diff. The first cut of each grepped `cmd_import` for the branch text; mutation-grading showed a branch disabled outright (condition → `false`) killed **nothing**, because a string survives dead code. Both predicates are extracted so the arms execute the shipped path. The third instance was subtler: a file-wide grep for a call site passed on the *other* call site, so an assertion about one caller is now evaluated inside that caller's body.

Two guards were also found to be graded *through* rather than graded: the hermes/openclaw exclusion is satisfied by the iteration source alone, so the empty-persona-path guard is now exercised by injecting a key mapped to `""` — the other way a harness can be unmapped, and the one no existing arm could see.

**12 mutants, distinct kill sets:**

| mutation | arms killed |
|---|---|
| codex unmapped in `TYPE_PERSONA_FILE` | 6 |
| narrowing made to widen | 6 |
| not-applied predicate neutered | 6 |
| memory renderer silent | 6 |
| inline drops the memory | 4 |
| inline claude fence removed | 3 |
| fact body dropped | 2 |
| export stops delegating | 2 (+3 in `pack_agents_md_unit`) |
| empty-persona-path guard removed | 1 |
| not-applied claude fence removed | 1 |
| `is_known_type` filter removed | 1 |
| fence trailing-newline guard removed | 1 |

Neighbours green at the same tree: `pack_agents_md_unit` 52, `pack_disclosure_unit` 30, `pack_import_model_alias_unit` 17, `hire_market_resolve_unit` 10, `pack_memory_leakscan_unit` 39.

`pack_agents_md_unit` (52 arms) is the real check that extracting the memory renderer changed **no export bytes** — mutation-confirmed: breaking the delegation reds 3 of its arms.

## Not established

**No live codex/opencode import.** codex is not installed on this box and its installer fails partway — the same gap DIVE-2565 shipped with. The cross-harness claim rests on the derived set, `persona_install_doc` routing by type (DIVE-2223), and the offline arms — not on a seat that came up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
