### PR TITLE
fix(byo): both BYO anthropic default pins named a model absent from their own provider catalogs (DIVE-2607)

### DIFF
--- a/src/header.sh
+++ b/src/header.sh
@@ -686,11 +686,14 @@ declare -A OPENCLAW_PROVIDER_URL=(
 # renamed upstream), the user can override via `5dive agent <name> tui`
 # and the agent CLI's own model picker.
 declare -A HERMES_PROVIDER_MODEL=(
-  # Both catalogs are PER-PROVIDER: grade a pin against its own provider's list,
-  # never against a grep of the whole catalog file. hermes' curated anthropic list
-  # (hermes_cli/models.py) carries claude-sonnet-5 and the DATED
-  # claude-sonnet-4-5-20250929, but not a bare claude-sonnet-4-5 — which does
-  # appear in that same file under `copilot` and `opencode-zen`. See DIVE-2607.
+  # Both catalogs are PER-PROVIDER, and so is the SPELLING: grade a pin against
+  # its own provider's list, never against a grep of the whole catalog file.
+  # hermes' curated anthropic list (hermes_cli/models.py) carries claude-sonnet-5
+  # and the DATED claude-sonnet-4-5-20250929, but no bare claude-sonnet-4-5.
+  # That bare id does appear in the same file, DASHED under `opencode-zen` and
+  # `novita`, and DOTTED as claude-sonnet-4.5 under `copilot` and `novita`.
+  # So a grep is blind twice over: wrong provider, and wrong spelling of the
+  # same model. See DIVE-2607.
   [anthropic]="claude-sonnet-5"
   [google]="gemini-2.0-flash"
   [deepseek]="deepseek-v4-pro"

--- a/src/header.sh
+++ b/src/header.sh
@@ -686,7 +686,12 @@ declare -A OPENCLAW_PROVIDER_URL=(
 # renamed upstream), the user can override via `5dive agent <name> tui`
 # and the agent CLI's own model picker.
 declare -A HERMES_PROVIDER_MODEL=(
-  [anthropic]="claude-sonnet-4-5"
+  # Both catalogs are PER-PROVIDER: grade a pin against its own provider's list,
+  # never against a grep of the whole catalog file. hermes' curated anthropic list
+  # (hermes_cli/models.py) carries claude-sonnet-5 and the DATED
+  # claude-sonnet-4-5-20250929, but not a bare claude-sonnet-4-5 — which does
+  # appear in that same file under `copilot` and `opencode-zen`. See DIVE-2607.
+  [anthropic]="claude-sonnet-5"
   [google]="gemini-2.0-flash"
   [deepseek]="deepseek-v4-pro"
   [moonshot]="kimi-k2-turbo-preview"

--- a/src/header.sh
+++ b/src/header.sh
@@ -694,7 +694,7 @@ declare -A HERMES_PROVIDER_MODEL=(
 )
 declare -A OPENCLAW_PROVIDER_MODEL=(
   [openai]="openai/gpt-4o"
-  [anthropic]="anthropic/claude-sonnet-4-5"
+  [anthropic]="anthropic/claude-sonnet-5"
   [google]="google/gemini-2.0-flash"
   [deepseek]="deepseek/deepseek-v4-pro"
   [moonshot]="moonshot/kimi-k2-instruct"


### PR DESCRIPTION
`src/header.sh` carried `claude-sonnet-4-5` in **both** BYO default-model tables. Neither provider's own catalog lists it.

| table | was | now | oracle |
|---|---|---|---|
| `OPENCLAW_PROVIDER_MODEL[anthropic]` | `anthropic/claude-sonnet-4-5` | `anthropic/claude-sonnet-5` | openclaw 2026.7.1-2 (`0790d9f`), `models list --all --plain`, empty state dir |
| `HERMES_PROVIDER_MODEL[anthropic]` | `claude-sonnet-4-5` | `claude-sonnet-5` | hermes v0.19.0 (2026.7.20), `hermes_cli/models.py` curated `anthropic` list |

Both sides graded in each case: the replacement id is confirmed **present**, not merely the old one confirmed absent.

**The trap, now commented at the site.** Both catalogs are **per-provider**, and so is the **spelling**. A bare `claude-sonnet-4-5` *is* in `hermes_cli/models.py` — dashed under `opencode-zen` and `novita`, and **dotted** as `claude-sonnet-4.5` under `copilot` and `novita` — while the `anthropic` list carries only `claude-sonnet-5` and the dated `claude-sonnet-4-5-20250929`. So a grep of the catalog file is blind twice over: wrong provider scope, and wrong spelling of the same model. Grepping the dashed form finds `opencode-zen`; grepping the dotted form finds `copilot`; neither tells you anything about `anthropic`.

**Retraction.** DIVE-1987 argued hermes needed no change because `~/.hermes/config.yaml:797,808` says any sensible spelling resolves. That note governs key matching for the `reasoning_overrides` dict, not the model resolver. The justification does not hold; the line was the same defect as its sibling.

**Re-graded and correctly left alone:** `deepseek-v4-pro` and `kimi-k2-turbo-preview` are both in their providers' hermes lists.

**Bound on the claim:** absent-from-catalog, not observed-to-404. Grading runtime behaviour needs live BYO keys and real spend, deliberately not done.

**Follow-up, deliberately not in this PR:** `HERMES_PROVIDER_MODEL[google]="gemini-2.0-flash"` is absent from hermes' `gemini` provider list (only 3.x ids). Left out because the canonical `google` -> hermes `gemini` provider-key mapping is unverified, and inferring it is the exact error this change is about.

No test changes: the BYO harnesses assert the override *structure* via `declare -f`, never a literal id.

Refs DIVE-2607.
