### PR TITLE
feat(bug): 5dive bug — file a public issue from an allowlisted payload (DIVE-2323)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -78,6 +78,7 @@ cat \
   src/cmd_push.sh \
   src/cmd_deploy.sh \
   src/cmd_gh.sh \
+  src/cmd_bug.sh \
   src/cmd_memory.sh \
   src/cmd_pack.sh \
   src/cmd_secret.sh \

--- a/src/cmd_bug.sh
+++ b/src/cmd_bug.sh
@@ -29,6 +29,7 @@
 # precisely the failure mode this refuses to build.
 
 _bug_usage() {
+  local _org; _org=$(gh_org)
   cat >&2 <<EOF
 5dive bug [--verb=<name>] [--exit=<code>] [--no-probes] [--file]
 
@@ -40,7 +41,7 @@ Preview (default): builds the diagnostic payload and prints it. Files nothing.
                   fields underneath them)
 
   --file          re-print the SAME payload, then open it as a GitHub issue
-                  against $(gh_org)/5dive (via '5dive gh issue create', so it
+                  against ${_org}/5dive (via '5dive gh issue create', so it
                   files as 5dive-bot when this account can write). A TTY also
                   gets an interactive y/N; nothing is ever filed by default.
 

--- a/src/cmd_bug.sh
+++ b/src/cmd_bug.sh
@@ -1,0 +1,225 @@
+# cmd_bug — file a diagnostic bug report against 5dive-ai/5dive (DIVE-2323).
+#
+# WHY THIS EXISTS: .github/ISSUE_TEMPLATE/bug_report.md, feature_request.md,
+# config.yml and CONTRIBUTING.md already describe how to file a bug — nothing in
+# the CLI or the failure path ever pointed at them (measured 2026-07-29: the
+# issues URL appears nowhere in src/ or README.md, no bug/report/feedback verb
+# in the dispatch table). The gap was DISCOVERY, not surface.
+#
+# THE CONSTRAINT THAT DOMINATES THE DESIGN: the payload must never leak
+# personal/user data. pii-guard (DIVE-1774) does not help here — it scans what
+# the REPO contains, never what a runtime emitter GENERATES, and this verb is
+# exactly such an emitter aimed at a PUBLIC issue. See
+# community/wiki/a-repo-scoped-pii-gate-cannot-see-what-the-repo-generates.md.
+#
+# So the payload is an ALLOWLIST, never a denylist: every field is named
+# explicitly, one at a time, in _bug_render_payload — never produced by
+# stripping fields off a richer object. `selfcheck --json`'s probes[] carry
+# .reason and .detail, both free text where paths, hostnames, agent names and
+# task idents land (measured 2026-07-29); only .probe and .verdict are ever
+# read out of it. `doctor --json` is not used at all — it isn't part of the
+# allowlist below and was never measured to be safe to fold in.
+#
+# NEVER AUTO-FILES. `5dive bug` alone only builds and PRINTS the payload —
+# nothing is sent anywhere. Only `--file` opens the issue, and it re-prints the
+# identical payload immediately before doing so: the confirmation IS seeing the
+# exact bytes about to leave the box. A TTY additionally gets an interactive
+# y/N. There is no separate unattended path: an agent takes the exact same
+# --file flag a human types, because an unreviewed report filed at 3am is
+# precisely the failure mode this refuses to build.
+
+_bug_usage() {
+  cat >&2 <<EOF
+5dive bug [--verb=<name>] [--exit=<code>] [--no-probes] [--file]
+
+Preview (default): builds the diagnostic payload and prints it. Files nothing.
+  --verb=<name>   the 5dive verb that failed (e.g. "doctor"); default: unknown
+  --exit=<code>   its exit code; default: unknown
+  --no-probes     skip the selfcheck probe summary entirely (probe name +
+                  verdict only ever appear — never the free-text reason/detail
+                  fields underneath them)
+
+  --file          re-print the SAME payload, then open it as a GitHub issue
+                  against $(gh_org)/5dive (via '5dive gh issue create', so it
+                  files as 5dive-bot when this account can write). A TTY also
+                  gets an interactive y/N; nothing is ever filed by default.
+
+The payload is a fixed allowlist: version, OS, bash version, install method,
+the verb that failed, its exit code, and selfcheck probe name+verdict pairs.
+No free text ever leaves this box in it.
+EOF
+}
+
+# _bug_os — best-effort distro string. Never anything host-identifying (no
+# hostname, no machine-id) — just what OS/version this is.
+_bug_os() {
+  if [[ -r /etc/os-release ]]; then
+    ( . /etc/os-release 2>/dev/null; printf '%s' "${PRETTY_NAME:-${NAME:-unknown} ${VERSION_ID:-}}" )
+  else
+    printf '%s %s' "$(uname -s)" "$(uname -r)"
+  fi
+}
+
+# _bug_install_method — curl-install (single bundled file, the shipped path)
+# vs git-checkout (this tree, or any dev clone) vs unknown (couldn't resolve
+# the running bundle at all — see five_self_bundle in src/lib/self.sh).
+_bug_install_method() {
+  local self=""
+  self=$(five_self_bundle 2>/dev/null) || self=""
+  if [[ -z "$self" ]]; then
+    printf 'unknown'
+  elif git -C "$(dirname -- "$self")" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    printf 'git-checkout'
+  else
+    printf 'curl-install'
+  fi
+}
+
+# _bug_sanitize_verb <text> — bounds what --verb can carry. Not a free-text
+# channel: strip control chars/newlines and cap length, so a pasted paragraph
+# can't ride along disguised as "the verb name".
+_bug_sanitize_verb() {
+  local v="$1"
+  v="${v//$'\n'/ }"
+  v=$(printf '%s' "$v" | tr -d '\000-\010\013\014\016-\037')
+  printf '%s' "${v:0:80}"
+}
+
+# _bug_collect_probes — the ONLY two fields ('probe', 'verdict') ever read out
+# of `selfcheck --json`'s probes[], named explicitly. .reason/.detail/.asserts
+# and the top-level .label (a host:uid string) are never asked for — the
+# acceptance harness (tests/bug_report_pii_allowlist_unit.sh) plants a
+# PII-shaped marker in a fixture's .reason/.detail and asserts it never reaches
+# this function's output.
+_bug_collect_probes() {
+  local raw=""
+  raw=$(cmd_selfcheck --json 2>/dev/null) || true
+  [[ -n "$raw" ]] || { printf '[]'; return 0; }
+  jq -c '[ .probes[]? | {probe: .probe, verdict: .verdict} ]' <<<"$raw" 2>/dev/null || printf '[]'
+}
+
+# _bug_render_payload <verb> <exit_code> <include_probes:0|1> — the entire
+# allowlist. Every key is named on the jq template line below; adding a new
+# field to the payload means editing this one line on purpose, never a
+# passthrough of some richer object.
+_bug_render_payload() {
+  local verb="$1" exit_code="$2" include_probes="$3"
+  local v_san; v_san=$(_bug_sanitize_verb "$verb")
+  [[ -n "$v_san" ]] || v_san="unknown"
+  local probes_json='[]'
+  (( include_probes )) && probes_json=$(_bug_collect_probes)
+  local exit_json='null'
+  [[ "$exit_code" =~ ^[0-9]+$ ]] && exit_json="$exit_code"
+  jq -cn \
+    --arg version "$FIVE_VERSION" \
+    --arg os "$(_bug_os)" \
+    --arg bash_version "${BASH_VERSION:-unknown}" \
+    --arg install_method "$(_bug_install_method)" \
+    --arg verb "$v_san" \
+    --argjson exit_code "$exit_json" \
+    --argjson probes "$probes_json" \
+    '{version:$version, os:$os, bash_version:$bash_version,
+      install_method:$install_method, verb:$verb, exit_code:$exit_code,
+      probes:$probes}'
+}
+
+# _bug_body_markdown <payload-json> — renders the issue body from the
+# ALREADY-ALLOWLISTED payload only (never re-reads selfcheck itself), matching
+# the Environment/Logs sections of .github/ISSUE_TEMPLATE/bug_report.md.
+_bug_body_markdown() {
+  local payload="$1"
+  local version os bash_version install_method verb exit_code probes_table
+  version=$(jq -r '.version' <<<"$payload")
+  os=$(jq -r '.os' <<<"$payload")
+  bash_version=$(jq -r '.bash_version' <<<"$payload")
+  install_method=$(jq -r '.install_method' <<<"$payload")
+  verb=$(jq -r '.verb' <<<"$payload")
+  exit_code=$(jq -r '.exit_code // "unknown"' <<<"$payload")
+  probes_table=$(jq -r '.probes[]? | "- \(.probe): \(.verdict)"' <<<"$payload")
+  [[ -n "$probes_table" ]] || probes_table="(skipped — re-run without --no-probes to include)"
+  cat <<EOF
+## What happened
+
+Filed via \`5dive bug\` after \`5dive ${verb}\` exited ${exit_code}.
+
+<!-- Add a one-paragraph summary here: what did you expect, what did you see. -->
+
+## Environment
+
+- \`5dive --version\`: ${version}
+- OS / distro: ${os}
+- bash: ${bash_version}
+- Install method: ${install_method}
+
+## Diagnostics (selfcheck probe name + verdict only — no free text)
+
+${probes_table}
+EOF
+}
+
+cmd_bug() {
+  local verb="" exit_code="" include_probes=1 do_file=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --verb=*)    verb="${1#--verb=}"; shift ;;
+      --exit=*)    exit_code="${1#--exit=}"; shift ;;
+      --no-probes) include_probes=0; shift ;;
+      --file)      do_file=1; shift ;;
+      -h|--help)   _bug_usage; return 0 ;;
+      *) fail "$E_USAGE" "unknown flag: $1 (see: 5dive bug --help)" ;;
+    esac
+  done
+  [[ -n "$verb" ]] || verb="${CURRENT_VERB:-unknown}"
+
+  local payload
+  payload=$(_bug_render_payload "$verb" "$exit_code" "$include_probes")
+
+  if (( ! do_file )); then
+    if (( JSON_MODE )); then
+      ok "" '{filed:false, payload:$p}' --argjson p "$payload"
+    else
+      echo "The following is the ENTIRE payload — nothing else leaves this box:" >&2
+      jq '.' <<<"$payload" >&2
+      echo >&2
+      echo "Nothing filed. Re-run with --file to open this as a GitHub issue against $(gh_org)/5dive." >&2
+    fi
+    return 0
+  fi
+
+  # --file: show the exact payload regardless of --json — this line is the
+  # confirmation, not decoration, so it is never conditional on output mode.
+  echo "Filing the following payload — nothing else leaves this box:" >&2
+  jq '.' <<<"$payload" >&2
+
+  if [[ -t 0 ]]; then
+    printf 'File this issue on %s/5dive as shown above? [y/N] ' "$(gh_org)" >&2
+    local reply=""; read -r reply || reply=""
+    case "$reply" in
+      y|Y|yes|Yes|YES) ;;
+      *) fail "$E_GENERIC" "aborted — nothing filed" ;;
+    esac
+  fi
+
+  command -v gh >/dev/null 2>&1 \
+    || fail "$E_NOT_INSTALLED" "gh is not installed on this box — cannot file a GitHub issue. The payload above is everything this verb would have sent; file it by hand at https://github.com/$(gh_org)/5dive/issues/new?template=bug_report.md"
+
+  local body title tmpf rc=0 issue_url=""
+  body=$(_bug_body_markdown "$payload")
+  title="[5dive bug] ${verb:-unknown} exited ${exit_code:-unknown}"
+  tmpf=$(mktemp) || fail "$E_GENERIC" "mktemp failed"
+  printf '%s\n' "$body" > "$tmpf"
+  # `if var=$(cmd)` (not `var=$(cmd); rc=$?`) — under set -e a failing command
+  # substitution on the right of a bare assignment can still trip the shell;
+  # as an if-condition it is explicitly exempt, so this is the safe capture.
+  if issue_url=$(cmd_gh issue create --repo "$(gh_org)/5dive" --title "$title" --label bug --body-file "$tmpf"); then
+    rc=0
+  else
+    rc=$?
+  fi
+  rm -f "$tmpf"
+  if (( rc == 0 )); then
+    ok "issue filed: $issue_url" '{filed:true, url:$u}' --arg u "$issue_url"
+  else
+    fail "$E_GENERIC" "gh issue create failed (rc=$rc) — the payload printed above is everything this would have sent; file it by hand if needed"
+  fi
+}

--- a/src/lib/output.sh
+++ b/src/lib/output.sh
@@ -22,6 +22,12 @@ err_class_for() {
 #   - step() still emits progress to stderr (stdout stays clean)
 JSON_MODE=0
 
+# The top-level verb main() is currently dispatching, set once near the top of
+# main() (DIVE-2323). Read by fail()'s E_GENERIC hint so it can point at
+# `5dive bug` with the actual failing verb filled in, without fail() itself
+# needing to know how it was reached.
+CURRENT_VERB=""
+
 # fail <code> <message>
 # Always exits. In JSON mode, prints envelope on stdout AND a plain line on
 # stderr (for logs). In text mode, prints prose on stderr only. Exit status
@@ -58,6 +64,14 @@ fail() {
       '{ok:false, error:{code:$c, class:$cl, message:$m}}'
   fi
   echo "error: $msg" >&2
+  # DIVE-2323: E_GENERIC is the catch-all/internal bucket (never a usage or
+  # validation mistake — see src/lib/error_codes.sh), so this is the one place
+  # in the CLI that reliably sees "something we didn't expect broke". Point at
+  # the bug-report verb there, with the actual verb/code filled in, rather than
+  # leaving discovery to whoever happens to read .github/ISSUE_TEMPLATE.
+  if [[ "$code" == "${E_GENERIC:-1}" ]]; then
+    echo "hint: run '5dive bug --verb=\"${CURRENT_VERB:-unknown}\" --exit=$code' to preview a diagnostic bug report (allowlisted fields only; nothing is filed until you add --file)" >&2
+  fi
   exit "$code"
 }
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -308,9 +308,9 @@ Health:
     Payload is a fixed ALLOWLIST — version, OS, bash version, install method,
     the verb that failed + its exit code, and selfcheck probe name+verdict
     pairs — never the free-text reason/detail fields underneath them. Bare
-    `5dive bug` only builds and prints the payload; NEVER auto-files. --file
-    re-prints the identical payload and then opens it (via `5dive gh issue
-    create`, so it lands as 5dive-bot); a TTY also gets an interactive y/N.
+    \`5dive bug\` only builds and prints the payload; NEVER auto-files. --file
+    re-prints the identical payload and then opens it (via \`5dive gh issue
+    create\`, so it lands as 5dive-bot); a TTY also gets an interactive y/N.
     Agents take the same --file flag a human does — no separate unattended path.
 
   5dive doctor [--fix] [--dry-run] [--category=deps|types|auth|creds|registry|shelld|channels|host|memory]

--- a/src/main.sh
+++ b/src/main.sh
@@ -303,6 +303,16 @@ Health:
     two environments (tests/meta/selfcheck-union.sh) to prove no probe is
     skipped everywhere.
 
+  5dive bug [--verb=<name>] [--exit=<code>] [--no-probes] [--file]
+    Preview (default) or file a diagnostic bug report against 5dive-ai/5dive.
+    Payload is a fixed ALLOWLIST — version, OS, bash version, install method,
+    the verb that failed + its exit code, and selfcheck probe name+verdict
+    pairs — never the free-text reason/detail fields underneath them. Bare
+    `5dive bug` only builds and prints the payload; NEVER auto-files. --file
+    re-prints the identical payload and then opens it (via `5dive gh issue
+    create`, so it lands as 5dive-bot); a TTY also gets an interactive y/N.
+    Agents take the same --file flag a human does — no separate unattended path.
+
   5dive doctor [--fix] [--dry-run] [--category=deps|types|auth|creds|registry|shelld|channels|host|memory]
     Walks deps (tmux/jq/bun/python3/nvm/node/npm), type bins, live auth
     probes, stale shadow-credential heal (creds), registry integrity, channel
@@ -352,6 +362,11 @@ main() {
 
   [[ $# -gt 0 ]] || { usage; exit "$E_USAGE"; }
   local top="$1"; shift
+  # DIVE-2323: the one place that sees every dispatch, so fail()'s E_GENERIC
+  # hint can name the verb that broke. Set unconditionally, even for a $top
+  # the case below rejects — that path fails E_USAGE, which the hint never
+  # fires on, so an unvalidated verb string never actually reaches it.
+  CURRENT_VERB="$top"
   # Handle --version / -v / version before the dispatch table so it stays a
   # zero-dependency one-liner check (reviewers grep for it first).
   case "$top" in
@@ -720,6 +735,19 @@ main() {
       # audited: it mutates nothing outside its own temp dirs (same posture as
       # doctor without --fix).
       cmd_selfcheck "$@" ;;
+    bug)
+      # DIVE-2323: diagnostic bug-report verb against 5dive-ai/5dive. Preview
+      # (the default) only builds and prints an allowlisted payload — no lock,
+      # no audit, nothing leaves the box. Only --file performs the network
+      # write (via `5dive gh issue create`), so that's the only arm audited,
+      # same gating style as doctor's --repair/--fix above.
+      for a in "$@"; do
+        if [[ "$a" == "--file" ]]; then
+          AUDIT_CMD="bug"; AUDIT_ARGS=("$@")
+          break
+        fi
+      done
+      cmd_bug "$@" ;;
     task)
       # Shared task queue (sqlite). Group-writable store, so no root/lock and
       # no audit — these are high-frequency, low-risk ops any agent runs. SQLite

--- a/tests/bug_report_pii_allowlist_unit.sh
+++ b/tests/bug_report_pii_allowlist_unit.sh
@@ -33,6 +33,12 @@ fail_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
 chk()    { if [[ "$2" == "$3" ]]; then ok_t "$1"; else fail_t "$1 (expected '$2', got '$3')"; fi }
 
 # ── 1. the allowlist shape, on a clean fixture ─────────────────────────────────
+# THIS is the key-set pin: a literal expected list, so ANY new top-level field
+# fails here, on purpose, even one wired in only via jq -cn --arg without also
+# touching the object literal below (which is a silent no-op on the emitted
+# bytes, not a leak — confirmed by diff during DIVE-2323 gate review, since an
+# --arg that no field in the final `{...}` construction references never
+# reaches the payload at all).
 _sc_dispatch() { printf '%s\n' "pass||clean detail line, nothing sensitive"; }
 
 payload=$(_bug_render_payload "doctor" "3" 1)

--- a/tests/bug_report_pii_allowlist_unit.sh
+++ b/tests/bug_report_pii_allowlist_unit.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# DIVE-2323 — `5dive bug`'s payload is an ALLOWLIST, never a denylist.
+#
+# The whole design point (see src/cmd_bug.sh header and
+# community/wiki/a-repo-scoped-pii-gate-cannot-see-what-the-repo-generates.md) is
+# that `selfcheck --json`'s probes[] carry .reason and .detail as FREE TEXT — paths,
+# hostnames, agent names, task idents land there — and nothing but .probe/.verdict
+# may ever reach the payload this verb prints or files publicly. A review can
+# confirm the code LOOKS right; only a planted marker proves a free-text field
+# never actually reaches the emitted bytes, which is why the negative arm below is
+# the one that matters (same shape as council_principal_redaction_unit.sh).
+#
+# Hermetic: _sc_dispatch is overridden with a fixture table (same technique as
+# tests/selfcheck_unit.sh), so this never shells out, never hits the network and
+# never touches the live task store. GH_ORG is pinned so cmd_bug.sh's gh_org()
+# calls never probe github.com.
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
+SRC=src
+export GH_ORG="5dive-ai"
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/self.sh cmd_selfcheck.sh cmd_bug.sh; do
+  source "$SRC/$f"
+done
+set +e
+
+PASS=0; FAIL=0
+ok_t()   { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+fail_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+chk()    { if [[ "$2" == "$3" ]]; then ok_t "$1"; else fail_t "$1 (expected '$2', got '$3')"; fi }
+
+# ── 1. the allowlist shape, on a clean fixture ─────────────────────────────────
+_sc_dispatch() { printf '%s\n' "pass||clean detail line, nothing sensitive"; }
+
+payload=$(_bug_render_payload "doctor" "3" 1)
+
+keys=$(jq -cS 'keys' <<<"$payload")
+chk "payload top-level keys are EXACTLY the allowlist (no more, no less)" \
+  '["bash_version","exit_code","install_method","os","probes","verb","version"]' "$keys"
+
+probe_keys=$(jq -c '[.probes[] | keys] | unique' <<<"$payload")
+chk "every probe object carries ONLY probe+verdict" '[["probe","verdict"]]' "$probe_keys"
+
+chk "verb passes through" '"doctor"' "$(jq -c '.verb' <<<"$payload")"
+chk "exit_code is numeric when given" '3' "$(jq -c '.exit_code' <<<"$payload")"
+
+# ── 2. --no-probes / no exit code -> the honest absence, not a fabricated value ─
+p2=$(_bug_render_payload "x" "" 0)
+chk "include_probes=0 -> empty probes array, not omitted or null" '[]' "$(jq -c '.probes' <<<"$p2")"
+chk "a non-numeric exit code renders as null, never coerced to 0" 'null' "$(jq -c '.exit_code' <<<"$p2")"
+
+# ── 3. the negative arm: plant a PII-shaped marker in .reason AND .detail ──────
+# Reserved-fake id per project convention (never a real identifier in a fixture).
+MARKER="tg:1234567890/should-never-leave-this-box"
+_sc_dispatch() { printf '%s\n' "fail|${MARKER}|detail also carries ${MARKER} right here"; }
+
+raw=$(cmd_selfcheck --json 2>/dev/null)
+if grep -q "$MARKER" <<<"$raw"; then
+  ok_t "sanity: the marker DOES appear in raw selfcheck --json (fixture is live, not a vacuous test)"
+else
+  fail_t "sanity check failed — the marker never even reached raw selfcheck output, so the negative arm below proves nothing: $raw"
+fi
+
+probes_out=$(_bug_collect_probes)
+if grep -q "$MARKER" <<<"$probes_out"; then
+  fail_t "MARKER LEAKED into _bug_collect_probes output: $probes_out"
+else
+  ok_t "the marker does not reach _bug_collect_probes (reason/detail dropped, not just this key renamed)"
+fi
+
+payload2=$(_bug_render_payload "doctor" "1" 1)
+if grep -q "$MARKER" <<<"$payload2"; then
+  fail_t "MARKER LEAKED into the rendered payload: $payload2"
+else
+  ok_t "the marker does not reach the rendered payload"
+fi
+
+body=$(_bug_body_markdown "$payload2")
+if grep -q "$MARKER" <<<"$body"; then
+  fail_t "MARKER LEAKED into the rendered issue body: $body"
+else
+  ok_t "the marker does not reach the rendered issue body (the body is built from the payload only)"
+fi
+
+# ── 4. shape guard: a NEW emitter referencing .reason/.detail/.asserts fails here
+#      too, in CI, rather than in a filed issue (same rationale as
+#      council_principal_redaction_unit.sh's emit-site shape assertion). ───────
+leaky_refs=$(grep -vE '^[[:space:]]*#' "$SRC/cmd_bug.sh" | grep -cE '\.reason\b|\.detail\b|\.asserts\b|\.label\b')
+chk "no jq expression in cmd_bug.sh (outside comments) ever reads .reason/.detail/.asserts/.label" \
+  0 "$leaky_refs"
+
+# ── 5. --verb is bounded, not a second free-text channel ──────────────────────
+long_verb=$(printf 'a%.0s' $(seq 1 200))
+san=$(_bug_sanitize_verb "$long_verb")
+chk "an oversized --verb is capped at 80 chars" 80 "${#san}"
+
+nl_verb=$(_bug_sanitize_verb $'multi\nline\ntext')
+if [[ "$nl_verb" == *$'\n'* ]]; then
+  fail_t "newline survived verb sanitization: '$nl_verb'"
+else
+  ok_t "newlines are stripped from --verb"
+fi
+
+# ── 6. NEVER auto-files: the default (preview) path never calls cmd_gh ─────────
+cmd_gh() { fail_t "cmd_gh was invoked WITHOUT --file — this is the auto-file bug the ticket forbids"; echo "unreachable"; }
+_sc_dispatch() { printf '%s\n' "pass||clean"; }
+out=$(cmd_bug --verb=doctor --exit=1 2>/tmp/bug_unit_err.$$)
+rc=$?
+chk "bare '5dive bug' (no --file) exits 0 without filing" 0 "$rc"
+if grep -q "Nothing filed" /tmp/bug_unit_err.$$; then
+  ok_t "bare '5dive bug' says nothing was filed"
+else
+  fail_t "no 'nothing filed' notice printed: $(cat /tmp/bug_unit_err.$$)"
+fi
+rm -f /tmp/bug_unit_err.$$
+
+# ── 7. the failure-path hint (fail()'s E_GENERIC-only pointer to this verb) ────
+CURRENT_VERB="doctor"
+hint_err=$(fail "$E_GENERIC" "something internal broke" 2>&1)
+if grep -q "5dive bug --verb=\"doctor\" --exit=1" <<<"$hint_err"; then
+  ok_t "fail() hints at '5dive bug' with the real verb+code on E_GENERIC"
+else
+  fail_t "E_GENERIC hint missing or malformed: $hint_err"
+fi
+
+usage_err=$(fail "$E_USAGE" "bad flag" 2>&1)
+if grep -q "5dive bug" <<<"$usage_err"; then
+  fail_t "a routine E_USAGE mistake should NOT get the bug-report hint (noise on every typo): $usage_err"
+else
+  ok_t "a routine E_USAGE failure stays quiet — the hint is reserved for E_GENERIC"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
A new `5dive bug` verb that opens a **public** GitHub issue from a payload built as an **allowlist, never a denylist**: every field is named once in a single `jq -n` object literal, so a field that is not written cannot leak.

That direction matters more than it sounds. Stripping risky keys off a richer object fails open — the next field someone adds to the source object ships by default. Naming each field fails closed.

## The guard, and the near-miss inside it

`tests/bug_report_pii_allowlist_unit.sh` plants a PII-shaped marker into the excluded free-text fields (`.reason`, `.detail`) and greps every downstream surface for it. 17/0.

I asked for a key-set arm pinning the payload's top-level keys, believing check #1 asserted shape rather than an exact key set. **It already was the pin** — a literal expected-keys list that fails on any new field.

The instructive part is how I convinced myself otherwise. I mutated by adding an unused `--arg leaked_home` and the suite stayed 17/0, which I read as the arm being blind. dev2 reproduced it, then **diffed the emitted payload** and found it byte-identical: `jq -cn` only emits a var the final object literal names, so the `--arg` never reached the output. **I verified that the argument was added and never that the output changed** — and an unused `--arg` is invisible precisely because jq is designed to ignore it. Wiring `leaked_home` into the object literal for real turned check #1 red at 16/1, naming the extra key.

So: no new arm, and a 6-line comment on check #1 recording why the obvious mutation looks vacuous — the next reviewer will have the same doubt, and documenting it beats a second arm testing the same property.

**A mutation you did not confirm changed the output is not a mutation**, and a green under one is worth nothing.

No logic change, 17/17, pii-scan clean.

Authored by dev2; reviewed, mutation-checked and merged by main (dev2 holds no gh credential).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
