### PR TITLE
fix(pack): the skills text told codex/opencode users NONE are installed while import lands bodies (DIVE-2583)

### DIFF
--- a/src/cmd_pack.sh
+++ b/src/cmd_pack.sh
@@ -103,7 +103,11 @@ _install_bundled_skill() {
   [[ -f "$srcdir/SKILL.md" ]] || return 1
   local user="agent-${name}" home="/home/agent-${name}" type install_dir
   type=$(agent_type "$name"); [[ -n "$type" ]] || return 1
-  install_dir="${SKILLS_INSTALL_DIR[$type]:-.claude/skills}"
+  # DIVE-2583: through the shared resolver, so the destination this function
+  # actually writes to is the same value the export text quotes. Note what this
+  # function does NOT do — it is not type-gated. It runs for EVERY type, which is
+  # why "codex/opencode install none" was wrong in the import direction.
+  install_dir=$(skills_install_dir "$type")
   # DIVE-2370 — THE DESTRUCTIVE SITE. $id reaches here from the pack manifest's skills[]
   # (jq over $stage/manifest.json, i.e. third-party content) via parse_skill_spec, which
   # splits on ":" and validates NOTHING. With id="..", dest resolves to $home/.claude and
@@ -1212,9 +1216,11 @@ _pack_scope_memory() {
 #     default anyway (DIVE-995), so carrying them would only ever be a trap.
 #   - skill BODIES: names travel as refs (exactly as the tarball manifest does).
 #     Inlining bodies would balloon a file whose whole value is being
-#     human-sized, and a harness with no skills directory still gets the NAMES —
-#     visible in the frontmatter, restated in a `## Skills` section, and warned
-#     about by name on import.
+#     human-sized, and every harness still gets the NAMES — visible in the
+#     frontmatter, restated in a `## Skills` section, and warned about by name on
+#     import. DIVE-2583: that is a claim about THIS CONTAINER only. It says
+#     nothing about where import puts a body it CAN resolve — that answer is
+#     skills_install_dir(<type>) and it is non-empty for every type.
 AGENTS_MD_FORMAT_VERSION=1
 
 # Sentinels are HTML comments: invisible in every markdown renderer, ignored by
@@ -1279,17 +1285,33 @@ _agents_md_render() {
   fi
   printf '\n'
 
-  # Skills: names, never bodies — and say so, because a silent drop is the bad
-  # outcome for a harness that has no skills directory.
+  # Skills: names, never bodies — and say so, PER DIRECTION (DIVE-2583). One
+  # sentence used to fuse two different mechanisms and got the joint wrong:
+  #   - EXPORT (this file): carries refs, not bodies. True for EVERY harness.
+  #   - the parenthetical "(codex, opencode)" have no skills directory: false
+  #     about all of them. SKILLS_INSTALL_DIR maps every known type and unmapped
+  #     types fall back, so the category the sentence named is empty.
+  #   - IMPORT: _install_bundled_skill is NOT type-gated and cmd_skill_add resolves
+  #     the same map, so a codex seat that imports DOES get bodies under $HOME.
+  #     Telling that reader "NONE are installed" is the permissive, dangerous half.
+  # So: name the direction, and take the destination from skills_install_dir —
+  # the resolver the installer itself calls — instead of restating a type list.
   local nskills; nskills=$(jq -r '(.skills // []) | length' "$mf")
   if (( nskills > 0 )); then
+    local sk_type sk_dir
+    sk_type=$(jq -r '.config.type // "claude"' "$mf")
+    sk_dir=$(skills_install_dir "$sk_type")
     printf '%s\n' "$AGENTS_MD_S_SKILLS"
     printf '## Skills\n\n'
-    printf 'This agent expects the skills below. They travel as NAMES, not bodies —\n'
-    printf 'the same refs the tarball pack records. `5dive agent import` re-installs\n'
-    printf 'them where it can and reports by name the ones it could not. On a harness\n'
-    printf 'with no skills directory (codex, opencode) NONE are installed: treat this\n'
-    printf 'list as the capabilities the agent was written to assume.\n\n'
+    printf 'This agent expects the skills below. THIS FILE carries their NAMES, not\n'
+    printf 'their bodies — the same refs the tarball pack records — so the file on its\n'
+    printf 'own installs nothing, on any harness.\n\n'
+    printf 'Importing it is the other direction. `5dive agent import` re-resolves each\n'
+    printf 'name from its source repo, installs the ones it can and reports by name the\n'
+    printf 'ones it could not; on a `%s` seat an installed body lands in\n' "$sk_type"
+    printf '`~/%s/<skill>/`. Whether %s then LOADS that directory is the\n' "$sk_dir" "$sk_type"
+    printf "harness's own behaviour and 5dive does not verify it — so treat this list as\n"
+    printf 'the capabilities the agent was written to assume, not as proof it has them.\n\n'
     jq -r '(.skills // [])[] | "- `" + . + "`"' "$mf"
     printf '\n'
   fi
@@ -1696,7 +1718,13 @@ cmd_export() {
     (( has_avatar )) && warn "dropped the avatar (binary): a single-file export carries no image — use --format=pack to keep avatar.png"
     (( n_hooks > 0 )) && warn "dropped $n_hooks hook block(s): a single-file export never carries arbitrary shell (export --format=pack if you need them)"
     local skill_n; skill_n=$(jq -r 'length' <<<"$skills" 2>/dev/null || echo 0)
-    (( skill_n > 0 )) && warn "skills travel as NAMES, not bodies ($skill_n listed in the file) — a harness with no skills directory installs none of them; the file says so"
+    # DIVE-2583: same correction as the rendered section — the FILE carries no
+    # bodies (true everywhere); importing it still installs into the importing
+    # seat's mapped skills dir, so do not tell the exporter that nothing lands
+    # anywhere. No dir is named here on purpose: at export time we do not know
+    # which type the file will be imported onto, and the old text's mistake was
+    # exactly this kind of unearned specificity.
+    (( skill_n > 0 )) && warn "skills travel as NAMES, not bodies ($skill_n listed in the file); the file says so. Importing it re-resolves each name from its source repo and installs what it can into the importing seat's skills dir — every harness has one"
     ok "exported '$name' as a single-file AGENTS.md (memory: $mem_inc) -> $out" \
        '{name:$n, file:$o, format:"agents-md", agentsMdFormat:$f, withMemory:($m != "false"), memory:$m, skills:$s, hooks:"dropped"}' \
        --arg n "$name" --arg o "$out" --argjson f "$AGENTS_MD_FORMAT_VERSION" --arg m "$mem_inc" --argjson s "$skills"

--- a/src/header.sh
+++ b/src/header.sh
@@ -416,8 +416,27 @@ declare -A SKILLS_AGENT_ID=(
 # and cmd_skill_rm. Probed empirically against npx skills v0.x — if upstream
 # changes a path, update here. Unknown types fall through to ".claude/skills"
 # in the lookup sites below.
+#
+# DIVE-2583 — THE CONTRACT, because prose elsewhere in this repo contradicted it:
+# every value here is $HOME-RELATIVE (it is joined to /home/agent-<name>/ at every
+# call site), and EVERY known type has one. There is no such thing as a 5dive type
+# "with no skills directory": an unmapped type does not get nothing, it gets the
+# .claude/skills fallback. Any sentence claiming a harness has no skills dir is
+# false about this map — see skills_install_dir() below for the resolver that
+# decides it, and use that rather than restating a type list in prose.
+#
+# What this map does NOT claim: that the harness READS the directory. Landing a
+# body is our side; loading it is the harness's. Two entries here are landed-but-
+# unverified and are marked as such (codex/opencode, antigravity) — do not upgrade
+# either note without a live seat.
 declare -A SKILLS_INSTALL_DIR=(
   [claude]=".claude/skills"
+  # codex/opencode: the upstream `npx skills --agent {codex,opencode}` install
+  # path. UNMEASURED, DIVE-2583: whether either binary then SCANS ~/.agents/skills
+  # has never been checked on a live seat — codex is not installed on this box and
+  # its installer fails partway. So a body we land here is landed, not proven
+  # loaded. State the mechanism ("import installs to <dir>"), never the outcome
+  # ("the agent has the skill"), until someone measures it.
   [codex]=".agents/skills"
   [hermes]=".hermes/skills"
   [openclaw]="skills"
@@ -426,6 +445,15 @@ declare -A SKILLS_INSTALL_DIR=(
   # by grepping the antigravity binary for the path constant. Earlier map said
   # .gemini/antigravity-cli/skills (matching its state dir), which was a guess
   # — wrong. Upstream npx skills fallback already lands at .agents/skills.
+  #
+  # DIVE-2583, the unreconciled half of that note: {workspace} is NOT $HOME for a
+  # 5dive agy seat (workdir is a project dir under /home/claude/projects), while
+  # every writer we have — preseed_antigravity_agent, the notify-user seed in the
+  # channel installer, install_default_skill_for_agent — joins this value to
+  # /home/agent-<name>/. If the binary really is workspace-relative, those bodies
+  # are present-but-inert, the same "present is not in effect" trap DIVE-2568 hit
+  # for memory. Nobody has run an agy seat to settle it (no antigravity agent
+  # exists in the fleet — DIVE-2037), so it stays recorded, not resolved.
   [antigravity]=".agents/skills"
   # pi reads user skills from ~/.pi/agent/skills AND ~/.agents/skills (per its
   # resource-loader). We target .agents/skills — the cross-CLI shared dir agy/
@@ -435,6 +463,18 @@ declare -A SKILLS_INSTALL_DIR=(
   [pi]=".agents/skills"
   [grok]=".grok/skills"
 )
+
+# skills_install_dir <type> -> the $HOME-relative dir an installed skill body
+# lands in for that type. THE resolver: this is the expression cmd_pack.sh's
+# import path, cmd_skill add/list/rm and agent_setup.sh each spell by hand, and
+# DIVE-2583 exists because a rendered sentence stated a DIFFERENT answer than the
+# one the installer computed. Anything that TELLS a user where skills go must ask
+# this function, so the claim and the behaviour cannot drift apart. Total by
+# construction — never empty, for any input — which is exactly why "a harness with
+# no skills directory" describes nothing here.
+skills_install_dir() {
+  printf '%s\n' "${SKILLS_INSTALL_DIR[${1:-}]:-.claude/skills}"
+}
 
 # api-key target per type: the env file (in /etc/5dive/connectors for the
 # default profile) and the env var inside it. Claude-family is special-cased

--- a/tests/pack_agents_md_unit.sh
+++ b/tests/pack_agents_md_unit.sh
@@ -119,7 +119,7 @@ truthy "hooks are declared dropped, not omitted" $(grep -q '^hooks: dropped' "$M
 # both arms, or "says dropped" would also pass on a stage that has no avatar.
 truthy "an avatar present in the stage is declared dropped, not omitted" $(grep -q "^avatar: dropped" "$MD"; echo $?)
 truthy "the file STATES that skills are names not bodies" \
-  $(grep -q 'travel as NAMES, not bodies' "$MD"; echo $?)
+  $(grep -q 'carries their NAMES, not' "$MD"; echo $?)
 truthy "memory sections are human-readable headings" \
   $(grep -qx '## memory/reference_thing.md' "$MD"; echo $?)
 # Non-vacuity for the tripwire below: the fixture really does hold both fences.
@@ -252,6 +252,82 @@ truthy "the tarball is what _pack_safe_extract accepts" \
   $(_pack_safe_extract "$TGZ" "$TMP/x" >/dev/null 2>&1; echo $?)
 check "extracted manifest is the same one" "$(jq -r '.agentName' "$TMP/x/manifest.json")" "ada"
 rm -f "$TGZ"
+
+# ------------------------------------------ DIVE-2583: the skills statement ---
+# The old text asserted "on a harness with no skills directory (codex, opencode)
+# NONE are installed". Both halves are gradable WITHOUT a codex seat, and neither
+# is graded by looking for words: the claim is a PREDICATE over SKILLS_INSTALL_DIR,
+# so run the predicate. (DIVE-2568 shipped three findings where a string survived
+# dead code — a grep for the sentence would have passed on either wording.)
+
+# 1. The category the sentence named is empty. Decided by the resolver every
+#    install site calls, over every key in the map.
+# NB: grade the MAP here, not the resolver — `${m[$k]:-default}` substitutes on
+# EMPTY as well as unset, so a resolver-side probe can never observe a type that
+# was mapped to "". Reading the array directly is the only way this arm can red.
+_empty=""; _swept=0; _disagree=""
+for _t in "${!SKILLS_INSTALL_DIR[@]}"; do
+  [[ -n "${SKILLS_INSTALL_DIR[$_t]}" ]] || _empty="$_empty $_t"
+  [[ "$(skills_install_dir "$_t")" == "${SKILLS_INSTALL_DIR[$_t]}" ]] || _disagree="$_disagree $_t"
+  _swept=$((_swept + 1))
+done
+check "no known type is mapped to an empty skills dir" "$_empty" ""
+check "the resolver returns the mapped value for every known type" "$_disagree" ""
+# ...and that sweep is only worth anything if it actually swept. A map that lost
+# its entries would satisfy the arm above vacuously.
+truthy "the sweep was non-vacuous (every mapped type visited)" \
+  $([[ "$_swept" -ge 8 && "$_swept" -eq "${#SKILLS_INSTALL_DIR[@]}" ]]; echo $?)
+check "codex — the type the old text called dir-less — maps to a real dir" \
+  "$(skills_install_dir codex)" ".agents/skills"
+check "opencode likewise" "$(skills_install_dir opencode)" ".agents/skills"
+# The resolver is TOTAL: an unmapped type does not get "no skills directory",
+# it gets the fallback. That is why the category cannot be non-empty.
+check "an unknown type falls back rather than resolving to nothing" \
+  "$(skills_install_dir definitely-not-a-type)" ".claude/skills"
+
+# 2. The rendered sentence is DERIVED from that resolver, not copied from it.
+#    Render once per mapped type and require the dir in the prose to EQUAL what
+#    the installer would compute. A hardcoded string passes for at most one type;
+#    this arm only goes green if the text moves with the map.
+_S83="$TMP/s2583"; _bad=""; _rendered=0
+for _t in "${!SKILLS_INSTALL_DIR[@]}"; do
+  rm -rf "$_S83"; mkdir -p "$_S83"
+  printf '# A\n\nbody\n' > "$_S83/CLAUDE.md"
+  jq -n --arg t "$_t" '{ packFormat: 1, agentName: "ada", createdWith: "0.99.0",
+     includes: { memory: false, persona: true },
+     config: { type: $t, isolation: "admin", channels: "telegram", workdir: "/w",
+               authProfile: null, model: "opus", effort: "high" },
+     plugins: [], skills: ["deep-research"], hooks: {} }' > "$_S83/manifest.json"
+  _md83="$TMP/A-$_t.md"; _agents_md_render "$_S83" > "$_md83" || { _bad="$_bad $_t(render)"; continue; }
+  _got=$(grep -oE '~/[A-Za-z0-9._/-]+/<skill>/' "$_md83" | head -1)
+  _got="${_got#\~/}"; _got="${_got%/<skill>/}"
+  [[ "$_got" == "$(skills_install_dir "$_t")" ]] || _bad="$_bad $_t(said:${_got:-none})"
+  _rendered=$((_rendered + 1))
+done
+check "the rendered skills dir equals the resolver's answer, for every type" "$_bad" ""
+truthy "…and every mapped type was actually rendered (arm above is not vacuous)" \
+  $([[ "$_rendered" -eq "${#SKILLS_INSTALL_DIR[@]}" ]]; echo $?)
+
+# 3. The two directions are stated separately, and the permissive one is gone.
+#    Graded on a CODEX render — the exact reader the old text misled.
+MD83="$TMP/A-codex.md"
+truthy "a codex export names .agents/skills as where an import lands a body" \
+  $(grep -q '`~/.agents/skills/<skill>/`' "$MD83"; echo $?)
+truthy "the file no longer claims any harness has no skills directory" \
+  $(! grep -qi 'no skills directory' "$MD83"; echo $?)
+truthy "nor that NONE are installed" $(! grep -q 'NONE are installed' "$MD83"; echo $?)
+# Negative arms need a liveness partner or they pass on an empty file: the
+# section must still be there, saying the export-direction truth.
+truthy "the Skills section still renders (negatives above are not vacuous)" \
+  $(grep -qx '## Skills' "$MD83"; echo $?)
+truthy "export direction: THIS FILE installs nothing, on any harness" \
+  $(grep -q 'own installs nothing, on any harness' "$MD83"; echo $?)
+truthy "import direction is named as a separate mechanism" \
+  $(grep -q '5dive agent import` re-resolves' "$MD83"; echo $?)
+# 4. And the load half stays UNMEASURED rather than being upgraded to a promise:
+#    we install a body, we do not claim the harness reads it.
+truthy "the text states landing, not loading (no codex seat has ever been measured)" \
+  $(grep -q 'does not verify it' "$MD83"; echo $?)
 
 printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$PASS" "$FAIL"
 (( FAIL == 0 ))


### PR DESCRIPTION
## The contradiction

Every exported `AGENTS.md` said:

> They travel as NAMES, not bodies … On a harness **with no skills directory (codex, opencode) NONE are installed**.

Both claims are wrong, and the code that contradicts them is two files away:

- `SKILLS_INSTALL_DIR` maps **codex → `.agents/skills`** and **opencode → `.agents/skills`**. An *unmapped* type does not get nothing either — it falls back to `.claude/skills`. The category "harness with no skills directory" is **empty**.
- `_install_bundled_skill` is **not type-gated**: it resolves that map for any type and `cp -r`s the body. `cmd_skill_add` (the fallback path a single-file import actually takes, since AGENTS.md carries refs) resolves the same map. So importing onto a codex seat **does** land bodies at `/home/agent-<n>/.agents/skills/<id>/` and lists them in `skillsAdded` — while the file the user is reading says none are installed. That is the permissive direction.

## Why it survived review

The two statements are about different **directions**, and one sentence fused them:

| direction | true statement |
|---|---|
| export (this file) | carries skill NAMES, never bodies — for **every** harness |
| import | resolves each name and installs bodies to `skills_install_dir(type)` — for **every** harness |

Each half is defensible alone. The falsehood lives only in the joint: a premise scoped to export welded to a parenthetical about the harness, which reads as a universal fact about codex.

## The fix

The sentence was a **fork of the map** — someone read `SKILLS_INSTALL_DIR` once, restated it in prose, and the copy aged independently. Better wording does not fix that, so the sentence now has no independent opinion:

```sh
skills_install_dir() { printf '%s\n' "${SKILLS_INSTALL_DIR[${1:-}]:-.claude/skills}"; }
```

called by the installer **and** by the renderer, which prints the resolved dir for the pack's own type. Claim and behaviour read the same array.

## Left unmeasured, on the record

- **Whether codex/opencode ever SCAN `~/.agents/skills`** — no codex seat on this box (its installer fails partway). The render states the *mechanism* ("a body lands in `~/.agents/skills/<skill>/`; whether codex then LOADS that directory is the harness's own behaviour and 5dive does not verify it") and never the outcome. Recorded at the map entry too.
- **The `antigravity` `{workspace}`-vs-`$HOME` discrepancy** folded in as asked: its own comment says agy reads `{workspace}/.agents/skills`, while every writer we have joins the value to `$HOME` — and an agy seat's workspace is a project dir. If the comment is right those bodies are present-and-inert. No antigravity agent exists in the fleet (DIVE-2037), so it is recorded, not resolved.

## Grading — the predicate, not the string

15 arms in `tests/pack_agents_md_unit.sh` (52 → 67, 1.0s, core). The acceptance criterion asked for an arm that **executes the predicate** rather than grepping the warn string. The load-bearing one renders once per mapped type and requires the dir in the prose to **equal `skills_install_dir(type)`** — a hardcoded string passes for at most one type out of eight.

Mutation-graded (5 mutants against the committed tree, all restored):

| mutant | reds |
|---|---|
| hardcode the rendered dir | `rendered dir == resolver`, `codex export names .agents/skills` |
| `[codex]=""` in the map | map arm, resolver-agreement arm, codex arm, codex render arm |
| resolver returns a constant | resolver-agreement, codex, opencode, codex render |
| old false sentence back in the render | both negatives + the export-direction arm |
| delete the load-disclaimer | the unmeasured-outcome arm |

One trap worth naming: `${map[$k]:-default}` substitutes on **empty as well as unset**, so a resolver-side "no type maps to nothing" sweep *cannot fail*. The arm reads the array directly instead — that is what makes the `[codex]=""` mutant red.

## Pre-existing, NOT from this branch

`tests/gate_tier2_decision_nonce_unit.sh` dies after T5 with **rc 6** and never prints its summary. Reproduced identically on pristine `origin/main` in this same worktree, so it is not this diff. Flagged, not fixed — out of scope here.

Parent DIVE-2568 → DIVE-2565.
