### PR TITLE
fix(heartbeat): lead-routed gate re-nags take the agent rail, not the human's phone (DIVE-2587)

### DIFF
--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -1750,6 +1750,70 @@ _hb_gate_renag_batch() { # <recipient_agent> <comma-separated task ids> <route_l
   return 0
 }
 
+# DIVE-2587 — the AGENT RAIL for lead-routed re-nags.
+#
+# MEASURED, not inferred (prod board + /var/log/5dive-heartbeat.log, 2026-08-03):
+# every engineering approval that reached the human that day on the T1 lane was
+# ALREADY correctly routed. One row isolates it — a push-for-review approval
+# filed 09:20:21 with routed_reviewer=olivia, gate_pinged_at 09:40:02, and the
+# heartbeat log carries the matching `[gate-renag] delivered <row> via olivia`
+# line for that exact second. The ping came from THIS sweep, not from filing:
+# the file-time routed rail (_task_need_route_deliver) never touches Telegram at
+# all, it hands off over `5dive agent send`, and every gate it filed that day
+# still has gate_pinged_at NULL. Routing was never the defect.
+#
+# WHY MORE ROUTING CANNOT FIX IT: `_task_agent_channel olivia` resolves olivia's
+# PAIRED channel, and on this host every paired agent is paired to the SAME human
+# chat. "Send it to the lead" and "send it to the human" are the same Bot API
+# call with a different bot token. Routing decides who may CLEAR a gate; it has
+# never decided whose phone rings. This sweep predates the lead-route rail and
+# has no agent branch at all, so it converts a correctly routed gate back into a
+# human ping — with tap buttons, which is why the human then answers it and the
+# record reads `human:olivia` on a row nobody mis-routed.
+#
+# So an AGENT reviewer's re-nag goes over the agent rail, the same rail the
+# file-time handoff already uses. It falls back to the paired-human channel when
+# that rail cannot deliver, and the caller keeps the human channel for gates past
+# _HB_GATE_AGENT_RAIL_HOURS. That backstop is what makes this a QUIETING change
+# and not a SILENCING one: a lead-routed gate nobody clears still reaches a
+# person, just not inside the first day.
+#
+# Synchronous by choice, unlike the file-time rail's detached poll: the org-parent
+# escalation a few lines up already calls `cmd_send` synchronously in this same
+# sweep, there are at most a handful of reviewers per tick, and an rc we can
+# branch on is the whole basis of the fallback. An unobserved send here would
+# reproduce DIVE-2011 on a fresh rail.
+_hb_gate_renag_agent_rail() { # <reviewer> <ids> -> 0 delivered, 1 = caller must fall back
+  local reviewer="$1" idlist="$2"
+  [[ "${FIVEDIVE_GATE_RENAG_AGENT_RAIL:-1}" != "0" ]] || return 1
+  [[ -n "$reviewer" && "$idlist" =~ ^[0-9]+(,[0-9]+)*$ ]] || return 1
+  # Only an agent has a terminal to read this in. A reviewer who is not on the
+  # org chart is not one, and keeps the human channel.
+  [[ -n "$(db "SELECT name FROM agents_org WHERE name=$(sqlq "$reviewer");")" ]] || return 1
+  local text row
+  text="🔁 Gate reminder — gate(s) routed to you for review, still unanswered:"
+  while IFS= read -r row; do
+    [[ -n "$row" ]] || continue
+    text+=$'\n'"• ${row}"
+  done < <(db "SELECT '['||ident||'] '||COALESCE(need_type,'gate')||' — '||substr(replace(COALESCE(ask,''),x'0a',' '),1,240)
+               FROM tasks WHERE id IN (${idlist}) ORDER BY COALESCE(need_asked_at,updated_at,created_at),id;")
+  text+=$'\n\n'"Clear one with: 5dive task answer <ident> --value=\"<choice>\" — or re-file to escalate to the human."
+  local out="" rc=0
+  out=$(cmd_send "$reviewer" --message="$text" 2>&1) || rc=$?
+  if (( rc != 0 )); then
+    _hb_log "[gate-renag] agent rail to ${reviewer} FAILED rc=${rc} for rows ${idlist}; falling back to the paired channel: ${out//$'\n'/ }"
+    return 1
+  fi
+  # gate_pinged_at is the receipt AND the throttle (see _HB_GATE_RENAG_WHERE).
+  # Not stamping it here would re-send to the lead on EVERY tick.
+  db "UPDATE tasks SET gate_pinged_at=datetime('now')
+      WHERE id IN (${idlist}) AND need_type IS NOT NULL AND need_answered_at IS NULL;" 2>/dev/null || true
+  _task_gate_delivery_log ok "$idlist" "agent:${reviewer}" "" \
+    "gate re-nag delivered to ${reviewer} over the agent rail (no human channel send)" || true
+  _hb_log "[gate-renag] delivered ${idlist} via agent rail to ${reviewer}"
+  return 0
+}
+
 _hb_gate_renag_sweep() {
   [[ "${FIVEDIVE_GATE_RENAG:-1}" != "0" ]] || return 0
   local owner ids
@@ -1791,8 +1855,25 @@ _hb_gate_renag_sweep() {
   done < <(db "SELECT id||x'1f'||COALESCE(NULLIF(gate_filed_by,''),NULLIF(created_by,''),assignee,'')||x'1f'||COALESCE(routed_reviewer,'')
                FROM tasks WHERE ${_HB_GATE_RENAG_WHERE} AND tier=1
                ORDER BY COALESCE(need_asked_at,updated_at,created_at),id;")
+  # DIVE-2587: split each reviewer's batch by AGE. Fresh gates go over the agent
+  # rail (quiet, in-band, no human push); anything past the backstop window keeps
+  # the paired-human channel, because in-band nagging has demonstrably not worked
+  # by then. A rail that refuses or fails hands its rows straight back to the
+  # human batch — the failure direction is LOUD, never dropped.
+  local _rail_h _fresh _stale
+  _rail_h="${FIVEDIVE_GATE_RENAG_AGENT_RAIL_HOURS:-24}"
+  [[ "$_rail_h" =~ ^[0-9]+$ ]] || _rail_h=24
   for reviewer in "${!lead_ids[@]}"; do
-    _hb_gate_renag_batch "$reviewer" "${lead_ids[$reviewer]}" "org lead"
+    _fresh=$(db "SELECT id FROM tasks WHERE id IN (${lead_ids[$reviewer]})
+                 AND COALESCE(need_asked_at,updated_at,created_at) > datetime('now','-${_rail_h} hours')
+                 ORDER BY id;" | paste -sd, -)
+    _stale=$(db "SELECT id FROM tasks WHERE id IN (${lead_ids[$reviewer]})
+                 AND COALESCE(need_asked_at,updated_at,created_at) <= datetime('now','-${_rail_h} hours')
+                 ORDER BY id;" | paste -sd, -)
+    if [[ -n "$_fresh" ]] && ! _hb_gate_renag_agent_rail "$reviewer" "$_fresh"; then
+      _stale="${_stale:+${_stale},}${_fresh}"
+    fi
+    [[ -n "$_stale" ]] && _hb_gate_renag_batch "$reviewer" "$_stale" "org lead"
   done
   return 0
 }

--- a/tests/heartbeat_gate_renag_unit.sh
+++ b/tests/heartbeat_gate_renag_unit.sh
@@ -50,12 +50,31 @@ _task_send_owner() {
 audit_log() { :; }
 _hb_log() { :; }
 
+# DIVE-2587 — the agent rail. `cmd_send` is REAL in this harness (cmd_agent.sh is
+# sourced above), so an unstubbed rail would try to inject into live tmux panes
+# from a unit test. Stubbed to a log + a settable rc, which is also what lets the
+# fallback arm drive a failing rail deterministically.
+AGENT_SEND_LOG="$TMP/agent_sends"; : >"$AGENT_SEND_LOG"
+LAST_AGENT_TEXT="$TMP/agent_text"; : >"$LAST_AGENT_TEXT"
+FAIL_AGENT_SEND=0
+cmd_send() {
+  local to="$1" a msg=""; shift
+  for a in "$@"; do [[ "$a" == --message=* ]] && msg="${a#--message=}"; done
+  printf '%s\n' "$to" >>"$AGENT_SEND_LOG"
+  printf '%s' "$msg" >"$LAST_AGENT_TEXT"
+  return "$FAIL_AGENT_SEND"
+}
+DELIV_LOG="$TMP/deliv"; : >"$DELIV_LOG"
+_task_gate_delivery_log() { printf '%s|%s|%s\n' "$1" "$2" "$3" >>"$DELIV_LOG"; return 0; }
+
 PASS=0; FAIL=0
 ok_t() { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 nsends() { grep -c . "$SEND_LOG"; }
 pinged() { db "SELECT CASE WHEN gate_pinged_at IS NULL THEN 'NULL' ELSE 'SET' END FROM tasks WHERE id=$1;"; }
-reset() { db "DELETE FROM tasks;"; : >"$SEND_LOG"; : >"$CHANNEL_LOG"; : >"$LAST_TEXT"; : >"$LAST_MARKUP"; FAIL_SEND=0; }
+nagent() { grep -c . "$AGENT_SEND_LOG"; }
+reset() { db "DELETE FROM tasks;"; : >"$SEND_LOG"; : >"$CHANNEL_LOG"; : >"$LAST_TEXT"; : >"$LAST_MARKUP"; FAIL_SEND=0
+          : >"$AGENT_SEND_LOG"; : >"$LAST_AGENT_TEXT"; : >"$DELIV_LOG"; FAIL_AGENT_SEND=0; }
 mk_gate() { # ident tier type asked_modifier ping_modifier options recommend routed
   local ping="NULL"; [[ "$5" != "NULL" ]] && ping="datetime('now','$5')"
   local routed="NULL"; [[ -n "${8:-}" ]] && routed="$(sqlq "$8")"
@@ -110,10 +129,13 @@ db "UPDATE tasks SET need_asked_at=datetime('now','-3 days'), gate_pinged_at=dat
 _hb_gate_renag_sweep
 [[ "$(nsends)" == "1" ]] && ok_t "subsequent reminder fires after 24h" || bad_t "24h reminder missing" "sends=$(nsends)"
 
-# T1 reminder resolves to the org lead's channel.
+# T1 reminder resolves to the org lead's channel. DIVE-2587 moved the DEFAULT for
+# an on-chart reviewer onto the agent rail, so this arm now pins the human-channel
+# lane explicitly — the routing it grades (which channel a T1 falls back to) is
+# still live and is exactly what the rail's fallback and backstop land on.
 reset
 t1=$(mk_gate DIVE-13 1 decision '-2 hours' '-119 minutes' 'yes|no' yes main)
-_hb_gate_renag_sweep
+FIVEDIVE_GATE_RENAG_AGENT_RAIL=0 _hb_gate_renag_sweep
 [[ "$(nsends)" == "1" && "$(tail -1 "$CHANNEL_LOG")" == "main" && "$(pinged "$t1")" == "SET" ]] \
   && ok_t "T1 re-nag routes to org lead" \
   || bad_t "T1 route wrong" "sends=$(nsends) channels=$(tr '\n' ',' <"$CHANNEL_LOG")"
@@ -132,12 +154,120 @@ newhash=$(db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE id=${bad};")
 # NOT acquire a nonce — the widened condition is tier>=2, not "every decision".
 # Green on BOTH the fixed and unfixed tree; red here means the mint over-widened
 # and tier-1 gates started dragging human-gate machinery around.
+# DIVE-2587 pins the human lane here ON PURPOSE: the mint lives in
+# _hb_gate_renag_batch, so letting this gate take the agent rail would make the
+# anchor pass because the mint never RAN — a vacuous green on the exact assertion
+# that exists to catch an over-widened mint.
 reset
 t1d=$(mk_gate DIVE-14 1 decision '-2 hours' '-119 minutes' 'A|B' A '')
-_hb_gate_renag_sweep
+FIVEDIVE_GATE_RENAG_AGENT_RAIL=0 _hb_gate_renag_sweep
 [[ -z "$(db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE id=${t1d};")" ]] \
   && ok_t "anchor: tier-1 decision gets NO nonce from the re-nag (DIVE-2356)" \
   || bad_t "anchor: tier-1 decision re-nag mint (DIVE-2356)" "over-widened — got a hash"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DIVE-2587 — the re-nag is what converts a correctly lead-routed gate back into
+# a human push. Measured on the prod board: the file-time routed rail leaves
+# gate_pinged_at NULL and hands off over `5dive agent send`; every T1 gate that
+# reached the human that day was stamped at a heartbeat tick with a matching
+# `[gate-renag] delivered <row> via <lead>` line. Routing was already correct —
+# the lead's PAIRED CHANNEL is the human's phone, so this sweep undid it.
+reset
+a1=$(mk_gate DIVE-15 1 approval '-2 hours' '-119 minutes' '' approved main)
+_hb_gate_renag_sweep
+[[ "$(nagent)" == "1" && "$(tail -1 "$AGENT_SEND_LOG")" == "main" \
+   && "$(nsends)" == "0" && "$(pinged "$a1")" == "SET" ]] \
+  && ok_t "DIVE-2587: an agent-routed T1 re-nag takes the agent rail, no human send" \
+  || bad_t "DIVE-2587: agent-routed T1 re-nag still pushed to the human" \
+           "agent=$(nagent) human=$(nsends) pinged=$(pinged "$a1")"
+
+# The assertion above passes on an EMPTY message. A reminder the lead cannot act
+# on is a buzz, not a handoff — so grade the payload, not just the destination.
+grep -q 'DIVE-15' "$LAST_AGENT_TEXT" \
+  && ok_t "DIVE-2587: the agent-rail reminder names the gate" \
+  || bad_t "DIVE-2587: agent-rail reminder does not name the gate" "text=$(cat "$LAST_AGENT_TEXT")"
+
+# gate_pinged_at is the throttle as well as the receipt. An unstamped agent-rail
+# send would re-fire on EVERY tick — trading the human's phone for the lead's
+# terminal at 5-minute cadence. Non-differential BY DESIGN: this grades a risk
+# that only EXISTS on the fixed tree, so it is paired with a liveness arm below
+# rather than with a red on origin/main.
+: >"$AGENT_SEND_LOG"; : >"$SEND_LOG"
+_hb_gate_renag_sweep
+[[ "$(nagent)" == "0" && "$(nsends)" == "0" ]] \
+  && ok_t "DIVE-2587: the agent-rail send stamps the receipt, so the next tick is quiet" \
+  || bad_t "DIVE-2587: agent rail re-fired on the next tick" "agent=$(nagent) human=$(nsends)"
+
+# LIVENESS for the arm above — "quiet" must mean throttled, not wedged. Drop the
+# receipt and the same sweep fires again, so the zero above is the stamp's doing.
+db "UPDATE tasks SET gate_pinged_at=NULL WHERE id=${a1};"
+_hb_gate_renag_sweep
+[[ "$(nagent)" == "1" ]] \
+  && ok_t "DIVE-2587: clearing the receipt re-arms the rail (the quiet tick was throttled, not dead)" \
+  || bad_t "DIVE-2587: rail did not re-fire after the receipt was cleared" "agent=$(nagent)"
+
+# A rail that cannot deliver hands its rows BACK to the human channel. This is
+# the property that makes the change quieting rather than silencing.
+reset
+a2=$(mk_gate DIVE-16 1 approval '-2 hours' '-119 minutes' '' approved main)
+FAIL_AGENT_SEND=1 _hb_gate_renag_sweep
+[[ "$(nagent)" == "1" && "$(nsends)" == "1" && "$(tail -1 "$CHANNEL_LOG")" == "main" \
+   && "$(pinged "$a2")" == "SET" ]] \
+  && ok_t "DIVE-2587: a failed agent rail falls back to the human channel — never dropped" \
+  || bad_t "DIVE-2587: failed agent rail dropped the gate" \
+           "agent=$(nagent) human=$(nsends) pinged=$(pinged "$a2")"
+
+# The backstop: in-band nagging that has not worked for a day stops being quiet.
+reset
+a3=$(mk_gate DIVE-17 1 approval '-30 hours' '-25 hours' '' approved main)
+_hb_gate_renag_sweep
+[[ "$(nagent)" == "0" && "$(nsends)" == "1" ]] \
+  && ok_t "DIVE-2587: past the 24h backstop the gate reaches the human again" \
+  || bad_t "DIVE-2587: backstop did not surface a day-old lead-routed gate" \
+           "agent=$(nagent) human=$(nsends)"
+
+# One reviewer, one fresh gate and one stale one: the age split must send BOTH,
+# on their own rails. A split that loses a row is the failure this arm exists for.
+reset
+m1=$(mk_gate DIVE-18 1 approval '-2 hours' '-119 minutes' '' approved main)
+m2=$(mk_gate DIVE-19 1 approval '-30 hours' '-25 hours' '' approved main)
+_hb_gate_renag_sweep
+[[ "$(nagent)" == "1" && "$(nsends)" == "1" \
+   && "$(pinged "$m1")" == "SET" && "$(pinged "$m2")" == "SET" ]] \
+  && ok_t "DIVE-2587: a mixed-age batch splits across both rails, losing neither" \
+  || bad_t "DIVE-2587: mixed-age batch lost a row" \
+           "agent=$(nagent) human=$(nsends) fresh=$(pinged "$m1") stale=$(pinged "$m2")"
+
+# Only an agent has a terminal to read the rail in. A reviewer who is not on the
+# org chart keeps the human channel.
+reset
+n1=$(mk_gate DIVE-20 1 approval '-2 hours' '-119 minutes' '' approved ghost)
+_hb_gate_renag_sweep
+[[ "$(nagent)" == "0" && "$(nsends)" == "1" && "$(tail -1 "$CHANNEL_LOG")" == "ghost" ]] \
+  && ok_t "DIVE-2587: an off-chart reviewer is not an agent — human channel kept" \
+  || bad_t "DIVE-2587: off-chart reviewer took the agent rail" \
+           "agent=$(nagent) human=$(nsends)"
+
+# Off-switch restores the pre-2587 behaviour exactly (and is what the two arms
+# above pin, so it must be load-bearing rather than decorative).
+reset
+o1=$(mk_gate DIVE-21 1 approval '-2 hours' '-119 minutes' '' approved main)
+FIVEDIVE_GATE_RENAG_AGENT_RAIL=0 _hb_gate_renag_sweep
+[[ "$(nagent)" == "0" && "$(nsends)" == "1" ]] \
+  && ok_t "DIVE-2587: FIVEDIVE_GATE_RENAG_AGENT_RAIL=0 restores the human ping" \
+  || bad_t "DIVE-2587: off-switch did not restore the human ping" \
+           "agent=$(nagent) human=$(nsends)"
+
+# ANCHOR — the T2 human floor is NOT what is being changed. A tier-2 gate goes to
+# the paired human whatever its filer's org position; this arm is green on both
+# trees and reds only if the rail ever widened past tier 1.
+reset
+z1=$(mk_gate DIVE-22 2 approval '-2 hours' '-119 minutes' '' approved '')
+_hb_gate_renag_sweep
+[[ "$(nagent)" == "0" && "$(nsends)" == "1" ]] \
+  && ok_t "anchor: the T2 human floor still re-nags the paired human (DIVE-2587)" \
+  || bad_t "anchor: the agent rail leaked into the T2 floor (DIVE-2587)" \
+           "agent=$(nagent) human=$(nsends)"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
A correctly lead-routed tier-1 gate still buzzed the human, and routing was
never the defect. `_task_agent_channel <lead>` resolves the LEAD'S PAIRED
CHANNEL, and every paired agent on this host is paired to the same human chat —
so "deliver to the lead" and "deliver to the human" are the same Bot API call
with a different bot token. Routing decides who may CLEAR a gate; it has never
decided whose phone rings.

Measured on the prod board, not inferred: the file-time routed rail
(_task_need_route_deliver) never touches Telegram — it hands off over
`5dive agent send` and leaves gate_pinged_at NULL, which every T1 gate filed
that day still shows. The gates that reached the human were stamped at a
heartbeat tick, each with a matching `[gate-renag] delivered <row> via <lead>`
line at the same second. _hb_gate_renag_sweep predates the lead-route rail and
has no agent branch at all, so it converted a routed gate back into a human
push — with tap buttons, which is why the record then reads `human:<lead>` on a
row nobody mis-routed.

So an on-chart reviewer's re-nag now goes over the same rail the file-time
handoff uses. It stays quieting rather than silencing:

  - a rail that refuses or fails hands its rows straight back to the human batch
  - gates past FIVEDIVE_GATE_RENAG_AGENT_RAIL_HOURS (24h) keep the human channel
  - an off-chart reviewer is not an agent and keeps the human channel
  - FIVEDIVE_GATE_RENAG_AGENT_RAIL=0 restores the previous behaviour exactly
  - the T2 human floor is untouched

The send is synchronous and its rc observed — the org-parent escalation in this
same sweep already calls cmd_send that way, and the rc is the whole basis of the
fallback. An unobserved send here would reproduce DIVE-2011 on a fresh rail.
gate_pinged_at is stamped on a delivered rail send because it is the throttle as
well as the receipt; without it the lead's terminal takes the buzz at tick
cadence.

tests/heartbeat_gate_renag_unit.sh 19/19. Five new arms are differential (red on
origin/main, green here); four are anchors green on both trees by design — the
backstop, the off-chart reviewer, the off-switch, and the T2 floor. Two existing
arms now pin the human lane with the off-switch: the DIVE-2356 mint anchor lives
in _hb_gate_renag_batch, so letting its gate take the agent rail would have made
it pass because the mint never ran.



Verifier: olivia — push-for-review APPROVED on the lead rail, diff reviewed before answering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
