### PR TITLE
fix(push): guard the installation lookup so its pinned-id fallback is reachable (DIVE-2566)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased — fix(push): the per-repo installation lookup could not fail, so its own fallback was dead code (DIVE-2566)
+
+DIVE-2563 taught `_push_do` to ask GitHub which installation owns the target repo instead of
+minting against one pinned `GITHUB_APP_INSTALLATION_ID`, with a documented fallback to the
+pinned id "when the lookup cannot answer". That fallback was **unreachable in exactly the case
+it was written for.**
+
+`curl -fsS` exits 22 on any HTTP >= 400, `pipefail` promotes that through the `| jq`, and a bare
+`var=$(...)` under the `set -euo pipefail` in `src/header.sh` takes the whole script down. The
+lookup 404s precisely when the repo sits outside every installation — which is the condition the
+fallback exists to survive — so delegated push to any `lodar/*` repo died with a bare `rc=22`,
+curl's exit code, from a namespace that shares no numbers with our own `E_` codes and carries no
+message. dev3 lost an hour to it on DIVE-1560 reading it as a sudo-grant problem.
+
+The fix is `|| _inst_for_repo=""` on the assignment. Empty rather than `|| true` because it
+states the post-condition the fallback branch actually reads.
+
+**The trap worth naming, because the code was written the careful way.** `local _inst_for_repo`
+sits on its own line, split from the assignment — the standard habit, since `local x=$(cmd)`
+always returns 0 and hides the command's failure. Here that correct habit is what made the
+failure fatal: splitting the declaration *stops masking* an error, and this probe is *allowed*
+to fail. **Splitting the declaration is necessary to see a probe's failure and not sufficient to
+handle it**; a probe that may legitimately fail needs the failure handled explicitly.
+
+Graded by mutation rather than by assertion count: removing the guard reddens both new arms
+(92/2), restoring it returns 94/0. `push_unit` 92 -> 94. The behavioural arm derives the shape it
+runs **from `cmd_push.sh` itself** — an inline guarded-vs-unguarded demo stayed green under that
+mutation on the first cut of this test, which is the reason the arm is written the way it is.
+
+This does not make `lodar/*` repos pushable. The App still has no installation on that account
+(DIVE-2033, a human-only step); this converts a silent `rc=22` into the intended named refusal.
+
 ## Unreleased — fix(task): the mandatory merge-gate now catches a branch cited in prose, not just a PR (DIVE-2577)
 
 DIVE-2556 closed `done`, verified by olivia, with its OWN result text stating "commit dc336f7

--- a/src/cmd_push.sh
+++ b/src/cmd_push.sh
@@ -610,13 +610,30 @@ cmd_push_do() {
   # Ask GitHub which installation owns the repo. Fall back to the pinned id when the
   # lookup cannot answer, so a box with one installation and no extra permission
   # behaves exactly as before.
+  #
+  # DIVE-2566: the assignment MUST NOT be allowed to fail the script. `curl -fsS`
+  # exits 22 on any HTTP >= 400, `pipefail` promotes that through the `| jq`, and a
+  # bare `var=$(...)` under `set -e` (src/header.sh:14) takes the whole push down —
+  # so the `elif [[ -z "$_inst_for_repo" ]]` fallback five lines below was
+  # UNREACHABLE in exactly the case it was written for: a repo outside every
+  # installation, where that endpoint 404s. Delegated push to any lodar/* repo died
+  # with a bare rc=22 and no message of its own.
+  #
+  # The trap is that the code was written the CAREFUL way. `local` is declared on
+  # its own line precisely so the substitution's exit status is not masked — the
+  # standard shellcheck-endorsed habit (`local x=$(cmd)` always returns 0 and hides
+  # failures). Here that correct habit is what makes the failure fatal. When a probe
+  # is ALLOWED to fail, splitting the declaration is not enough; the failure has to
+  # be handled explicitly, which is what the `|| _inst_for_repo=""` below does.
+  # Assigning empty rather than `|| true` is deliberate: it states the post-condition
+  # the fallback branch reads, instead of leaving it to the substitution's behaviour.
   local _inst_for_repo
   _inst_for_repo=$(curl -fsS --max-time 15 \
         -H "Authorization: Bearer ${jwt}" \
         -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
         "https://api.github.com/repos/${slug}/installation" 2>/dev/null \
-        | jq -r '.id // empty')
+        | jq -r '.id // empty') || _inst_for_repo=""
   if [[ -n "$_inst_for_repo" && "$_inst_for_repo" != "$inst" ]]; then
     echo "[5dive] ${slug} belongs to installation ${_inst_for_repo}, not the pinned ${inst} — minting against the repo's own installation" >&2
     inst="$_inst_for_repo"

--- a/tests/push_unit.sh
+++ b/tests/push_unit.sh
@@ -834,6 +834,47 @@ grep -q "message // empty" "$SRC/cmd_push.sh" \
   && ok_t "installation: a failed mint surfaces GitHub's own message" \
   || bad_t "installation: mint failure names the cause" "the API error body is discarded"
 
+
+# DIVE-2566: the installation lookup is a probe that is ALLOWED to fail — a repo
+# outside every installation 404s it, which is precisely the case the pinned-id
+# fallback exists for. `curl -fsS` exits 22 on HTTP>=400, `pipefail` promotes it
+# through the `| jq`, and a bare `var=$(...)` under `set -e` kills the push, so the
+# fallback branch was UNREACHABLE in its own motivating case (delegated push to any
+# lodar/* repo died with a bare rc=22 and no message).
+#
+# STATIC ARM: the assignment must handle its own failure.
+grep -qE "jq -r '\.id // empty'\) \|\| _inst_for_repo=" "$SRC/cmd_push.sh" \
+  && ok_t "installation: the lookup assignment cannot fail the script (DIVE-2566)" \
+  || bad_t "installation: lookup is guarded" "the \$( ) assignment is unguarded — under set -e + pipefail a 404 kills the push and the fallback below is dead code"
+
+# BEHAVIOURAL ARM. The grep above only proves a STRING is present, so this one runs
+# the shape the SOURCE actually carries under a real `set -euo pipefail` against a
+# command that exits non-zero. Deriving the tail FROM cmd_push.sh is the whole point:
+# an inline guarded-vs-unguarded demo would pass no matter what the source says, and
+# a mutation to the source would leave it green. (It did, on the first cut of this
+# arm — caught by mutation-grading the guard away and finding only the static arm
+# reddened.) The unguarded control runs alongside it so the arm cannot pass by the
+# probe simply never failing.
+_probe() {  # $1 = tail to append to the assignment
+  bash -c 'set -euo pipefail
+f() {
+  local _inst_for_repo
+  _inst_for_repo=$(sh -c "exit 22" | jq -r ".id // empty" 2>/dev/null)'"$1"'
+  echo "FALLBACK-REACHED:[${_inst_for_repo}]"
+}
+f' 2>/dev/null
+}
+_src_tail=""
+grep -qE "jq -r '\.id // empty'\) \|\| _inst_for_repo=" "$SRC/cmd_push.sh" && _src_tail=' || _inst_for_repo=""'
+_src_out="$(_probe "$_src_tail")"          # the shape cmd_push.sh actually has
+_unguarded_out="$(_probe "")"              # negative control: no guard at all
+if [[ "$_src_out" == "FALLBACK-REACHED:[]" && -z "$_unguarded_out" ]]; then
+  ok_t "installation: the SOURCE's assignment shape reaches the fallback under set -e (DIVE-2566)"
+else
+  bad_t "installation: source shape survives a failing lookup (DIVE-2566)" \
+        "source shape gave '${_src_out:-<died before the fallback>}', unguarded control gave '${_unguarded_out:-<died, correct>}' — the source's own shape must reach the fallback AND the unguarded control must not"
+fi
+
 echo "-----"
 printf 'push_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
DIVE-2563 taught `_push_do` to resolve the App installation per repo, with a documented fallback to the pinned id "when the lookup cannot answer". **That fallback was unreachable in exactly the case it was written for.**

`curl -fsS` exits 22 on HTTP>=400, `pipefail` promotes it through the `| jq`, and a bare `var=$(...)` under `set -euo pipefail` (src/header.sh:14) kills the script. The lookup 404s precisely when the repo is outside every installation — the fallback's own motivating condition — so delegated push to any `lodar/*` repo died with a bare `rc=22`, from a namespace sharing no numbers with our `E_` codes and carrying no message. dev3 lost an hour to it on DIVE-1560, reading it as a sudo-grant problem.

## Reproduced before fixing

```
unguarded shape, set -euo pipefail, failing lookup  ->  exit 22, fallback line never printed
guarded shape,   same conditions                    ->  exit 0,  "FALLBACK-REACHED: inst=''"
```

## The trap, because the code was written the CAREFUL way

`local _inst_for_repo` is declared on its own line, split from the assignment — the standard habit, since `local x=$(cmd)` always returns 0 and hides failures. Here that correct habit is what makes the failure fatal. **Splitting the declaration is necessary to SEE a probe's failure and not sufficient to HANDLE it.** A probe allowed to fail needs its failure handled explicitly.

`|| _inst_for_repo=""` rather than `|| true`: it states the post-condition the fallback branch reads instead of leaving it to the substitution's behaviour.

## Grading

`push_unit` 92 -> 94. Mutation-graded, not assertion-counted: removing the guard reddens **both** new arms (92 passed / 2 failed); restoring returns 94/0.

The behavioural arm derives the shape it runs **from `cmd_push.sh` itself**. The first cut ran an inline guarded-vs-unguarded demo and stayed **green** under that mutation — it proved the mechanism, not the source. That miscarry is why the arm is written the way it is, and it is noted in the test comment.

## What this does NOT do

It does not make `lodar/*` repos pushable. The App still has no installation on that account (DIVE-2033 — a human-only step). This converts a silent `rc=22` into the intended named refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)