### PR TITLE
fix(heartbeat): never ship-flag a type=secret gate on a commit or PR hit (DIVE-2068)

### DIFF
--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -1906,6 +1906,18 @@ _hb_gate_shipped_sweep() {
     [[ -n "$grow" ]] || continue
     IFS=$'\x1f' read -r gid gident gtype gowner <<<"$grow"
     [[ -n "$gid" && -n "$gident" ]] || continue
+    # DIVE-2068: type=secret is satisfied ONLY by a human handing over a
+    # credential — that event cannot appear in a commit or a merged PR, ever.
+    # So for this type a commit/PR hit carries ZERO information and "likely
+    # shipped, verify and close" would be a false positive 100% of the time.
+    # Skip both evidence paths below (subject-PR and row-commit) up front;
+    # decision/approval/manual are unaffected — a commit genuinely can be
+    # evidence for those.
+    if [[ "$gtype" == "secret" ]]; then
+      _hb_log "[gate-shipped] ${gident} — type=secret: a commit/PR can never be evidence a credential was handed over (DIVE-2068); NOT flagging, gate stays eligible"
+      _task_store_audit_log "gate shipped-flag" "skip" 0 -- "task=$gident" "reason=type-secret" || true
+      continue
+    fi
     # DIVE-2414: READ WHAT THE GATE IS ABOUT BEFORE READING THE ROW.
     # The commit-stream lookup below is row-level evidence: it answers "did
     # something naming this ROW land", which on a multi-item row is routinely a

--- a/tests/heartbeat_gate_shipped_unit.sh
+++ b/tests/heartbeat_gate_shipped_unit.sh
@@ -259,6 +259,30 @@ ct_epoch=1767225600   # 2026-01-01Z, the COMMITTER date
 [[ "$ctf3" == "$ct_epoch" ]] \
   && ok_t "DIVE-2014: field 3 is the COMMITTER date (%ct), not the author date (%at)" \
   || bad_t "DIVE-2014: field 3 is not %ct" "got [$ctf3]; %at would be $at_epoch, %ct is $ct_epoch"
+# --- Case 13 (DIVE-2068): type=secret is never flagged, even on a commit hit ---
+# A secret gate is satisfied only by a human handing over a credential — that
+# event cannot appear in a commit, so a commit citing the ident carries zero
+# information about it. Same MERGED fixture as Case 1 (which DOES flag for
+# decision), just a different need_type, to prove the type check is what's
+# gating this and not some other difference in the fixture.
+reset
+gid=$(mk_gate 1 secret)
+MERGED="DIVE-${gid}"
+out=$(_hb_gate_shipped_sweep 2>&1)
+flag=$(db "SELECT COALESCE(shipped_flag_at,'NULL') FROM tasks WHERE id=${gid};")
+[[ "$flag" == "NULL" ]] \
+  && ok_t "DIVE-2068: type=secret gate is NOT flagged on a commit hit (a commit can never be the evidence)" \
+  || bad_t "DIVE-2068: secret gate was flagged" "shipped_flag_at=$flag"
+[[ ! -s "$SEND_LOG" ]] \
+  && ok_t "DIVE-2068: type=secret gate's owner is not pinged" \
+  || bad_t "DIVE-2068: secret gate owner was pinged" "sent=[$(tr '\n' ',' <"$SEND_LOG")]"
+grep -q "reason=type-secret" "$AUDIT_LOG_CALLS" \
+  && ok_t "DIVE-2068: the skip is recorded in the audit log (reason=type-secret)" \
+  || bad_t "DIVE-2068: no audit row for the type-secret skip" "audit=[$(tr '\n' ',' <"$AUDIT_LOG_CALLS")]"
+grep -q "type=secret" <<<"$out" \
+  && ok_t "DIVE-2068: the skip is announced in _hb_log" \
+  || bad_t "DIVE-2068: skip not logged" "out=[${out//$'\n'/ | }]"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 # DIVE-2003 (olivia's reject): this MUST be the LAST command in the file. When the
 # tally printf was moved to the end, this line was left stranded mid-file and the


### PR DESCRIPTION
A `secret` gate is satisfied by **a human handing over a credential**. That event cannot appear in a commit or a merged PR, ever — so for this type a commit/PR hit carries **zero information** and "likely shipped, verify and close" is a false positive 100% of the time. There are no true positives to lose by suppressing it, which is what makes this safe where a general tightening would not be.

Observed 2026-07-26: DIVE-1817 (an open tier-2 secret gate asking for four Telegram MTProto CI secrets) was auto-flagged "likely shipped, verify and close" because an unrelated commit *cited it as an example* in its message. Nothing had shipped for it; all four secrets were still absent from the box.

`_hb_gate_shipped_sweep` now skips both evidence paths up front for `type=secret`, logs why, and writes an audit row. **`decision`/`approval`/`manual` are deliberately unchanged** — for those a commit genuinely can be evidence, and the sweep's general over-flagging is the *safe* direction for a flag-only pass (a false positive costs one ping; a false negative leaves a shipped gate open unnoticed). DIVE-1965 is explicit that gate and sweep want opposite safe defaults.

Why it is worth fixing despite being low severity: a "likely shipped" ping on a gate that *structurally cannot have shipped* trains the reader to discount the flag, and the flag's whole value is that someone acts on it.

Branch pushed by dev2 (no gh credential in that env); PR opened by main. Gate cleared and bound via the task's `Branch:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)