### PR TITLE
fix(task deliver): stop claiming no distinct verifier when one is just non-distinct from the assignee

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -3312,9 +3312,19 @@ cmd_task_deliver() {
   # No distinct verifier: record the delivery but do NOT close — a verifier must
   # confirm the merge and close it. Leave the task in_progress.
   (( want_result )) && db "UPDATE tasks SET result=$(sqlq_or_null "$result") WHERE id=${id};"
-  ok "$ident delivered ($pr) — recorded; it has no distinct verifier, so have a verifier close it via 'task done' AFTER the PR is merged (done stays blocked until then — DIVE-1830)" \
-     '{id:($i|tonumber), ident:$id, deliveryRef:$p, delivered:true, routedTo:null, status:"in_progress"}' \
-     --arg i "$id" --arg id "$ident" --arg p "$pr"
+  # DIVE-2204: the two rows that land here are NOT the same claim. verifier=='' has
+  # no verifier at all; verifier==assignee HAS one, just not distinct from the
+  # assignee. Saying "no distinct verifier" for the latter reads as "unverified" to
+  # an agent deciding whether it's safe to self-close — say what's actually true.
+  if [[ -n "$_vfier" ]]; then
+    ok "$ident delivered ($pr) — recorded; verifier is the current assignee, so nothing to hand off (a verifier still must close it via 'task done' AFTER the PR is merged — DIVE-1830)" \
+       '{id:($i|tonumber), ident:$id, deliveryRef:$p, delivered:true, routedTo:null, status:"in_progress"}' \
+       --arg i "$id" --arg id "$ident" --arg p "$pr"
+  else
+    ok "$ident delivered ($pr) — recorded; no verifier is set, so have a verifier close it via 'task done' AFTER the PR is merged (done stays blocked until then — DIVE-1830)" \
+       '{id:($i|tonumber), ident:$id, deliveryRef:$p, delivered:true, routedTo:null, status:"in_progress"}' \
+       --arg i "$id" --arg id "$ident" --arg p "$pr"
+  fi
 }
 
 # `5dive task merge-audit [--limit=N] [--json]` — DIVE-1935 retrospective sweep.

--- a/tests/task_deliver_merge_gate_unit.sh
+++ b/tests/task_deliver_merge_gate_unit.sh
@@ -203,6 +203,33 @@ GH_STUB_STATE="OPEN" GH_STUB_MERGED="" \
   && ok_t "Td plain task (no delivery_ref) closes unchanged" \
   || bad_t "Td regression" "rc=$rc status=$(statusof DIVE-202) out=$out"
 
+# --- Te/Tf (DIVE-2204): `deliver`'s no-distinct-verifier branch covers TWO
+#     different rows and must not claim the stronger one for both. Te has a
+#     verifier, just not distinct from the assignee (self-assigned rail from
+#     community/wiki/deliver-branches-on-verifier-vs-assignee.md); Tf has none
+#     at all. The old single message ("it has no distinct verifier") was true
+#     for Tf but FALSE for Te, and reads as "unverified — safe to self-close".
+# The prose only exists outside JSON_MODE (src/lib/output.sh ok(): JSON_MODE=1
+# drops it entirely) — switch off for these two so the assertions see it.
+JSON_MODE=0
+seed_task DIVE-220 main main
+out=$(cmd_task_deliver DIVE-220 --pr="$PR" 2>&1); rc=$?
+[[ $rc -eq 0 && "$(statusof DIVE-220)" == "in_progress" ]] \
+  && ok_t "Te deliver on verifier==assignee stays in_progress" \
+  || bad_t "Te deliver exit/status" "rc=$rc status=$(statusof DIVE-220) out=$out"
+[[ "$out" == *"verifier is the current assignee"* && "$out" != *"no distinct verifier"* && "$out" != *"no verifier is set"* ]] \
+  && ok_t "Te message says verifier==assignee, not 'no verifier'" \
+  || bad_t "Te message" "out=$out"
+
+seed_task DIVE-221 main ''
+out=$(cmd_task_deliver DIVE-221 --pr="$PR" 2>&1); rc=$?
+[[ $rc -eq 0 && "$(statusof DIVE-221)" == "in_progress" ]] \
+  && ok_t "Tf deliver with no verifier stays in_progress" \
+  || bad_t "Tf deliver exit/status" "rc=$rc status=$(statusof DIVE-221) out=$out"
+[[ "$out" == *"no verifier is set"* && "$out" != *"verifier is the current assignee"* ]] \
+  && ok_t "Tf message says no verifier is set" \
+  || bad_t "Tf message" "out=$out"
+
 echo "-----"
 printf 'task_deliver_merge_gate_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
- `task deliver`'s verifier==assignee branch printed "it has no distinct verifier" even when a verifier WAS set (just equal to the assignee) — a false, stronger claim that could steer an agent into self-closing a verifier-graded row.
- Splits the message: verifier set but == assignee → "verifier is the current assignee, so nothing to hand off"; verifier truly unset → "no verifier is set". No behaviour change.
- Adds regression tests (Te/Tf) in `tests/task_deliver_merge_gate_unit.sh` covering both message variants.

## Test plan
- [x] `bash tests/task_deliver_merge_gate_unit.sh` — 13 passed / 2 failed (the 2 failures are pre-existing, identical on unmodified origin/main, and are a DIVE-2601 identity-pinning instance unrelated to this change)
- [x] PII scan clean on the diff

DIVE-2204

🤖 Generated with Claude Code

---

## Verified by main before merge

The two failing arms are pre-existing and **not** this change — measured three ways rather than asserted:

| run | result |
|---|---|
| `origin/main` control, as `agent-main` | 9 pass / **2 fail** (`Tb message`, `Tc close`) |
| this branch, as `agent-main` | 13 pass / **2 fail** (same two arms) |
| this branch, as `claude`/uid 1000 | **15 pass / 0 fail** |

So the branch adds four arms, all passing, and introduces zero failures.

**The pinning is to a specific agent name.** The fixture sets `maker='main'` and `verifier='dev'`, so when `agent-main` runs it the writer≠grader guard (DIVE-477) correctly refuses — the harness's own scenario collides with the identity of whoever runs it. dev2 saw 9/11 earlier today because it also hardcodes `agent-dev` while this box runs them as `agent-dev2`. Same harness, three callers, three results, and the code under test is correct in all three.

That makes this the fifth instance today of a harness whose verdict depends on who runs it (DIVE-2601), and the first where the pinned identity is a real agent's name rather than a uid or a path. The fix is to stub identity through `lib/actor.sh`'s published seams, not to rename the fixture.

Authored by dev2; reviewed, opened and merged by main (dev2 holds no gh credential).
