### PR TITLE
fix(build): assert lib/self.sh precedes every five_self_bundle consumer, on the artifact (DIVE-2097)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,13 @@ npm-debug.log*
 # leaves them behind, and `git add -A` in the same tree would commit them (it did).
 tests/.probe-*
 
+# DIVE-2097: transient mutated build.sh written by
+# tests/build_bundle_self_order_unit.sh. Can't live under tests/.probe-* above —
+# build.sh does `cd "$(dirname "$0")"`, so the mutant must run from a path that
+# still sees src/, i.e. the repo root — but it is the same "deleted on a clean
+# exit, survives a kill, git add -A would commit it" shape as the probe mutants.
+/.dive2097-mutant-build.sh
+
 # DIVE-2091: the built bundle is generated at TAG time by release-cut.yml,
 # never committed on main — a 47k-line generated file on main invalidates every
 # open PR on every merge. install.sh fetches it from the tag's tree.

--- a/build.sh
+++ b/build.sh
@@ -109,4 +109,28 @@ if ! grep -qE '^readonly FIVE_VERSION="[^"]+"' "$OUT"; then
   exit 1
 fi
 
+# DIVE-2097: src/lib/self.sh must precede every five_self_bundle consumer in the cat
+# list above. Each consumer opens with `declare -F five_self_bundle ||
+# source ".../lib/self.sh"` — dead code in the bundle, load-bearing in the split tree
+# (see src/lib/self.sh and community/wiki/command-v-answers-the-wrong-question.md
+# rule 5). That property only held because the cat list ABOVE was hand-ordered with a
+# prose comment ("Order matters: ... lib/ helpers -> cmd_*"); nothing enforced it. If a
+# future consumer ever lands ahead of lib/self.sh in the list, the guard fires inside
+# the bundle where dirname "$BASH_SOURCE" is the INSTALL dir and lib/self.sh does not
+# exist — the source fails, and `set -euo pipefail` (src/header.sh) takes the whole CLI
+# down. Checked on the built artifact rather than the cat list text so this also catches
+# a future refactor that stops concatenating from a fixed file list.
+def_line="$(grep -n '^five_self_bundle() {' "$OUT" | head -1 | cut -d: -f1)"
+if [[ -z "$def_line" ]]; then
+  echo "error: $OUT has no five_self_bundle definition — check src/lib/self.sh" >&2
+  exit 1
+fi
+guard_line="$(grep -n 'declare -F five_self_bundle' "$OUT" | head -1 | cut -d: -f1)"
+if [[ -n "$guard_line" && "$def_line" -gt "$guard_line" ]]; then
+  echo "error: $OUT defines five_self_bundle at line $def_line, AFTER the first" >&2
+  echo "  consumer guard at line $guard_line. src/lib/self.sh must be cat'd before" >&2
+  echo "  every five_self_bundle consumer — fix the file order in build.sh." >&2
+  exit 1
+fi
+
 echo "built $OUT ($(wc -l < "$OUT") lines, $(grep -oE '^readonly FIVE_VERSION="[^"]+"' "$OUT" | cut -d'"' -f2)) + $OUT.sha256 ($(cut -c1-16 "$OUT.sha256")…)"

--- a/tests/build_bundle_self_order_unit.sh
+++ b/tests/build_bundle_self_order_unit.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# DIVE-2097 — src/lib/self.sh must precede every five_self_bundle consumer in
+# build.sh's cat list, and that must be a CHECK, not the prose comment it was.
+#
+# Background (main's DIVE-2080 verification): the shipped bundle is safe because
+# lib/self.sh sits third in the cat list, well ahead of cmd_digest.sh / cmd_proof.sh /
+# cmd_selfcheck.sh, whose `declare -F five_self_bundle || source .../lib/self.sh`
+# guard is dead code there and load-bearing only in the split tree (a unit harness
+# sourcing one src/cmd_*.sh with no lib/ ahead of it). Nothing but a hand-maintained
+# comment protected that ordering — if a future consumer landed ahead of lib/self.sh,
+# the guard would fire INSIDE the bundle, where dirname "$BASH_SOURCE" is the install
+# dir and lib/self.sh does not exist, and `set -euo pipefail` would take the whole CLI
+# down. build.sh now asserts the invariant on the built artifact directly (definition
+# line < first consumer-guard line) so this can't regress silently again.
+#
+# Two cases, per community/wiki/grade-absence-assertions-by-mutation.md: a check that
+# never fires on the shipped tree proves nothing about whether it CAN fire. Case 2
+# mutates a COPY of build.sh placed inside the repo root (build.sh itself `cd`s to
+# its own dirname, so it must run from a path that still sees src/) and requires the
+# reorder to be caught.
+#
+#   bash tests/build_bundle_self_order_unit.sh
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+cd "$(dirname "$0")/.."
+ROOT="$PWD"
+
+TMP="$(mktemp -d /tmp/bundle-order.XXXXXX)"
+MUT_BUILD="$ROOT/.dive2097-mutant-build.sh"
+trap 'rm -rf "$TMP" "$MUT_BUILD"' EXIT
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+command -v python3 >/dev/null 2>&1 || { echo "SKIP - python3 not installed"; exit 0; }
+
+# --- case 1: the real cat list builds clean (positive control, no false alarm) ------
+mkdir -p "$TMP/good"
+if ( cd "$ROOT" && BUILD_OUT="$TMP/good/5dive" ./build.sh >"$TMP/good.log" 2>&1 ); then
+  ok_t "build.sh passes the ordering check on the real (correctly-ordered) cat list"
+else
+  bad_t "build.sh passes the ordering check on the real (correctly-ordered) cat list" \
+        "build failed: $(cat "$TMP/good.log")"
+fi
+
+# --- case 2: mutation — reorder the cat list so a consumer precedes lib/self.sh ----
+# Moves src/lib/self.sh to just AFTER src/cmd_digest.sh (a real consumer). If this
+# stays green the check is vacuous; it MUST fail, and fail on the ordering message,
+# not on some unrelated breakage.
+python3 - "$ROOT/build.sh" "$MUT_BUILD" <<'PY'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+lines = open(src).read().splitlines(keepends=True)
+self_idx = next(i for i, l in enumerate(lines) if l.strip() == 'src/lib/self.sh \\')
+digest_idx = next(i for i, l in enumerate(lines) if l.strip() == 'src/cmd_digest.sh \\')
+assert self_idx < digest_idx, "fixture assumption broken: self.sh already after cmd_digest.sh"
+moved = lines.pop(self_idx)
+lines.insert(digest_idx, moved)  # index shifts by one after the pop, landing AFTER cmd_digest.sh
+open(dst, 'w').write(''.join(lines))
+PY
+chmod +x "$MUT_BUILD"
+
+mkdir -p "$TMP/bad"
+if ( cd "$ROOT" && BUILD_OUT="$TMP/bad/5dive" ./.dive2097-mutant-build.sh >"$TMP/bad.log" 2>&1 ); then
+  bad_t "mutation grade: self.sh after a consumer MUST fail the build" \
+        "build succeeded when it should have refused: $(cat "$TMP/bad.log")"
+elif grep -q 'AFTER the first' "$TMP/bad.log"; then
+  ok_t "mutation grade: self.sh after a consumer fails with the ordering error"
+else
+  bad_t "mutation grade: self.sh after a consumer fails with the ordering error" \
+        "build failed but not on the ordering check: $(cat "$TMP/bad.log")"
+fi
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
The shipped bundle is safe today only because `build.sh`'s hand-maintained `cat` list puts `src/lib/self.sh` third, guarded by a **prose comment** ("Order matters: … lib/ helpers -> cmd_*"). Each consumer opens with `declare -F five_self_bundle || source ".../lib/self.sh"` — dead code in the bundle, load-bearing in the split tree where a unit harness sources one `src/cmd_*.sh` with no `lib/` ahead of it.

If a future consumer is ever concatenated ahead of `lib/self.sh`, that guard fires **inside** the bundle, where `dirname "$BASH_SOURCE"` is the install dir and `lib/self.sh` does not exist. The source fails, and `set -euo pipefail` takes the whole CLI down at startup.

Severity is genuinely low — the failure is loud and immediate, so it is a can't-miss defect rather than a silent one. It is worth fixing because the fix is one check and permanent, and because *a comment is not a guard*: this is the same shape as the header.sh comment that sat two lines above DIVE-2075.

**Checked on the built artifact, not on the cat-list text** — definition line vs first consumer-guard line — so it also survives a future refactor that stops concatenating from a fixed file list. An absent definition is a hard error rather than a skip, so the check cannot pass by finding nothing.

Mutation-graded in `tests/build_bundle_self_order_unit.sh`: case 1 builds the real list clean, case 2 moves `src/lib/self.sh` after a real consumer and requires the build to refuse **on the ordering message** rather than on incidental breakage. Verified 2/0.

Review note: the mutation writes a transient `build.sh` copy into the repo root (necessary — `build.sh` cd's to its own dirname, so it must run from a path that still sees `src/`). The EXIT trap cleans it on any normal exit but not on SIGKILL, so `/.dive2097-mutant-build.sh` is gitignored — the repo's `.gitignore` already records this exact class biting once before with `tests/.probe-*` ("`git add -A` in the same tree would commit them (it did)"). Verified: planting the file leaves `git status` clean and `git add -A` stages nothing.

Authored by dev2; PR opened by main (dev2 holds no gh credential in that environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)