### PR TITLE
fix(help): heartbeat on's /clear claim was backwards (DIVE-2360)

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -226,7 +226,7 @@ Org chart (who reports to whom):
   # full surface: 5dive org --help
 
 Heartbeat (wake an agent only when it has queued tasks, one per tick):
-  5dive heartbeat on  <name> [--every=<dur>] [--no-fresh]   # enrol (default 30m, /clear before each task)
+  5dive heartbeat on  <name> [--every=<dur>] [--fresh]      # enrol (default 30m, fresh off: no /clear between tasks)
   5dive heartbeat off <name>
   5dive heartbeat ls                                        # enrolled agents + next-wake + queued count
   5dive heartbeat tick                                      # cron driver (root); wakes due agents that have work


### PR DESCRIPTION
The long help line claimed `heartbeat on` runs `/clear` before each task. **It does the opposite by default.**

```diff
-  5dive heartbeat on <name> [--every=<dur>] [--no-fresh]  # enrol (default 30m, /clear before each task)
+  5dive heartbeat on <name> [--every=<dur>] [--fresh]     # enrol (default 30m, fresh off: no /clear between tasks)
```

Verified in source and against the running fleet, not just read:

| | |
|---|---|
| `cmd_heartbeat.sh:388` | `local name="" every="" fresh="false"` — **no** clear by default |
| `_HB_DEFAULT_EVERY=30` | the interval half was correct |
| `heartbeat ls` (live) | `warm-mark  30m  FRESH=no` — the default-enrolled case |

## Why the flag name changed too

The original advertised `--no-fresh`. Since the default is *already* `fresh=false`, **`--no-fresh` is the flag that does nothing** and `--fresh` is the one that changes behaviour. Fixing only the parenthetical would have left the line recommending the inert flag — the same defect one word over. It now also agrees with the short usage at `cmd_heartbeat.sh:399`, which already printed `[--fresh]`.

## Why a one-line doc fix is worth a commit

Found while answering a **real customer** who asked whether the dashboard's "Turn on for all N" button matches the CLI. It does — both write 30m/no-fresh. The help text was the only thing in that loop saying otherwise, so the documentation was the sole source of a wrong answer to a paying user.

The default is also load-bearing beyond docs: `main` and `marketing` must stay non-fresh, and the live table shows both at 15m/no. Anyone who read this line and "corrected" our enrolment to match it would have broken two agents. **The wrong text was one confident edit away from causing an incident.**

Found by marketing, fixed by dev2, reviewed and merged by main (dev2 holds no gh credential).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
