### PR TITLE
fix(init): codex recipe locates the binary via npm prefix, not nvm which (DIVE-2596)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,27 @@ preference is to merge by subject). The behavioural arm runs the **real** recipe
 namespace where the two locators disagree, and runs the **pre-fix** locator through the same
 rig as a red anchor: it dangles *at rc=0*, which is the "reported success" half.
 
+The rig **builds** the recipe's hardcoded `/home/claude` inside the namespace (tmpfs over
+`/home`, then `mkdir`) rather than borrowing the host's. The first cut bind-mounted straight
+onto `/home/claude/.nvm` and `/home/claude/.local/bin` — the right addresses, since they are
+what the recipe reads, but they exist only on a 5dive host. On a GitHub runner home is
+`/home/runner`, both mounts failed with *mount point does not exist*, and the driver — `set -u`
+with no `-e` — graded an unrigged namespace and returned `VERDICT=absent rc=1` from both arms.
+Deriving the mount point from `$HOME` does not fix that: the literal `/home/claude` is in the
+**recipe under test**, so a rig at `/home/runner` is just as unrigged, only quieter. The path
+has to be created, not relocated — which also removes the host-dependence that let this pass
+locally and only locally. Everything is namespace-local (unshare defaults to private
+propagation); a host that has `/home/claude` gets it shadowed, never touched.
+
+Two guards keep the arm honest rather than merely working. The driver **refuses** — printing
+nothing verdict-shaped — if any rig step fails, so a rig that did not build can no longer
+emit a string shaped exactly like a measurement; and the environment guard now grades *the
+rig it needs* (build one, check it reports `RIGOK`) instead of the proxy question "is
+`unshare` permitted", which answers **yes** on a runner and was why the unrigged run got
+through. Where no launcher can build the rig the arm skips loudly, naming each candidate's
+failure. Both guards are themselves graded: breaking a rig on purpose asserts the refusal
+fires, names the failed step, and leaks no `VERDICT`.
+
 ## Unreleased — SECURITY fix(gate): a tier-2 human floor whose OFF switch was reachable by the agents it constrains (DIVE-2588)
 
 Any agent, unprivileged and without sudo, could forge a human tap on a tier-2 **decision**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## Unreleased — fix(init): the `codex` recipe asked nvm which node it SELECTED, not npm where it INSTALLED (DIVE-2596)
+
+`sudo 5dive agent create --type=codex` aborted with
+
+```
+error: codex install reported success but /home/claude/.local/bin/codex still missing — investigate manually
+```
+
+on a host where codex works fine. The message is a true statement about the wrong object:
+codex was installed. The **locator** was wrong.
+
+The recipe aimed the `~/.local/bin/codex` symlink at `` `dirname $(nvm which 24)` `` and the
+comment above it asserted that this equals `` `npm prefix -g`/bin ``, "so the symlink is
+guaranteed to point at the codex we just installed". It is not, and it is not. They answer
+two different questions:
+
+| | question | value on the 5dive host |
+|---|---|---|
+| `nvm which 24` | which node did nvm **select**? (an intent) | `…/v24.19.0/bin/node` |
+| `npm prefix -g` | which node is **running npm**? (the outcome) | `…/v24.18.0` |
+
+They diverge because `~/.local/bin` precedes nvm's bin dir on `PATH` and holds a `node`
+symlink — planted by the **openclaw** recipe, pinned at whatever `nvm which 24` meant the
+day openclaw was last installed. npm is a `#!/usr/bin/env node` script, so nvm's npm is
+**executed by that pinned node**, and `npm prefix -g` (derived from `process.execPath`)
+reports the pinned node's prefix — which is where `npm install -g` then puts the binary.
+`nvm use` cannot correct this: it edits `PATH`, and the shadow is *earlier* on `PATH`.
+
+Compounding it, `nvm install 24` resolves `24` against the **remote**, so it downloads a
+brand-new v24 whenever upstream cuts one — measured, it pulled `v24.19.0` onto a host that
+already had `v24.18.1`. That is what moves `nvm which 24` out from under a box nobody
+touched, and it is why the `-x` short-circuit stays first: an already-installed codex must
+not drag a node download onto every create.
+
+The symlink now targets `` `$(npm prefix -g)/bin/codex` ``, which is immune by construction —
+the same npm process answers the locator query and performs the install, so target and
+outcome cannot disagree. Mirrors the openclaw recipe, which already derives its target this
+way. The recipe also now asserts the link resolves (`-x`) before reporting success, so a
+dangling link fails with an honest rc instead of being re-diagnosed downstream as a missing
+binary.
+
+Graded in `tests/codex_install_node24_unit.sh` (folded in there rather than shipped as a
+218th harness file — the core tier is over its 300s cap and the budget guard's first
+preference is to merge by subject). The behavioural arm runs the **real** recipe in a mount
+namespace where the two locators disagree, and runs the **pre-fix** locator through the same
+rig as a red anchor: it dangles *at rc=0*, which is the "reported success" half.
+
 ## Unreleased — SECURITY fix(gate): a tier-2 human floor whose OFF switch was reachable by the agents it constrains (DIVE-2588)
 
 Any agent, unprivileged and without sudo, could forge a human tap on a tier-2 **decision**

--- a/src/header.sh
+++ b/src/header.sh
@@ -313,18 +313,53 @@ declare -A TYPE_INSTALL=(
   # dir even when the `v24` alias has drifted (same drift the nightly
   # soft-updates hit — DIVE-1189). We then one-hop-symlink the just-installed
   # codex into ~/.local/bin (where TYPE_BIN[codex] and the agent unit's PATH
-  # look). We resolve its real path deterministically as
-  # `dirname $(nvm which 24)/codex` — NOT `command -v codex`, which can land on
-  # a stray /usr/bin/codex, and NOT the `/home/.../v24/bin` alias, which lags
-  # real node upgrades (a box on v24.18.0 left the alias pointing at v24.16.0
-  # and surfaced codex as not_installed — DIVE-1329). `npm install -g` lands the
-  # binary in exactly this dir (== `npm prefix -g`/bin), so the symlink is
-  # guaranteed to point at the codex we just installed. Mirrors opencode below.
+  # look). We resolve its real path as `$(npm prefix -g)/bin/codex` — NOT
+  # `command -v codex`, which can land on a stray /usr/bin/codex, and NOT
+  # `dirname $(nvm which 24)`, which is what this recipe used until DIVE-2596.
+  #
+  # DIVE-2596: `nvm which 24` and `npm prefix -g` are NOT the same directory,
+  # and the comment that used to sit here asserted they were ("== `npm prefix
+  # -g`/bin, so the symlink is guaranteed to point at the codex we just
+  # installed"). They are two different questions:
+  #   nvm which 24  — which node did nvm SELECT   (an intent)
+  #   npm prefix -g — which node is RUNNING npm   (the outcome of this install)
+  # They diverge because ~/.local/bin precedes nvm's bin dir on PATH and holds a
+  # `node` symlink planted by the openclaw recipe below, pinned at whatever
+  # `nvm which 24` meant on the day openclaw was last installed. npm is a
+  # `#!/usr/bin/env node` script, so nvm's npm gets EXECUTED BY that pinned
+  # node, and `npm prefix -g` (derived from process.execPath) reports the
+  # pinned node's prefix — which is where `npm install -g` then puts the
+  # binary. `nvm use` cannot correct this: it edits PATH, and the shadow is
+  # EARLIER on PATH. Measured on the 5dive host: nvm which 24 -> v24.19.0,
+  # npm prefix -g -> v24.18.0, codex under v24.18.0/bin, symlink dangling,
+  # create aborting with "install reported success but bin still missing" on a
+  # box where codex works fine.
+  #
+  # `npm prefix -g` is immune by construction: the same npm process answers the
+  # locator query and performs the install, so target and outcome cannot
+  # disagree. Mirrors openclaw below, which already derives its target this way.
+  # Note we do NOT copy openclaw's `nvm use 24 --silent`: measured on the host,
+  # it does not move `npm prefix -g` (the shadow is earlier on PATH than
+  # anything `nvm use` edits), and tests/codex_install_node24_unit.sh forbids
+  # the substring outright because `nvm use` alone cannot provision a fresh box
+  # (DIVE-1329). Adding it would buy nothing and cost that guard.
+  #
+  # `nvm install 24` also resolves 24 against the REMOTE, so it downloads and
+  # installs a brand-new v24 whenever upstream cuts one — which is what makes
+  # `nvm which 24` move out from under a box that has not changed. That is why
+  # the -x short-circuit stays FIRST: an already-installed codex must not drag
+  # a node download onto every create.
+  #
+  # The trailing `-x` assert is the second half of the fix: a dangling symlink
+  # now fails the recipe with an honest rc instead of being reported as a
+  # successful install and re-diagnosed downstream (cmd_auth.sh) as a missing
+  # binary, which is a true statement about the wrong object — codex IS
+  # installed; the LOCATOR was wrong.
   # DIVE-1189: `5dive agent install codex --upgrade` sets FORCE_INSTALL=1 to skip
   # the -x short-circuit and reinstall @latest in place; without it (the
   # provisioning path) an existing codex is left untouched. \$-escaped so the
   # var expands when the recipe runs under `bash -lc`, not at array-definition time.
-  [codex]="{ [[ -z \"\${FORCE_INSTALL:-}\" ]] && [[ -x /home/claude/.local/bin/codex ]]; } || { . /home/claude/.nvm/nvm.sh && nvm install 24 >/dev/null && npm install -g @openai/codex@latest && mkdir -p /home/claude/.local/bin && ln -sfn \"\$(dirname \"\$(nvm which 24)\")/codex\" /home/claude/.local/bin/codex; }"
+  [codex]="{ [[ -z \"\${FORCE_INSTALL:-}\" ]] && [[ -x /home/claude/.local/bin/codex ]]; } || { . /home/claude/.nvm/nvm.sh && nvm install 24 >/dev/null && npm install -g @openai/codex@latest && mkdir -p /home/claude/.local/bin && ln -sfn \"\$(npm prefix -g)/bin/codex\" /home/claude/.local/bin/codex && [[ -x /home/claude/.local/bin/codex ]]; }"
   # opencode.ai's installer drops the binary at ~/.opencode/bin/opencode and
   # only adds it to PATH via .bashrc — but bash -lc skips .bashrc on
   # non-interactive shells, so neither the verify check below nor the agent

--- a/tests/codex_install_node24_unit.sh
+++ b/tests/codex_install_node24_unit.sh
@@ -104,17 +104,35 @@ echo "PASS: codex locator targets the installing npm's prefix and asserts it res
 # locator through the SAME rig as a red anchor — a green here with no red
 # anchor would also pass on a rig that cannot fail.
 #
-# The recipe hardcodes /home/claude/.nvm and /home/claude/.local/bin, so the rig
-# needs a mount namespace. Where that is not permitted, SKIP LOUDLY: a silent
-# skip reads as coverage this harness did not provide.
-if unshare -m --map-root-user true 2>/dev/null; then
-  UNSHARE=(unshare -m --map-root-user)
-elif sudo -n unshare -m true 2>/dev/null; then
-  UNSHARE=(sudo -n unshare -m)
-else
-  echo "SKIP: codex locator behavioural arm (no usable 'unshare -m'; static arms only)" >&2
-  exit 0
-fi
+# ITERATION 3 — why this arm is built the way it is. Iteration 2 bind-mounted
+# the rig straight onto /home/claude/.nvm and /home/claude/.local/bin. Those
+# are the right ADDRESSES (they are what the recipe reads) but they exist only
+# on a 5dive host. On a GitHub runner home is /home/runner, both mounts failed
+# with "mount point does not exist", and because the driver ran `set -u` with
+# no `-e` the failures went to stderr and the recipe was graded in an UNRIGGED
+# namespace: both arms returned `VERDICT=absent rc=1`, a string shaped exactly
+# like a measurement. Two independent holes, two independent repairs:
+#
+#  1. The rig SYNTHESISES /home/claude inside the namespace (tmpfs over /home,
+#     then mkdir) rather than borrowing the host's. Deriving the mount point
+#     from $HOME — the obvious fix — does NOT work here: the literal string
+#     /home/claude is hardcoded in the RECIPE UNDER TEST, so a rig mounted at
+#     /home/runner would be just as unrigged, only quieter. The path has to be
+#     CREATED, not relocated. Doing it unconditionally is also what kills the
+#     host-dependence that hid the CI failure from every local run: this host
+#     has /home/claude, so borrowing it passed here and only here. Everything
+#     below is namespace-local — unshare(1) defaults to private propagation —
+#     and on a host that DOES have /home/claude it is shadowed, never touched.
+#
+#  2. The driver REFUSES rather than emitting a verdict when any rig step
+#     fails, and the environment guard now grades THE RIG IT NEEDS (build one,
+#     check it reports RIGOK) instead of the proxy question "is unshare
+#     permitted". On a runner unshare IS permitted, which is exactly why the
+#     old guard let the run through to an unrigged measurement.
+#
+# Where the rig genuinely cannot be built, SKIP LOUDLY with the named reason
+# from each candidate: a silent skip reads as coverage this harness did not
+# provide, and an unnamed one cannot be told from a rig that is merely broken.
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -159,25 +177,103 @@ RIG
   # The SELECTED prefix has a node but no codex — that is the whole point.
   printf '#!/bin/sh\necho node\n' >"$root/selected/bin/node"
   chmod +x "$root/selected/bin/node"
+  # Witness file. `mount --bind` reporting success is not the same claim as the
+  # rig being VISIBLE at the path the recipe reads; the driver checks for this
+  # mark on the far side of the bind rather than trusting mount's exit status.
+  : >"$root/localbin/.rigmark"
 }
 
-# Runs one recipe in a namespace with the rig bound over the hardcoded paths.
-run_recipe() {
-  local root="$1" script="$2"
-  printf '%s\n' "$script" >"$root/recipe.sh"
-  cat >"$root/drive.sh" <<RIG
-set -u
-mount --bind "$root/nvm" /home/claude/.nvm
-mount --bind "$root/localbin" /home/claude/.local/bin
-export PATH="$root/path:/usr/bin:/bin"
-bash "$root/recipe.sh" >/dev/null 2>&1; rc=\$?
-link=/home/claude/.local/bin/codex
-if [[ ! -L \$link && ! -e \$link ]]; then echo "VERDICT=absent rc=\$rc"
-elif [[ -x \$link ]]; then echo "VERDICT=ok rc=\$rc"
-else echo "VERDICT=dangling rc=\$rc"; fi
+# Everything that must run INSIDE the namespace before a recipe can be graded.
+# Emitted from ONE function so the preflight and every measurement drive the
+# same mechanism — a preflight that exercised a different code path would be
+# back to grading a proxy.
+rig_preamble() {
+  printf 'set -u\nexport PATH=/usr/sbin:/usr/bin:/sbin:/bin\n'
+  printf 'RIG_ROOT=%q\n' "$1"
+  cat <<'RIG'
+fail() { echo "RIGFAIL=$1"; exit 3; }
+# Build the recipe's hardcoded home, do not borrow the host's.
+mount -t tmpfs tmpfs /home                                || fail "tmpfs-over-home"
+[[ ! -e /home/claude ]]                                   || fail "tmpfs-did-not-shadow-home"
+mkdir -p /home/claude/.nvm /home/claude/.local/bin        || fail "mkdir-bind-targets"
+mount --bind "$RIG_ROOT/nvm" /home/claude/.nvm            || fail "bind-nvm"
+mount --bind "$RIG_ROOT/localbin" /home/claude/.local/bin || fail "bind-localbin"
+export PATH="$RIG_ROOT/path:/usr/bin:/bin"
+# Witnesses, read through the paths the recipe will use.
+[[ -r /home/claude/.nvm/nvm.sh ]]                         || fail "nvm-not-visible"
+[[ -e /home/claude/.local/bin/.rigmark ]]                 || fail "localbin-not-visible"
+[[ "$(command -v npm)" == "$RIG_ROOT/path/npm" ]]         || fail "npm-not-rigged"
 RIG
-  "${UNSHARE[@]}" bash "$root/drive.sh"
 }
+
+# The measurement itself. Separate from the preamble so a rig failure can never
+# reach it: `fail` exits 3 before this line is ever read.
+drive_tail='bash "$RIG_ROOT/recipe.sh" >/dev/null 2>&1; rc=$?
+link=/home/claude/.local/bin/codex
+if [[ ! -L $link && ! -e $link ]]; then echo "VERDICT=absent rc=$rc"
+elif [[ -x $link ]]; then echo "VERDICT=ok rc=$rc"
+else echo "VERDICT=dangling rc=$rc"; fi'
+
+# Runs one recipe in a namespace with the rig bound over the recipe's hardcoded
+# paths. REFUSES — loudly, and without printing anything verdict-shaped — if the
+# namespace it got back was not actually rigged.
+run_recipe() {
+  local root="$1" script="$2" out
+  printf '%s\n' "$script" >"$root/recipe.sh"
+  { rig_preamble "$root"; printf '%s\n' "$drive_tail"; } >"$root/drive.sh"
+  out="$("${UNSHARE[@]}" bash "$root/drive.sh" 2>"$root/drive.err")" || true
+  [[ "$out" =~ ^VERDICT=(ok|dangling|absent)\ rc=[0-9]+$ ]] || {
+    echo "FAIL: the rig did not build under '${UNSHARE[*]}' — refusing to emit a verdict from an unrigged namespace" >&2
+    echo "      driver stdout: [${out:-<empty>}]" >&2
+    echo "      driver stderr: [$(tr '\n' ' ' <"$root/drive.err")]" >&2
+    exit 1
+  }
+  printf '%s\n' "$out"
+}
+
+# Environment guard: pick the first launcher under which a rig ACTUALLY BUILDS.
+# Not "is unshare permitted" — that question is answered YES on a GitHub runner,
+# where the rig then failed to build anyway.
+rig_reasons=()
+for cand in "unshare -m --map-root-user" "sudo -n unshare -m"; do
+  read -r -a UNSHARE <<<"$cand"
+  build_rig "$TMP/preflight"
+  { rig_preamble "$TMP/preflight"; printf 'echo RIGOK\n'; } >"$TMP/preflight/drive.sh"
+  pf="$("${UNSHARE[@]}" bash "$TMP/preflight/drive.sh" 2>&1)" || true
+  [[ "$pf" == *RIGOK ]] && break
+  rig_reasons+=("$cand -> ${pf:-<no output>}")
+  UNSHARE=()
+done
+if (( ${#UNSHARE[@]} == 0 )); then
+  echo "SKIP: codex locator behavioural arm — no launcher could build the mount-namespace rig; static arms only" >&2
+  printf '  tried: %s\n' "${rig_reasons[@]}" >&2
+  exit 0
+fi
+
+# --- rig-integrity arm ------------------------------------------------------
+# The refusal above is the only thing standing between a broken rig and a
+# verdict-shaped string, and iteration 2 proved that gap is not hypothetical.
+# Grade the refusal by BREAKING a rig on purpose: remove the bind source, so the
+# driver hits `fail bind-nvm` exactly where the runner hit "mount point does not
+# exist". The driver must refuse, name the reason, and emit no VERDICT at all.
+integrity_root="$TMP/rigfail"; build_rig "$integrity_root"; rm -rf "$integrity_root/nvm"
+if rigfail_out="$(run_recipe "$integrity_root" "$recipe" 2>&1)"; then
+  echo "FAIL: driver emitted a verdict from a rig that did not build ($rigfail_out)" >&2
+  exit 1
+fi
+[[ "$rigfail_out" == *"refusing to emit a verdict from an unrigged namespace"* ]] || {
+  echo "FAIL: driver failed on a broken rig but did not name it as a rig failure ($rigfail_out)" >&2
+  exit 1
+}
+[[ "$rigfail_out" == *"RIGFAIL=bind-nvm"* ]] || {
+  echo "FAIL: expected the driver to stop at the failed bind; got ($rigfail_out)" >&2
+  exit 1
+}
+[[ "$rigfail_out" != *"VERDICT="* ]] || {
+  echo "FAIL: the refusal still leaked a verdict-shaped string ($rigfail_out)" >&2
+  exit 1
+}
+echo "PASS: driver refuses, names the failed rig step, and emits no VERDICT when the rig does not build"
 
 build_rig "$TMP/red";   red="$(run_recipe "$TMP/red" "$old_recipe")"
 build_rig "$TMP/green"; green="$(run_recipe "$TMP/green" "$recipe")"

--- a/tests/codex_install_node24_unit.sh
+++ b/tests/codex_install_node24_unit.sh
@@ -54,8 +54,11 @@ echo "PASS: codex install recipe provisions Node 24 before Codex"
 # reported success but bin still missing" on a box where codex works.
 # ---------------------------------------------------------------------------
 
+ln_stmt='ln -sfn "$(npm prefix -g)/bin/codex" /home/claude/.local/bin/codex'
+assert_tail=' && [[ -x /home/claude/.local/bin/codex ]]; }'
+
 # The shipping locator asks the npm that performed the install.
-[[ "$recipe" == *'ln -sfn "$(npm prefix -g)/bin/codex" /home/claude/.local/bin/codex'* ]] || {
+[[ "$recipe" == *"$ln_stmt"* ]] || {
   echo "FAIL: codex symlink must target \$(npm prefix -g)/bin/codex — the npm that installed it" >&2
   exit 1
 }
@@ -65,8 +68,24 @@ echo "PASS: codex install recipe provisions Node 24 before Codex"
   exit 1
 }
 # A dangling link must fail the recipe instead of being reported as success.
-[[ "$recipe" == *'&& [[ -x /home/claude/.local/bin/codex ]]'* ]] || {
-  echo "FAIL: recipe must assert the symlink resolves before reporting success" >&2
+#
+# DIVE-2596 iteration 1 shipped this arm as a bare `*'&& [[ -x …codex ]]'*`
+# substring test and it graded NOTHING: the recipe opens with
+# `{ [[ -z "${FORCE_INSTALL:-}" ]] && [[ -x /home/claude/.local/bin/codex ]]; }`
+# — the FORCE_INSTALL short-circuit — which contains that substring verbatim.
+# The pattern was therefore satisfied by the PRE-FIX recipe, and deleting the
+# real trailing assert left the harness green. An unanchored substring arm
+# cannot distinguish two identical substrings in one string; anchor it by
+# POSITION and by COUNT.
+[[ "$recipe" == *"$ln_stmt$assert_tail" ]] || {
+  echo "FAIL: recipe must END with the symlink followed by '$assert_tail' — assert the link resolves before reporting success" >&2
+  exit 1
+}
+# Second, independent anchor: the -x test must appear TWICE (short-circuit +
+# trailing assert). Counted off the raw string, not a deduped view.
+n_asserts="$(grep -o -F -- '[[ -x /home/claude/.local/bin/codex ]]' <<<"$recipe" | wc -l)"
+(( n_asserts == 2 )) || {
+  echo "FAIL: expected 2 occurrences of the -x test (FORCE_INSTALL short-circuit + trailing assert), found $n_asserts" >&2
   exit 1
 }
 # The -x short-circuit stays FIRST. `nvm install 24` resolves 24 against the
@@ -107,8 +126,19 @@ old_recipe='{ [[ -z "${FORCE_INSTALL:-}" ]] && [[ -x /home/claude/.local/bin/cod
 # Rig: fake nvm SELECTS one prefix; fake npm reports and installs into ANOTHER.
 # Reproduces the measured divergence (nvm which 24 -> v24.19.0, npm prefix -g ->
 # v24.18.0) without needing two real node builds.
+#
+# `lands=no` is the second rig: npm reports the SAME prefix and exits 0 having
+# put no codex under it. The locator is then correct and the link still
+# dangles — which is the shape the trailing -x assert exists to catch, and the
+# only rig on which a no-assert recipe is distinguishable from the shipping one
+# (with a correct locator and a real install, both always resolve).
 build_rig() {
-  local root="$1"
+  local root="$1" lands="${2:-yes}" install_body
+  if [[ "$lands" == yes ]]; then
+    install_body="printf '#!/bin/sh\necho codex\n' > \"$root/prefix/bin/codex\"; chmod +x \"$root/prefix/bin/codex\""
+  else
+    install_body=":"
+  fi
   rm -rf "$root"; mkdir -p "$root"/{nvm,localbin,selected/bin,prefix/bin,path}
   cat >"$root/nvm/nvm.sh" <<RIG
 nvm() {
@@ -122,8 +152,7 @@ RIG
 #!/usr/bin/env bash
 case "\$1 \$2" in
   "prefix -g") echo "$root/prefix" ;;
-  "install -g") printf '#!/bin/sh\necho codex\n' > "$root/prefix/bin/codex"
-                chmod +x "$root/prefix/bin/codex" ;;
+  "install -g") $install_body ;;
 esac
 RIG
   chmod +x "$root/path/npm"
@@ -171,3 +200,40 @@ echo "  SHIPPING recipe -> $green"
   exit 1
 }
 echo "PASS: pre-fix locator dangles at rc=0; shipping locator resolves"
+
+# --- assert-half arm: the -x assert graded by its EFFECT, not its presence ---
+# The two arms above cover the LOCATOR half. Neither covers the trailing -x
+# assert behaviourally: on the rig above the shipping locator always resolves,
+# so a recipe with the assert and a recipe without it produce the same verdict.
+# Grade it on the rig where the locator is RIGHT and the binary is still absent
+# from the prefix — then the assert is the only thing standing between rc=0 and
+# an honest failure.
+#
+# The mutant is DERIVED from the shipping recipe by removing exactly the assert,
+# never hand-written: a hand-written twin grades a string this repo does not
+# ship. The round-trip check below proves the removal is the only difference.
+noassert_recipe="${recipe%"$assert_tail"}; }"
+[[ "${noassert_recipe%'; }'}$assert_tail" == "$recipe" ]] || {
+  echo "FAIL: could not derive the no-assert twin by removing exactly '$assert_tail'; the differential below would grade the wrong mutation" >&2
+  exit 1
+}
+
+build_rig "$TMP/ship_noland" no; ship_noland="$(run_recipe "$TMP/ship_noland" "$recipe")"
+build_rig "$TMP/mut_noland"  no; mut_noland="$(run_recipe "$TMP/mut_noland" "$noassert_recipe")"
+echo "  SHIPPING  recipe, npm lands nothing -> $ship_noland"
+echo "  NO-ASSERT twin,   npm lands nothing -> $mut_noland"
+
+# Liveness: without the assert the recipe reports SUCCESS on a dangling link —
+# verbatim the "install reported success but bin still missing" shape this
+# ticket is about. If this is not rc=0 the rig is not exercising the assert and
+# the shipping verdict below is vacuous.
+[[ "$mut_noland" == "VERDICT=dangling rc=0" ]] || {
+  echo "FAIL: no-assert twin did not exit 0 on a dangling link ($mut_noland); this arm is not grading the -x assert" >&2
+  exit 1
+}
+# The differential: same rig, same locator, assert present -> non-zero rc.
+[[ "$ship_noland" == VERDICT=dangling* && "$ship_noland" != *"rc=0"* ]] || {
+  echo "FAIL: shipping recipe reported success on a dangling link ($ship_noland); the trailing -x assert is not doing its job" >&2
+  exit 1
+}
+echo "PASS: -x assert turns a dangling link into a non-zero rc (no-assert twin: rc=0)"

--- a/tests/codex_install_node24_unit.sh
+++ b/tests/codex_install_node24_unit.sh
@@ -36,3 +36,138 @@ npm_pos="${recipe%%npm install -g @openai/codex@latest*}"
 }
 
 echo "PASS: codex install recipe provisions Node 24 before Codex"
+
+# ---------------------------------------------------------------------------
+# DIVE-2596 — LOCATOR. Folded in here rather than shipped as a 218th harness
+# file: the core tier is over its 300s cap, and the budget guard's first
+# preference is to merge by subject. Same subject (the codex install recipe),
+# same `source src/header.sh`, no assertion dropped.
+#
+# Provisioning the right node is only half the recipe. The other half is
+# locating the binary it just installed, and the recipe got that wrong: it
+# aimed the ~/.local/bin/codex symlink at `dirname $(nvm which 24)` — which
+# node nvm SELECTED — while npm installed codex under the node that was
+# RUNNING npm. Those diverge whenever ~/.local/bin holds a stale `node`
+# symlink (the openclaw recipe plants one), because ~/.local/bin precedes
+# nvm's bin dir on PATH and npm is a `#!/usr/bin/env node` script. The link
+# then dangles, the recipe still exits 0, and create aborts with "install
+# reported success but bin still missing" on a box where codex works.
+# ---------------------------------------------------------------------------
+
+# The shipping locator asks the npm that performed the install.
+[[ "$recipe" == *'ln -sfn "$(npm prefix -g)/bin/codex" /home/claude/.local/bin/codex'* ]] || {
+  echo "FAIL: codex symlink must target \$(npm prefix -g)/bin/codex — the npm that installed it" >&2
+  exit 1
+}
+# The pre-fix locator must be GONE, not merely unused: a string survives dead code.
+[[ "$recipe" != *'dirname "$(nvm which 24)"'* ]] || {
+  echo "FAIL: codex symlink still derived from 'nvm which 24' (DIVE-2596)" >&2
+  exit 1
+}
+# A dangling link must fail the recipe instead of being reported as success.
+[[ "$recipe" == *'&& [[ -x /home/claude/.local/bin/codex ]]'* ]] || {
+  echo "FAIL: recipe must assert the symlink resolves before reporting success" >&2
+  exit 1
+}
+# The -x short-circuit stays FIRST. `nvm install 24` resolves 24 against the
+# REMOTE and downloads a brand-new v24 whenever upstream cuts one (measured:
+# it pulled v24.19.0 onto a host that had v24.18.1), so an already-installed
+# codex must not drag a node download onto every create.
+[[ "${recipe#"${recipe%%[![:space:]]*}"}" == '{ [[ -z "${FORCE_INSTALL:-}" ]] && [[ -x /home/claude/.local/bin/codex ]]; } ||'* ]] || {
+  echo "FAIL: the -x short-circuit must precede the nvm/npm work" >&2
+  exit 1
+}
+echo "PASS: codex locator targets the installing npm's prefix and asserts it resolves"
+
+# --- behavioural arm --------------------------------------------------------
+# Static assertions cannot tell a working locator from a broken one. Run the
+# REAL recipe under a rig where the two locators disagree, and run the PRE-FIX
+# locator through the SAME rig as a red anchor — a green here with no red
+# anchor would also pass on a rig that cannot fail.
+#
+# The recipe hardcodes /home/claude/.nvm and /home/claude/.local/bin, so the rig
+# needs a mount namespace. Where that is not permitted, SKIP LOUDLY: a silent
+# skip reads as coverage this harness did not provide.
+if unshare -m --map-root-user true 2>/dev/null; then
+  UNSHARE=(unshare -m --map-root-user)
+elif sudo -n unshare -m true 2>/dev/null; then
+  UNSHARE=(sudo -n unshare -m)
+else
+  echo "SKIP: codex locator behavioural arm (no usable 'unshare -m'; static arms only)" >&2
+  exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# The PRE-FIX locator, verbatim from before DIVE-2596, so the red anchor grades
+# the shape that actually shipped rather than a paraphrase of it.
+old_recipe='{ [[ -z "${FORCE_INSTALL:-}" ]] && [[ -x /home/claude/.local/bin/codex ]]; } || { . /home/claude/.nvm/nvm.sh && nvm install 24 >/dev/null && npm install -g @openai/codex@latest && mkdir -p /home/claude/.local/bin && ln -sfn "$(dirname "$(nvm which 24)")/codex" /home/claude/.local/bin/codex; }'
+
+# Rig: fake nvm SELECTS one prefix; fake npm reports and installs into ANOTHER.
+# Reproduces the measured divergence (nvm which 24 -> v24.19.0, npm prefix -g ->
+# v24.18.0) without needing two real node builds.
+build_rig() {
+  local root="$1"
+  rm -rf "$root"; mkdir -p "$root"/{nvm,localbin,selected/bin,prefix/bin,path}
+  cat >"$root/nvm/nvm.sh" <<RIG
+nvm() {
+  case "\$1 \$2" in
+    "which 24") echo "$root/selected/bin/node" ;;
+    *) return 0 ;;
+  esac
+}
+RIG
+  cat >"$root/path/npm" <<RIG
+#!/usr/bin/env bash
+case "\$1 \$2" in
+  "prefix -g") echo "$root/prefix" ;;
+  "install -g") printf '#!/bin/sh\necho codex\n' > "$root/prefix/bin/codex"
+                chmod +x "$root/prefix/bin/codex" ;;
+esac
+RIG
+  chmod +x "$root/path/npm"
+  # The SELECTED prefix has a node but no codex — that is the whole point.
+  printf '#!/bin/sh\necho node\n' >"$root/selected/bin/node"
+  chmod +x "$root/selected/bin/node"
+}
+
+# Runs one recipe in a namespace with the rig bound over the hardcoded paths.
+run_recipe() {
+  local root="$1" script="$2"
+  printf '%s\n' "$script" >"$root/recipe.sh"
+  cat >"$root/drive.sh" <<RIG
+set -u
+mount --bind "$root/nvm" /home/claude/.nvm
+mount --bind "$root/localbin" /home/claude/.local/bin
+export PATH="$root/path:/usr/bin:/bin"
+bash "$root/recipe.sh" >/dev/null 2>&1; rc=\$?
+link=/home/claude/.local/bin/codex
+if [[ ! -L \$link && ! -e \$link ]]; then echo "VERDICT=absent rc=\$rc"
+elif [[ -x \$link ]]; then echo "VERDICT=ok rc=\$rc"
+else echo "VERDICT=dangling rc=\$rc"; fi
+RIG
+  "${UNSHARE[@]}" bash "$root/drive.sh"
+}
+
+build_rig "$TMP/red";   red="$(run_recipe "$TMP/red" "$old_recipe")"
+build_rig "$TMP/green"; green="$(run_recipe "$TMP/green" "$recipe")"
+echo "  PRE-FIX  recipe -> $red"
+echo "  SHIPPING recipe -> $green"
+
+# Red anchor: the rig must reproduce the bug, or the green below is vacuous.
+[[ "$red" == VERDICT=dangling* ]] || {
+  echo "FAIL: rig did not reproduce the dangling link on the PRE-FIX recipe ($red); the green verdict would be vacuous" >&2
+  exit 1
+}
+# ...and it reported SUCCESS while dangling. That is the half the -x assert
+# fixes, and it is why the downstream error described the wrong object.
+[[ "$red" == *"rc=0"* ]] || {
+  echo "FAIL: expected the PRE-FIX recipe to exit 0 despite the dangling link ($red)" >&2
+  exit 1
+}
+[[ "$green" == VERDICT=ok* ]] || {
+  echo "FAIL: shipping recipe did not produce a resolvable ~/.local/bin/codex ($green)" >&2
+  exit 1
+}
+echo "PASS: pre-fix locator dangles at rc=0; shipping locator resolves"


### PR DESCRIPTION
The codex install recipe aimed `~/.local/bin/codex` at `$(dirname $(nvm which 24))/codex`, while npm installed the binary under whatever node was **running npm**. Those diverge because `~/.local/bin` holds a stale node symlink earlier on `PATH` than anything `nvm use` edits.

Result: the symlink dangles, **the recipe still exits 0**, and `agent create --type=codex` aborts with *"install reported success but bin still missing"* on a box where codex works fine.

Fix: locate via `$(npm prefix -g)/bin/codex` — ask the process that **did** the install, not the one that chose it — plus a trailing `-x` assert so a dangling link fails honestly instead of exiting 0.

## Evidence, and what it is NOT

**The unit harness is the evidence.** `tests/codex_install_node24_unit.sh`, mutation-graded, including the escape olivia caught in review at iteration 1.

**Smoke was run and bought zero evidence about this change. Stating that plainly rather than implying a pass this row never got.** `SMOKE_OSS_CLI_DIR` appears twice in `test-vm.sh` — once to tar/scp the tree, once in a skip message — and the only consumer of the uploaded bundle is the `install-idempotency` row, which grades `install.sh`. Every other row, **`install-codex` included**, runs `sudo 5dive agent install <type>` against the CLI **already installed on the box**: the released build.

So the run produced:

```
OK   install-codex        17s   ← graded the RELEASED recipe, i.e. the bug this PR fixes
FAIL install-idempotency         ← the only row that read the tree
```

**The green row is the problem, not the red one.** A row named after this exact subject reported success about an artifact that cannot contain the change. That is this ticket's own shape one level up — a success code decoupled from its effect — reproduced by the harness meant to catch it.

The red row is correct behaviour and unrelated: an unreleased tree stamps `FIVE_VERSION=0.0.0-dev`, the box runs a real release, and DIVE-2042's downgrade guard refuses at rerun 1 of 3, so the tree never lands. Any unmerged branch trips it identically; this diff touches no versioning code.

Harness gap filed as **DIVE-2636**. Re-smoking as wired would cost another Hetzner box for a guaranteed zero return, so this merges on the unit harness and smokes after a release stamps a real version.

## Provenance

Authored by **dev**. Reviewed by **olivia** (iteration 1 passed the product fix, bounced one ungraded half of the harness; iteration 2 is test-only — `src/header.sh` byte-identical to the commit she verified, confirmed: `aadbf50..561632b` touches one file, `tests/codex_install_node24_unit.sh`, +72/-6).

Pushed and merged by **main**. dev held the push deliberately: filing the push-for-review gate rewrites `assignee` to the filer, which clears the `handoff: delivered` line and pulls the row out of olivia's queue mid-review (DIVE-2619). Pushing directly avoids mutating the handoff at all, so olivia's review survives and the iteration count stays honest rather than inflating to a third "rejection" that never happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update — iteration 3: the evidence is no longer host-bound

The first CI run went **red**, and correctly: the rig bind-mounts `/home/claude/.nvm` and `/home/claude/.local/bin`, which do not exist on a GitHub runner. Both mounts failed, both arms returned `VERDICT=absent`, and **the harness refused to emit a verdict** — `the green verdict would be vacuous`. It detected that its own control had stopped discriminating rather than passing quietly.

**My proposed fix was wrong and would have been worse than the bug.** I suggested deriving the path from `${HOME}`. But `/home/claude` is hardcoded in the *recipe under test* (`TYPE_INSTALL[codex]`), so a rig mounted at `/home/runner/.local/bin` sits where the recipe never looks: the mounts would succeed, the errors would stop, and it would grade the same unrigged universe **only quieter**. Deriving the path fixes the mount and breaks the measurement.

dev's fix instead **builds** `/home/claude` inside the namespace — tmpfs over `/home`, `mkdir`, then bind — done *unconditionally*, because an "if it doesn't exist" guard would let this box keep taking the borrow branch and preserve the host dependence.

Now measured on the runner, in both `changed-harnesses` and `test-installed-host`:

```
PRE-FIX  recipe -> VERDICT=dangling rc=0
SHIPPING recipe -> VERDICT=ok      rc=0
SHIPPING  recipe, npm lands nothing -> VERDICT=dangling rc=1
NO-ASSERT twin,   npm lands nothing -> VERDICT=dangling rc=0
```

The first pair proves the locator change; the second grades the `-x` assert independently — a dangling link exits non-zero only because the assert is there.

Two integrity holes olivia named are also closed: the driver now **refuses**, printing nothing verdict-shaped, if any rig step fails; and the environment guard builds a rig and checks it reports `RIGOK` rather than asking "is `unshare` permitted", which answers *yes* on a runner and is exactly how the unrigged run got through.

Mutants red for locator-revert, assert-delete, short-circuit-removal and refusal-weakening. Removing the tmpfs synthesis degrades to a **loud SKIP, not a false pass**.

`src/header.sh` remains untouched from the blob olivia passed at iteration 1, so no new smoke is owed — and per DIVE-2636 smoke grades `src/` changes not at all.

Compiled: `community/wiki/a-rig-must-build-the-hardcoded-path-not-relocate-to-an-equivalent-one.md`.
