### PR TITLE
fix(tasks-db): scope the restore guard to the store being initialised (DIVE-1986)

### DIFF
--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -860,15 +860,54 @@ SQL
 #
 # Paths are resolved at CALL time (not sourced into constants) so the DIVE-1475
 # STATE_DIR/TASKS_DIR test-isolation overrides still redirect them to a temp tree.
-# The sentinel lives in TASKS_DIR (2770 group-writable, so any agent can write
+# The sentinel lives beside the active store — for prod that is TASKS_DIR
+# (2770 group-writable, so any agent can write
 # it and it survives a bare `rm tasks.db`); the backups + incident log live in
 # the sibling tasks-backups dir. If the whole TASKS_DIR is wiped the sentinel
 # goes with it, but the backup snapshots in the sibling dir still trip the alarm.
 _tasks_backup_dir() { printf '%s' "${TASKS_BACKUP_DIR:-${STATE_DIR}/tasks-backups}"; }
-_tasks_sentinel()   { printf '%s' "${TASKS_SENTINEL:-${TASKS_DIR}/.board-initialized}"; }
+# DIVE-1986: the sentinel is a fact about the store BESIDE it, so derive it from
+# the active store's own directory rather than from TASKS_DIR. Identical whenever
+# TASKS_DB is that dir's tasks.db (every isolated harness, and prod); different
+# only in the case this fixes — TASKS_DB aimed elsewhere with TASKS_DIR left at
+# its default, where reading the prod sentinel makes prod's history testify about
+# a store it has never met.
+_tasks_store_dir() { local d; d="$(dirname -- "$TASKS_DB" 2>/dev/null)"; printf '%s' "${d:-$TASKS_DIR}"; }
+_tasks_sentinel()  { printf '%s' "${TASKS_SENTINEL:-$(_tasks_store_dir)/.board-initialized}"; }
 
-# Newest backup snapshot path (most recent first), or empty when none exist.
+# DIVE-1986: do the snapshots in the backup dir belong to the ACTIVE store?
+#
+# 5dive-tasks-backup.sh snapshots ONE board: ${TASKS_DIR}/tasks.db. Those .db.gz
+# files are that board's history and no other's. The restore path did not check,
+# so `TASKS_DB=/tmp/x/tasks.db 5dive task init` — TASKS_DB overridden alone,
+# STATE_DIR left at its default, which is what a harness that only wants a
+# throwaway store naturally writes — found the prod sentinel, then the prod
+# snapshots, and auto-restored 579 rows of production task bodies, results and
+# gate ASK text into /tmp. Two costs, both real: task content that names people,
+# decisions and spend lands wherever the caller pointed, and a fixture store the
+# author believes is empty silently is not.
+#
+# An explicit TASKS_BACKUP_DIR is the caller pairing a backup set with their own
+# store on purpose, so it is honoured as-is — the override cannot be the source of
+# the mismatch it would have to describe.
+#
+# readlink -f prints nothing when a path's PARENT does not exist, so fall back to
+# the literal path rather than comparing "" == "" and matching everything — the
+# same three-state care _tasks_store_is_prod takes, and the opposite failure
+# direction matters just as much here: an empty result must not read as a match.
+_tasks_backups_match_store() {
+  [[ -n "${TASKS_BACKUP_DIR:-}" ]] && return 0
+  local active canon ra rc
+  active="$TASKS_DB"; canon="${TASKS_DIR}/tasks.db"
+  ra="$(readlink -f "$active" 2>/dev/null)"; [[ -n "$ra" ]] || ra="$active"
+  rc="$(readlink -f "$canon"  2>/dev/null)"; [[ -n "$rc" ]] || rc="$canon"
+  [[ "$ra" == "$rc" ]]
+}
+
+# Newest backup snapshot path (most recent first), or empty when none exist —
+# or when the snapshots are a DIFFERENT board's history (DIVE-1986).
 _tasks_newest_backup() {
+  _tasks_backups_match_store || return 0
   ls -1t "$(_tasks_backup_dir)"/tasks-*.db.gz 2>/dev/null | head -n1
 }
 
@@ -929,7 +968,7 @@ _tasks_board_recover() {
     rm -f "${TASKS_DB}-wal" "${TASKS_DB}-shm" 2>/dev/null || true
     mv -f "$tmp" "$TASKS_DB" && chmod 0660 "$TASKS_DB" 2>/dev/null
     _tasks_alarm "AUTO-RESTORED $rows rows from $(basename "$newest") — verify integrity."
-  ) 9>"${TASKS_DIR}/.recover.lock"
+  ) 9>"$(_tasks_store_dir)/.recover.lock"   # DIVE-1986: lock beside the store being recovered, not always prod's
   # Confirm we ended with a real table; if not, fail loudly rather than proceed empty.
   local h3
   h3=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \

--- a/tests/tasks_db_restore_guard_unit.sh
+++ b/tests/tasks_db_restore_guard_unit.sh
@@ -111,6 +111,66 @@ out=$(tasks_db_init 2>&1); rc=$?
 [[ $rc -eq 0 && "$(row_count)" == "3" ]] && ok "idempotent: re-init keeps rows" || bad "idempotent: rc=$rc rows=$(row_count)"
 grep -q 'MISSING\|AUTO-RESTORED' <<<"$out" && bad "idempotent: spurious alarm ($out)" || ok "idempotent: no alarm"
 
+# --- Case 6 (DIVE-1986): TASKS_DB aimed elsewhere must NOT inherit this board --
+# The reported shape: TASKS_DB overridden ALONE at a throwaway path, STATE_DIR (and
+# so TASKS_DIR + tasks-backups) left pointing at a populated board. Before the fix
+# the sentinel and the snapshots of THIS board answered "has the board existed?"
+# for a store they have never met, and init auto-restored every row of it into the
+# throwaway path. Here the populated tree stands in for prod, so the case runs the
+# real shape without going near the live board.
+fresh_tree
+tasks_db_init >/dev/null 2>&1
+seed_rows
+snapshot "20260725T154721Z"                        # this board HAS a restorable history
+home_db="$TASKS_DB"; home_sentinel="$(_tasks_sentinel)"
+foreign="$TMP/foreign"; mkdir -p "$foreign"        # a dir the caller just created
+TASKS_DB="$foreign/tasks.db"                       # ONLY TASKS_DB moves — the reported shape
+out=$(tasks_db_init 2>&1); rc=$?
+[[ $rc -eq 0 ]] && ok "foreign: init succeeds" || bad "foreign: rc=$rc ($out)"
+[[ "$(row_count)" == "0" ]] && ok "foreign: store is EMPTY (no rows imported)" \
+  || bad "foreign: imported $(row_count) rows from another board"
+grep -q 'AUTO-RESTORED' <<<"$out" && bad "foreign: auto-restored into a foreign store ($out)" \
+  || ok "foreign: no auto-restore alarm"
+[[ -f "$foreign/.board-initialized" ]] && ok "foreign: sentinel stamped BESIDE the foreign store" \
+  || bad "foreign: sentinel not scoped to the store"
+[[ ! -e "$TASKS_DIR/.recover.lock" ]] && ok "foreign: no recover lock left in the other board's dir" \
+  || bad "foreign: wrote .recover.lock into the other board's dir"
+# The board that was NOT the target must be untouched by any of the above.
+[[ "$(sqlite3 "$home_db" 'SELECT count(*) FROM tasks;' 2>/dev/null)" == "3" ]] \
+  && ok "foreign: the other board still has its 3 rows" || bad "foreign: the other board changed"
+[[ -f "$home_sentinel" ]] && ok "foreign: the other board's sentinel intact" || bad "foreign: other sentinel gone"
+
+# --- Case 7 (DIVE-1986): a foreign store still gets the guard ON ITS OWN TERMS --
+# Scoping the lookup must not disarm the guard for non-prod stores: once a store
+# has its own sentinel, a vanished table there is still an incident, and with no
+# snapshot of ITS OWN it must fail loudly rather than silently create an empty
+# board — and must not reach for the other board's snapshots to fill the gap.
+rm -f "$TASKS_DB" "$TASKS_DB-wal" "$TASKS_DB-shm"   # wipe the foreign store; its sentinel survives
+[[ -f "$foreign/.board-initialized" ]] || bad "case7: foreign sentinel should survive a bare rm"
+out=$( ( tasks_db_init ) 2>&1 ); rc=$?
+[[ $rc -ne 0 ]] && ok "foreign-wipe: fails LOUDLY (rc=$rc)" || bad "foreign-wipe: silently succeeded"
+grep -q 'MANUAL recovery required\|no backup' <<<"$out" \
+  && ok "foreign-wipe: alarm names manual recovery" || bad "foreign-wipe: weak msg ($out)"
+[[ "$(row_count)" == "ERR" || "$(row_count)" == "0" ]] \
+  && ok "foreign-wipe: no rows pulled from the other board's snapshot" \
+  || bad "foreign-wipe: imported $(row_count) rows from the other board"
+
+# --- Case 8 (DIVE-1986): an explicit TASKS_BACKUP_DIR pairing still restores ----
+# The caller who names a backup dir is pairing it with their store deliberately,
+# so the scoping check must not fence that off — otherwise recovering a relocated
+# board by hand becomes impossible.
+fresh_tree
+tasks_db_init >/dev/null 2>&1
+seed_rows
+snapshot "20260725T160000Z"
+paired_backups="$STATE_DIR/tasks-backups"
+elsewhere="$TMP/elsewhere"; mkdir -p "$elsewhere"
+TASKS_DB="$elsewhere/tasks.db"
+out=$(TASKS_BACKUP_DIR="$paired_backups" tasks_db_init 2>&1); rc=$?
+[[ $rc -eq 0 ]] && ok "paired: init succeeds" || bad "paired: rc=$rc ($out)"
+[[ "$(row_count)" == "3" ]] && ok "paired: explicit TASKS_BACKUP_DIR still restores" \
+  || bad "paired: rows=$(row_count) ($out)"
+
 echo
 echo "tasks-db restore guard: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## What

`5dive task init` with `TASKS_DB` pointed at a fresh temp path printed:

```
board table MISSING but previously initialized (sentinel/backup present) — refusing to silently recreate an EMPTY board.
AUTO-RESTORED 579 rows from tasks-<ts>.db.gz — verify integrity.
```

579 is the production board's task count, so a full copy of production task content
was written into a temp directory that had just been created.

**The DIVE-1479 guard itself is right and stays.** Refusing to silently recreate an
empty board is protective, and that failure has happened on this host. The defect is
narrower: the guard's two *prior-existence* signals both read the **prod** tree no
matter which store `init` was actually opening.

- `_tasks_sentinel` → `${TASKS_DIR}/.board-initialized`
- `_tasks_backup_dir` → `${STATE_DIR}/tasks-backups`

Neither is a function of `TASKS_DB`. So `TASKS_DB=/tmp/x/tasks.db` with `STATE_DIR`
left at its default — which is what a harness that just wants a throwaway store
naturally writes — found prod's sentinel, then prod's snapshots, and restored prod's
rows into `/tmp`.

Two costs, both real: task bodies, results and gate ASK text that can name people,
decisions and spend land wherever the caller pointed (including a world-readable
`/tmp` path); and a fixture store the author believes is empty silently is not, so a
harness can pass or fail for reasons unrelated to what it tests.

## The fix

Scope both signals to the store being initialised.

- **Sentinel** derives from the active store's own directory (`_tasks_store_dir`),
  not `TASKS_DIR`. Identical whenever `TASKS_DB` is that dir's `tasks.db` — every
  isolated harness, and prod — and different only in the case being fixed.
- **Snapshots** count as prior-existence proof only when they are *that store's*
  history. `5dive-tasks-backup.sh` snapshots exactly one board, `${TASKS_DIR}/tasks.db`;
  when the active store is not that one, its `.db.gz` files are a different board's
  past and `_tasks_newest_backup` returns empty.
- An explicit `TASKS_BACKUP_DIR` is the caller pairing a backup set with their own
  store on purpose, so it is honoured as-is — the override cannot be the source of
  the mismatch it would have to describe. (Recovering a relocated board by hand stays
  possible; asserted, see case 8.)
- The recover `flock` moves beside the store being recovered, so a foreign init no
  longer drops a `.recover.lock` into the prod tasks dir either.

`readlink -f` prints nothing when a path's parent does not exist, so an empty result
falls back to the literal path rather than comparing `"" == ""` and matching
everything — the same three-state care `_tasks_store_is_prod` already takes, with the
opposite failure direction mattering just as much here.

**A foreign store keeps the full guard on its own terms.** Scoping the lookup must not
disarm it: once a store has its own sentinel, a vanished table there is still an
incident, and with no snapshot of its own it fails loudly rather than silently creating
an empty board or reaching for another board's rows (case 7).

## Verification

**Non-vacuity.** Against pristine `src/`, the three new cases fail **8 graded
assertions** and reproduce the report verbatim: `AUTO-RESTORED 3 rows from
tasks-20260725T154721Z.db.gz`. Not a crash — the assertions are reached and graded.

**Corpus, not just my own arm.** This is shared plumbing (`tasks_db_init` runs at the
head of every task verb), so per
`community/wiki/shared-plumbing-is-graded-by-the-corpus-not-by-your-own-arm.md` the
grader is the corpus. Full `core` tier, **bundle built in both trees**, this branch vs
a **same-actor pristine `origin/main` control** on the same host:

| | branch | control |
|---|---|---|
| harnesses | 212 | 212 |
| failing | 4 | 4 |
| wall-clock | 293s | 281s |

Identical failure set — `actor_claim_corroboration_unit`, `council_ballot_e2e`,
`gate_tier2_decision_nonce_unit`, `task_deliver_merge_gate_unit` — all pre-existing on
`origin/main`, **zero new**. (An earlier unbundled run showed three more failures that
were purely the missing `./5dive` bundle; building it in both trees removed them from
both sides.)

## Budget

13 → 25 assertions, **+0.96s** (1.54s → 2.51s), folded into the **existing** harness
rather than a new file — the "merge by subject" route in CLAUDE.md, so the setup cost
is reclaimed rather than duplicated. Measured on this control-plane host, same tree as
the table above. Stays out of the tier's ten slowest (4.9s cut-off). Worth stating
plainly: `core` is at 93-97% of its 300s cap, so this +1s is small but not free.

## Scope / not in scope

Source-only — the bundle is gitignored on `main` and rebuilt at merge. No version bump.
