### PR TITLE
fix(byo): repoint 6 BYO default-model pins at ids their own provider catalog lists (DIVE-2628, DIVE-2631)

### DIFF
--- a/src/header.sh
+++ b/src/header.sh
@@ -747,15 +747,25 @@ declare -A HERMES_PROVIDER_MODEL=(
   [openrouter]="openrouter/auto"
 )
 declare -A OPENCLAW_PROVIDER_MODEL=(
-  [openai]="openai/gpt-4o"
+  # Grade a pin here with `openclaw models list --provider <native> --plain`,
+  # NEVER with `--all`: `--all` is a SUBSET that omits the openai/ and google/
+  # namespaces entirely, and reading that omission as "no oracle" is what left
+  # [openai] and [google] ungraded until DIVE-2631. The per-provider list is the
+  # same static catalog (byte-identical to --all on `anthropic`, and unchanged
+  # with the network cut, so it cannot flap).
+  #
+  # And do NOT settle one of these against a DIFFERENT tool's catalog: models.dev
+  # — which hermes itself prefers at runtime — lists both the old openai/gpt-4o
+  # and the old google/gemini-2.0-flash as PRESENT. A cross-oracle read would
+  # have cleared two genuinely stale pins. Only the list that resolves the pin
+  # has authority over it (DIVE-2631).
+  #
+  # Measured on openclaw 2026.7.1-2: openai carries no gpt-4 family at all (20
+  # ids, starting at gpt-5.3), google carries only 2.5.x/3.x (7 ids), moonshot
+  # only k2.6 / k2.7-code, deepseek only chat / reasoner (DIVE-2628, DIVE-2631).
+  [openai]="openai/gpt-5.6"
   [anthropic]="anthropic/claude-sonnet-5"
-  # openclaw's catalog is namespace-qualified and it enumerates no `google/`
-  # lines at all, so [google] cannot be graded by that oracle and is left as it
-  # is — an absence there means nothing (DIVE-2626). deepseek/moonshot ARE
-  # enumerated, and both pins below were absent from their own namespace until
-  # DIVE-2628 (openclaw 2026.7.1-2: moonshot carries only k2.6 / k2.7-code,
-  # deepseek only chat / reasoner).
-  [google]="google/gemini-2.0-flash"
+  [google]="google/gemini-3.5-flash"
   [deepseek]="deepseek/deepseek-chat"
   [moonshot]="moonshot/kimi-k2.6"
   [openrouter]="openrouter/auto"

--- a/src/header.sh
+++ b/src/header.sh
@@ -694,18 +694,35 @@ declare -A HERMES_PROVIDER_MODEL=(
   # `novita`, and DOTTED as claude-sonnet-4.5 under `copilot` and `novita`.
   # So a grep is blind twice over: wrong provider, and wrong spelling of the
   # same model. See DIVE-2607.
+  #
+  # And hermes has TWO catalogs per provider, which disagree:
+  # curated_models_for_provider() prefers a LIVE models.dev/API fetch
+  # (provider_model_ids) and falls back to the static _PROVIDER_MODELS only when
+  # that fetch fails. `gemini` and `deepseek` are both in _MODELS_DEV_PREFERRED,
+  # so the live list is the one that resolves a BYO pin — and it is SMALLER:
+  # static deepseek carries deepseek-v4-pro, live carries only chat/reasoner.
+  # DIVE-2607 cleared deepseek-v4-pro against the weaker list. So these pins are
+  # chosen from the INTERSECTION of live and static: the pin then resolves
+  # whichever catalog wins at runtime, including with the network down.
+  # See DIVE-2628 and community/wiki/a-byo-model-pin-can-only-be-graded-off-ci.md.
   [anthropic]="claude-sonnet-5"
-  [google]="gemini-2.0-flash"
-  [deepseek]="deepseek-v4-pro"
+  [google]="gemini-3.5-flash"
+  [deepseek]="deepseek-chat"
   [moonshot]="kimi-k2-turbo-preview"
   [openrouter]="openrouter/auto"
 )
 declare -A OPENCLAW_PROVIDER_MODEL=(
   [openai]="openai/gpt-4o"
   [anthropic]="anthropic/claude-sonnet-5"
+  # openclaw's catalog is namespace-qualified and it enumerates no `google/`
+  # lines at all, so [google] cannot be graded by that oracle and is left as it
+  # is — an absence there means nothing (DIVE-2626). deepseek/moonshot ARE
+  # enumerated, and both pins below were absent from their own namespace until
+  # DIVE-2628 (openclaw 2026.7.1-2: moonshot carries only k2.6 / k2.7-code,
+  # deepseek only chat / reasoner).
   [google]="google/gemini-2.0-flash"
-  [deepseek]="deepseek/deepseek-v4-pro"
-  [moonshot]="moonshot/kimi-k2-instruct"
+  [deepseek]="deepseek/deepseek-chat"
+  [moonshot]="moonshot/kimi-k2.6"
   [openrouter]="openrouter/auto"
 )
 declare -A BYO_PROVIDER_LABEL=(

--- a/src/header.sh
+++ b/src/header.sh
@@ -760,6 +760,15 @@ declare -A OPENCLAW_PROVIDER_MODEL=(
   # have cleared two genuinely stale pins. Only the list that resolves the pin
   # has authority over it (DIVE-2631).
   #
+  # WHAT "STALE" MEANS HERE, AND WHAT IT DOES NOT. None of the replaced ids is
+  # retired upstream. Google's own v1beta still serves gemini-2.0-flash (50
+  # models, HTTP 200, queried with our key by main 2026-08-03), and models.dev
+  # still lists gpt-4o. A pin is wrong here when the list that RESOLVES it does
+  # not carry it, which is a property of the vendor agent's catalog, not of the
+  # model's lifecycle. Write it that way in any future ticket or commit: "absent
+  # from <the resolving list>, still present at <upstream>" — never "the vendor
+  # dropped it". The two get fixed differently and only one of them is our bug.
+  #
   # Measured on openclaw 2026.7.1-2: openai carries no gpt-4 family at all (20
   # ids, starting at gpt-5.3), google carries only 2.5.x/3.x (7 ids), moonshot
   # only k2.6 / k2.7-code, deepseek only chat / reasoner (DIVE-2628, DIVE-2631).


### PR DESCRIPTION
Six BYO default-model pins in src/header.sh named ids the catalog that resolves them does not carry. Four came from the DIVE-2626 checker's first live run; the other two it had been SKIPping as 'no oracle' until DIVE-2631 showed the oracle existed.

WHAT CHANGED (src/header.sh only)
  HERMES_PROVIDER_MODEL[google]     gemini-2.0-flash          -> gemini-3.5-flash
  HERMES_PROVIDER_MODEL[deepseek]   deepseek-v4-pro           -> deepseek-chat
  OPENCLAW_PROVIDER_MODEL[openai]   openai/gpt-4o             -> openai/gpt-5.6
  OPENCLAW_PROVIDER_MODEL[google]   google/gemini-2.0-flash   -> google/gemini-3.5-flash
  OPENCLAW_PROVIDER_MODEL[deepseek] deepseek/deepseek-v4-pro  -> deepseek/deepseek-chat
  OPENCLAW_PROVIDER_MODEL[moonshot] moonshot/kimi-k2-instruct -> moonshot/kimi-k2.6

WHAT 'ABSENT' MEANS, PRECISELY
No vendor retired any of these. Each old id is absent from the list that RESOLVES the pin while upstream still serves it:
- gemini-2.0-flash: absent from hermes' gemini list (14 ids, curated/live models.dev, 2026-08-03) and openclaw's google list (7 ids); PRESENT in Google's own v1beta (50 models, HTTP 200, your query).
- gpt-4o: absent from openclaw's openai list (20 ids, no gpt-4 family at all); still listed on models.dev.
- deepseek-v4-pro: absent from hermes' resolver-preferred LIVE deepseek list, PRESENT in its static _PROVIDER_MODELS. Absent from the one that resolves it.
A pin is wrong here when the resolving catalog lacks the id, which is a property of the vendor agent's catalog and not of the model's lifecycle.

HOW IT WAS GRADED
Every pin, both sides, against its own provider's list: openclaw 'models list --provider <native> --plain' (NOT --all, a subset that omits the openai/ and google/ namespaces entirely — that omission is why two pins went ungraded); hermes curated_models_for_provider(native). Every old id ABSENT, every new id PRESENT. Both hermes picks come from the INTERSECTION of the live and static catalogs, so they resolve whichever the resolver reaches, including with the network down.
Not settled cross-oracle: models.dev, the catalog hermes prefers at runtime, lists both gpt-4o and gemini-2.0-flash as PRESENT and would have cleared two genuinely stale pins.

VERIFICATION
- DIVE-2626 checker @ branch: graded=9 skipped=0 drift=0
- same checker @ origin/main: graded=9 skipped=0 drift=6 (red anchor)
- tests/hermes_openclaw_byo_model_unit.sh: 7 passed, 0 failed
- tests/byo_model_create_unit.sh: rc=0; pii-scan clean
Bound unchanged: absent-from-catalog, not observed-to-404 — no vendor key spent on a runtime resolve.

History note: the branch carries a MERGE of origin/main, not a rebase — 5dive push is a plain push and the already-pushed 3a58c0b could not be rewritten. olivia accepted this explicitly; please do not force it linear.

Authored by dev3, reviewed by olivia, opened and merged by main (dev3 holds no gh credential).
