### PR TITLE
SECURITY(gate): an agent could forge a human tap on a tier-2 decision gate with one env var (DIVE-2588)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## Unreleased — SECURITY fix(gate): a tier-2 human floor whose OFF switch was reachable by the agents it constrains (DIVE-2588)
+
+Any agent, unprivileged and without sudo, could forge a human tap on a tier-2 **decision**
+gate with one environment variable:
+
+```
+GATE_PROOF_ENFORCE=/nonexistent/nope  5dive task answer <T2-decision> --value=A --human
+```
+
+succeeded where the identical command without it was refused, and wrote
+`need_answered_by=human:<agent>` — the same row the human's own relayed tap writes, so the
+record could not tell them apart. Found by main while grading DIVE-2515 on the released
+v0.18.2 artifact; reproduced on the installed 0.18.0+dive2563 in an isolated store.
+`_gate_proof_enforced` was a file-**existence** test on a path the constrained party
+supplies, so pointing it at anything absent evaluated the whole tier-2 branch false. Scope
+was exactly `decision`: approval/secret/manual/access carry an independent type guard that
+never consults the flag.
+
+Two independent halves, because either alone would have closed the reported command while
+leaving the shape intact:
+
+- **The override may only make enforcement stricter.** An existing sentinel at *either* the
+  root-owned default or the `GATE_PROOF_ENFORCE` path arms it; an absent path now says
+  nothing at all instead of saying "off". Harnesses keep the override they already use —
+  every caller in `tests/` points it at `$STATE_DIR/gate-proof.enforce`, the default it
+  would have resolved anyway.
+- **The tier-2 human floor no longer consults the flag**, in either direction. It was a
+  rollout envelope for a rollout that finished 2026-07-30, and while it stood it made a hard
+  human floor switchable. Safe to make unconditional: the provenance floor refuses only a
+  *non-human* answer on a tier-2 gate, and the evidence block is already scoped to gates
+  carrying a minted nonce — so a box that mints nothing reaches no new assertion, and every
+  real human path passes `--human` (DIVE-525 holds by construction).
+
+Behaviour change worth naming, and its bound: on a box where the sentinel was never armed,
+tier-2 gates now behave as they already do everywhere else. That population is small by
+construction — `install.sh` arms enforcement on every box, fresh install and upgrade alike
+(DIVE-758, "secure-by-default"), so an unarmed box is one where that line failed (it is
+`|| true`) or one that predates it. Both now match the fleet, which is the direction that
+cannot refuse a tap the rest of the fleet accepts. `gate-proof enforce off` no longer leaves
+the default sentinel behind — it used to print OFF while the predicate read ON — and `status`
+now reports which sentinel armed it (`default` / `env-override` / `both`).
+
+New: `5dive selfcheck --only=t2-forge` performs the forge for real in a throwaway store and
+reds if it lands — DIVE-2520's "forge an actor, the rail goes red" one layer up. It also
+answers a second gate down a real human path, because a floor that refuses everything and a
+floor that refuses the forge are the same observation from the refusal alone.
+
+Tests: `tests/gate_enforce_env_bypass_unit.sh` (19 arms; graded against the pre-fix code,
+which reproduces the exploit inside the harness at `state=closed prov=human:dev`).
+`tests/gate_tier2_floor_unit.sh` and `tests/gate_t2_routed_escalate_unit.sh` had arms
+asserting the *opposite* contract — that clearing the flag made the floor dormant — and now
+assert that it does not.
 ## Unreleased — feat(agent): `agent list` reports credential health, so a lapsed seat stops rendering live (DIVE-1953)
 
 On the DIVE-1868 flagship demo a grok seat's credential lapsed. The systemd unit stayed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,24 @@ reds if it lands — DIVE-2520's "forge an actor, the rail goes red" one layer u
 answers a second gate down a real human path, because a floor that refuses everything and a
 floor that refuses the forge are the same observation from the refusal alone.
 
-Tests: `tests/gate_enforce_env_bypass_unit.sh` (19 arms; graded against the pre-fix code,
+Tests: `tests/gate_enforce_env_bypass_unit.sh` (23 arms; graded against the pre-fix code,
 which reproduces the exploit inside the harness at `state=closed prov=human:dev`).
 `tests/gate_tier2_floor_unit.sh` and `tests/gate_t2_routed_escalate_unit.sh` had arms
 asserting the *opposite* contract — that clearing the flag made the floor dormant — and now
 assert that it does not.
+
+Both the harness and the probe had a defect worth naming, because it is the same class this
+row is about. Each stubbed `id -un` to model "the caller is an agent" — and the uid-first
+resolver has not read `id -un` since DIVE-2330; it walks `/etc/passwd` for `$EUID` in pure
+bash, precisely so a PATH shim cannot forge it. The stub was inert, so agent-ness was
+supplied BY THE HOST: `agent-dev` owns uid 1007 on a 5dive box, and 19/19 green there said
+nothing about the property. On a CI runner the same uid is `runner`, no agent claims it, and
+the forge arm was a *legitimate human tap* — 8 arms red, and the probe reported a bypass that
+had not happened. Both now pin `_gate_caller_uid` and `_gate_passwd_stream`, the seams
+`lib/actor.sh` publishes for this, and both assert the pin through the real resolver first: a
+pin that silently yields nothing would make every refusal look right for the wrong reason.
+The probe reports `not-reached` rather than `pass` when its caller does not resolve as an
+agent, since a refusal it cannot attribute measures nothing.
 ## Unreleased — feat(agent): `agent list` reports credential health, so a lapsed seat stops rendering live (DIVE-1953)
 
 On the DIVE-1868 flagship demo a grok seat's credential lapsed. The systemd unit stayed

--- a/src/cmd_selfcheck.sh
+++ b/src/cmd_selfcheck.sh
@@ -59,6 +59,7 @@ fi
 # the union script's contract all read this, so they cannot drift into three lists.
 SELFCHECK_PROBES=(
   lead-clear-seal
+  t2-forge
   gate-delivery
   audit-root
   audit-nonroot
@@ -71,6 +72,7 @@ SELFCHECK_PROBES=(
 _sc_title() {
   case "$1" in
     lead-clear-seal)   echo "the sealed lead-clear allowlist is armed, or reported inert before a gate hits it" ;;
+    t2-forge)          echo "an agent forging a human tap on a tier-2 gate is refused, and a real human path still clears" ;;
     gate-delivery)     echo "a filed gate leaves a delivery row on the filer's own channel" ;;
     audit-root)        echo "a privileged action lands an audit row" ;;
     audit-nonroot)     echo "an UNPRIVILEGED agent action lands an audit row, or leaves a drop marker" ;;
@@ -197,6 +199,90 @@ _sc_probe_lead_clear_seal() {
     *)
       _sc_pass "routed lead-clear is INERT on this box ($why): NO agent can clear an approval/manual/access gate routed to it, and every such gate falls through to a human. Fail-closed and safe — arming it means sealing authority.gate_clear_leads via a council motion, which is deliberately not something an agent can do for itself. $standing" ;;
   esac
+}
+
+# --- probe: forge a human tap, the rail must go RED (DIVE-2588) ----------------
+# DIVE-2520 proved an actor rail by FORGING an actor and demanding the rail notice.
+# This is that probe one layer up, and it exists because the thing it measures was
+# real: until 2026-08-03 an ordinary agent cleared a tier-2 DECISION gate with
+#
+#   GATE_PROOF_ENFORCE=/nonexistent/nope  5dive task answer <gate> --value=A --human
+#
+# no sudo, landing need_answered_by=human:<agent> — a row indistinguishable from the
+# human's own relayed tap. Two guards protected that gate and BOTH consulted one
+# caller-supplied file-existence test.
+#
+# The probe does the forge for real, in a throwaway store, as a stubbed agent caller.
+# It reports fail if the forge lands. It ALSO answers a second gate down a real human
+# path, because a floor that refuses everything and a floor that refuses the forge are
+# the same observation from the refusal alone — and this file's whole thesis is that
+# an instrument reporting success while measuring something else is the defect class.
+_sc_probe_t2_forge() {
+  declare -F cmd_task_answer >/dev/null 2>&1 \
+    || { _sc_notreached "no-answer-path" "cmd_task_answer is not defined in this build"; return; }
+  declare -F _gate_proof_enforced >/dev/null 2>&1 \
+    || { _sc_notreached "no-enforce-predicate" "_gate_proof_enforced is not defined in this build"; return; }
+  local d; d=$(_sc_tmp) || { _sc_notreached "no-tmpdir" "could not create an isolated state dir"; return; }
+  local out; out=$(
+    set +e
+    STATE_DIR="$d"; TASKS_DIR="$d/tasks"; TASKS_DB="$d/tasks/tasks.db"
+    GATE_PROOF_KEY="$d/gate-proof.key"
+    mkdir -p "$TASKS_DIR"
+    export FIVEDIVE_NO_HUMAN_SEND=1
+    JSON_MODE=1
+    tasks_db_init >/dev/null 2>&1
+    task_need_notify() { :; }
+    audit_log() { :; }
+    # FENCE THE OUTBOUND RAIL TOO. The header's two fences (FIVEDIVE_NO_HUMAN_SEND +
+    # a non-prod TASKS_DB) cover the HUMAN send; the answer path's "gate cleared —
+    # resume the task" ping goes out over `cmd_send`, which is the AGENT rail, and it
+    # is not covered by either. Caught the honest way on 2026-08-03: the first run of
+    # this probe delivered a real 5dive-msg about a fixture gate to a live agent.
+    # A prover that emits real traffic is contaminating the evidence base it exists
+    # to protect (DIVE-2010, and the DIVE-1506 fixture leak before it).
+    cmd_send() { return 1; }
+    : > "$d/gate-proof.enforce"     # the live fleet posture since 2026-07-30
+
+    seed() { db "INSERT INTO tasks (ident,title,status,created_by) VALUES ('$1','selfcheck','todo','main');" >/dev/null 2>&1
+             cmd_task_need "$1" --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 >/dev/null 2>&1; }
+    by() { db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident='$1';"; }
+
+    # (a) THE FORGE: an ordinary agent, unprivileged, no sudo — what every agent is.
+    id() { if [[ "${1:-}" == -un ]]; then echo "agent-selfcheck"; else command id "$@"; fi; }
+    _gate_is_root() { return 1; }
+    unset SUDO_UID
+    seed DIVE-990001
+    printf 'tier=%s\n' "$(db "SELECT COALESCE(tier,'') FROM tasks WHERE ident='DIVE-990001';")"
+    ( GATE_PROOF_ENFORCE=/nonexistent/nope cmd_task_answer DIVE-990001 --value=A --human ) >/dev/null 2>&1
+    printf 'forged=%s\n' "$(by DIVE-990001)"
+
+    # (b) LIVENESS: a real human path on an identical gate must still clear.
+    seed DIVE-990002
+    id() { if [[ "${1:-}" == -un ]]; then echo "root"; else command id "$@"; fi; }
+    _gate_is_root() { return 0; }
+    export SUDO_UID=0
+    ( cmd_task_answer DIVE-990002 --value=A --human ) >/dev/null 2>&1
+    printf 'human=%s\n' "$(by DIVE-990002)"
+  )
+  rm -rf "$d"
+
+  local tier forged human
+  tier=$(sed -n 's/^tier=//p' <<<"$out" | head -1)
+  forged=$(sed -n 's/^forged=//p' <<<"$out" | head -1)
+  human=$(sed -n 's/^human=//p' <<<"$out" | head -1)
+
+  [[ "$tier" == "2" ]] \
+    || { _sc_notreached "no-tier2-gate" "the probe's own gate filed as tier '${tier:-?}', so the tier-2 floor was never in play — nothing was measured"; return; }
+
+  if [[ -n "$forged" ]]; then
+    _sc_fail "AN AGENT FORGED A HUMAN TAP: a tier-2 decision gate was cleared by an unprivileged agent with GATE_PROOF_ENFORCE pointed at an absent path, and the row reads need_answered_by='$forged' — indistinguishable from the human's own tap (DIVE-2588)"
+    return
+  fi
+  if [[ "$human" != human:* ]]; then
+    _sc_fail "the forge was refused, but so was a REAL human path on an identical gate (need_answered_by='${human:-empty}') — this probe cannot tell a working floor from a store that refuses everything, so its pass would be meaningless"
+    return
+  fi
+  _sc_pass "the forge is refused (gate left unanswered, nothing stamped) while a real human path on an identical tier-2 gate clears as '$human' — the floor discriminates rather than blocking everything"
 }
 
 _sc_probe_gate_delivery() {
@@ -606,6 +692,7 @@ _sc_probe_scorecard_honesty() {
 _sc_dispatch() {
   case "$1" in
     lead-clear-seal)   _sc_probe_lead_clear_seal ;;
+    t2-forge)          _sc_probe_t2_forge ;;
     gate-delivery)     _sc_probe_gate_delivery ;;
     audit-root)        _sc_probe_audit_root ;;
     audit-nonroot)     _sc_probe_audit_nonroot ;;

--- a/src/cmd_selfcheck.sh
+++ b/src/cmd_selfcheck.sh
@@ -248,17 +248,45 @@ _sc_probe_t2_forge() {
     by() { db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident='$1';"; }
 
     # (a) THE FORGE: an ordinary agent, unprivileged, no sudo — what every agent is.
-    id() { if [[ "${1:-}" == -un ]]; then echo "agent-selfcheck"; else command id "$@"; fi; }
+    #
+    # PIN THE CALLER, do not inherit it (DIVE-2365). The first cut stubbed `id -un`,
+    # which the uid-first resolver has not read since DIVE-2330 — it walks /etc/passwd
+    # for $EUID in pure bash. So the stub was inert and "is the caller an agent?" was
+    # answered by whoever ran the probe: an `agent-*` uid on a 5dive box (where it
+    # passed) and `runner` in CI, where the forge arm was a legitimate HUMAN tap and
+    # this probe reported a bypass that had not happened. `lib/actor.sh` publishes
+    # _gate_passwd_stream / _gate_caller_uid as the seams for modelling a caller uid;
+    # `id -u` + `getent` stay stubbed for `_gate_sudo_uid_nonagent`, which is a
+    # separate resolver with separate seams.
+    AUID=987654
+    _agentrow() { printf 'agent-fixture:x:%s:%s::/home/agent-fixture:/bin/bash\n' "$AUID" "$AUID"; }
+    id() {
+      if   [[ "${1:-}" == -un ]]; then echo "agent-fixture"
+      elif [[ "${1:-}" == -u  ]]; then printf '%s\n' "$AUID"
+      else command id "$@"; fi
+    }
+    getent() {
+      if [[ "${1:-}" == passwd && "${2:-}" == "$AUID" ]]; then _agentrow; return 0; fi
+      command getent "$@"
+    }
+    _gate_passwd_stream() { _agentrow; printf '%s\n' "$(</etc/passwd)"; }
+    _gate_caller_uid() { printf '%s' "$AUID"; }
     _gate_is_root() { return 1; }
     unset SUDO_UID
+    printf 'pinned=%s\n' "$(_gate_authenticated_actor)"
     seed DIVE-990001
     printf 'tier=%s\n' "$(db "SELECT COALESCE(tier,'') FROM tasks WHERE ident='DIVE-990001';")"
     ( GATE_PROOF_ENFORCE=/nonexistent/nope cmd_task_answer DIVE-990001 --value=A --human ) >/dev/null 2>&1
     printf 'forged=%s\n' "$(by DIVE-990001)"
 
-    # (b) LIVENESS: a real human path on an identical gate must still clear.
+    # (b) LIVENESS: a real human path on an identical gate must still clear. The pin
+    # from (a) is REMOVED here rather than overridden — leaving _gate_caller_uid
+    # pointing at the fixture agent would resolve this caller as an agent too and the
+    # liveness arm would grade a refusal.
     seed DIVE-990002
-    id() { if [[ "${1:-}" == -un ]]; then echo "root"; else command id "$@"; fi; }
+    unset -f id getent _gate_passwd_stream _gate_caller_uid 2>/dev/null
+    _gate_caller_uid() { printf '%s' "0"; }
+    _gate_passwd_stream() { printf '%s\n' "$(</etc/passwd)"; }
     _gate_is_root() { return 0; }
     export SUDO_UID=0
     ( cmd_task_answer DIVE-990002 --value=A --human ) >/dev/null 2>&1
@@ -266,10 +294,17 @@ _sc_probe_t2_forge() {
   )
   rm -rf "$d"
 
-  local tier forged human
+  local tier forged human pinned
   tier=$(sed -n 's/^tier=//p' <<<"$out" | head -1)
   forged=$(sed -n 's/^forged=//p' <<<"$out" | head -1)
   human=$(sed -n 's/^human=//p' <<<"$out" | head -1)
+  pinned=$(sed -n 's/^pinned=//p' <<<"$out" | head -1)
+
+  # The forge arm is only a FORGE if the caller reads as an agent. If the pin did not
+  # take, a clean "refused" and a clean "cleared" are both unreadable — that is not a
+  # pass and it is not a failure, it is nothing measured, and it must say so.
+  [[ "$pinned" == "fixture" ]] \
+    || { _sc_notreached "caller-not-pinned-as-agent" "the probe's fixture caller resolved as '${pinned:-nobody}', not an agent, so its forge arm would have graded a legitimate human tap — the seams in lib/actor.sh did not take in this build"; return; }
 
   [[ "$tier" == "2" ]] \
     || { _sc_notreached "no-tier2-gate" "the probe's own gate filed as tier '${tier:-?}', so the tier-2 floor was never in play — nothing was measured"; return; }

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -8412,16 +8412,31 @@ cmd_gate_proof() {
     case "${2:-status}" in
       on)  : > "$_ef"; chmod 0644 "$_ef" 2>/dev/null || true
            ok "gate-proof enforcement ON: approval/secret/manual answers now require human evidence (a valid --human-proof nonce or a non-agent SUDO_UID)" ;;
-      off) rm -f "$_ef"
-           ok "gate-proof enforcement OFF: audit-only; approval/secret/manual answers allowed without human evidence" ;;
+      off) # DIVE-2588: enforcement is now armed by EITHER sentinel, so removing only
+           # the override path would print OFF while the default kept it ON — a status
+           # line that disagrees with the predicate is how the flag got trusted in the
+           # first place. Root asked for off; take both. (Still root-only: this widens
+           # nothing an unprivileged caller can reach.)
+           rm -f "$_ef" "${STATE_DIR}/gate-proof.enforce"
+           ok "gate-proof enforcement OFF: audit-only; approval/secret/manual answers allowed without human evidence. NOTE the tier-2 human floor is NOT affected — since DIVE-2588 it is unconditional and no flag can lower it." ;;
       status)
-           local _e _k
+           local _e _k _src
            _gate_proof_enforced && _e=on || _e=off
            [[ -s "$(_gate_proof_key_file)" ]] && _k=present || _k=absent
+           # DIVE-2588: name WHICH sentinel armed it. "on" alone cannot tell an
+           # operator that an env override is in play on this invocation.
+           _src=none
+           [[ -f "${STATE_DIR}/gate-proof.enforce" ]] && _src=default
+           if [[ -n "${GATE_PROOF_ENFORCE:-}" && -f "$GATE_PROOF_ENFORCE" ]]; then
+             [[ "$_src" == default ]] && _src=both || _src=env-override
+           fi
            if (( JSON_MODE )); then
-             ok "gate-proof: enforce=$_e key=$_k" '{enforce:$e, key:$k}' --arg e "$_e" --arg k "$_k"
+             ok "gate-proof: enforce=$_e key=$_k armed_by=$_src" \
+               '{enforce:$e, key:$k, armedBy:$s, t2FloorUnconditional:true}' \
+               --arg e "$_e" --arg k "$_k" --arg s "$_src"
            else
-             echo "enforce: $_e"; echo "key: $_k"
+             echo "enforce: $_e"; echo "key: $_k"; echo "armed by: $_src"
+             echo "tier-2 human floor: unconditional (DIVE-2588 — not switchable by this flag)"
            fi ;;
       *) fail "$E_USAGE" "usage: 5dive gate-proof enforce on|off|status" ;;
     esac
@@ -8992,7 +9007,17 @@ cmd_task_answer() {
   # first; do not infer that it has drained. NO downgrade path from the answer side by design: an over-fired T2
   # (the heuristic can over-match) waits for a human — the conservative correct
   # default for a hard floor; re-file at a lower --tier if the floor misfired.
-  if [[ "$gtier" == "2" ]] && (( ! human )) && _gate_proof_enforced; then
+  # DIVE-2588: NO LONGER CONTINGENT ON THE ROLLOUT FLAG. The `_gate_proof_enforced`
+  # conjunct was a staging envelope for a rollout that completed on 2026-07-30, and
+  # while it stood it made a hard human floor switchable — the same variable that
+  # armed it could disarm it, and until DIVE-2588 the party it constrains could set
+  # that variable. A control whose OFF position is reachable by its subject is not a
+  # control. The flag can now only make the floor STRICTER (see _gate_proof_enforced),
+  # and this branch does not consult it at all. Safe to make unconditional: it refuses
+  # only a NON-human answer on a tier-2 gate, which is precisely what a hard human
+  # floor means on every box, armed or not — every real human path passes --human, so
+  # DIVE-525 ("a real tap is never rejected") still holds by construction.
+  if [[ "$gtier" == "2" ]] && (( ! human )); then
     local _caller3; _caller3=$(_gate_caller_user)
     # DIVE-1437: a tier-2 gate that was LEAD-ROUTED (routed_reviewer set) but is an
     # approval/manual builder gate is the DIVE-1429 stall — the DIVE-1145/1182
@@ -9063,9 +9088,16 @@ cmd_task_answer() {
   # rendered without a nonce in its callback_data. `human_nonce_hash` non-empty is the
   # exact, per-row witness that this gate's buttons CAN carry proof.
   #
-  # Runs under `_gate_proof_enforced` for the same rollout envelope as every other
-  # evidence rule (enforce is ON fleet-wide since DIVE-950).
-  if [[ "$gtier" == "2" ]] && (( human )) && _gate_proof_enforced; then
+  # DIVE-2588: the `_gate_proof_enforced` conjunct is GONE here too, and this is the
+  # branch the bypass actually rode. A forged `--human` was already refused by this
+  # block on any gate carrying a minted nonce — main measured that on v0.18.2 AND
+  # v0.17.11 — so the exploit was not the flag; it was that ONE env var switched this
+  # block off and the floor above at the same time. Making it unconditional costs
+  # nothing on a box where the rollout never happened: the block is already scoped to
+  # gates whose `human_nonce_hash` is non-empty, i.e. the per-row witness that this
+  # gate's buttons CAN carry proof, so a box that mints nothing reaches no assertion
+  # here. That scoping, not the flag, was always what kept real taps safe.
+  if [[ "$gtier" == "2" ]] && (( human )); then
     local _t2_hash; _t2_hash=$(db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE id=${id};")
     if [[ -n "$_t2_hash" ]]; then
       local _t2_hp=0 _t2_su=0

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -1891,7 +1891,30 @@ _gate_proof_ct_equal() {
 # Enforcement is OFF until the sentinel exists. DIVE-519 ships DORMANT (audit-only):
 # flip on only after the plugin mint is confirmed live on the box, else live taps
 # that can't mint yet would fail closed. Root toggles it.
-_gate_proof_enforced() { [[ -f "$(_gate_proof_enforce_file)" ]]; }
+#
+# DIVE-2588 — THE OVERRIDE MAY ONLY MAKE THIS STRICTER, NEVER WEAKER. This used to
+# read the ENV-OR-DEFAULT path, so an unprivileged agent turned the whole enforcement
+# envelope off with one variable and no sudo:
+#
+#   GATE_PROOF_ENFORCE=/nonexistent/nope  5dive task answer <T2-decision> --value=A --human
+#
+# succeeded where the identical command without it was refused, and landed
+# need_answered_by=human:<agent> — byte-identical to a real relayed human tap. A file-
+# EXISTENCE test on a path the constrained party supplies is not a control: its OFF
+# position was reachable by its own subject. Reversing the sense fixes that without
+# taking the override away — an existing sentinel at EITHER path arms enforcement, so
+# a harness can still turn it ON for an isolated store (which is all any of them do:
+# every caller in tests/ sets it to "$STATE_DIR/gate-proof.enforce", the default it
+# would have resolved anyway), and pointing it at an absent path now says nothing at
+# all instead of saying "off".
+#
+# STATE_DIR is deliberately read directly here rather than through
+# _gate_proof_enforce_file: that helper resolves the override, and the whole point of
+# this branch is that the root-owned default is consulted whether or not one is set.
+_gate_proof_enforced() {
+  [[ -f "${STATE_DIR}/gate-proof.enforce" ]] && return 0
+  [[ -n "${GATE_PROOF_ENFORCE:-}" && -f "$GATE_PROOF_ENFORCE" ]]
+}
 
 # ── DIVE-2235: the HUMAN CLASS, and class-over-tier ──────────────────────────
 # The gate types that mint and verify a one-time human nonce. This list already

--- a/tests/gate_enforce_env_bypass_unit.sh
+++ b/tests/gate_enforce_env_bypass_unit.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# TIER: nightly — 8.6s measured on the 5dive host (uid 1007, warm tree). The budget number
+# that gates is CI's, not mine: PR #395 read 209 harnesses / 289s / 96% of the 300s cap, so a
+# new core harness would spend most of the remaining 11s of headroom. (This box reads 309s for
+# the same 209 — ~7% slower than the runner, which is why the CI figure is the one quoted.)
+# And 289s is ONE SAMPLE of a noisy quantity, not a constant: main measured 356s and 289s on
+# the same commit an hour apart (DIVE-2592). The argument only gets stronger at the high end —
+# at 356s the tier is already over, so a core harness added on the strength of a lucky 96%
+# reading would red the budget (exit 4) on the next unlucky one, for reasons having nothing to
+# do with gates. The reason
+# this demotion does not leave the property unguarded at PR time — which is the only
+# argument that would make it acceptable for a live authority hole — is that the same
+# forge is probed on EVERY PR by `5dive selfcheck --only=t2-forge` (DIVE-2588), which
+# unit-tests.yml runs in both the pristine and installed-host jobs. Per-PR coverage is
+# the probe; this file is the exhaustive matrix (5 predicate states, both fix halves
+# isolated, the scope table, and the liveness arms) and the nightly sweep runs it.
+#
+# DIVE-2588 — the enforcement flag's OFF POSITION must not be reachable by the party
+# it constrains.
+#
+# THE HOLE, measured by main on the released v0.18.2 artifact and reproduced here on
+# the installed 0.18.0+dive2563 as agent-dev uid 1007, no sudo:
+#
+#   GATE_PROOF_ENFORCE=/nonexistent/nope  5dive task answer <T2-decision> --value=A --human
+#
+# SUCCEEDED where the identical command without the variable was REFUSED, and landed
+# need_answer=A, need_answered_by=human:dev, need_answered_uid=1007 — the same row a
+# real relayed human tap writes. `_gate_proof_enforced` was a file-EXISTENCE test on a
+# path the unprivileged caller supplies, so pointing it anywhere absent evaluated the
+# whole tier-2 branch false. Scope was exactly `decision`: approval/manual/access carry
+# an independent type guard that never consults the flag.
+#
+# THE FIX HAS TWO INDEPENDENT HALVES and this harness grades both, because either one
+# alone would close the reported command while leaving the shape intact:
+#   1. the override may only make enforcement STRICTER (an existing sentinel at EITHER
+#      path arms it; an absent path now says nothing at all), and
+#   2. the tier-2 human floor no longer consults the flag in either direction.
+#
+# WHAT MAKES THE BYPASS ARMS NON-VACUOUS: every "refused" assertion below is paired
+# with a row-state check (the gate must still be OPEN, not merely an error printed),
+# and L1/L2 prove this same harness CAN clear a gate and CAN report enforcement off —
+# without those, a harness that refused everything would score perfect.
+#
+# Isolation matches the sibling gate harnesses: source src/ libs, throwaway STATE_DIR,
+# the live shared tasks.db is NEVER touched. Run: bash tests/gate_enforce_env_bypass_unit.sh
+# (no root, no network).
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/gate-enforce-bypass.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+GATE_PROOF_KEY="$STATE_DIR/gate-proof.key"
+DEFAULT_SENTINEL="$STATE_DIR/gate-proof.enforce"
+ALT_SENTINEL="$TMP/alt-enforce"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"; set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+tasks_db_init
+task_need_notify() { :; }
+audit_log() { :; }
+# The answer path pings the gate's owner over `cmd_send` — a REAL inter-agent rail
+# that no STATE_DIR fence covers. An arm that successfully clears a gate (L2 below)
+# therefore sends live traffic about a fixture row unless it is stubbed here.
+cmd_send() { return 1; }
+
+seed_task() { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
+answered() { db "SELECT CASE WHEN need_answered_at IS NULL THEN 'open' ELSE 'closed' END FROM tasks WHERE ident='$1';"; }
+provby()   { db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident='$1';"; }
+tierof()   { db "SELECT COALESCE(tier,'') FROM tasks WHERE ident='$1';"; }
+hashof()   { db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE ident='$1';"; }
+
+# ── the two callers this harness models ──────────────────────────────────────────
+# THE ATTACKER is the ordinary case, not a privileged one: an agent, unprivileged, no
+# sudo — exactly what every agent on every box already is. That is the whole severity
+# argument, so it is the default posture here.
+FAKE_CALLER="agent-dev"
+id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+as_agent()        { FAKE_CALLER="agent-dev"; unset SUDO_UID; _gate_is_root() { return 1; }; }
+# The human-on-box / dashboard-exec path: a NON-agent SUDO_UID, trusted only at EUID 0
+# (DIVE-1413), which is why the root seam is stubbed rather than the assertion weakened.
+as_human_on_box() { FAKE_CALLER="root"; export SUDO_UID=0; _gate_is_root() { return 0; }; }
+as_agent
+
+file_gate() { # file_gate <ident> <type> [extra args...]
+  local ident="$1" type="$2"; shift 2
+  seed_task "$ident"
+  cmd_task_need "$ident" --type="$type" "$@" >/dev/null 2>&1
+}
+
+# `fail` exits. Every answer below runs in a command substitution ON PURPOSE so a
+# refusal reds ONE arm instead of ending the harness at status 6.
+answer() { ( cmd_task_answer "$@" ) 2>&1; }
+
+# ── P: the predicate itself ──────────────────────────────────────────────────────
+# Graded directly because it is the single decision the exploit rewrote, and because
+# the end-to-end arms below can only show it through one call site.
+enforced() { _gate_proof_enforced && echo on || echo off; }
+
+rm -f "$DEFAULT_SENTINEL" "$ALT_SENTINEL"
+: > "$DEFAULT_SENTINEL"
+[[ "$(unset GATE_PROOF_ENFORCE; enforced)" == on ]] \
+  && ok_t "P1 default sentinel present, no override => ON" \
+  || bad_t "P1 default sentinel arms enforcement" "got $(unset GATE_PROOF_ENFORCE; enforced)"
+
+[[ "$(GATE_PROOF_ENFORCE=/nonexistent/nope enforced)" == on ]] \
+  && ok_t "P2 THE FIX: an override pointing at an absent path can NOT switch enforcement off" \
+  || bad_t "P2 absent override cannot disarm" "got $(GATE_PROOF_ENFORCE=/nonexistent/nope enforced)"
+
+rm -f "$DEFAULT_SENTINEL"; : > "$ALT_SENTINEL"
+[[ "$(GATE_PROOF_ENFORCE="$ALT_SENTINEL" enforced)" == on ]] \
+  && ok_t "P3 override at an EXISTING path still arms it (every tests/ caller does this)" \
+  || bad_t "P3 override can still arm" "got $(GATE_PROOF_ENFORCE="$ALT_SENTINEL" enforced)"
+
+rm -f "$ALT_SENTINEL"
+[[ "$(GATE_PROOF_ENFORCE=/nonexistent/nope enforced)" == off ]] \
+  && ok_t "P4 with NO sentinel anywhere it is off — the fix did not just hardcode on" \
+  || bad_t "P4 off when nothing is armed" "got $(GATE_PROOF_ENFORCE=/nonexistent/nope enforced)"
+
+[[ "$(unset GATE_PROOF_ENFORCE; enforced)" == off ]] \
+  && ok_t "P5 L1 liveness: this harness CAN read enforcement as off, so P1-P3 are not constants" \
+  || bad_t "P5 harness can observe off" "got $(unset GATE_PROOF_ENFORCE; enforced)"
+
+# ── E: the reported exploit, end to end ──────────────────────────────────────────
+: > "$DEFAULT_SENTINEL"   # the live posture: enforcement armed by the root-owned file
+
+file_gate DIVE-401 decision --ask="approve the spend for the volume resize" \
+  --options="A|B" --recommend="A" --tier=2
+[[ "$(tierof DIVE-401)" == "2" ]] \
+  && ok_t "E0 precondition: the gate really is tier 2" \
+  || bad_t "E0 tier-2 precondition" "tier=$(tierof DIVE-401)"
+[[ "$(hashof DIVE-401)" =~ ^[0-9a-f]{64}$ ]] \
+  && ok_t "E0 precondition: it minted a per-gate human nonce (DIVE-2356)" \
+  || bad_t "E0 nonce precondition" "hash='$(hashof DIVE-401)'"
+
+# THE LOAD-BEARING BASELINE. Without it the bypass arm proves nothing: a command that
+# refuses everywhere is not evidence that the variable was neutralised.
+out=$(answer DIVE-401 --value=A --human); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-401)" == "open" ]] \
+  && ok_t "E1 baseline: a forged --human from an agent is REFUSED and the row is untouched" \
+  || bad_t "E1 baseline refusal" "rc=$rc state=$(answered DIVE-401) out=$out"
+
+out=$(GATE_PROOF_ENFORCE=/nonexistent/nope answer DIVE-401 --value=A --human); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-401)" == "open" ]] \
+  && ok_t "E2 THE BYPASS IS CLOSED: same command + GATE_PROOF_ENFORCE=/nonexistent still REFUSED" \
+  || bad_t "E2 env bypass closed" "rc=$rc state=$(answered DIVE-401) prov=$(provby DIVE-401) out=$out"
+# An rc alone passes on ANY error, including one raised before the floor was reached.
+grep -qi 'unproven\|tier-2' <<<"$out" \
+  && ok_t "E3 the bypass refusal names the forge, so it is the floor refusing and not an incidental error" \
+  || bad_t "E3 refusal names the forge" "out=$out"
+[[ -z "$(provby DIVE-401)" ]] \
+  && ok_t "E4 nothing was stamped: need_answered_by is still empty after both attempts" \
+  || bad_t "E4 no provenance written" "prov=$(provby DIVE-401)"
+
+# Half 2 of the fix, isolated: even with NO sentinel anywhere — the state the override
+# used to fake — the tier-2 floor stands on its own.
+rm -f "$DEFAULT_SENTINEL"
+file_gate DIVE-402 decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2
+out=$(answer DIVE-402 --value=A); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-402)" == "open" ]] \
+  && ok_t "E5 with enforcement genuinely OFF the tier-2 floor STILL refuses a non-human answer" \
+  || bad_t "E5 floor is unconditional" "rc=$rc state=$(answered DIVE-402) out=$out"
+
+# E6 ISOLATES THE SECOND SITE. E5 above rides the provenance floor, which a forged
+# `--human` walks straight past by setting human=1 — so with the floor now
+# unconditional, the ONLY thing left that can refuse a forged --human on a
+# nonce-bearing tier-2 gate is the DIVE-2356 evidence block. Enforcement is still
+# genuinely off here, so this arm reds if that block's flag conjunct comes back and
+# stays green if only the floor's does. Without it, half the fix is untested.
+file_gate DIVE-406 decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2
+[[ "$(hashof DIVE-406)" =~ ^[0-9a-f]{64}$ ]] || bad_t "E6 precondition: gate minted a nonce" "hash='$(hashof DIVE-406)'"
+out=$(answer DIVE-406 --value=A --human); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-406)" == "open" ]] \
+  && ok_t "E6 enforcement OFF: a forged --human on a nonce-bearing tier-2 gate is refused by the EVIDENCE block" \
+  || bad_t "E6 evidence block is unconditional" "rc=$rc state=$(answered DIVE-406) out=$out"
+: > "$DEFAULT_SENTINEL"
+
+# ── L2: liveness. A harness whose every arm expects a refusal proves nothing. ─────
+as_human_on_box
+file_gate DIVE-403 decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2
+out=$(answer DIVE-403 --value=A --human); rc=$?
+[[ $rc -eq 0 && "$(answered DIVE-403)" == "closed" ]] \
+  && ok_t "L2 liveness: a REAL human path (non-agent SUDO_UID at EUID 0) still clears the same gate" \
+  || bad_t "L2 real human path still clears" "rc=$rc state=$(answered DIVE-403) out=$out"
+[[ "$(provby DIVE-403)" == human:* ]] \
+  && ok_t "L2 and it is stamped human:* — DIVE-525 holds, a real tap is never rejected" \
+  || bad_t "L2 human provenance" "prov=$(provby DIVE-403)"
+as_agent
+
+# ── B: the boundary. The fix must not have widened into tier 1. ──────────────────
+file_gate DIVE-404 decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=1
+[[ "$(tierof DIVE-404)" == "1" ]] || bad_t "B0 tier-1 precondition" "tier=$(tierof DIVE-404)"
+out=$(answer DIVE-404 --value=A); rc=$?
+[[ $rc -eq 0 && "$(answered DIVE-404)" == "closed" ]] \
+  && ok_t "B1 boundary: a bare-agent answer on a TIER-1 decision still clears (not over-widened)" \
+  || bad_t "B1 tier-1 unaffected" "rc=$rc state=$(answered DIVE-404) out=$out"
+
+# ── S: main's scope table. The other three tier-2 types refused in BOTH arms before
+#      this change (an independent type guard, not the flag). Anchor that they still
+#      do — a fix to the decision path must not have moved them.
+: > "$DEFAULT_SENTINEL"
+n=405
+for ty in approval manual access; do
+  idt="DIVE-$n"; n=$((n+1))
+  case "$ty" in
+    manual) file_gate "$idt" manual --ask="run the physical box swap" ;;
+    access) file_gate "$idt" access --ask="grant me the prod console" ;;
+    # --tier=2 explicitly: manual/access floor themselves by type, but "approve the
+    # deploy" trips no tier-2 keyword and files as tier 1 — which would silently
+    # grade the tier-1 path under a tier-2 name. The precondition below catches it,
+    # and this is why it is asserted rather than assumed.
+    *)      file_gate "$idt" approval --ask="approve the deploy" --tier=2 ;;
+  esac
+  [[ "$(tierof "$idt")" == "2" ]] || { bad_t "S precondition $ty is tier 2" "tier=$(tierof "$idt")"; continue; }
+  b_out=$(answer "$idt" --value=approved --human); b_rc=$?
+  y_out=$(GATE_PROOF_ENFORCE=/nonexistent/nope answer "$idt" --value=approved --human); y_rc=$?
+  if [[ $b_rc -ne 0 && $y_rc -ne 0 && "$(answered "$idt")" == "open" ]]; then
+    ok_t "S $ty: refused in BOTH arms and still open (scope table unchanged)"
+  else
+    bad_t "S $ty refused in both arms" "baseline rc=$b_rc bypass rc=$y_rc state=$(answered "$idt") b=$b_out y=$y_out"
+  fi
+done
+
+echo "-----"
+printf 'gate_enforce_env_bypass_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/gate_enforce_env_bypass_unit.sh
+++ b/tests/gate_enforce_env_bypass_unit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# TIER: nightly — 8.6s measured on the 5dive host (uid 1007, warm tree). The budget number
+# TIER: nightly — 9.5s measured on the 5dive host (uid 1007, warm tree). The budget number
 # that gates is CI's, not mine: PR #395 read 209 harnesses / 289s / 96% of the 300s cap, so a
 # new core harness would spend most of the remaining 11s of headroom. (This box reads 309s for
 # the same 209 — ~7% slower than the runner, which is why the CI figure is the one quoted.)
@@ -72,6 +72,29 @@ ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 
 tasks_db_init
+
+# ── I: STORE ISOLATION, PROVED BEFORE THE FIRST WRITE (DIVE-2518) ────────────────
+# An empty scratch store is not evidence of isolation — a read that merely ERRORED is
+# also empty. So assert both sides in the same breath: the db this harness writes to
+# is the one under $TMP, and the box's real store is a different file reading a
+# non-zero count. A pristine runner has no real store; that is REPORTED as the reason
+# the differential is unavailable, not folded into a pass on its own.
+DEFAULT_DB="${FIVE_DEFAULT_DB:-/var/lib/5dive/tasks/tasks.db}"
+[[ "$TASKS_DB" == "$TMP/"* ]] \
+  && ok_t "I1 the resolved tasks db is this harness's throwaway ($TASKS_DB)" \
+  || bad_t "I1 store isolation" "TASKS_DB='$TASKS_DB' is not under $TMP — every write below would land in a shared store"
+if [[ -r "$DEFAULT_DB" ]] && command -v sqlite3 >/dev/null 2>&1; then
+  _live=$(sqlite3 "$DEFAULT_DB" "SELECT COUNT(*) FROM tasks;" 2>/dev/null)
+  _scratch=$(db "SELECT COUNT(*) FROM tasks;" 2>/dev/null)
+  if [[ "${_live:-0}" =~ ^[0-9]+$ && "${_live:-0}" -gt 0 && "${_scratch:-x}" == "0" ]]; then
+    ok_t "I2 differential: the box's store reads $_live rows and this harness's reads 0, printed together — two different files"
+  else
+    bad_t "I2 differential isolation" "live='${_live:-unreadable}' scratch='${_scratch:-unreadable}' — an all-zero or unreadable pair proves nothing"
+  fi
+else
+  ok_t "I2 differential unavailable: no readable store at $DEFAULT_DB on this host (a pristine runner has none), so I1 is what pins the write target here"
+fi
+
 task_need_notify() { :; }
 audit_log() { :; }
 # The answer path pings the gate's owner over `cmd_send` — a REAL inter-agent rail
@@ -79,7 +102,18 @@ audit_log() { :; }
 # therefore sends live traffic about a fixture row unless it is stubbed here.
 cmd_send() { return 1; }
 
-seed_task() { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
+# A colliding ident is NOT a benign duplicate. The row it lands on already carries a
+# filed gate, so the arm goes on to grade an EARLIER arm's row while sqlite prints a
+# bare `UNIQUE constraint failed: tasks.ident` that reads exactly like a store-isolation
+# defect. On PR #399 that line sat one line above eight unrelated failures and cost a
+# reviewer the wrong root cause. Red the arm and name it instead.
+seed_task() {
+  if [[ -n "$(db "SELECT ident FROM tasks WHERE ident='$1';")" ]]; then
+    bad_t "seed $1" "ident already exists in this harness's OWN store — a later arm would grade the row an earlier one filed"
+    return 1
+  fi
+  db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"
+}
 answered() { db "SELECT CASE WHEN need_answered_at IS NULL THEN 'open' ELSE 'closed' END FROM tasks WHERE ident='$1';"; }
 provby()   { db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE ident='$1';"; }
 tierof()   { db "SELECT COALESCE(tier,'') FROM tasks WHERE ident='$1';"; }
@@ -89,13 +123,55 @@ hashof()   { db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE ident='$1
 # THE ATTACKER is the ordinary case, not a privileged one: an agent, unprivileged, no
 # sudo — exactly what every agent on every box already is. That is the whole severity
 # argument, so it is the default posture here.
-FAKE_CALLER="agent-dev"
-id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
-as_agent()        { FAKE_CALLER="agent-dev"; unset SUDO_UID; _gate_is_root() { return 1; }; }
+#
+# CALLER-IDENTITY PIN (DIVE-2365 / DIVE-2330). The first cut of this file stubbed only
+# `id -un`, and the resolver has not read `id -un` since DIVE-2330 — it walks
+# /etc/passwd for $EUID in pure bash, precisely because a PATH shim could forge `id`.
+# So the stub was INERT and the caller's agent-ness came FROM THE HOST: uid 1007 is
+# `agent-dev` on this box, and 19/19 green here said nothing about the property. On the
+# CI runner the same uid is `runner`, no agent row claims it, and the "forge" arm was a
+# legitimate human tap — 8 arms red, including the baseline the whole file rests on.
+# `lib/actor.sh` exposes `_gate_passwd_stream` and `_gate_caller_uid` as seams for
+# exactly this. Pin BOTH, keep the resolver's own agent-*/registry logic real, and
+# assert the pin through the real resolver before any arm leans on it — a pin that
+# silently yields '' would make every refusal below look correct for the wrong reason.
+AGENT_UID=987654
+FAKE_CALLER="agent-dev"; CALLER_UID="$AGENT_UID"
+_agentrow() { printf 'agent-fixture:x:%s:%s::/home/agent-fixture:/bin/bash\n' "$AGENT_UID" "$AGENT_UID"; }
+# `id -u` and `getent` are still read by `_gate_sudo_uid_nonagent` (the type guard on
+# approval/manual/access), which is NOT part of the uid-first derivation and keeps its
+# own seams. The scope table below depends on that guard, so pin it too.
+id() {
+  if   [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"
+  elif [[ "${1:-}" == -u  ]]; then printf '%s\n' "$CALLER_UID"
+  else command id "$@"; fi
+}
+getent() {
+  if [[ "${1:-}" == passwd && "${2:-}" == "$AGENT_UID" ]]; then _agentrow; return 0; fi
+  command getent "$@"
+}
+_gate_passwd_stream() { _agentrow; printf '%s\n' "$(</etc/passwd)"; }
+_gate_caller_uid() { printf '%s' "$CALLER_UID"; }
+as_agent()        { FAKE_CALLER="agent-dev"; CALLER_UID="$AGENT_UID"; unset SUDO_UID; _gate_is_root() { return 1; }; }
 # The human-on-box / dashboard-exec path: a NON-agent SUDO_UID, trusted only at EUID 0
 # (DIVE-1413), which is why the root seam is stubbed rather than the assertion weakened.
-as_human_on_box() { FAKE_CALLER="root"; export SUDO_UID=0; _gate_is_root() { return 0; }; }
+as_human_on_box() { FAKE_CALLER="root"; CALLER_UID=0; export SUDO_UID=0; _gate_is_root() { return 0; }; }
 as_agent
+
+# The two preconditions every arm below inherits, asserted through the REAL resolvers
+# rather than assumed. These are the arms that would have gone red on the runner
+# instead of eight downstream ones naming the wrong thing.
+_pin_actor="$(_gate_authenticated_actor)"
+[[ "$_pin_actor" == "fixture" ]] \
+  && ok_t "precond: the pinned caller resolves as AGENT 'fixture' through the real uid-first resolver" \
+  || bad_t "precond: pinned caller resolves as an agent" \
+     "resolver returned '${_pin_actor:-empty}' — the caller is not an agent here, so every 'refused' arm below would grade a human tap, not a forge (DIVE-2365)"
+if _gate_sudo_uid_nonagent; then
+  bad_t "precond: caller carries no NON-agent human evidence" \
+    "_gate_sudo_uid_nonagent still reports non-agent evidence — the scope table below would grade the type guard's human branch"
+else
+  ok_t "precond: the pinned caller carries no non-agent human evidence (the type guard sees an agent)"
+fi
 
 file_gate() { # file_gate <ident> <type> [extra args...]
   local ident="$1" type="$2"; shift 2
@@ -214,7 +290,7 @@ out=$(answer DIVE-404 --value=A); rc=$?
 #      this change (an independent type guard, not the flag). Anchor that they still
 #      do — a fix to the decision path must not have moved them.
 : > "$DEFAULT_SENTINEL"
-n=405
+n=410      # NOT 405: DIVE-406 is already filed above, and seed_task now reds on collision
 for ty in approval manual access; do
   idt="DIVE-$n"; n=$((n+1))
   case "$ty" in

--- a/tests/gate_t2_routed_escalate_unit.sh
+++ b/tests/gate_t2_routed_escalate_unit.sh
@@ -222,17 +222,26 @@ out=$(cmd_task_answer DIVE-305 --value=approved --human 2>&1); rc=$?
   && ok_t "E3b bare --human from an agent (the DIVE-2131 forge) is REFUSED on the same gate" \
   || bad_t "E3b forge refused" "rc=$rc state=$(answered DIVE-305) out=$out"
 
-# --- E4: rollout safety — enforcement OFF => the floor (and thus the escalation) is
-#     dormant; a routed tier-2 manual gate is cleared by its lead directly (DIVE-1182). -
+# --- E4: DIVE-2588 — enforcement OFF IS NO LONGER A DOWNGRADE PATH. This arm used
+#     to assert that clearing the flag made the floor (and this escalation) dormant,
+#     so a routed tier-2 manual gate fell to a direct lead clear. That dormancy is
+#     what the DIVE-2588 bypass bought with one env var, and the tier-2 floor no
+#     longer consults the flag at all. With it OFF the box now behaves exactly as it
+#     does with it ON — which, since the rollout completed 2026-07-30, is what every
+#     live box was already doing. Same assertions as E1, deliberately: the claim is
+#     that the two are INDISTINGUISHABLE, so they must be graded the same way.
 rm -f "$GATE_PROOF_ENFORCE"
 seed_task DIVE-304
 cmd_task_need DIVE-304 --type=manual --ask="run the physical box swap" >/dev/null 2>&1
 route_to DIVE-304 marcus
 _nf_reset
-cmd_task_answer DIVE-304 --value=approved >/dev/null 2>&1
-[[ "$(answered DIVE-304)" == "closed" && -z "$(_nf)" ]] \
-  && ok_t "E4 enforce OFF => floor dormant, lead clears routed gate directly (no escalation)" \
-  || bad_t "E4 enforce OFF dormant" "state=$(answered DIVE-304) notified='$(_nf)'"
+out=$(cmd_task_answer DIVE-304 --value=approved 2>&1); rc=$?
+[[ "$(answered DIVE-304)" == "open" ]] \
+  && ok_t "E4 enforce OFF: routed tier-2 gate still NOT lead-cleared — stays open for the human (DIVE-2588)" \
+  || bad_t "E4 floor survives enforce OFF" "rc=$rc state=$(answered DIVE-304) out=$out"
+[[ -n "$(_nf)" ]] \
+  && ok_t "E4 enforce OFF: the human was notified with a tap — escalation fires identically to enforce ON" \
+  || bad_t "E4 escalation fires with enforce OFF" "notified='$(_nf)'"
 touch "$GATE_PROOF_ENFORCE"
 
 echo "-----"

--- a/tests/gate_tier2_floor_unit.sh
+++ b/tests/gate_tier2_floor_unit.sh
@@ -136,15 +136,37 @@ else
   bad_t "T4 category heuristic floored to tier 2" "got tier '$(tierof DIVE-104)' (keyword floor may have moved)"
 fi
 
-# --- T5: rollout safety — enforcement OFF => the floor is dormant (audit-only), a
-#     bare-agent answer on a tier-2 gate clears (matches the evidence-block envelope).
+# --- T5: DIVE-2588 — THE FLOOR IS NOT SWITCHABLE. This arm asserted the OPPOSITE
+#     until 2026-08-03 (enforcement OFF => floor dormant, bare-agent clears), and
+#     that dormancy was the whole exploit: the flag reached the floor, and one env
+#     var reached the flag. `_gate_proof_enforced` was a ROLLOUT envelope, not an
+#     authority decision, and it finished rolling out on 2026-07-30. The floor no
+#     longer consults it in either direction.
+#     Captured in a command substitution ON PURPOSE: `fail` exits, and calling the
+#     answer bare would end the harness at status 6 instead of reddening one arm.
 rm -f "$GATE_PROOF_ENFORCE"
 seed_task DIVE-105
 cmd_task_need DIVE-105 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 >/dev/null 2>&1
-cmd_task_answer DIVE-105 --value=A >/dev/null 2>&1
-[[ "$(answered DIVE-105)" == "closed" ]] \
-  && ok_t "T5 enforce OFF => tier-2 floor dormant, bare-agent clears (audit-only)" \
-  || bad_t "T5 enforce OFF dormant" "still $(answered DIVE-105)"
+out=$(cmd_task_answer DIVE-105 --value=A 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-105)" == "open" ]] \
+  && ok_t "T5 enforce OFF does NOT lower the tier-2 floor — bare-agent answer still REFUSED (DIVE-2588)" \
+  || bad_t "T5 floor survives enforce OFF" "rc=$rc state=$(answered DIVE-105) out=$out"
+# The reason matters as much as the refusal: an rc alone would pass on ANY error,
+# including one that never reached the floor.
+grep -qi 'tier-2' <<<"$out" \
+  && ok_t "T5 the refusal names the tier-2 floor (not some incidental error)" \
+  || bad_t "T5 refusal names the floor" "out=$out"
+
+# --- T5b: the reported DIVE-2588 bypass, at this layer. An unprivileged caller
+#     pointing GATE_PROOF_ENFORCE at an absent path used to switch the whole
+#     enforcement envelope off. It must now say NOTHING — the floor stands, and
+#     the sentinel that is present (none here) is the only thing that can speak.
+seed_task DIVE-106
+cmd_task_need DIVE-106 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 >/dev/null 2>&1
+out=$(GATE_PROOF_ENFORCE=/nonexistent/nope cmd_task_answer DIVE-106 --value=A 2>&1); rc=$?
+[[ $rc -ne 0 && "$(answered DIVE-106)" == "open" ]] \
+  && ok_t "T5b GATE_PROOF_ENFORCE=/nonexistent does not clear a tier-2 gate (DIVE-2588 bypass)" \
+  || bad_t "T5b env bypass refused" "rc=$rc state=$(answered DIVE-106) out=$out"
 touch "$GATE_PROOF_ENFORCE"
 
 echo "-----"


### PR DESCRIPTION

  GATE_PROOF_ENFORCE=/nonexistent/nope  5dive task answer <T2-decision> --value=A --human

succeeded, unprivileged and without sudo, where the identical command without
the variable was refused — and wrote need_answered_by=human:<agent>, the same
row the human's own relayed tap writes. Found by main on the released v0.18.2
while grading DIVE-2515; reproduced here on the installed 0.18.0+dive2563 as
agent-dev uid 1007 in an isolated store, baseline and bypass as a pair.

_gate_proof_enforced was a file-EXISTENCE test on a path the constrained party
supplies. Its OFF position was reachable by its own subject, which is not a
control. Scope was exactly 'decision': approval/secret/manual/access carry an
independent type guard that never consults the flag.

Two independent halves, because either alone closes the reported command while
leaving the shape intact:

1. src/lib/tasks_db.sh — the override may only make enforcement STRICTER. A
   sentinel existing at EITHER the root-owned default or $GATE_PROOF_ENFORCE
   arms it; an absent path now says nothing instead of saying 'off'. Every
   caller in tests/ points the override at $STATE_DIR/gate-proof.enforce, the
   default it would have resolved anyway, so the harness pattern is untouched.
2. src/cmd_task.sh — the tier-2 provenance floor and the DIVE-2356 evidence
   block no longer consult the flag at all. It was a rollout envelope for a
   rollout that completed 2026-07-30, and while it stood it made a hard human
   floor switchable. The floor refuses only a NON-human answer, and the
   evidence block is already scoped to gates carrying a minted nonce, so a box
   that mints nothing reaches no new assertion (DIVE-525 holds).

Also: 'gate-proof enforce off' no longer leaves the default sentinel behind
(it would have printed OFF while the predicate read ON), and 'status' names
which sentinel armed it.

selfcheck: new t2-forge probe performs the forge for real in a throwaway store
and reds if it lands — DIVE-2520's forge-an-actor probe one layer up. It also
clears a second gate down a real human path, because a floor that refuses
everything and a floor that refuses the forge are the same observation from the
refusal alone. Runs on every PR in both unit-tests.yml selfcheck jobs. Its
first run delivered a real inter-agent message about a fixture gate: the answer
path's resume ping rides cmd_send, which no STATE_DIR fence covers, so that
rail is stubbed in the probe and in the new harness.

tests/gate_enforce_env_bypass_unit.sh (19 arms, TIER: nightly — the core tier
already reads 325s/300s). Mutation matrix, by failing assertion NAME:
  pristine                      19/0
  predicate reverted            18/1  P2
  floor conjunct restored       18/1  E5
  evidence conjunct restored    18/1  E6
  all three (the pre-fix code)  13/6  P2 E2 E3 E4 E5 E6, with the exploit
                                      reproduced inside the harness as
                                      state=closed prov=human:dev
tests/gate_tier2_floor_unit.sh and tests/gate_t2_routed_escalate_unit.sh each
carried an arm asserting the OPPOSITE contract — that clearing the flag made
the floor dormant — and now assert that it does not.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
