### PR TITLE
fix(merge-gate): accumulate every unreachable repo in the coverage diagnostic (DIVE-2324)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -2695,7 +2695,7 @@ _task_status_cmd() {
         # a squash rewrites the sha, so the branch tip is NOT an ancestor of main even
         # though the content is in. Attribution finds it anyway, because the squash
         # commit subject carries the ident.
-        local _slug _bmerged="" _merged_slug="" _searched="" _attr_slug="" _anc="" _attr="" _anc_novac="" _attr_bound="" _attr_unreach="" _attr_scope=""
+        local _slug _bmerged="" _merged_slug="" _searched="" _attr_slug="" _anc="" _attr="" _anc_novac="" _attr_bound="" _attr_unreach="" _attr_scope="" _attr_unreach_note=""
         while IFS= read -r _slug; do
           [[ -n "$_slug" ]] || continue
           _searched="${_searched:+$_searched, }$_slug"
@@ -2721,7 +2721,10 @@ _task_status_cmd() {
           # fell through to the same generic "branch is NOT on main" refusal, so an API
           # failure and an exhaustive miss printed the identical sentence. Only one of
           # them is a finding. Carry it so the refusal below can tell them apart.
-          [[ -z "$_attr" ]] && _attr_unreach="$_slug"
+          # DIVE-2324: accumulate, don't overwrite — a plain assignment named only the
+          # LAST unreachable repo of a set search, under-reporting the coverage gap the
+          # variable exists to describe. Same fix as DIVE-2266 made for _attr_bound above.
+          [[ -z "$_attr" ]] && _attr_unreach="${_attr_unreach:+$_attr_unreach, }$_slug"
           _bmerged=$(GH_TOKEN="$_ghtok" gh pr list --repo "$_slug" --head "$_branch" --state merged --json number,mergedAt -q '.[0].mergedAt' 2>/dev/null || echo "")
           if [[ -n "$_bmerged" && "$_bmerged" != "null" ]]; then
             _merged_slug="$_slug"
@@ -2764,7 +2767,13 @@ _task_status_cmd() {
           # record names the whole set that hit a bound, with each repo's own count.
           # DIVE-2266: a repo outside the searched set is a third live explanation; a
           # larger bound cannot find it, so give the binding remedies that can terminate.
-          policy_refuse "$E_CONFLICT" done-ident-not-found-within-scan-bound DIVE-2120 "$ident" "$ident cannot close: NOT FOUND WITHIN THE COMMIT SCAN BOUNDS on ${FIVE_GATE_MAIN_BRANCH:-main} in $_attr_bound (repo:commits-walked) — every named repo stopped at its own bound with main's history NOT exhausted, so this is INCONCLUSIVE, not a finding that the work is absent. THREE explanations survive and this scan cannot separate them: (a) the delivery landed before the scanned window in one of those repos, (b) nothing on main ever named $ident in a commit SUBJECT — which is what an EMPTY branch looks like, and a delivery whose subject omits the ident looks the same, or (c) the branch lives in a repo that was NEVER SCANNED. For (a) raise the bound and retry (FIVE_GATE_ANCESTRY_SCAN=<n>, paginated since DIVE-2120, so n>100 really does walk n). For (b) land a commit whose SUBJECT names $ident (\`5dive push $ident\`) or bind the branch that carries it. For (c) add a \`Repo: <owner/repo>\` line to the task body or bind the full delivery_ref (\`task deliver $ident --pr=https://github.com/<owner>/<repo>/pull/N\`). A merged PR for '$_branch' also satisfies the gate."
+          # DIVE-2324: this arm is MEASURED and wins ahead of the unreachable-sibling
+          # arm below, deliberately (see that arm's ordering comment) — but winning
+          # silently dropped the fact that the scan was ALSO incomplete elsewhere. Name
+          # it here too, so the record does not read as "only the bound was inconclusive".
+          _attr_unreach_note=""
+          [[ -n "$_attr_unreach" ]] && _attr_unreach_note=" Additionally, $_attr_unreach never answered at all (unreachable, not merely bounded) — the scan is incomplete there too."
+          policy_refuse "$E_CONFLICT" done-ident-not-found-within-scan-bound DIVE-2120 "$ident" "$ident cannot close: NOT FOUND WITHIN THE COMMIT SCAN BOUNDS on ${FIVE_GATE_MAIN_BRANCH:-main} in $_attr_bound (repo:commits-walked) — every named repo stopped at its own bound with main's history NOT exhausted, so this is INCONCLUSIVE, not a finding that the work is absent.$_attr_unreach_note THREE explanations survive and this scan cannot separate them: (a) the delivery landed before the scanned window in one of those repos, (b) nothing on main ever named $ident in a commit SUBJECT — which is what an EMPTY branch looks like, and a delivery whose subject omits the ident looks the same, or (c) the branch lives in a repo that was NEVER SCANNED. For (a) raise the bound and retry (FIVE_GATE_ANCESTRY_SCAN=<n>, paginated since DIVE-2120, so n>100 really does walk n). For (b) land a commit whose SUBJECT names $ident (\`5dive push $ident\`) or bind the branch that carries it. For (c) add a \`Repo: <owner/repo>\` line to the task body or bind the full delivery_ref (\`task deliver $ident --pr=https://github.com/<owner>/<repo>/pull/N\`). A merged PR for '$_branch' also satisfies the gate."
         elif [[ -n "$_anc_novac" && -z "$_bmerged" ]]; then
           # The vacuous shape, named as itself: an ancestor tip carrying nothing
           # attributable is exactly what an EMPTY branch looks like, and a generic

--- a/tests/task_merge_gate_ancestry_unit.sh
+++ b/tests/task_merge_gate_ancestry_unit.sh
@@ -407,6 +407,34 @@ else
   bad_t 'bound remediation must cover work outside the searched set' "out=$OUT"
 fi
 
+# --- DIVE-2324: A BOUND-HIT REFUSAL ALSO NAMES ANY UNREACHABLE SIBLING ---------
+# The bound arm wins ahead of the unreachable-sibling arm (deliberately — see that
+# arm's own ordering comment), but winning silently dropped the fact that the scan
+# was ALSO incomplete elsewhere. Mix one bound repo with one unreachable repo: the
+# refusal must still fire under the bound slug (it is the more specific, measured
+# finding) AND must say the unreachable repo was never answered.
+attr_impl=$(declare -f _gate_branch_ident_on_main)
+_gate_branch_ident_on_main() {
+  case "$1" in
+    5dive-ai/5dive)  printf 'bound:3' ;;
+    lodar/5dive-api) printf ''       ;;  # unreachable
+  esac
+}
+clear_fx
+seed ANC-2324 'Branch: lives-somewhere-in-the-set'
+FIVE_GATE_REPOS='5dive-ai/5dive,lodar/5dive-api' \
+  run_done ANC-2324 --result='landed somewhere'
+eval "$attr_impl"
+slug=$(db "SELECT COALESCE(policy,'') FROM policy_refusals WHERE ident='ANC-2324' ORDER BY rowid DESC LIMIT 1;")
+# ANCHORED on the exact clause, not bare substrings (DIVE-2324, per main's review of
+# T5c's same class of gap): pin the sentence that names the unreachable repo so the
+# assertion cannot pass for a reason unrelated to the note actually being emitted.
+[[ $RC -ne 0 && "$slug" == "done-ident-not-found-within-scan-bound" \
+   && "$OUT" == *"5dive-ai/5dive:3 COMMITS WALKED"* \
+   && "$OUT" == *"Additionally, lodar/5dive-api never answered at all (unreachable, not merely bounded)"* ]] \
+  && ok_t 'DIVE-2324: a bound-hit refusal also names an unreachable sibling in the same set' \
+  || bad_t 'bound refusal must not hide a sibling scan gap' "rc=$RC slug=[$slug] out=$OUT"
+
 # --- DIVE-2120: AN INCIDENTAL MENTION IS NOT A DELIVERY -------------------------
 # Searching main widened the attribution set: every commit reachable from a branch tip
 # is on main, but not every commit on main is reachable from that tip — so a

--- a/tests/task_merge_gate_diagnostic_unit.sh
+++ b/tests/task_merge_gate_diagnostic_unit.sh
@@ -243,6 +243,37 @@ run_done B-5 --result='landed'
   && ok_t 'T5b one repo answered and two did not — refuses as PARTIAL COVERAGE, not as absent' \
   || bad_t 'T5b partial coverage' "rc=$RC slug=[$(slugof B-5)] out=$OUT"
 
+# T5c — DIVE-2324: ACCUMULATE every unreachable repo, not just the last one seen.
+# A plain overwrite (`_attr_unreach="$_slug"`) named only the FINAL unreachable repo
+# of a multi-repo search, under-reporting the coverage gap this message exists to
+# describe — the same overwrite-vs-accumulate bug DIVE-2266 fixed for `_attr_bound`.
+# Stub the attribution seam directly (as ANC-2266 does) rather than the raw gh commit
+# pages: it gives exact per-repo control without depending on pagination fixtures.
+attr_impl=$(declare -f _gate_branch_ident_on_main)
+_gate_branch_ident_on_main() {
+  case "$1" in
+    5dive-ai/5dive)       printf '0' ;;  # one repo answers cleanly (exhausted, no hit)
+    lodar/5dive-api)      printf ''  ;;  # unreachable
+    lodar/5dive-frontend) printf ''  ;;  # unreachable
+  esac
+}
+clear_fx; a_token
+seed B-6 'Branch: dive-2324-multi-unreach'
+FIVE_GATE_REPOS='5dive-ai/5dive,lodar/5dive-api,lodar/5dive-frontend' \
+  run_done B-6 --result='landed'
+eval "$attr_impl"
+# ANCHORED, not a bare substring match: $_searched (every repo that was searched,
+# regardless of whether it answered) ALSO contains 'lodar/5dive-api' and
+# 'lodar/5dive-frontend', so asserting on the names alone is true whether
+# _attr_unreach accumulated or overwrote — it does not grade the fix (main, on
+# review: verified by mutation, the overwrite-reverted source still passed this
+# exact assertion). Pin the phrase that immediately precedes $_attr_unreach in the
+# message instead, so the comma-joined list is graded in its own position.
+[[ $RC -eq $E_CONFLICT && "$(slugof B-6)" == "done-attribution-unresolved" \
+   && "$OUT" == *"COULD NOT SCAN main in lodar/5dive-api, lodar/5dive-frontend for a commit naming"* ]] \
+  && ok_t 'T5c DIVE-2324: names EVERY unreachable repo, not just the last' \
+  || bad_t 'T5c accumulate unreachable' "rc=$RC slug=[$(slugof B-6)] out=$OUT"
+
 # ---------------------------------------------------------------------------
 # T6 — token present, main's history EXHAUSTED with no commit naming the ident and
 # no merged PR. This is the one true "not landed" on the branch path. It must


### PR DESCRIPTION
`_attr_unreach="$_slug"` kept only the **last** unreachable repo of a multi-repo search. A diagnostic whose entire purpose is telling an operator what was *not* checked was under-reporting its own coverage gap — and an operator hitting the bound-hit message had no way to learn that other repos never answered at all.

Now accumulated, and the bound-hit refusal names them: *"Additionally, X, Y never answered at all (unreachable, not merely bounded) — the scan is incomplete there too."*

## The review round this went through, because it is the reusable part

The first cut carried arms named for the fix that **did not detect the fix being reverted**. `T5c DIVE-2324: names EVERY unreachable repo, not just the last` passed with the accumulation removed.

Cause: T5c lands on `done-attribution-unresolved`, whose message interpolates **both** `$_attr_unreach` and `$_searched`. `$_searched` lists every repo searched, so both repo names appeared in the output whether the accumulation happened or not — **the assertion matched bare strings present for a different reason than the one under test.**

Re-anchored on the literal clause preceding the interpolated variable rather than on the names. In a message built from several interpolated variables, an assertion on a bare value cannot tell you *which* variable put it there.

## Mutation-graded, verified independently by main

| state | diagnostic | ancestry |
|---|---|---|
| baseline | 18/0 | 36/0 |
| accumulation reverted | **17/1** | — |
| bound-arm note reverted | — | **35/1** |
| restored | 18/0 | 36/0 |

Each mutation reddens exactly one arm in the harness that owns it. Each was confirmed applied in source before re-running — a mutation not verified present is not a mutation.

Authored by dev2; reviewed, bounced once for vacuous assertions, re-verified and merged by main (dev2 holds no gh credential).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
