### PR TITLE
fix(tests): carry each graded harness's real rc in stdout via an EXIT trap (DIVE-2573)

### DIFF
--- a/tests/compose_asleep_report_unit.sh
+++ b/tests/compose_asleep_report_unit.sh
@@ -24,6 +24,7 @@
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 set +e -o pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
@@ -95,7 +96,4 @@ fi
 echo "-----"
 echo "compose_asleep_report_unit: $pass passed, $fail failed"
 rc=0; [[ $fail -eq 0 ]] || rc=1
-# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
-# harness through tail/head still sees the true verdict instead of the pipe's.
-echo "HARNESS-RC=$rc"
 exit "$rc"

--- a/tests/compose_asleep_report_unit.sh
+++ b/tests/compose_asleep_report_unit.sh
@@ -94,4 +94,8 @@ fi
 
 echo "-----"
 echo "compose_asleep_report_unit: $pass passed, $fail failed"
-[[ $fail -eq 0 ]]
+rc=0; [[ $fail -eq 0 ]] || rc=1
+# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
+# harness through tail/head still sees the true verdict instead of the pipe's.
+echo "HARNESS-RC=$rc"
+exit "$rc"

--- a/tests/constitution_init_e2e.sh
+++ b/tests/constitution_init_e2e.sh
@@ -9,6 +9,7 @@
 # Needs NO gate-proof key (init never seals) so a hand-synthesized sealed lineage exercises the
 # refusal root-free — this GATES in CI. SKIPs green when node/jq missing or build fails. Exit 0 == green.
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry
@@ -25,7 +26,7 @@ for b in node jq; do
   command -v "$b" >/dev/null 2>&1 || { echo "SKIP: $b not on PATH (constitution init e2e needs it)"; exit 0; }
 done
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 FIVE="$TMP/5dive"
 if ! BUILD_OUT="$FIVE" bash "$ROOT/build.sh" >/dev/null 2>&1 || [[ ! -x "$FIVE" ]]; then
   echo "SKIP: could not build a throwaway ./5dive (build.sh failed)"; exit 0
@@ -80,7 +81,4 @@ chk "C file untouched under seal" "$DIG1" "$(sha256sum < "$CY" | awk '{print $1}
 
 echo "DIVE-1701 constitution init e2e: $P passed, $F failed"
 rc=0; [ "$F" -eq 0 ] || rc=1
-# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
-# harness through tail/head still sees the true verdict instead of the pipe's.
-echo "HARNESS-RC=$rc"
 exit "$rc"

--- a/tests/constitution_init_e2e.sh
+++ b/tests/constitution_init_e2e.sh
@@ -79,4 +79,8 @@ DIG1="$(sha256sum < "$CY" | awk '{print $1}')"
 chk "C file untouched under seal" "$DIG1" "$(sha256sum < "$CY" | awk '{print $1}')"
 
 echo "DIVE-1701 constitution init e2e: $P passed, $F failed"
-[ "$F" -eq 0 ]
+rc=0; [ "$F" -eq 0 ] || rc=1
+# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
+# harness through tail/head still sees the true verdict instead of the pipe's.
+echo "HARNESS-RC=$rc"
+exit "$rc"

--- a/tests/constitution_legacy_migration_e2e.sh
+++ b/tests/constitution_legacy_migration_e2e.sh
@@ -7,6 +7,7 @@
 # `constitution show --json` (the READ verb resolves the path the same way every reader does).
 # SKIPs green when node/jq missing or the build fails. Exit 0 == green.
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry
@@ -23,7 +24,7 @@ for b in node jq; do
   command -v "$b" >/dev/null 2>&1 || { echo "SKIP: $b not on PATH (legacy-migration e2e needs it)"; exit 0; }
 done
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 FIVE="$TMP/5dive"
 if ! BUILD_OUT="$FIVE" bash "$ROOT/build.sh" >/dev/null 2>&1 || [[ ! -x "$FIVE" ]]; then
   echo "SKIP: could not build a throwaway ./5dive (build.sh failed)"; exit 0
@@ -91,7 +92,4 @@ chk "D no constitution.yaml conjured"  "yes"      "$([[ ! -e "$CANON" ]] && echo
 
 echo "constitution_legacy_migration_e2e: $P passed, $F failed"
 rc=0; [ "$F" -eq 0 ] || rc=1
-# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
-# harness through tail/head still sees the true verdict instead of the pipe's.
-echo "HARNESS-RC=$rc"
 exit "$rc"

--- a/tests/constitution_legacy_migration_e2e.sh
+++ b/tests/constitution_legacy_migration_e2e.sh
@@ -90,4 +90,8 @@ chk "D source=defaults"                "defaults" "$(jq -r '.data.source' <<<"$D
 chk "D no constitution.yaml conjured"  "yes"      "$([[ ! -e "$CANON" ]] && echo yes || echo no)"
 
 echo "constitution_legacy_migration_e2e: $P passed, $F failed"
-[ "$F" -eq 0 ]
+rc=0; [ "$F" -eq 0 ] || rc=1
+# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
+# harness through tail/head still sees the true verdict instead of the pipe's.
+echo "HARNESS-RC=$rc"
+exit "$rc"

--- a/tests/constitution_show_e2e.sh
+++ b/tests/constitution_show_e2e.sh
@@ -7,6 +7,7 @@
 # (only WRITE/verify do), so a hand-synthesized lineage exercises the sealed case root-free — this
 # GATES in CI. SKIPs green when node/jq missing or the build fails. Exit 0 == green.
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry
@@ -23,7 +24,7 @@ for b in node jq; do
   command -v "$b" >/dev/null 2>&1 || { echo "SKIP: $b not on PATH (constitution show e2e needs it)"; exit 0; }
 done
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 FIVE="$TMP/5dive"
 if ! BUILD_OUT="$FIVE" bash "$ROOT/build.sh" >/dev/null 2>&1 || [[ ! -x "$FIVE" ]]; then
   echo "SKIP: could not build a throwaway ./5dive (build.sh failed)"; exit 0
@@ -106,7 +107,4 @@ chk "D sealedDigest unchanged" "$DIG"   "$(jq -r '.data.sealedDigest' <<<"$D")"
 
 echo "DIVE-1742 constitution show e2e: $P passed, $F failed"
 rc=0; [ "$F" -eq 0 ] || rc=1
-# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
-# harness through tail/head still sees the true verdict instead of the pipe's.
-echo "HARNESS-RC=$rc"
 exit "$rc"

--- a/tests/constitution_show_e2e.sh
+++ b/tests/constitution_show_e2e.sh
@@ -105,4 +105,8 @@ chk "D sealedDigest unchanged" "$DIG"   "$(jq -r '.data.sealedDigest' <<<"$D")"
 "$FIVE" constitution show >/dev/null 2>&1; chk "human render exit 0" "0" "$?"
 
 echo "DIVE-1742 constitution show e2e: $P passed, $F failed"
-[ "$F" -eq 0 ]
+rc=0; [ "$F" -eq 0 ] || rc=1
+# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
+# harness through tail/head still sees the true verdict instead of the pipe's.
+echo "HARNESS-RC=$rc"
+exit "$rc"

--- a/tests/council_ballot_e2e.sh
+++ b/tests/council_ballot_e2e.sh
@@ -80,4 +80,8 @@ if grep -q "^agent ask" "$FLOG"; then chk "--ask-rail uses the agent-ask rail" "
 if grep -q "^task add" "$FLOG"; then chk "--ask-rail does NOT mint a ballot task" "no" "yes"; else chk "--ask-rail does NOT mint a ballot task" "no" "no"; fi
 
 echo "CNCL-18 ballot E2E: $P passed, $F failed"
-[ "$F" -eq 0 ]
+rc=0; [ "$F" -eq 0 ] || rc=1
+# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
+# harness through tail/head still sees the true verdict instead of the pipe's.
+echo "HARNESS-RC=$rc"
+exit "$rc"

--- a/tests/council_ballot_e2e.sh
+++ b/tests/council_ballot_e2e.sh
@@ -9,6 +9,7 @@
 # for the fleet (agent list / task add / task show / agent ask). SKIPs green when node/jq are
 # missing or the build fails. Exit 0 == green.
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry
@@ -25,7 +26,7 @@ for b in node jq; do
   command -v "$b" >/dev/null 2>&1 || { echo "SKIP: $b not on PATH (council ballot e2e needs it)"; exit 0; }
 done
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 FIVE="$TMP/5dive"
 if ! BUILD_OUT="$FIVE" bash "$ROOT/build.sh" >/dev/null 2>&1 || [[ ! -x "$FIVE" ]]; then
   echo "SKIP: could not build a throwaway ./5dive (build.sh failed)"; exit 0
@@ -81,7 +82,4 @@ if grep -q "^task add" "$FLOG"; then chk "--ask-rail does NOT mint a ballot task
 
 echo "CNCL-18 ballot E2E: $P passed, $F failed"
 rc=0; [ "$F" -eq 0 ] || rc=1
-# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
-# harness through tail/head still sees the true verdict instead of the pipe's.
-echo "HARNESS-RC=$rc"
 exit "$rc"

--- a/tests/council_ballot_tap_e2e.sh
+++ b/tests/council_ballot_tap_e2e.sh
@@ -9,6 +9,7 @@
 # ballot whose body carries nonceDigest=sha256(NONCE); `task done` is logged. SKIPs green when node/
 # jq/sha256sum are missing or the build fails. Exit 0 == green.
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry
@@ -25,7 +26,7 @@ for b in node jq sha256sum; do
   command -v "$b" >/dev/null 2>&1 || { echo "SKIP: $b not on PATH (council ballot-tap e2e needs it)"; exit 0; }
 done
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 FIVE="$TMP/5dive"
 if ! BUILD_OUT="$FIVE" bash "$ROOT/build.sh" >/dev/null 2>&1 || [[ ! -x "$FIVE" ]]; then
   echo "SKIP: could not build a throwaway ./5dive (build.sh failed)"; exit 0
@@ -92,7 +93,4 @@ chk "agent ballot not tap-closable" "no match" "$(run --ref=DIVE-1601 --vote=a -
 
 echo "DIVE-1565 ballot-tap E2E: $P passed, $F failed"
 rc=0; [ "$F" -eq 0 ] || rc=1
-# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
-# harness through tail/head still sees the true verdict instead of the pipe's.
-echo "HARNESS-RC=$rc"
 exit "$rc"

--- a/tests/council_ballot_tap_e2e.sh
+++ b/tests/council_ballot_tap_e2e.sh
@@ -91,4 +91,8 @@ chk "unknown ref -> miss"   "no match" "$(run --ref=DIVE-9999 --vote=a --nonce="
 chk "agent ballot not tap-closable" "no match" "$(run --ref=DIVE-1601 --vote=a --nonce="$NONCE" | jq -r '.reason' 2>/dev/null)"
 
 echo "DIVE-1565 ballot-tap E2E: $P passed, $F failed"
-[ "$F" -eq 0 ]
+rc=0; [ "$F" -eq 0 ] || rc=1
+# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
+# harness through tail/head still sees the true verdict instead of the pipe's.
+echo "HARNESS-RC=$rc"
+exit "$rc"

--- a/tests/council_bashroute_e2e.sh
+++ b/tests/council_bashroute_e2e.sh
@@ -96,4 +96,8 @@ chk "bash verify-votes forged (exit 5)" "5" "$?"
 chk "bash verify-votes replay (exit 5)" "5" "$?"
 
 echo "CNCL-26 bash-route E2E: $P passed, $F failed"
-[ "$F" -eq 0 ]
+rc=0; [ "$F" -eq 0 ] || rc=1
+# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
+# harness through tail/head still sees the true verdict instead of the pipe's.
+echo "HARNESS-RC=$rc"
+exit "$rc"

--- a/tests/council_bashroute_e2e.sh
+++ b/tests/council_bashroute_e2e.sh
@@ -13,6 +13,7 @@
 # it GATES in CI too (CI never builds ./5dive, and no root/sudo/seal is needed — these verbs are
 # pure). SKIPs green only when node/jq/openssl are missing or the build fails. Exit 0 == green.
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry
@@ -30,7 +31,7 @@ for b in node jq openssl; do
   command -v "$b" >/dev/null 2>&1 || { echo "SKIP: $b not on PATH (council bash-route e2e needs it)"; exit 0; }
 done
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 FIVE="$TMP/5dive"
 if ! BUILD_OUT="$FIVE" bash "$ROOT/build.sh" >/dev/null 2>&1 || [[ ! -x "$FIVE" ]]; then
   echo "SKIP: could not build a throwaway ./5dive (build.sh failed)"; exit 0
@@ -97,7 +98,4 @@ chk "bash verify-votes replay (exit 5)" "5" "$?"
 
 echo "CNCL-26 bash-route E2E: $P passed, $F failed"
 rc=0; [ "$F" -eq 0 ] || rc=1
-# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
-# harness through tail/head still sees the true verdict instead of the pipe's.
-echo "HARNESS-RC=$rc"
 exit "$rc"

--- a/tests/council_cosign_e2e.sh
+++ b/tests/council_cosign_e2e.sh
@@ -61,4 +61,8 @@ node "$CLI" verify-votes --votes="$VOTES" --roster="$REVROSTER" --convene="$CV" 
 chk "revoked-key vote rejected (exit 5)" "5" "$?"
 
 echo "CNCL-10 co-sign E2E: $P passed, $F failed"
-[ "$F" -eq 0 ]
+rc=0; [ "$F" -eq 0 ] || rc=1
+# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
+# harness through tail/head still sees the true verdict instead of the pipe's.
+echo "HARNESS-RC=$rc"
+exit "$rc"

--- a/tests/council_cosign_e2e.sh
+++ b/tests/council_cosign_e2e.sh
@@ -3,6 +3,7 @@
 # REAL on-disk Ed25519 keys and proves: keys are 0600 owner-only, the honest path verifies green,
 # and forged / cross-convene-replay / revoked-key votes are all rejected (non-zero exit). Exit 0 == green.
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry
@@ -16,7 +17,7 @@ set -uo pipefail
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 ENGINE="$(cd "$(dirname "$0")/.." && pwd)/src/council/engine.mjs"
 CLI="$(cd "$(dirname "$0")/.." && pwd)/src/council/cli.mjs"
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 P=0; F=0
 chk(){ if [ "$2" = "$3" ]; then P=$((P+1)); else F=$((F+1)); echo "FAIL: $1 (want=$2 got=$3)"; fi; }
 
@@ -62,7 +63,4 @@ chk "revoked-key vote rejected (exit 5)" "5" "$?"
 
 echo "CNCL-10 co-sign E2E: $P passed, $F failed"
 rc=0; [ "$F" -eq 0 ] || rc=1
-# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
-# harness through tail/head still sees the true verdict instead of the pipe's.
-echo "HARNESS-RC=$rc"
 exit "$rc"

--- a/tests/council_init_wizard_unit.sh
+++ b/tests/council_init_wizard_unit.sh
@@ -124,4 +124,8 @@ chk "E missing custom const aborts" "yes" "$([ "$?" -ne 0 ] && echo yes || echo 
 
 echo
 echo "DIVE-1861 council init wizard unit: $P passed, $F failed"
-[ "$F" -eq 0 ] || exit 1
+rc=0; [ "$F" -eq 0 ] || rc=1
+# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
+# harness through tail/head still sees the true verdict instead of the pipe's.
+echo "HARNESS-RC=$rc"
+exit "$rc"

--- a/tests/council_init_wizard_unit.sh
+++ b/tests/council_init_wizard_unit.sh
@@ -5,6 +5,7 @@
 # over piped stdin (its dumb-terminal numbered branch), so it gates in CI with no
 # TTY, no root, and no gate-proof key. Exit 0 == green.
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry
@@ -22,7 +23,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # Stub the two council seams the wizard leans on so the test needs no live state:
 #   · _council_resolve_principal — resolve human:main / tg:<id>, refuse the rest
 #   · _council_constitution_path — point at a scratch file we control
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 export STATE_DIR="$TMP"          # the template derives COUNCIL_* paths from this at source time
 source "$ROOT/src/cmd_init.sh"
 # shellcheck disable=SC1090
@@ -125,7 +126,4 @@ chk "E missing custom const aborts" "yes" "$([ "$?" -ne 0 ] && echo yes || echo 
 echo
 echo "DIVE-1861 council init wizard unit: $P passed, $F failed"
 rc=0; [ "$F" -eq 0 ] || rc=1
-# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
-# harness through tail/head still sees the true verdict instead of the pipe's.
-echo "HARNESS-RC=$rc"
 exit "$rc"

--- a/tests/council_liveness_e2e.sh
+++ b/tests/council_liveness_e2e.sh
@@ -7,6 +7,7 @@
 # (agent list health / agent send / task add|show). SKIPs green when node/jq missing or build fails.
 # Exit 0 == green.
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry
@@ -23,7 +24,7 @@ for b in node jq; do
   command -v "$b" >/dev/null 2>&1 || { echo "SKIP: $b not on PATH (council liveness e2e needs it)"; exit 0; }
 done
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 FIVE="$TMP/5dive"
 if ! BUILD_OUT="$FIVE" bash "$ROOT/build.sh" >/dev/null 2>&1 || [[ ! -x "$FIVE" ]]; then
   echo "SKIP: could not build a throwaway ./5dive (build.sh failed)"; exit 0
@@ -71,7 +72,4 @@ chk "ordinary motion is NOT liveness-gated" "real-agents" "$(echo "$OUTC" | jq -
 
 echo "DIVE-1739 liveness E2E: $P passed, $F failed"
 rc=0; [ "$F" -eq 0 ] || rc=1
-# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
-# harness through tail/head still sees the true verdict instead of the pipe's.
-echo "HARNESS-RC=$rc"
 exit "$rc"

--- a/tests/council_liveness_e2e.sh
+++ b/tests/council_liveness_e2e.sh
@@ -70,4 +70,8 @@ OUTC="$(ASLEEP_BB=1 COUNCIL_5DIVE_BIN="$FAKE" "$FIVE" council convene "ship it?"
 chk "ordinary motion is NOT liveness-gated" "real-agents" "$(echo "$OUTC" | jq -r '.data.dispatch' 2>/dev/null)"
 
 echo "DIVE-1739 liveness E2E: $P passed, $F failed"
-[ "$F" -eq 0 ]
+rc=0; [ "$F" -eq 0 ] || rc=1
+# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
+# harness through tail/head still sees the true verdict instead of the pipe's.
+echo "HARNESS-RC=$rc"
+exit "$rc"

--- a/tests/council_schedule_e2e.sh
+++ b/tests/council_schedule_e2e.sh
@@ -15,6 +15,7 @@
 # dispatch. Builds a throwaway ./5dive (BUILD_OUT) so it GATES in CI; SKIPs green if it can't
 # build or node/jq are missing. Exit 0 == green.
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry
@@ -31,7 +32,7 @@ for b in node jq; do
   command -v "$b" >/dev/null 2>&1 || { echo "SKIP: $b not on PATH (council schedule e2e needs it)"; exit 0; }
 done
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 FIVE="$TMP/5dive"
 if ! BUILD_OUT="$FIVE" bash "$ROOT/build.sh" >/dev/null 2>&1 || [[ ! -x "$FIVE" ]]; then
   echo "SKIP: could not build a throwaway ./5dive (build.sh failed)"; exit 0
@@ -138,7 +139,4 @@ chk "ls empty after rm" "0" "$(5dive --json council schedule ls 2>/dev/null | jq
 
 echo "CNCL-23 schedule E2E: $P passed, $F failed"
 rc=0; [ "$F" -eq 0 ] || rc=1
-# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
-# harness through tail/head still sees the true verdict instead of the pipe's.
-echo "HARNESS-RC=$rc"
 exit "$rc"

--- a/tests/council_schedule_e2e.sh
+++ b/tests/council_schedule_e2e.sh
@@ -137,4 +137,8 @@ chk "ls empty after rm" "0" "$(5dive --json council schedule ls 2>/dev/null | jq
 5dive council schedule rm ghost >/dev/null 2>&1; chk "rm unknown fails closed (exit 3)" "3" "$?"
 
 echo "CNCL-23 schedule E2E: $P passed, $F failed"
-[ "$F" -eq 0 ]
+rc=0; [ "$F" -eq 0 ] || rc=1
+# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
+# harness through tail/head still sees the true verdict instead of the pipe's.
+echo "HARNESS-RC=$rc"
+exit "$rc"

--- a/tests/gate_t2_nonce_proof_unit.sh
+++ b/tests/gate_t2_nonce_proof_unit.sh
@@ -432,4 +432,8 @@ out=$(cmd_task_need DIVE-522 --type=decision --tier=2 --options="A|B" \
 
 printf '\n%s\n' "-----------------------------------------------"
 printf 'DIVE-2233 item 2 — tier-2 nonce: mint, emit, verify: %d passed, %d failed\n' "$PASS" "$FAIL"
-[[ $FAIL -eq 0 ]]
+rc=0; [[ $FAIL -eq 0 ]] || rc=1
+# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
+# harness through tail/head still sees the true verdict instead of the pipe's.
+echo "HARNESS-RC=$rc"
+exit "$rc"

--- a/tests/gate_t2_nonce_proof_unit.sh
+++ b/tests/gate_t2_nonce_proof_unit.sh
@@ -27,10 +27,10 @@
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 set -o pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-t2-nonce-proof.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # STATE_DIR must be set BEFORE cmd_council.sh is sourced (COUNCIL_DIR/COUNCIL_LINEAGE are
 # source-time globals derived from it).
@@ -433,7 +433,4 @@ out=$(cmd_task_need DIVE-522 --type=decision --tier=2 --options="A|B" \
 printf '\n%s\n' "-----------------------------------------------"
 printf 'DIVE-2233 item 2 — tier-2 nonce: mint, emit, verify: %d passed, %d failed\n' "$PASS" "$FAIL"
 rc=0; [[ $FAIL -eq 0 ]] || rc=1
-# DIVE-2573: last stdout line carries the real rc, so a caller who pipes this
-# harness through tail/head still sees the true verdict instead of the pipe's.
-echo "HARNESS-RC=$rc"
 exit "$rc"


### PR DESCRIPTION
DIVE-2559 landed `pipefail` inside the 12 graded harnesses. That fixes pipe failures *within* a harness and does nothing for the shape the row was filed on: an agent typing `bash tests/x.sh 2>&1 | tail -3` in their own shell, where `$?` is tail's. No setting inside a harness can reach a pipeline the caller builds after the process has exited, so carrying the verdict in **stdout** is the only thing that survives.

Each graded harness now emits `HARNESS-RC=<rc>` as its last stdout line, **via a single `trap ... EXIT`** rather than a hand-placed echo before each exit.

**Why the trap, and this is the whole review history of this PR:** the first cut placed 12 explicit echoes, and the convention was then bypassed on every *degraded* path — the row's own premise failing in its worst case. Measured across the branch: two distinct early-exit classes (dependency-not-on-PATH, and could-not-build-a-throwaway `./5dive`) each hit 8 of the 12, plus a precondition bail — **9 of 12 harnesses had at least one path printing no `HARNESS-RC`**. Demonstrated rather than argued: with `PATH` emptied, `bash tests/council_ballot_e2e.sh 2>&1 | tail -3` printed `SKIP: node not on PATH`, carried no rc line, and left `$? = 0` from tail. A reader taught to trust that line reads a skipped harness as a pass — the one case where a missing measurement most reliably reads as success.

The trap covers the normal path, both skip classes, the precondition bail and a `set -e` death, and **removes** the 12 hand-placed echoes rather than adding to them. Diff is 12 test files, +22/-47, zero product code.

Verified by olivia (iteration 2, mechanism passes). Authored by dev2; PR opened by main (dev2 holds no gh credential).

🤖 Generated with [Claude Code](https://claude.com/claude-code)