### PR TITLE
test(gate): keep the failure output when gate_answer_audit_unit reds (DIVE-2187)

### DIFF
--- a/tests/gate_answer_audit_unit.sh
+++ b/tests/gate_answer_audit_unit.sh
@@ -50,7 +50,29 @@ set -uo pipefail
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-answer-audit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
+FAILURES=()
+# DIVE-2187: an unexplained rc=1 under concurrent runs (11/12) was only ever
+# seen live, because a green-or-red exit both nuked $TMP on the way out — the
+# next occurrence had nothing to inspect and needed a repro. On failure, keep
+# the dir and dump every captured artifact instead of deleting the evidence.
+cleanup() {
+  local rc=$?
+  if [[ "${FAIL:-0}" -gt 0 || "$rc" -ne 0 ]]; then
+    printf '\n=== FAILURE: TMP preserved for inspection: %s ===\n' "$TMP" >&2
+    if [[ ${#FAILURES[@]} -gt 0 ]]; then
+      printf -- '--- failing assertions (repeated so scrollback does not need a repro) ---\n' >&2
+      printf '%s\n' "${FAILURES[@]}" >&2
+    fi
+    for f in "${AUDIT_CALLS:-}" "$TMP"/*.out "$TMP"/*.err; do
+      [[ -n "$f" && -s "$f" ]] || continue
+      printf -- '--- %s ---\n' "$f" >&2
+      cat "$f" >&2
+    done
+  else
+    rm -rf "$TMP"
+  fi
+}
+trap cleanup EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
@@ -74,7 +96,11 @@ tasks_db_init
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
-bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+bad_t() {
+  FAIL=$((FAIL+1))
+  printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"
+  FAILURES+=("FAIL - $1"$'\n'"   ${2:-}")
+}
 addt()  { ( cmd_task_add "$@" ) 2>/dev/null | jq -r '.data.id'; }
 
 AUDIT_CALLS="$TMP/audit.calls"; : >"$AUDIT_CALLS"


### PR DESCRIPTION
On failure the harness now preserves its `TMP` directory, names it, and **repeats the failing assertions at the end** — after the banner — rather than leaving them thousands of lines up in a sweep's scrollback. "The output exists somewhere above" is the kind of availability that is technically true and practically useless.

Two details that make it worth having rather than a debug convenience:

- **It still cleans up on success.** Lines 71-73 are `else rm -rf "$TMP"`, so preservation is strictly the failure path. A debug aid quietly accumulating temp dirs on every green run would cost more than it saves on a box already at 92% disk.
- **It keys on both `${FAIL:-0} -gt 0` and `rc -ne 0`.** `FAIL` alone would miss a `set -e` death or an unsubshelled refusal that exits before the tally — the DIVE-2603 / DIVE-2610 shape, which has bitten this gate-answer harness family twice today. Catching the `rc` path is what makes it useful in the case it will actually be needed.

Test-only, 30 lines, one file.

Authored by dev2; reviewed and merged by main (dev2 holds no gh credential).

**Footnote worth keeping:** my first approval of this gate was read as a REJECTION by `broker_gate_check`, because its reject regex is un-word-bounded and `grep` is line-based — my closing line began "Nothing to fix" and `^\s*no` matched. dev2 diagnosed it and filed DIVE-2614. The gate could not be re-answered, so a false reject cost a re-file and two round trips. This PR body is therefore an artifact of the defect it links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
