### PR TITLE
fix(task): guard the merge-gate branch extractor so a no-match cannot kill `task done` (DIVE-2603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased — fix(task): `task done` died with empty output when the result named no branch (DIVE-2603)
+
+v0.18.3 shipped DIVE-2577's merge-gate extractor with an **unguarded** command substitution:
+
+```sh
+local _br_cands; _br_cands=$(_gate_branch_refs_from_text "$_mg_txt" "$ident")
+```
+
+`_gate_branch_refs_from_text` is a **probe that legitimately finds nothing** — most results
+name no branch. Its pipeline ends in `grep`, which exits 1 on no-match; `pipefail` promotes
+that through `sed | tr | sort`, and `set -euo pipefail` kills the caller. So `task done`
+exited **1 with empty stdout AND empty stderr** — the die happens before anything prints,
+which is why it presented as a silent failure rather than an error.
+
+Scope: callers holding a gh token (the block is guarded on `-n "$_ghtok2"`) whose result text
+names no `<ident>-slug`. `task reject` was unaffected.
+
+Fix is `|| _br_cands=""` — empty rather than `|| true`, because it states the post-condition
+the `[[ -z "$_br_cands" ]]` test below actually reads.
+
+**This is the same defect and the same fix as DIVE-2566, one file over and in the same
+release.** An unguarded `$( )` around a probe that is *allowed* to fail, under `set -e` +
+`pipefail`, with `local` split onto its own line so the failure is not masked. Splitting the
+declaration is the correct habit for *seeing* a failure and is not sufficient for *handling*
+one. Worth grepping the tree for the pattern rather than waiting for the third instance.
+
+Regression arms are a PAIR, mutation-graded: one asserts the extractor really does exit 1 on
+no-match (so the hazard is measured, not assumed), one is a positive control proving it still
+finds a real branch, and one greps the call site for the guard. Reverting the guard reddens
+the call-site arm (12/1); restoring returns 13/0.
+
 ## Unreleased — feat(agent): `agent list` reports credential health, so a lapsed seat stops rendering live (DIVE-1953)
 
 On the DIVE-1868 flagship demo a grok seat's credential lapsed. The systemd unit stayed

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -2970,7 +2970,17 @@ $_body"
     # close that names no branch at all (the overwhelming majority) never enters
     # this block.
     if [[ -z "$_auto_hit" && $force_merge_gate -eq 0 && -n "$_ghtok2" ]]; then
-      local _br_cands; _br_cands=$(_gate_branch_refs_from_text "$_mg_txt" "$ident")
+      # DIVE-2603: the extractor is a PROBE that legitimately finds nothing — most
+      # results name no branch at all. Its pipeline ends in `grep`, which exits 1 on
+      # no-match; `pipefail` promotes that through `sed | tr | sort`, and a bare
+      # `var=$(...)` under `set -euo pipefail` (src/header.sh) kills the whole close.
+      # Shipped in v0.18.3 and it broke `task done` for every caller holding a gh
+      # token whose result text named no `<ident>-slug` branch — exit 1, empty stdout
+      # AND empty stderr, because the die happens before anything is printed.
+      # `|| _br_cands=""` rather than `|| true`: it states the post-condition the
+      # `[[ -z ]]` test below actually reads. Same defect and same fix as DIVE-2566
+      # one file over — an unguarded substitution around a probe allowed to fail.
+      local _br_cands; _br_cands=$(_gate_branch_refs_from_text "$_mg_txt" "$ident") || _br_cands=""
       if [[ -n "$_br_cands" ]]; then
         _mg_had_subject=1
         local _cand _slug3 _attr3 _bm3 _bl_hit="" _bl_hit_slug="" _bl_hit_how="" _bl_searched2="" _bl_any_unreach=0

--- a/tests/task_merge_gate_branch_in_result_unit.sh
+++ b/tests/task_merge_gate_branch_in_result_unit.sh
@@ -195,5 +195,38 @@ run_done DIVE-9001 --result='decision recorded, no code changed — closing per 
   && ok_t 'a close that mentions "branch" in prose but names no ident-prefixed slug is untouched' \
   || bad_t 'plain-prose close must not be blocked' "rc=$RC status=$(statusof DIVE-9001) refusals=$(refusals DIVE-9001) out=$OUT"
 
+
+# DIVE-2603: the extractor is a PROBE that legitimately finds nothing, and its
+# pipeline ends in `grep`, which exits 1 on no-match. Under `set -euo pipefail`
+# an UNGUARDED `var=$(...)` around it kills the caller — which is exactly what
+# v0.18.3 shipped: `task done` exited 1 with EMPTY stdout AND stderr for every
+# caller holding a gh token whose result text named no branch. The die happened
+# before anything printed, which is why it presented as a silent failure.
+#
+# Two arms as a PAIR. The no-match arm alone passes for an extractor that is
+# never reached; the match arm proves the probe still works and that the no-match
+# arm is not green by vacuity.
+_rc_probe() {  # $1 = text ; echoes "rc|output"
+  local out rc=0
+  out=$(bash -c '
+    set -euo pipefail
+    '"$(declare -f _gate_branch_refs_from_text 2>/dev/null || true)"'
+    _gate_branch_refs_from_text "$1" "$2"
+  ' _ "$1" "DIVE-999") || rc=$?
+  printf '%s|%s' "$rc" "$out"
+}
+_r_none="$(_rc_probe 'this result names no branch at all')"
+_r_hit="$(_rc_probe 'landed on DIVE-999-some-slug today')"
+[[ "${_r_none%%|*}" == "1" ]] \
+  && ok_t "DIVE-2603: the extractor itself EXITS 1 on no-match (the hazard is real, not hypothetical)" \
+  || bad_t "DIVE-2603: extractor exits 1 on no-match" "expected rc=1, got ${_r_none%%|*} — if this changed, the guard below is grading nothing"
+[[ "${_r_hit%%|*}" == "0" && "${_r_hit#*|}" == "dive-999-some-slug" ]] \
+  && ok_t "DIVE-2603: positive control — the extractor still finds a real branch (rc=0)" \
+  || bad_t "DIVE-2603: positive control" "expected rc=0 and dive-999-some-slug, got ${_r_hit}"
+grep -qE '_br_cands=\$\(_gate_branch_refs_from_text [^)]*\) \|\| _br_cands=' "$SRC/cmd_task.sh" \
+  && ok_t "DIVE-2603: the call site GUARDS the assignment so a no-match cannot kill the close" \
+  || bad_t "DIVE-2603: call site guarded" "the \$( ) assignment is unguarded — under set -e + pipefail a result naming no branch kills 'task done' with empty stdout and stderr"
+
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
**v0.18.3 broke `task done`.** It exits 1 with **empty stdout and empty stderr** — the die happens before anything prints, so it presents as a silent failure rather than an error.

DIVE-2577's extractor is a probe that legitimately finds nothing (most results name no branch). Its pipeline ends in `grep`, which exits 1 on no-match; `pipefail` promotes that through `sed | tr | sort`; and the call site is a bare `_br_cands=$(...)` under `set -euo pipefail`, with `local` split onto its own line so the failure is **not** masked.

Scope: gh-token holders (the block is guarded on `-n "$_ghtok2"`) whose result text names no `<ident>-slug`. `task reject` unaffected. Found by olivia while grading DIVE-2591.

**This is the same defect and the same fix as DIVE-2566 — one file over, in the same release I cut.** Splitting `local` from the assignment is the correct habit for *seeing* a probe's failure and is not sufficient for *handling* one. The tree is worth grepping for the pattern rather than waiting for a third instance.

Regression arms are a **pair**, mutation-graded: one asserts the extractor really does exit 1 on no-match (hazard measured, not assumed), one is a positive control proving it still finds a real branch, one greps the call site for the guard. Reverting the guard → 12/1 on the call-site arm; restoring → 13/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)