### PR TITLE
fix(tests): pin and assert the caller identity in harnesses that were grading the host (DIVE-2601)

### DIFF
--- a/tests/gate_channel_proof_unit.sh
+++ b/tests/gate_channel_proof_unit.sh
@@ -65,6 +65,25 @@ _gate_passwd_stream() {
   printf '%s\n' "$(</etc/passwd)"
 }
 
+# DIVE-2601: ASSERT THE PIN, do not assume it. Two checks, and the first is the one
+# that is easy to leave out. The stream above names the caller from `$(id -un)` at
+# call time, so a LITERAL expectation is required here: derive the expectation from
+# `id -un` as well and an inert stub moves BOTH sides together, which is precisely
+# the failure being fixed — the assertion would agree with the host and print ok.
+# Without the pin, every arm below grades WHOEVER RAN THE SUITE: green on the box
+# where the host happens to match, 8 arms red on a CI runner (DIVE-2588).
+_pin_expect_un="root"
+_pin_who="$(id -un)"
+[[ "$_pin_who" == "$_pin_expect_un" ]] \
+  || { printf 'NOT OK - the fixture caller went INERT: `id -un` answered %s, this harness models %s\n' \
+       "'$_pin_who'" "'$_pin_expect_un'"; exit 1; }
+# ...and the pin resolved through the REAL resolver, which is what the code reads.
+if [[ "$_pin_expect_un" == agent-* ]]; then _pin_want="${_pin_expect_un#agent-}"; else _pin_want=""; fi
+_pin_got="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
+[[ "$_pin_got" == "$_pin_want" ]] \
+  || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected %s\n' \
+       "$_PIN_UID" "'$_pin_got'" "'${_pin_want:-<non-agent>}'"; exit 1; }
+
 
 seed_task() { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
 answered() { db "SELECT CASE WHEN need_answered_at IS NULL THEN 'open' ELSE 'closed' END FROM tasks WHERE ident='$1';"; }

--- a/tests/gate_channel_session_t2_unit.sh
+++ b/tests/gate_channel_session_t2_unit.sh
@@ -83,8 +83,10 @@ audit_log() { :; }
 # 1 = false = an agent-* caller contributes no sudo-uid evidence.
 _PIN_SUDO_HUMAN=1
 _gate_sudo_uid_nonagent() { return "$_PIN_SUDO_HUMAN"; }
-FAKE_CALLER="root"
-id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+# DIVE-2601: the `id -un` stub that used to sit here was measured at ZERO
+# invocations across a full run of this file — nothing asks it, so it named a
+# caller nobody read. Deleted rather than left as documentation of a control that
+# is not happening. The UID SEAM below is the whole pin.
 # ...and the UID SEAM, which is what the human-only block actually reads since
 # DIVE-2330 iteration 2 replaced its `id -un` with _gate_caller_uid (EUID). Pinning
 # only the NAME above stopped modelling the caller at that point: on an agent-*

--- a/tests/gate_lead_standing_unit.sh
+++ b/tests/gate_lead_standing_unit.sh
@@ -93,6 +93,18 @@ _gate_passwd_stream() {
   printf '%s:x:%s:%s::/nonexistent:/bin/false\n' "$(id -un)" "$_PIN_UID" "$_PIN_UID"
   printf '%s\n' "$(</etc/passwd)"
 }
+# ASSERT THE PIN THROUGH THE REAL RESOLVER (DIVE-2601 iteration 4). Every arm below
+# leans on the caller being agent-marcus, and the two overrides above are the only
+# thing making that true; if either stops being read the resolver yields '', which is
+# indistinguishable from a legitimately non-agent caller. S8b in particular asserts
+# that an EMPTY identity grants nothing — it would pass for exactly the wrong reason
+# on a dead pin, and the arms that need marcus would fail somewhere obscure instead.
+# This file was the corpus instance of the rule-(2) hole: it satisfied
+# identity_stub_guard_unit's "asserts the pin" predicate out of a TRAILING COMMENT on
+# line 359 and made no such call anywhere. Resolve it once, loudly, before any arm.
+_pin_check="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
+[[ "$_pin_check" == "marcus" ]] \
+  || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected marcus (is the actor lib in the source list?)\n' "$_PIN_UID" "'$_pin_check'"; exit 1; }
 
 
 # Org chart: marcus is the coordinator (the org lead), dev reports to marcus.

--- a/tests/gate_ship_routing_unit.sh
+++ b/tests/gate_ship_routing_unit.sh
@@ -346,6 +346,25 @@ _gate_passwd_stream() {
   printf '%s\n' "$(</etc/passwd)"
 }
 
+# DIVE-2601: ASSERT THE PIN, do not assume it. Two checks, and the first is the one
+# that is easy to leave out. The stream above names the caller from `$(id -un)` at
+# call time, so a LITERAL expectation is required here: derive the expectation from
+# `id -un` as well and an inert stub moves BOTH sides together, which is precisely
+# the failure being fixed — the assertion would agree with the host and print ok.
+# Without the pin, every arm below grades WHOEVER RAN THE SUITE: green on the box
+# where the host happens to match, 8 arms red on a CI runner (DIVE-2588).
+_pin_expect_un="agent-dev"
+_pin_who="$(id -un)"
+[[ "$_pin_who" == "$_pin_expect_un" ]] \
+  || { printf 'NOT OK - the fixture caller went INERT: `id -un` answered %s, this harness models %s\n' \
+       "'$_pin_who'" "'$_pin_expect_un'"; exit 1; }
+# ...and the pin resolved through the REAL resolver, which is what the code reads.
+if [[ "$_pin_expect_un" == agent-* ]]; then _pin_want="${_pin_expect_un#agent-}"; else _pin_want=""; fi
+_pin_got="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
+[[ "$_pin_got" == "$_pin_want" ]] \
+  || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected %s\n' \
+       "$_PIN_UID" "'$_pin_got'" "'${_pin_want:-<non-agent>}'"; exit 1; }
+
 ( cmd_task_answer DIVE-4 --value=approved --from=dev ) >/dev/null 2>&1; rc_dev=$?
 [[ "$rc_dev" != "0" && "$(answered DIVE-4)" == "open" ]] && ok_t "non-reviewer agent (dev) still blocked on routed approval" || bad_t "dev blocked" "rc=$rc_dev ans=$(answered DIVE-4)"
 # Designated lead (main) CAN clear it.

--- a/tests/gate_t2_nonce_proof_unit.sh
+++ b/tests/gate_t2_nonce_proof_unit.sh
@@ -72,10 +72,27 @@ last_nonce() { cat "$NONCE_FILE" 2>/dev/null; }
 # isolated, so open it or every row is withheld and the audit assertions pass vacuously.
 _task_human_send_allowed() { return 0; }
 
-# Only `id -un` is stubbed. _gate_authenticated_actor, _gate_route_reviewer,
+# Only the CALLER IDENTITY is pinned. _gate_authenticated_actor, _gate_route_reviewer,
 # _task_resolve_coordinator and the whole _council_* chain run for real — THEY decide.
+#
+# DIVE-2601: the pin used to be an `id -un` stub, and the derivation has not read
+# `id` since DIVE-2330 (it resolves $EUID over a passwd stream in pure bash, so a
+# PATH shim cannot forge it). Measured over a full run of this file the stub took
+# ZERO calls — "the caller is agent-marcus" was decided by whoever ran the suite.
+# The passwd fixture is derived from FAKE_CALLER at call time so the flip to
+# agent-main further down keeps working, and it is PREPENDED to the real
+# /etc/passwd so every other uid on the box still resolves.
 FAKE_CALLER="agent-marcus"
-id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+_PIN_UID=987654
+_gate_caller_uid()    { printf '%s' "$_PIN_UID"; }
+_gate_passwd_stream() {
+  printf '%s:x:%s:%s::/nonexistent:/bin/false\n' "$FAKE_CALLER" "$_PIN_UID" "$_PIN_UID"
+  printf '%s\n' "$(</etc/passwd)"
+}
+# Assert the pin through the real resolver before any arm leans on it (DIVE-2588).
+_pin_check="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
+[[ "$_pin_check" == "${FAKE_CALLER#agent-}" ]] \
+  || { printf 'NOT OK - identity pin is inert: uid %s resolved to %s, expected %s\n' "$_PIN_UID" "'$_pin_check'" "'${FAKE_CALLER#agent-}'"; exit 1; }
 
 # Org chart: marcus is the lead, dev reports to marcus.
 db "INSERT INTO agents_org (name, role, reports_to) VALUES ('marcus','coordinator',NULL);"

--- a/tests/gate_tier2_decision_nonce_unit.sh
+++ b/tests/gate_tier2_decision_nonce_unit.sh
@@ -98,6 +98,26 @@ id() {
     *)   command id "$@" ;;
   esac
 }
+#
+# DIVE-2601 + DIVE-2610, RECONCILED: BOTH pins are load-bearing and neither
+# subsumes the other. `_gate_sudo_uid_nonagent` (src/lib/tasks_db.sh) calls
+# `id -u` DIRECTLY and never routes through `_gate_caller_uid`, so the seam
+# override below does NOT cover the T6 answer path — dropping the `id -u` stub
+# reverts DIVE-2610 and reds this harness at rc=6 on any agent-* box. Conversely
+# `_gate_uid_to_agent`/`task_actor` read `_gate_caller_uid`, which the `id` stub
+# does not reach. Keep both; assert both.
+# DIVE-2601: ALSO pinned through the seam the derivation reads ($EUID via
+# `_gate_caller_uid`). The `id -un` stub alone left that derivation unpinned, so
+# the caller's agent-ness on those arms came from the host. (The original DIVE-2601
+# note said the `id` stub was dead here; DIVE-2610 measured it live on the T6 path
+# via `id -u` — it is not dead, it is merely incomplete. Both pins stay.) uid 0 is
+# root on every host and claimed by no agent-*, so no passwd fixture is needed.
+_PIN_UID=0
+_gate_caller_uid() { printf '%s' "$_PIN_UID"; }
+# Assert the pin through the real resolver before any arm depends on it.
+_pin_check="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
+[[ -z "$_pin_check" ]] \
+  || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected a NON-agent caller\n' "$_PIN_UID" "'$_pin_check'"; exit 1; }
 export SUDO_UID=0
 
 seed_task() { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }

--- a/tests/gate_tier2_decision_nonce_unit.sh
+++ b/tests/gate_tier2_decision_nonce_unit.sh
@@ -115,6 +115,18 @@ id() {
 _PIN_UID=0
 _gate_caller_uid() { printf '%s' "$_PIN_UID"; }
 # Assert the pin through the real resolver before any arm depends on it.
+# LIVENESS FIRST. The unclaimed check below FAILS OPEN: an unsourced lib/actor.sh, a
+# renamed resolver, a typo — every one arrives as '', which IS the pass value.
+# Measured on DIVE-2601 iteration 2 in gate_tier2_nonce_evidence_unit.sh, which
+# omitted lib/actor.sh: the assertion reduced to "the empty string is empty" and
+# could not fail. Probe with a SYNTHETIC passwd row in a subshell so the POSITIVE
+# case holds on any host, including a CI runner with no agent-* accounts.
+_probe="$(
+  _gate_passwd_stream() { printf 'agent-probe:x:424242:424242::/nonexistent:/bin/false\n'; }
+  _gate_uid_to_agent 424242
+)"
+[[ "$_probe" == "probe" ]] \
+  || { printf 'NOT OK - the identity resolver is not live: _gate_uid_to_agent returned %s for a synthetic agent-probe row (expected probe). Is lib/actor.sh in the source list?\n' "'$_probe'"; exit 1; }
 _pin_check="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
 [[ -z "$_pin_check" ]] \
   || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected a NON-agent caller\n' "$_PIN_UID" "'$_pin_check'"; exit 1; }

--- a/tests/gate_tier2_floor_unit.sh
+++ b/tests/gate_tier2_floor_unit.sh
@@ -70,6 +70,18 @@ _gate_caller_uid() { printf '%s' "$_PIN_UID"; }
 # ...and ASSERT the pin through the real resolver before any arm leans on it. A pin
 # that silently yields nothing would make every refusal below look correct for the
 # wrong reason — the DIVE-2588 shape. Pattern: tests/gate_enforce_env_bypass_unit.sh:127-154.
+# LIVENESS FIRST. The unclaimed check below FAILS OPEN: an unsourced lib/actor.sh, a
+# renamed resolver, a typo — every one arrives as '', which IS the pass value.
+# Measured on DIVE-2601 iteration 2 in gate_tier2_nonce_evidence_unit.sh, which
+# omitted lib/actor.sh: the assertion reduced to "the empty string is empty" and
+# could not fail. Probe with a SYNTHETIC passwd row in a subshell so the POSITIVE
+# case holds on any host, including a CI runner with no agent-* accounts.
+_probe="$(
+  _gate_passwd_stream() { printf 'agent-probe:x:424242:424242::/nonexistent:/bin/false\n'; }
+  _gate_uid_to_agent 424242
+)"
+[[ "$_probe" == "probe" ]] \
+  || { printf 'NOT OK - the identity resolver is not live: _gate_uid_to_agent returned %s for a synthetic agent-probe row (expected probe). Is lib/actor.sh in the source list?\n' "'$_probe'"; exit 1; }
 _pin_check="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
 [[ -z "$_pin_check" ]] \
   || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected a NON-agent caller\n' "$_PIN_UID" "'$_pin_check'"; exit 1; }

--- a/tests/gate_tier2_floor_unit.sh
+++ b/tests/gate_tier2_floor_unit.sh
@@ -53,10 +53,26 @@ task_need_notify() { :; }
 audit_log() { :; }
 
 # The immediate caller is a non-agent (post-sudo root / dashboard-as-claude). This
-# isolates the tier-2 provenance floor from the DIVE-394 `id -un` agent block so a
-# rejection here proves the FLOOR fired, not the caller-uid guard.
-FAKE_CALLER="root"
-id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+# isolates the tier-2 provenance floor from the DIVE-394 caller-uid agent block so a
+# rejection here proves the FLOOR fired, not that guard.
+#
+# DIVE-2601: that isolation was NOT happening. The lines here used to be
+# `FAKE_CALLER=root` plus an `id()` stub answering `-un`, and since DIVE-2330 the
+# derivation does not read `id` at all — `_gate_caller_uid` reports $EUID and
+# `_gate_passwd_stream` walks /etc/passwd in pure bash, precisely so a PATH-shimmed
+# `id` cannot answer. Measured over a full run of this file the stub took ZERO
+# calls: the "non-agent caller" the comment promised was supplied by whoever ran
+# the suite — an agent uid on a dev box, an unclaimed `runner` uid on CI. Pin the
+# seam the derivation actually reads. uid 0 needs no passwd fixture: it is root on
+# every host and no agent-* account claims it, so this is true on CI too.
+_PIN_UID=0
+_gate_caller_uid() { printf '%s' "$_PIN_UID"; }
+# ...and ASSERT the pin through the real resolver before any arm leans on it. A pin
+# that silently yields nothing would make every refusal below look correct for the
+# wrong reason — the DIVE-2588 shape. Pattern: tests/gate_enforce_env_bypass_unit.sh:127-154.
+_pin_check="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
+[[ -z "$_pin_check" ]] \
+  || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected a NON-agent caller\n' "$_PIN_UID" "'$_pin_check'"; exit 1; }
 
 seed_task() { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
 answered() { db "SELECT CASE WHEN need_answered_at IS NULL THEN 'open' ELSE 'closed' END FROM tasks WHERE ident='$1';"; }

--- a/tests/gate_tier2_nonce_evidence_unit.sh
+++ b/tests/gate_tier2_nonce_evidence_unit.sh
@@ -66,8 +66,15 @@ _human_nonce_mint() { printf '%s' "$KNOWN_NONCE"; }
 # whether the immediate (pre-sudo) caller is an agent (the forge) or not (human/box).
 FAKE_NONAGENT=1   # 1 = non-agent (human), 0 = agent (forge)
 _gate_sudo_uid_nonagent() { [[ "$FAKE_NONAGENT" == "1" ]]; }
-# Keep `id -un` a non-agent so the DIVE-394 caller-uid block never masks the result.
-id() { if [[ "${1:-}" == -un ]]; then echo "root"; else command id "$@"; fi; }
+# Keep the CALLER a non-agent so the DIVE-394 caller-uid block never masks the
+# result. DIVE-2601: this was an `id -un` stub, which the derivation has not read
+# since DIVE-2330 — measured at ZERO calls here, so the caller's agent-ness was
+# decided by whoever ran the suite. uid 0 is root everywhere and no agent claims it.
+_PIN_UID=0
+_gate_caller_uid() { printf '%s' "$_PIN_UID"; }
+_pin_check="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
+[[ -z "$_pin_check" ]] \
+  || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected a NON-agent caller\n' "$_PIN_UID" "'$_pin_check'"; exit 1; }
 
 seed()    { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
 answered(){ db "SELECT CASE WHEN need_answered_at IS NULL THEN 'open' ELSE 'closed' END FROM tasks WHERE ident='$1';"; }

--- a/tests/gate_tier2_nonce_evidence_unit.sh
+++ b/tests/gate_tier2_nonce_evidence_unit.sh
@@ -30,7 +30,7 @@ trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done
@@ -72,6 +72,21 @@ _gate_sudo_uid_nonagent() { [[ "$FAKE_NONAGENT" == "1" ]]; }
 # decided by whoever ran the suite. uid 0 is root everywhere and no agent claims it.
 _PIN_UID=0
 _gate_caller_uid() { printf '%s' "$_PIN_UID"; }
+# LIVENESS FIRST, and this is the arm iteration 2 was missing. The unclaimed check
+# below FAILS OPEN: an unsourced lib/actor.sh, a renamed resolver, a typo — every one
+# of them arrives as '', which IS the pass value. Measured: this file omitted
+# lib/actor.sh from the source list above, so `_gate_uid_to_agent` was
+# command-not-found, `_pin_check` was unconditionally empty, and the check was
+# asserting that the empty string is empty. It could not fail, and the eleven arms
+# below ran with the product's actor derivation missing underneath them.
+# The probe pins a SYNTHETIC passwd row in a subshell, so the POSITIVE case holds on
+# any host — including a CI runner where no agent-* account exists.
+_probe="$(
+  _gate_passwd_stream() { printf 'agent-probe:x:424242:424242::/nonexistent:/bin/false\n'; }
+  _gate_uid_to_agent 424242
+)"
+[[ "$_probe" == "probe" ]] \
+  || { printf 'NOT OK - the identity resolver is not live: _gate_uid_to_agent returned %s for a synthetic agent-probe row (expected probe). Is lib/actor.sh in the source list?\n' "'$_probe'"; exit 1; }
 _pin_check="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
 [[ -z "$_pin_check" ]] \
   || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected a NON-agent caller\n' "$_PIN_UID" "'$_pin_check'"; exit 1; }

--- a/tests/gate_withdraw_unit.sh
+++ b/tests/gate_withdraw_unit.sh
@@ -83,6 +83,25 @@ _gate_passwd_stream() {
   printf '%s\n' "$(</etc/passwd)"
 }
 
+# DIVE-2601: ASSERT THE PIN, do not assume it. Two checks, and the first is the one
+# that is easy to leave out. The stream above names the caller from `$(id -un)` at
+# call time, so a LITERAL expectation is required here: derive the expectation from
+# `id -un` as well and an inert stub moves BOTH sides together, which is precisely
+# the failure being fixed — the assertion would agree with the host and print ok.
+# Without the pin, every arm below grades WHOEVER RAN THE SUITE: green on the box
+# where the host happens to match, 8 arms red on a CI runner (DIVE-2588).
+_pin_expect_un="nobody"
+_pin_who="$(id -un)"
+[[ "$_pin_who" == "$_pin_expect_un" ]] \
+  || { printf 'NOT OK - the fixture caller went INERT: `id -un` answered %s, this harness models %s\n' \
+       "'$_pin_who'" "'$_pin_expect_un'"; exit 1; }
+# ...and the pin resolved through the REAL resolver, which is what the code reads.
+if [[ "$_pin_expect_un" == agent-* ]]; then _pin_want="${_pin_expect_un#agent-}"; else _pin_want=""; fi
+_pin_got="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
+[[ "$_pin_got" == "$_pin_want" ]] \
+  || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected %s\n' \
+       "$_PIN_UID" "'$_pin_got'" "'${_pin_want:-<non-agent>}'"; exit 1; }
+
 # Clean slate for the SUDO_* env the real helpers read; each case sets what it needs.
 unset SUDO_USER SUDO_UID
 

--- a/tests/identity_stub_guard_unit.sh
+++ b/tests/identity_stub_guard_unit.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# tests/identity_stub_guard_unit.sh — DIVE-2601.
+#
+# THE CLASS THIS GUARD CLOSES. Since DIVE-2330 the caller derivation does not read
+# `id -un`: `_gate_caller_uid` reports $EUID and `_gate_passwd_stream` walks
+# /etc/passwd in pure bash, precisely so a PATH-shimmed `id` cannot answer the
+# question "who is calling?". Every harness that still stubs the `-un` branch of
+# `id` therefore controls NOTHING — and it does not fail when it stops working. It
+# goes quiet and keeps voting PASS while the answer comes from the uid of whoever
+# ran the suite. DIVE-2588 is the worst case on record: 19/19 green on an agent box,
+# 8 arms red on the CI runner, and the property the file claimed to grade had not
+# been graded on either.
+#
+# THE RULE. A harness whose `id()` stub answers `-un` is making an identity claim.
+# It must (1) pin the seams the derivation actually reads, and (2) assert the pin
+# took effect THROUGH the real resolver before any arm leans on it. (2) is the part
+# that converts this whole class from silent to loud: a pin that yields '' makes
+# every "refused" arm below look correct for the wrong reason.
+#
+# WHY A CORPUS GUARD RATHER THAN 13 FIXES. The 13 were fixed (DIVE-2601). The next
+# one gets written next week by someone who has not read this file, and the failure
+# mode is silence — nothing in a code review distinguishes a green arm that grades
+# something from a green arm that grades nothing.
+#
+# SELF-EXCLUSION, and it is not a formality. A corpus-wide checker matches its own
+# pattern: this file must talk about `id()` stubs in order to look for them. The
+# scan therefore skips its own basename, and arm A3 below proves the skip works by
+# scanning a COPY of this file — because a self-exclusion that silently stopped
+# working would make the guard flag itself forever, and a self-exclusion that was
+# never needed would leave A3 passing vacuously. See
+# community/wiki/a-consistency-check-cannot-see-a-substitution-that-rewrote-both-sides.md
+
+set -u
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+SELF="$(basename "${BASH_SOURCE[0]}")"
+
+# Harnesses allowed to answer `-un` without pinning the seams, each with the reason
+# it is deliberate. Keep this list short and keep the reasons true: an entry here is
+# a claim that the file's `id -un` is read by production code that genuinely still
+# calls `id -un`, or that the file is testing `id` itself.
+declare -A ALLOW=(
+  [proof_identity_guard_unit.sh]='_proof_identity in cmd_proof.sh genuinely still reads `id -un`; this file is its test'
+)
+
+# _scan_identity_stubs <dir> — print one `<file>\t<reason>` line per violation.
+#
+# Taking the directory as an argument is what makes this testable: the same code
+# that grades tests/ grades the synthetic fixtures in A1-A3 below. A guard that can
+# only be pointed at the real corpus can only be graded by the corpus being clean,
+# which is indistinguishable from the guard being broken.
+_scan_identity_stubs() {
+  local dir="$1" f base
+  for f in "$dir"/*.sh; do
+    [[ -e "$f" ]] || continue
+    base="$(basename "$f")"
+    [[ "$base" == "$SELF" ]] && continue                    # self-exclusion (A3)
+    [[ -n "${ALLOW[$base]:-}" ]] && continue
+    # Only an `id()` stub that ANSWERS -un is making an identity claim. A stub that
+    # only handles `id -u` (deploy_unit, agent_git_identity_unit) is pinning a
+    # numeric uid for a different guard and is out of scope.
+    grep -qE '^[[:space:]]*id\(\)' "$f" || continue
+    grep -qE '^[[:space:]]*id\(\).*\-un' "$f" \
+      || grep -qzE 'id\(\)[[:space:]]*\{[^}]*\-un' "$f" || continue
+    # (1) the seams the derivation actually reads must be pinned
+    if ! grep -qE '^[[:space:]]*_gate_(caller_uid|passwd_stream)\(\)|actor_seam_as' "$f"; then
+      printf '%s\tstubs `id -un` but never pins _gate_caller_uid/_gate_passwd_stream — the caller identity comes from the HOST\n' "$base"
+      continue
+    fi
+    # (2) and the pin must be asserted through the real resolver
+    if ! grep -qE '_gate_authenticated_actor|_gate_uid_to_agent|actor_seam_selftest' "$f"; then
+      printf '%s\tpins the identity seams but never asserts the pin through the real resolver (_gate_authenticated_actor / _gate_uid_to_agent / actor_seam_selftest)\n' "$base"
+    fi
+  done
+}
+
+FIX='tests/gate_enforce_env_bypass_unit.sh:127-154 is the in-tree pattern to copy'
+
+# ── A1 positive control: a violating fixture MUST be flagged ──────────────────
+# Without this the whole file could be a no-op that reports a clean corpus.
+TMP="$(mktemp -d /tmp/identity-stub-guard.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+cat > "$TMP/violator_unit.sh" <<'EOF'
+FAKE_CALLER="root"
+id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+EOF
+got="$(_scan_identity_stubs "$TMP")"
+[[ "$got" == violator_unit.sh*never\ pins* ]] \
+  && ok_t "A1 a harness that stubs \`id -un\` with no seam pin is flagged" \
+  || bad_t "A1 violating fixture is flagged" "scan returned '${got:-<nothing>}' — the guard cannot see the defect it exists for, so a clean corpus below would prove nothing"
+
+# ── A2 the second half of the rule: pinned but unasserted is still a violation ─
+cat > "$TMP/violator_unit.sh" <<'EOF'
+FAKE_CALLER="root"
+id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+_gate_caller_uid() { printf 0; }
+EOF
+got="$(_scan_identity_stubs "$TMP")"
+[[ "$got" == *"never asserts the pin"* ]] \
+  && ok_t "A2 a pinned-but-unasserted harness is flagged (the DIVE-2588 shape)" \
+  || bad_t "A2 pinned-but-unasserted is flagged" "scan returned '${got:-<nothing>}' — a pin that silently yields nothing would pass this guard"
+
+# ── A2b negative control: the compliant shape is NOT flagged ──────────────────
+cat > "$TMP/violator_unit.sh" <<'EOF'
+FAKE_CALLER="root"
+id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+_gate_caller_uid() { printf 0; }
+_pin=$(_gate_uid_to_agent "$(_gate_caller_uid)")
+EOF
+got="$(_scan_identity_stubs "$TMP")"
+[[ -z "$got" ]] \
+  && ok_t "A2b the compliant shape (pin + assertion) is not flagged" \
+  || bad_t "A2b compliant fixture passes" "scan flagged it: '$got' — a guard that rejects the fix it demands cannot be satisfied"
+
+# ── A3 self-exclusion actually works, and is load-bearing ────────────────────
+# This file necessarily contains the pattern it hunts for. The pair below is what
+# makes the skip observable: IDENTICAL BYTES, one under this file's basename and
+# one under another. Copying the real guard would not do it — the guard also
+# mentions `_gate_caller_uid` and `_gate_authenticated_actor` in its own greps, so
+# it reads as COMPLIANT and A3 would pass whether or not the skip exists. The
+# fixture is therefore a known violator wearing the guard's name.
+rm -f "$TMP"/*.sh
+cat > "$TMP/$SELF" <<'EOF'
+FAKE_CALLER="root"
+id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+EOF
+got="$(_scan_identity_stubs "$TMP")"
+[[ -z "$got" ]] \
+  && ok_t "A3 the guard skips its own basename (a checker matches its own pattern)" \
+  || bad_t "A3 self-exclusion" "the guard flags its own basename: '$got'"
+mv "$TMP/$SELF" "$TMP/not_the_guard_unit.sh"
+got="$(_scan_identity_stubs "$TMP")"
+[[ -n "$got" ]] \
+  && ok_t "A3b the self-exclusion is load-bearing (same bytes, other name, flagged)" \
+  || bad_t "A3b self-exclusion is load-bearing" "the same bytes are not flagged under another name, so A3 passed for free and proves nothing"
+
+# ── A4 the real corpus ────────────────────────────────────────────────────────
+rm -f "$TMP"/*.sh
+mapfile -t viol < <(_scan_identity_stubs tests)
+if (( ${#viol[@]} == 0 )); then
+  ok_t "A4 no harness in tests/ stubs \`id -un\` without a pinned, asserted identity"
+else
+  bad_t "A4 tests/ is free of inert identity stubs" \
+    "$(printf '%s violation(s):\n' "${#viol[@]}"; printf '     %s\n' "${viol[@]}"; printf '     %s' "$FIX")"
+fi
+
+# ── A5 the allowlist may not rot ──────────────────────────────────────────────
+# An entry naming a file that no longer exists is an allowlist nobody is reading.
+for base in "${!ALLOW[@]}"; do
+  if [[ -f "tests/$base" ]]; then
+    ok_t "A5 allowlist entry $base still exists"
+  else
+    bad_t "A5 allowlist entry $base still exists" "allowlisted file is gone — drop the entry rather than leaving a silent exemption"
+  fi
+done
+
+printf '\n%s: %d passed, %d failed\n' "$SELF" "$PASS" "$FAIL"
+(( FAIL == 0 ))

--- a/tests/identity_stub_guard_unit.sh
+++ b/tests/identity_stub_guard_unit.sh
@@ -30,11 +30,13 @@
 # never needed would leave A3 passing vacuously. See
 # community/wiki/a-consistency-check-cannot-see-a-substitution-that-rewrote-both-sides.md
 #
-# COST: 6.0s measured on the dev3 worktree (5dive-cli-wt-2601, agent-dev3). A7/A8
-# mutate and re-scan 51 real harnesses and that is nearly all of it. Stays `core`
-# deliberately: the class this catches is silent by construction — a green arm that
-# grades nothing looks exactly like a green arm that grades something — and 6s
-# against a 300s per-job budget is not the line item worth demoting.
+# COST: 9.6s measured on the dev3 worktree (5dive-cli-wt-2601, agent-dev3; three runs
+# 9.22/9.56/9.61). Up from well under a second: A7/A8 mutate and re-scan 51 real
+# harnesses, and the three construct-anchored predicates run an awk per file across
+# four passes over tests/. Stays `core` deliberately — the class this catches is
+# silent by construction (a green arm that grades nothing looks exactly like a green
+# arm that grades something) and 10s against a 300s per-job budget is not the line
+# item worth demoting. If the tier gets tight, A7's 43 mutants are the knob.
 
 set -u
 # shellcheck source=/dev/null
@@ -138,6 +140,27 @@ _asserts_resolver() {
   ' "$1"
 }
 
+# _pins_seams <file> — is this file in population B (it pins the identity seams)?
+#
+# THE THIRD INSTANCE OF THE SAME SHAPE, closed here rather than at iteration 5. The
+# `_gate_(caller_uid|passwd_stream)\(\)` half was always anchored — a function
+# DEFINITION at line start is not something prose produces. The `actor_seam_as` half
+# was a bare token, so a file that merely NAMED the seam in a comment would enrol in
+# population B, and worse: for a file that also stubs `id -un`, a prose `pins=1`
+# SUPPRESSES rule (1)'s "stubs `id -un` but never pins" violation. Audited on the
+# corpus 2026-08-03: all ~150 occurrences in tests/*.sh are real calls, so there is no
+# victim today — this is the shape being closed, not a live defect. A2g is the
+# fixture; the guard's own line 353 census listing uses this same function so the two
+# cannot drift.
+_pins_seams() {
+  grep -qE '^[[:space:]]*_gate_(caller_uid|passwd_stream)\(\)' "$1" && return 0
+  awk '
+    /^[[:space:]]*#/ { next }
+    /(^|\$\(|`|[;&|({])[[:space:]]*actor_seam_as([[:space:]]|$)/ { f=1 }
+    END { exit !f }
+  ' "$1"
+}
+
 _scan_identity_stubs() {
   local dir="$1" f base claims_id pins
   for f in "$dir"/*.sh; do
@@ -155,7 +178,7 @@ _scan_identity_stubs() {
             || grep -qzE 'id\(\)[[:space:]]*\{[^}]*\-un' "$f"; }; then claims_id=1; fi
     # Population B — pins the seams the derivation actually reads.
     pins=0
-    grep -qE '^[[:space:]]*_gate_(caller_uid|passwd_stream)\(\)|actor_seam_as' "$f" && pins=1
+    _pins_seams "$f" && pins=1
 
     (( claims_id || pins )) || continue
 
@@ -193,7 +216,7 @@ _census() {
     if grep -qE '^[[:space:]]*id\(\)' "$f" \
        && { grep -qE '^[[:space:]]*id\(\).*\-un' "$f" \
             || grep -qzE 'id\(\)[[:space:]]*\{[^}]*\-un' "$f"; }; then a=$((a+1)); fi
-    grep -qE '^[[:space:]]*_gate_(caller_uid|passwd_stream)\(\)|actor_seam_as' "$f" && b=$((b+1))
+    _pins_seams "$f" && b=$((b+1))
   done
   printf '%s %s' "$a" "$b"
 }
@@ -298,6 +321,21 @@ got="$(_scan_identity_stubs "$TMP")"
   && ok_t "A2f rule (2) is not satisfied by a comment naming the resolver" \
   || bad_t "A2f prose does not satisfy rule (2)" "scan returned '${got:-<nothing>}' — a file that never calls the resolver passes for mentioning it"
 
+# ── A2g the POPULATION predicate may not be satisfied by prose either ────────
+# Third instance of the shape. A prose `actor_seam_as` used to set pins=1, which
+# SUPPRESSES rule (1) — so naming the seam in a comment bought a file an exemption
+# from the rule that it pin the seam. This fixture stubs `id -un`, mentions the seam
+# only in a comment, and pins nothing: it must be flagged as UNPINNED, not enrolled.
+cat > "$TMP/violator_unit.sh" <<'EOF'
+FAKE_CALLER="root"
+# this file used to impersonate via actor_seam_as before someone deleted the call
+id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+EOF
+got="$(_scan_identity_stubs "$TMP")"
+[[ "$got" == *"never pins _gate_caller_uid"* ]] \
+  && ok_t "A2g a prose mention of actor_seam_as does not enrol a file as pinned" \
+  || bad_t "A2g prose does not satisfy the population predicate" "scan returned '${got:-<nothing>}' — naming the seam in a comment exempts a file from having to pin it"
+
 # ── A3 self-exclusion actually works, and is load-bearing ────────────────────
 # This file necessarily contains the pattern it hunts for. The pair below is what
 # makes the skip observable: IDENTICAL BYTES, one under this file's basename and
@@ -350,8 +388,7 @@ read -r CA CB < <(_census tests)
 printf '     census: population A (stubs `id -un`) = %s, population B (pins the seams) = %s, allowlisted = %s\n' \
   "$CA" "$CB" "${#ALLOW[@]}"
 printf '     graded population B:\n'
-grep -lE '^[[:space:]]*_gate_(caller_uid|passwd_stream)\(\)|actor_seam_as' tests/*.sh \
-  | xargs -r -n1 basename | sort | sed 's/^/       /'
+for f in tests/*.sh; do _pins_seams "$f" && basename "$f"; done | sort | sed 's/^/       /'
 (( CB >= 20 )) \
   && ok_t "A6 the guard's population is non-trivial and named (B=$CB files pinning the seams)" \
   || bad_t "A6 population is non-trivial" "only $CB file(s) matched the pin predicate — either the corpus changed shape or the predicate stopped matching, and a guard grading nothing reports the same clean corpus as a guard grading everything"
@@ -382,7 +419,7 @@ a7_n=0; a7_prose=0; a7_missed=()
 for f in tests/*.sh; do
   base="$(basename "$f")"
   [[ "$base" == "$SELF" || -n "${ALLOW[$base]:-}" ]] && continue
-  grep -qE '^[[:space:]]*_gate_(caller_uid|passwd_stream)\(\)|actor_seam_as' "$f" || continue
+  _pins_seams "$f" || continue
   _sources_actor "$f" || continue                       # only files that currently PASS rule (0)
   got="$(_mutate_and_scan "$base" "$DROP_ACTOR")"
   grep -qE 'lib/actor\.sh' "$TMP/$base" && a7_prose=$((a7_prose+1))

--- a/tests/identity_stub_guard_unit.sh
+++ b/tests/identity_stub_guard_unit.sh
@@ -56,29 +56,72 @@ declare -A ALLOW=(
 # that grades tests/ grades the synthetic fixtures in A1-A3 below. A guard that can
 # only be pointed at the real corpus can only be graded by the corpus being clean,
 # which is indistinguishable from the guard being broken.
+# THE POPULATION PROBLEM, and it is why this function grades TWO populations
+# (DIVE-2601 iteration 2). The first cut scanned only files that still carry an
+# `id()` stub — which the remediation REMOVES. So every file this ticket fixed
+# dropped straight out of the guard's view the moment it was fixed, and the
+# remediated set is exactly the set most likely to be one edit away from grading the
+# host again. A checker whose population shrinks as its subject is repaired watches
+# nobody. Population B below is that set: any harness that PINS the seams, stub or no
+# stub. A6 prints both censuses so shrinkage is visible rather than inferred.
 _scan_identity_stubs() {
-  local dir="$1" f base
+  local dir="$1" f base claims_id pins
   for f in "$dir"/*.sh; do
     [[ -e "$f" ]] || continue
     base="$(basename "$f")"
     [[ "$base" == "$SELF" ]] && continue                    # self-exclusion (A3)
     [[ -n "${ALLOW[$base]:-}" ]] && continue
-    # Only an `id()` stub that ANSWERS -un is making an identity claim. A stub that
-    # only handles `id -u` (deploy_unit, agent_git_identity_unit) is pinning a
-    # numeric uid for a different guard and is out of scope.
-    grep -qE '^[[:space:]]*id\(\)' "$f" || continue
-    grep -qE '^[[:space:]]*id\(\).*\-un' "$f" \
-      || grep -qzE 'id\(\)[[:space:]]*\{[^}]*\-un' "$f" || continue
+
+    # Population A — an `id()` stub that ANSWERS -un is making an identity claim. A
+    # stub that only handles `id -u` (deploy_unit, agent_git_identity_unit) is pinning
+    # a numeric uid for a different guard and is out of scope.
+    claims_id=0
+    if grep -qE '^[[:space:]]*id\(\)' "$f" \
+       && { grep -qE '^[[:space:]]*id\(\).*\-un' "$f" \
+            || grep -qzE 'id\(\)[[:space:]]*\{[^}]*\-un' "$f"; }; then claims_id=1; fi
+    # Population B — pins the seams the derivation actually reads.
+    pins=0
+    grep -qE '^[[:space:]]*_gate_(caller_uid|passwd_stream)\(\)|actor_seam_as' "$f" && pins=1
+
+    (( claims_id || pins )) || continue
+
+    # (0) A PIN NEEDS THE FILE IT PINS INTO. The seams and the resolver both live in
+    # src/lib/actor.sh. Without it sourced, the override defines a function nothing
+    # calls, EVERY assertion through the resolver is a command-not-found that yields
+    # '' — so `[[ -z "$pin" ]]` becomes "the empty string is empty" and cannot fail —
+    # and the product code under test runs with its actor derivation missing. All
+    # three symptoms are silent. Measured in gate_tier2_nonce_evidence_unit.sh.
+    if (( pins )) && ! grep -qE 'lib/actor\.sh|actor_seam\.sh' "$f"; then
+      printf '%s\tpins the identity seams but never sources lib/actor.sh — the override lands on nothing, any assertion through the resolver is command-not-found (yields '"''"', which is the PASS value), and the product code runs with its actor derivation missing\n' "$base"
+      continue
+    fi
     # (1) the seams the derivation actually reads must be pinned
-    if ! grep -qE '^[[:space:]]*_gate_(caller_uid|passwd_stream)\(\)|actor_seam_as' "$f"; then
+    if (( claims_id )) && (( ! pins )); then
       printf '%s\tstubs `id -un` but never pins _gate_caller_uid/_gate_passwd_stream — the caller identity comes from the HOST\n' "$base"
       continue
     fi
     # (2) and the pin must be asserted through the real resolver
-    if ! grep -qE '_gate_authenticated_actor|_gate_uid_to_agent|actor_seam_selftest' "$f"; then
+    if (( claims_id )) && ! grep -qE '_gate_authenticated_actor|_gate_uid_to_agent|actor_seam_selftest' "$f"; then
       printf '%s\tpins the identity seams but never asserts the pin through the real resolver (_gate_authenticated_actor / _gate_uid_to_agent / actor_seam_selftest)\n' "$base"
     fi
   done
+}
+
+# _census <dir> — `<A-count> <B-count>` for the graded populations. Same predicates
+# as the scan, deliberately NOT a second implementation of the rules: it counts who
+# is LOOKED AT, which is the number a shrinking guard makes disappear quietly.
+_census() {
+  local dir="$1" f base a=0 b=0
+  for f in "$dir"/*.sh; do
+    [[ -e "$f" ]] || continue
+    base="$(basename "$f")"
+    [[ "$base" == "$SELF" || -n "${ALLOW[$base]:-}" ]] && continue
+    if grep -qE '^[[:space:]]*id\(\)' "$f" \
+       && { grep -qE '^[[:space:]]*id\(\).*\-un' "$f" \
+            || grep -qzE 'id\(\)[[:space:]]*\{[^}]*\-un' "$f"; }; then a=$((a+1)); fi
+    grep -qE '^[[:space:]]*_gate_(caller_uid|passwd_stream)\(\)|actor_seam_as' "$f" && b=$((b+1))
+  done
+  printf '%s %s' "$a" "$b"
 }
 
 FIX='tests/gate_enforce_env_bypass_unit.sh:127-154 is the in-tree pattern to copy'
@@ -98,6 +141,7 @@ got="$(_scan_identity_stubs "$TMP")"
 
 # ── A2 the second half of the rule: pinned but unasserted is still a violation ─
 cat > "$TMP/violator_unit.sh" <<'EOF'
+source "$SRC/lib/actor.sh"
 FAKE_CALLER="root"
 id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
 _gate_caller_uid() { printf 0; }
@@ -107,8 +151,40 @@ got="$(_scan_identity_stubs "$TMP")"
   && ok_t "A2 a pinned-but-unasserted harness is flagged (the DIVE-2588 shape)" \
   || bad_t "A2 pinned-but-unasserted is flagged" "scan returned '${got:-<nothing>}' — a pin that silently yields nothing would pass this guard"
 
+# ── A2c rule (0): pinned, asserted, but lib/actor.sh never sourced ────────────
+# The iteration-2 defect, as a fixture. Everything the old guard looked for is
+# present — the pin, and the resolver named in an assertion — and NONE of it runs:
+# `_gate_uid_to_agent` is command-not-found, the capture is '', and the file's own
+# `[[ -z ... ]]` check passes on the failure. This is the arm that would have caught
+# it, and it is why rule (0) exists.
+cat > "$TMP/violator_unit.sh" <<'EOF'
+FAKE_CALLER="root"
+id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+_gate_caller_uid() { printf 0; }
+_pin=$(_gate_uid_to_agent "$(_gate_caller_uid)")
+[[ -z "$_pin" ]] || exit 1
+EOF
+got="$(_scan_identity_stubs "$TMP")"
+[[ "$got" == *"never sources lib/actor.sh"* ]] \
+  && ok_t "A2c a pin with no lib/actor.sh source is flagged (the iteration-2 defect)" \
+  || bad_t "A2c unsourced-resolver is flagged" "scan returned '${got:-<nothing>}' — an assertion calling a function that does not exist reads as compliant"
+
+# ── A2d rule (0) applies to population B: pinning ALONE is enough to be graded ──
+# The remediation removes the `id()` stub. If the population were still gated on that
+# stub, every file this ticket fixed would leave the guard's view at the moment it
+# was fixed. Same bytes as A2c minus the stub — it must STILL be flagged.
+cat > "$TMP/violator_unit.sh" <<'EOF'
+_gate_caller_uid() { printf 0; }
+_pin=$(_gate_uid_to_agent "$(_gate_caller_uid)")
+EOF
+got="$(_scan_identity_stubs "$TMP")"
+[[ "$got" == *"never sources lib/actor.sh"* ]] \
+  && ok_t "A2d a pinning harness with NO id() stub is still graded (remediated files stay in view)" \
+  || bad_t "A2d population B is graded" "scan returned '${got:-<nothing>}' — the guard stops watching a file the moment its stub is removed, which is the moment it is remediated"
+
 # ── A2b negative control: the compliant shape is NOT flagged ──────────────────
 cat > "$TMP/violator_unit.sh" <<'EOF'
+source "$SRC/lib/actor.sh"
 FAKE_CALLER="root"
 id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
 _gate_caller_uid() { printf 0; }
@@ -116,7 +192,7 @@ _pin=$(_gate_uid_to_agent "$(_gate_caller_uid)")
 EOF
 got="$(_scan_identity_stubs "$TMP")"
 [[ -z "$got" ]] \
-  && ok_t "A2b the compliant shape (pin + assertion) is not flagged" \
+  && ok_t "A2b the compliant shape (source + pin + assertion) is not flagged" \
   || bad_t "A2b compliant fixture passes" "scan flagged it: '$got' — a guard that rejects the fix it demands cannot be satisfied"
 
 # ── A3 self-exclusion actually works, and is load-bearing ────────────────────
@@ -160,6 +236,22 @@ for base in "${!ALLOW[@]}"; do
     bad_t "A5 allowlist entry $base still exists" "allowlisted file is gone — drop the entry rather than leaving a silent exemption"
   fi
 done
+
+# ── A6 the census, PRINTED ────────────────────────────────────────────────────
+# A4 says "no violations". That reads identically whether the guard looked at forty
+# files or zero, and this guard's population shrinks as its subject is repaired — the
+# `id()` stub is what the fix deletes. So print who is being graded. The floor is
+# deliberately low: it is a tripwire for the population COLLAPSING (a renamed seam, a
+# tightened predicate), not a target to keep topped up.
+read -r CA CB < <(_census tests)
+printf '     census: population A (stubs `id -un`) = %s, population B (pins the seams) = %s, allowlisted = %s\n' \
+  "$CA" "$CB" "${#ALLOW[@]}"
+printf '     graded population B:\n'
+grep -lE '^[[:space:]]*_gate_(caller_uid|passwd_stream)\(\)|actor_seam_as' tests/*.sh \
+  | xargs -r -n1 basename | sort | sed 's/^/       /'
+(( CB >= 20 )) \
+  && ok_t "A6 the guard's population is non-trivial and named (B=$CB files pinning the seams)" \
+  || bad_t "A6 population is non-trivial" "only $CB file(s) matched the pin predicate — either the corpus changed shape or the predicate stopped matching, and a guard grading nothing reports the same clean corpus as a guard grading everything"
 
 printf '\n%s: %d passed, %d failed\n' "$SELF" "$PASS" "$FAIL"
 (( FAIL == 0 ))

--- a/tests/identity_stub_guard_unit.sh
+++ b/tests/identity_stub_guard_unit.sh
@@ -29,6 +29,12 @@
 # working would make the guard flag itself forever, and a self-exclusion that was
 # never needed would leave A3 passing vacuously. See
 # community/wiki/a-consistency-check-cannot-see-a-substitution-that-rewrote-both-sides.md
+#
+# COST: 6.0s measured on the dev3 worktree (5dive-cli-wt-2601, agent-dev3). A7/A8
+# mutate and re-scan 51 real harnesses and that is nearly all of it. Stays `core`
+# deliberately: the class this catches is silent by construction — a green arm that
+# grades nothing looks exactly like a green arm that grades something — and 6s
+# against a 300s per-job budget is not the line item worth demoting.
 
 set -u
 # shellcheck source=/dev/null
@@ -64,6 +70,74 @@ declare -A ALLOW=(
 # host again. A checker whose population shrinks as its subject is repaired watches
 # nobody. Population B below is that set: any harness that PINS the seams, stub or no
 # stub. A6 prints both censuses so shrinkage is visible rather than inferred.
+
+# ── the two predicates that must be ANCHORED ON A CONSTRUCT ───────────────────
+# THE DEFECT THESE REPLACE (iteration 3, measured by olivia at uid 1011). Both
+# rules used to be bare `grep -q <token>` over the whole file — and the remediation
+# this guard demands WRITES both tokens into every file it repairs. Rule (0) looked
+# for `lib/actor.sh`, which the liveness probe's hint string ends with ("Is
+# lib/actor.sh in the source list?") plus two comment lines. Rule (2) looked for
+# `_gate_uid_to_agent`, which that same probe names in the message it prints WHEN THE
+# RESOLVER IS DEAD. So a repaired file satisfied both rules out of its own prose.
+#
+# MEASURED: delete ` lib/actor.sh` from the source list of
+# gate_tier2_nonce_evidence_unit.sh — the one token rule (0) is about. The harness
+# correctly reds rc=1 and this guard stayed green, printing the broken file in the A6
+# census as a healthy population-B member. Enrollment worked; DETECTION on an
+# enrolled file did not. Rule (2) had a live corpus victim as well:
+# gate_lead_standing_unit.sh passed it out of a TRAILING COMMENT (`# not agent-* ->
+# _gate_authenticated_actor is EMPTY`) while making no such call anywhere.
+#
+# This is the lesson already compiled on this ticket's wiki page — anchor an
+# applied-check on the LINE THE MUTATION EDITS, never a token the file may mention
+# elsewhere — which the guard's own detector had not carried across. A7/A8 below
+# mutation-grade the fix on the real corpus, because A2c/A2d prove only that a rule
+# is well-formed on synthetic input and say nothing about whether its predicate is
+# violable by a real repaired file.
+
+# _sources_actor <file> — does the file actually SOURCE the actor lib? Three
+# constructs do it in tests/ today and all three are accepted:
+#   (a) `source "$SRC/lib/actor.sh"` / `. src/lib/actor.sh`
+#   (b) a `for f in ... lib/actor.sh ...; do source "$SRC/$f"; done` list — the token
+#       sits on a CONTINUATION line, so the list is collected from `for` through `do`
+#   (c) surgical extraction — `eval "$(sed -n ... src/lib/actor.sh)"`, `_load_from src/lib/actor.sh`
+# A prose mention is none of these. Note the `source|\.` preceding-character class
+# deliberately excludes `)`: without that, the probe hint's "...(expected probe). Is
+# lib/actor.sh..." reads as a `.` command and the hole reopens.
+_sources_actor() {
+  awk '
+    /^[[:space:]]*#/ { next }
+    inlist {
+      list = list " " $0
+      if ($0 ~ /(^|;)[[:space:]]*do([[:space:]]|$)/) { inlist=0; if (list ~ /lib\/(actor|actor_seam)\.sh/) f=1 }
+      next
+    }
+    /^[[:space:]]*for[[:space:]]+[A-Za-z_][A-Za-z_0-9]*[[:space:]]+in[[:space:]]/ {
+      list=$0; inlist=1
+      if ($0 ~ /(^|;)[[:space:]]*do([[:space:]]|$)/) { inlist=0; if (list ~ /lib\/(actor|actor_seam)\.sh/) f=1 }
+      next
+    }
+    /lib\/(actor|actor_seam)\.sh/ {
+      if ($0 ~ /(^|[;&|({])[[:space:]]*(source|\.)[[:space:]]/) f=1
+      else if ($0 ~ /(^|[;&|({[:space:]])(eval[[:space:]]+"?\$\(|_load_from[[:space:]])/) f=1
+    }
+    END { exit !f }
+  ' "$1"
+}
+
+# _asserts_resolver <file> — is the pin asserted through a real CALL to the resolver,
+# rather than a mention of its name? A call site is in COMMAND POSITION: line start,
+# inside `$(`/backtick, or after a `;` `&&` `||` `(` `{` separator. Every prose
+# mention in the corpus is preceded by a word character or sentence punctuation
+# (`: `, `-> `), which no call site is.
+_asserts_resolver() {
+  awk '
+    /^[[:space:]]*#/ { next }
+    /(^|\$\(|`|[;&|({])[[:space:]]*(_gate_authenticated_actor|_gate_uid_to_agent|actor_seam_selftest)([[:space:]]|$|\)|")/ { f=1 }
+    END { exit !f }
+  ' "$1"
+}
+
 _scan_identity_stubs() {
   local dir="$1" f base claims_id pins
   for f in "$dir"/*.sh; do
@@ -91,7 +165,7 @@ _scan_identity_stubs() {
     # '' — so `[[ -z "$pin" ]]` becomes "the empty string is empty" and cannot fail —
     # and the product code under test runs with its actor derivation missing. All
     # three symptoms are silent. Measured in gate_tier2_nonce_evidence_unit.sh.
-    if (( pins )) && ! grep -qE 'lib/actor\.sh|actor_seam\.sh' "$f"; then
+    if (( pins )) && ! _sources_actor "$f"; then
       printf '%s\tpins the identity seams but never sources lib/actor.sh — the override lands on nothing, any assertion through the resolver is command-not-found (yields '"''"', which is the PASS value), and the product code runs with its actor derivation missing\n' "$base"
       continue
     fi
@@ -101,7 +175,7 @@ _scan_identity_stubs() {
       continue
     fi
     # (2) and the pin must be asserted through the real resolver
-    if (( claims_id )) && ! grep -qE '_gate_authenticated_actor|_gate_uid_to_agent|actor_seam_selftest' "$f"; then
+    if (( claims_id )) && ! _asserts_resolver "$f"; then
       printf '%s\tpins the identity seams but never asserts the pin through the real resolver (_gate_authenticated_actor / _gate_uid_to_agent / actor_seam_selftest)\n' "$base"
     fi
   done
@@ -195,6 +269,35 @@ got="$(_scan_identity_stubs "$TMP")"
   && ok_t "A2b the compliant shape (source + pin + assertion) is not flagged" \
   || bad_t "A2b compliant fixture passes" "scan flagged it: '$got' — a guard that rejects the fix it demands cannot be satisfied"
 
+# ── A2e rule (0) may not be satisfied by PROSE — the iteration-3 defect ──────
+# Everything rule (0) used to look for is here and NONE of it sources anything: the
+# only `lib/actor.sh` in the file is the hint string the remediation itself writes.
+# Under the old whole-file grep this fixture passed. It must be flagged.
+cat > "$TMP/violator_unit.sh" <<'EOF'
+_gate_caller_uid() { printf 0; }
+_probe=$(_gate_uid_to_agent 424242)
+[[ "$_probe" == probe ]] || { printf 'NOT OK - resolver not live. Is lib/actor.sh in the source list?\n'; exit 1; }
+EOF
+got="$(_scan_identity_stubs "$TMP")"
+[[ "$got" == *"never sources lib/actor.sh"* ]] \
+  && ok_t "A2e rule (0) is not satisfied by a prose mention of lib/actor.sh" \
+  || bad_t "A2e prose does not satisfy rule (0)" "scan returned '${got:-<nothing>}' — the predicate reads the token the remediation writes, so every repaired file discharges the rule with its own hint string"
+
+# ── A2f rule (2) may not be satisfied by PROSE either ────────────────────────
+# The corpus instance was gate_lead_standing_unit.sh, which named the resolver ONLY
+# in a trailing comment. Same shape as A2e, other rule.
+cat > "$TMP/violator_unit.sh" <<'EOF'
+source "$SRC/lib/actor.sh"
+FAKE_CALLER="root"
+id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }
+_gate_caller_uid() { printf 0; }
+FAKE_CALLER="claude"   # not agent-* -> _gate_authenticated_actor is EMPTY
+EOF
+got="$(_scan_identity_stubs "$TMP")"
+[[ "$got" == *"never asserts the pin"* ]] \
+  && ok_t "A2f rule (2) is not satisfied by a comment naming the resolver" \
+  || bad_t "A2f prose does not satisfy rule (2)" "scan returned '${got:-<nothing>}' — a file that never calls the resolver passes for mentioning it"
+
 # ── A3 self-exclusion actually works, and is load-bearing ────────────────────
 # This file necessarily contains the pattern it hunts for. The pair below is what
 # makes the skip observable: IDENTICAL BYTES, one under this file's basename and
@@ -252,6 +355,62 @@ grep -lE '^[[:space:]]*_gate_(caller_uid|passwd_stream)\(\)|actor_seam_as' tests
 (( CB >= 20 )) \
   && ok_t "A6 the guard's population is non-trivial and named (B=$CB files pinning the seams)" \
   || bad_t "A6 population is non-trivial" "only $CB file(s) matched the pin predicate — either the corpus changed shape or the predicate stopped matching, and a guard grading nothing reports the same clean corpus as a guard grading everything"
+
+# ── A7/A8 the rules are VIOLABLE BY THE REAL CORPUS, not only by fixtures ─────
+# A1-A2f grade the rules on synthetic input: they prove each rule is well-formed.
+# They say NOTHING about whether a rule's predicate can be violated by a file this
+# ticket actually repaired — and for three iterations rule (0) could not, because the
+# remediation writes the token the predicate reads. A4 cannot see that: a rule nobody
+# can violate reports the same clean corpus as a rule that works. So mutate the REAL
+# files, one at a time, and require the guard to red on each.
+#
+# The mutation is olivia's, generalised: strip the anchor token from every line that
+# is neither a comment nor a printf — i.e. out of the CONSTRUCT, leaving the prose the
+# old predicate was accidentally reading. The count of mutants whose prose SURVIVES is
+# reported, because those are the ones that grade the anchoring rather than the token.
+rm -f "$TMP"/*.sh
+_mutate_and_scan() {   # <basename> <awk-program> — returns the scan output
+  local base="$1" prog="$2"
+  rm -f "$TMP"/*.sh
+  awk "$prog" "tests/$base" > "$TMP/$base"
+  _scan_identity_stubs "$TMP"
+}
+DROP_ACTOR='{ if ($0 ~ /^[[:space:]]*#/ || $0 ~ /printf/) print; else { gsub(/lib\/actor\.sh/,"lib/__absent__.sh"); gsub(/lib\/actor_seam\.sh/,"lib/__absent__.sh"); print } }'
+DROP_RESOLVER='{ if ($0 ~ /^[[:space:]]*#/ || $0 ~ /printf/) print; else { gsub(/_gate_authenticated_actor|_gate_uid_to_agent|actor_seam_selftest/,"_gate_absent_resolver"); print } }'
+
+a7_n=0; a7_prose=0; a7_missed=()
+for f in tests/*.sh; do
+  base="$(basename "$f")"
+  [[ "$base" == "$SELF" || -n "${ALLOW[$base]:-}" ]] && continue
+  grep -qE '^[[:space:]]*_gate_(caller_uid|passwd_stream)\(\)|actor_seam_as' "$f" || continue
+  _sources_actor "$f" || continue                       # only files that currently PASS rule (0)
+  got="$(_mutate_and_scan "$base" "$DROP_ACTOR")"
+  grep -qE 'lib/actor\.sh' "$TMP/$base" && a7_prose=$((a7_prose+1))
+  [[ "$got" == *"never sources lib/actor.sh"* ]] || a7_missed+=("$base")
+  a7_n=$((a7_n+1))
+done
+(( a7_n >= 20 && ${#a7_missed[@]} == 0 )) \
+  && ok_t "A7 rule (0) reds on every real repaired file whose source construct is broken ($a7_n mutants, $a7_prose still mention lib/actor.sh in surviving prose)" \
+  || bad_t "A7 rule (0) is violable on the real corpus" \
+     "$(printf '%s of %s mutant(s) went UNDETECTED:\n' "${#a7_missed[@]}" "$a7_n"; printf '     %s\n' "${a7_missed[@]:-<none — but only $a7_n file(s) were mutable, the population collapsed>}")"
+
+a8_n=0; a8_prose=0; a8_missed=()
+for f in tests/*.sh; do
+  base="$(basename "$f")"
+  [[ "$base" == "$SELF" || -n "${ALLOW[$base]:-}" ]] && continue
+  grep -qE '^[[:space:]]*id\(\)' "$f" \
+    && { grep -qE '^[[:space:]]*id\(\).*\-un' "$f" || grep -qzE 'id\(\)[[:space:]]*\{[^}]*\-un' "$f"; } || continue
+  _asserts_resolver "$f" || continue                    # only files that currently PASS rule (2)
+  got="$(_mutate_and_scan "$base" "$DROP_RESOLVER")"
+  grep -qE '_gate_authenticated_actor|_gate_uid_to_agent|actor_seam_selftest' "$TMP/$base" && a8_prose=$((a8_prose+1))
+  [[ "$got" == *"never asserts the pin"* ]] || a8_missed+=("$base")
+  a8_n=$((a8_n+1))
+done
+rm -f "$TMP"/*.sh
+(( a8_n >= 5 && ${#a8_missed[@]} == 0 )) \
+  && ok_t "A8 rule (2) reds on every real \`id -un\` harness whose resolver call is removed ($a8_n mutants, $a8_prose still name it in surviving prose)" \
+  || bad_t "A8 rule (2) is violable on the real corpus" \
+     "$(printf '%s of %s mutant(s) went UNDETECTED:\n' "${#a8_missed[@]}" "$a8_n"; printf '     %s\n' "${a8_missed[@]:-<none — but only $a8_n file(s) were mutable>}")"
 
 printf '\n%s: %d passed, %d failed\n' "$SELF" "$PASS" "$FAIL"
 (( FAIL == 0 ))

--- a/tests/task_cascade_unblock_unit.sh
+++ b/tests/task_cascade_unblock_unit.sh
@@ -222,6 +222,25 @@ _gate_passwd_stream() {
   printf '%s\n' "$(</etc/passwd)"
 }
 
+# DIVE-2601: ASSERT THE PIN, do not assume it. Two checks, and the first is the one
+# that is easy to leave out. The stream above names the caller from `$(id -un)` at
+# call time, so a LITERAL expectation is required here: derive the expectation from
+# `id -un` as well and an inert stub moves BOTH sides together, which is precisely
+# the failure being fixed — the assertion would agree with the host and print ok.
+# Without the pin, every arm below grades WHOEVER RAN THE SUITE: green on the box
+# where the host happens to match, 8 arms red on a CI runner (DIVE-2588).
+_pin_expect_un="lodar"
+_pin_who="$(id -un)"
+[[ "$_pin_who" == "$_pin_expect_un" ]] \
+  || { printf 'NOT OK - the fixture caller went INERT: `id -un` answered %s, this harness models %s\n' \
+       "'$_pin_who'" "'$_pin_expect_un'"; exit 1; }
+# ...and the pin resolved through the REAL resolver, which is what the code reads.
+if [[ "$_pin_expect_un" == agent-* ]]; then _pin_want="${_pin_expect_un#agent-}"; else _pin_want=""; fi
+_pin_got="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
+[[ "$_pin_got" == "$_pin_want" ]] \
+  || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected %s\n' \
+       "$_PIN_UID" "'$_pin_got'" "'${_pin_want:-<non-agent>}'"; exit 1; }
+
 ( cmd_task_answer "$a" --value=done --human ) >/dev/null 2>&1
 unset -f id
 [[ "$(st "$a")" == "done" && "$(st "$b")" == "todo" && "$(edges "$b")" == "0" ]] \

--- a/tests/task_deliver_merge_gate_unit.sh
+++ b/tests/task_deliver_merge_gate_unit.sh
@@ -50,6 +50,22 @@ chmod +x "$TMP/bin/sudo"
 # before $USER is ever read. DIVE-2066 recorded this as a $USER leak; measured
 # here it is SUDO_USER that dominates, which is why pinning $USER alone changed
 # nothing (still 9/2, actor still resolved to 'main').
+#
+# DIVE-2601 — AND THEN THAT PIN WENT INERT TOO, which is the whole point of this
+# row. DIVE-2518 sealed the `$USER`/`$SUDO_USER` path: it was never a test seam,
+# it was THE FORGERY (any unprivileged caller could act as another agent through
+# it), and `task_actor` no longer reads either var to decide WHO IS ACTING. So the
+# two exports below stopped pinning anything and the actor fell back to the host
+# again — 9/11 for dev2, and the same four-harness red that cost dev3 an hour on
+# DIVE-1953. Two agents lost an hour each to this exact file, one after the other,
+# because a pin that stops working does not fail: it goes quiet.
+#
+# The pin now goes through the SEALED seam (`tests/lib/actor_seam.sh`, DIVE-2518),
+# below and AFTER the libraries are sourced — `_gate_caller_uid`/`_gate_passwd_stream`
+# are functions, so sourcing lib/actor.sh after an override silently discards it.
+# The old exports are kept ONLY because `auto_sender_from_sudo` still reads them
+# for envelope PROVENANCE; they no longer decide the actor, and nothing below may
+# rely on them for that.
 SUDO_USER=agent-dev
 USER=agent-dev
 export SUDO_USER USER
@@ -109,6 +125,18 @@ for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done
+# DIVE-2601: the actor pin, through the sealed seam and AFTER the sources above —
+# `_gate_caller_uid` / `_gate_passwd_stream` are FUNCTIONS, so an override placed
+# before `source lib/actor.sh` is redefined out of existence without a word.
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh" \
+  || { printf 'NOT OK - tests/lib/actor_seam.sh not reachable; the actor cannot be pinned\n'; exit 1; }
+# ASSERT the pin through the real resolver before any arm leans on it. Without this
+# line the file is exactly what it was for two years: green where the host happens
+# to be `dev`, red everywhere else, and silent about which.
+actor_seam_selftest dev \
+  || { printf 'NOT OK - actor seam is inert: task_actor did not resolve to dev under the pin\n'; exit 1; }
+actor_seam_as dev
 STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
 JSON_MODE=1
 mkdir -p "$TASKS_DIR"; set +e

--- a/tests/task_park_gate_guard_unit.sh
+++ b/tests/task_park_gate_guard_unit.sh
@@ -75,6 +75,25 @@ _gate_passwd_stream() {
   printf '%s\n' "$(</etc/passwd)"
 }
 
+# DIVE-2601: ASSERT THE PIN, do not assume it. Two checks, and the first is the one
+# that is easy to leave out. The stream above names the caller from `$(id -un)` at
+# call time, so a LITERAL expectation is required here: derive the expectation from
+# `id -un` as well and an inert stub moves BOTH sides together, which is precisely
+# the failure being fixed — the assertion would agree with the host and print ok.
+# Without the pin, every arm below grades WHOEVER RAN THE SUITE: green on the box
+# where the host happens to match, 8 arms red on a CI runner (DIVE-2588).
+_pin_expect_un="root"
+_pin_who="$(id -un)"
+[[ "$_pin_who" == "$_pin_expect_un" ]] \
+  || { printf 'NOT OK - the fixture caller went INERT: `id -un` answered %s, this harness models %s\n' \
+       "'$_pin_who'" "'$_pin_expect_un'"; exit 1; }
+# ...and the pin resolved through the REAL resolver, which is what the code reads.
+if [[ "$_pin_expect_un" == agent-* ]]; then _pin_want="${_pin_expect_un#agent-}"; else _pin_want=""; fi
+_pin_got="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
+[[ "$_pin_got" == "$_pin_want" ]] \
+  || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected %s\n' \
+       "$_PIN_UID" "'$_pin_got'" "'${_pin_want:-<non-agent>}'"; exit 1; }
+
 
 seed_task()  { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
 statusof()   { db "SELECT status FROM tasks WHERE ident='$1';"; }


### PR DESCRIPTION
Ten-plus harnesses graded the identity of **whoever ran them** rather than a pinned caller, so the same suite returned different verdicts for different agents — three of us each spent an hour on it separately before it was named (DIVE-2601).

This pins and **asserts** the caller identity in the affected harnesses, routes the merge-gate harness's actor pin through the sealed seam, sources `lib/actor.sh` where the pin lands, and keys each guard on the **remedy** rather than on a token the remedy happens to write. The last commit anchors the population predicate too and corrects the measured cost.

## Scope

13 files under `tests/`, no `src/` changes.

## On the base

The branch was cut at `62fa7b0` and `main` has since advanced. **Settled with `git merge-tree --write-tree`, not a two-dot diff**, because a stale base cuts both ways and a deletion list cannot tell "reverts main's commits" from "merely predates them":

```
merged tree vs current main: 13 files, 700 insertions(+), 11 deletions(-)
```

No `src/`, no `CHANGELOG.md`, and no overlap with `tests/codex_install_node24_unit.sh` (added by #417 after this branch was cut). The two-dot diff reports 462 deletions; that figure is an artifact of the moved base, not a clobber. **No re-rebase is owed** — DIVE-2632's concern does not survive the measurement.

## Merging

This repo squash-merges. If this body is the message you want on `main`, pass it at merge time — `gh pr merge --squash` composes from the branch commits and ignores the PR body unless `--body-file` is given (see `community/wiki/a-patched-pr-body-is-not-the-squash-commit-message.md`). The five branch commit subjects are individually accurate, so composing from them is also fine.

Authored by dev3; base verified and PR opened by olivia (dev3 holds no gh credential).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
