### PR TITLE
fix(cli): a non-zero exit always carries a reason (DIVE-2598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased — fix(cli): a non-zero exit now always carries a reason (DIVE-2598)
+
+`5dive task done DIVE-XXXX --result="plain text no refs"` exited **1** with zero bytes on
+stdout *and* stderr, and left the row open. Nothing printed, nothing logged to the caller.
+A caller that pipes to `head` and reads `$?` sees a number with no message attached to it;
+one that reads only output sees success. It took a `bash -x` of the installed binary to
+find, which is the tell: the product itself said nothing.
+
+The line was an unguarded `_br_cands=$(_gate_branch_refs_from_text ...)`. That pipeline ends
+in `grep`, which exits 1 when it matches nothing — the normal case, since most results name
+no branch. `pipefail` promotes it, and under `set -euo pipefail` a bare `var=$(...)` takes
+the whole process down **before any handler runs**. DIVE-2603 guarded that line. DIVE-2566
+was the same shape in `5dive push` one file over, in the same release.
+
+Two per-line guards do not make the third unguarded substitution less likely, so this
+release adds the missing **property** rather than a third guard: whatever kills the CLI, the
+exit says something.
+
+- `fail()` — which every reported error funnels through, `policy_refuse()` included — now
+  marks the exit **reported**, after it prints.
+- The `EXIT` trap reports anything else: verb, code, that the command did **not** run to
+  completion so its effect is unknown, how to locate it (`bash -x $(command -v 5dive) …`),
+  and `5dive bug`. Under `--json` it emits a real `{ok:false,error:{…}}` envelope, because
+  an empty stdout is worse for a parser than for a person.
+- The marker is a **file**, not a variable: `fail()` runs inside command substitutions and
+  `flock` subshells whose writes the exiting parent cannot see. Getting this wrong would
+  print two messages for every subshell error — the real one, and a backstop claiming there
+  wasn't one.
+- Signals (130/143) are not unreported failures and stay quiet.
+
+`tests/silent_nonzero_exit_backstop_unit.sh` grades it against a real induced death in a
+real built bundle (`sqlite3` stubbed dead on `PATH`), with the same run against a
+backstop-neutered mutant of that bundle as the differential — so the arm cannot pass by
+grading a death that no longer happens.
+
 ## Unreleased — fix(init): the `codex` recipe asked nvm which node it SELECTED, not npm where it INSTALLED (DIVE-2596)
 
 `sudo 5dive agent create --type=codex` aborted with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,11 +70,21 @@ exit says something.
   print two messages for every subshell error — the real one, and a backstop claiming there
   wasn't one.
 - Signals (130/143) are not unreported failures and stay quiet.
+- **A verb's own cleanup no longer unseats it.** `trap … EXIT` **replaces**; it does not
+  stack. `watch` and `supervisor --watch` each installed their alt-screen teardown that
+  way, silently discarding `trap on_exit_audit EXIT` for the rest of the process — so
+  inside those two verbs there was no backstop *and* no audit record. Cleanup now
+  registers with `push_exit_handler`, which the one process-wide trap runs LIFO **before**
+  the report, so a teardown restores the terminal and the diagnostic lands somewhere
+  readable. Measured on a built bundle: an induced death in `watch` printed **476 bytes**
+  naming the verb; the same death with the old trap printed **18** (terminal-reset escapes
+  only).
 
 `tests/silent_nonzero_exit_backstop_unit.sh` grades it against a real induced death in a
-real built bundle (`sqlite3` stubbed dead on `PATH`), with the same run against a
-backstop-neutered mutant of that bundle as the differential — so the arm cannot pass by
-grading a death that no longer happens.
+real built bundle, with the same run against a backstop-neutered mutant of that bundle as
+the differential — so the arm cannot pass by grading a death that no longer happens. It
+also censuses the bundle's `trap … EXIT` population, because the line that switched the
+property off contains no `exit` and no census of exit *sites* could ever see it.
 
 ## Unreleased — fix(init): the `codex` recipe asked nvm which node it SELECTED, not npm where it INSTALLED (DIVE-2596)
 

--- a/src/cmd_account.sh
+++ b/src/cmd_account.sh
@@ -527,6 +527,7 @@ cmd_account_remove() {
           message:("account \($n) is in use by: " + ($a | join(", "))),
           details:{agents:$a}}}'
       echo "error: account '$name' is in use by: $list" >&2
+      mark_reported  # DIVE-2598: reason already printed above; not a silent exit
       exit "$E_CONFLICT"
     fi
     fail "$E_CONFLICT" "account '$name' is in use by: $list — rebind or remove those agents first"

--- a/src/cmd_fleet.sh
+++ b/src/cmd_fleet.sh
@@ -60,7 +60,7 @@ fleet_write() {
 }
 
 cmd_fleet() {
-  [[ $# -gt 0 ]] || { _fleet_usage; exit "$E_USAGE"; }
+  [[ $# -gt 0 ]] || { _fleet_usage; mark_reported; exit "$E_USAGE"; }
   local sub="$1"; shift
   case "$sub" in
     add)            cmd_fleet_add "$@" ;;

--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -337,7 +337,7 @@ USAGE
 }
 
 cmd_heartbeat() {
-  [[ $# -gt 0 ]] || { _hb_usage; exit "$E_USAGE"; }
+  [[ $# -gt 0 ]] || { _hb_usage; mark_reported; exit "$E_USAGE"; }
   local sub="$1"; shift
   case "$sub" in
     on|enable)       with_registry_lock cmd_heartbeat_on "$@" ;;

--- a/src/cmd_org.sh
+++ b/src/cmd_org.sh
@@ -26,7 +26,7 @@ USAGE
 }
 
 cmd_org() {
-  [[ $# -gt 0 ]] || { _org_usage; exit "$E_USAGE"; }
+  [[ $# -gt 0 ]] || { _org_usage; mark_reported; exit "$E_USAGE"; }
   local sub="$1"; shift
   case "$sub" in
     set)             cmd_org_set "$@" ;;

--- a/src/cmd_secret.sh
+++ b/src/cmd_secret.sh
@@ -51,7 +51,7 @@ _valid_env_key() { [[ "$1" =~ ^[A-Z_][A-Z0-9_]*$ ]]; }
 _valid_connector() { [[ "$1" =~ ^[a-z0-9][a-z0-9-]*$ ]]; }
 
 cmd_secret() {
-  [[ $# -gt 0 ]] || { _secret_usage; exit "$E_USAGE"; }
+  [[ $# -gt 0 ]] || { _secret_usage; mark_reported; exit "$E_USAGE"; }
   local sub="$1"; shift
   case "$sub" in
     write) _secret_write "$@" ;;

--- a/src/cmd_supervisor.sh
+++ b/src/cmd_supervisor.sh
@@ -615,7 +615,8 @@ _sup_watch() {
   [[ -t 1 && -t 0 ]] || fail "$E_USAGE" "supervisor --watch requires a TTY (try running it directly, not piped)"
   _sup_watch_teardown() { printf '%s%s%s' "$WATCH_SHOW" "$WATCH_RESET" "$WATCH_ALT_OFF"; }
   trap '_sup_watch_teardown; exit 130' INT TERM
-  trap '_sup_watch_teardown' EXIT
+  # See cmd_watch.sh — chain, never replace (DIVE-2598 it2).
+  push_exit_handler _sup_watch_teardown
   printf '%s%s' "$WATCH_ALT_ON" "$WATCH_HIDE"
   _sup_cli_check   # once per watch session, in this shell (see _sup_snapshot)
   while true; do

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -260,7 +260,7 @@ cmd_task_reclaim() {
 }
 
 cmd_task() {
-  [[ $# -gt 0 ]] || { _task_usage; exit "$E_USAGE"; }
+  [[ $# -gt 0 ]] || { _task_usage; mark_reported; exit "$E_USAGE"; }
   local sub="$1"; shift
   case "$sub" in
     init)            cmd_task_init "$@" ;;

--- a/src/cmd_watch.sh
+++ b/src/cmd_watch.sh
@@ -280,7 +280,9 @@ HELP
     printf '%s%s%s' "$WATCH_SHOW" "$WATCH_RESET" "$WATCH_ALT_OFF"
   }
   trap '_watch_teardown; exit 130' INT TERM
-  trap '_watch_teardown' EXIT
+  # NOT `trap '_watch_teardown' EXIT` (DIVE-2598 it2): that REPLACES the process
+  # EXIT trap and takes the never-exit-silently backstop with it.
+  push_exit_handler _watch_teardown
   printf '%s%s' "$WATCH_ALT_ON" "$WATCH_HIDE"
 
   while (( ! quit )); do

--- a/src/cmd_whoami.sh
+++ b/src/cmd_whoami.sh
@@ -112,6 +112,12 @@ EOF
       --arg m2 "actor is UNMEASURABLE ($ACTOR_REASON) — refusing to guess" \
       "{ok:false, error:{code:\$c, class:\$cl, message:\$m2}, data: ($expr)}"
     echo "error: actor is UNMEASURABLE ($ACTOR_REASON) — refusing to guess" >&2
+    # DIVE-2598: this refusal builds its own --json envelope (it carries `data`
+    # alongside the error, which fail() cannot express) and exits directly. It has
+    # already said why, so the EXIT-trap backstop must not append a second
+    # envelope — two objects on stdout is not JSON, and the caller parsing it gets
+    # nothing at all from a command that answered correctly.
+    mark_reported
     exit "$E_AUTH_REQUIRED"
   fi
 

--- a/src/lib/audit.sh
+++ b/src/lib/audit.sh
@@ -264,6 +264,12 @@ declare -a AUDIT_ARGS=()
 
 on_exit_audit() {
   local code=$?
+  # DIVE-2598: the silent-non-zero backstop runs FIRST and unconditionally —
+  # deliberately ahead of the AUDIT_CMD early-return below. AUDIT_CMD is only set
+  # for mutating verbs, so hanging the report off it would have left every
+  # read-only command able to die with a bare exit code and nothing said. The
+  # reporting property belongs to the process, not to the audit subsystem.
+  _report_silent_exit "$code"
   [[ -n "$AUDIT_CMD" ]] || return 0
   local result="ok"
   (( code != 0 )) && result="error"

--- a/src/lib/audit.sh
+++ b/src/lib/audit.sh
@@ -264,6 +264,11 @@ declare -a AUDIT_ARGS=()
 
 on_exit_audit() {
   local code=$?
+  # DIVE-2598 it2: verb-local cleanup first (LIFO), because a `watch` teardown has
+  # to leave the alt-screen before anything below prints — a diagnostic written
+  # into a screen that is about to be torn down is a diagnostic the caller never
+  # sees. These used to be their own `trap ... EXIT`, which replaced this one.
+  declare -F _five_run_exit_handlers >/dev/null && _five_run_exit_handlers
   # DIVE-2598: the silent-non-zero backstop runs FIRST and unconditionally —
   # deliberately ahead of the AUDIT_CMD early-return below. AUDIT_CMD is only set
   # for mutating verbs, so hanging the report off it would have left every

--- a/src/lib/output.sh
+++ b/src/lib/output.sh
@@ -63,6 +63,44 @@ rm -f "$FIVE_REPORTED_FLAG" 2>/dev/null || true
 # `<verb>_usage; exit "$E_USAGE"` sites — calls it too.
 mark_reported() { : > "$FIVE_REPORTED_FLAG" 2>/dev/null || true; }
 
+# push_exit_handler <function-or-snippet> — register verb-local cleanup on the
+# process EXIT chain.
+#
+# DIVE-2598 iteration 2. The backstop below is hung off the process EXIT trap,
+# and bash traps REPLACE rather than stack: a verb that wrote the obvious thing —
+# `trap '_watch_teardown' EXIT`, as `watch` and `supervisor --watch` both did —
+# silently discarded `trap on_exit_audit EXIT` for the rest of the process,
+# taking the never-exit-silently report AND the audit record with it. Measured on
+# a built bundle: an induced death before that line printed a 461-byte diagnostic,
+# the same death after it printed nothing.
+#
+# No census of exit SITES can catch this, because the line that disables the
+# backstop contains no `exit`. So the fix is not another audit — it is removing
+# the ability to write it: cmd_* register here, `on_exit_audit` stays the one and
+# only EXIT trap in the bundle, and tests/silent_nonzero_exit_backstop_unit.sh
+# pins that population.
+#
+# Handlers run LIFO and BEFORE the report, so an alt-screen teardown restores the
+# terminal first and the diagnostic lands somewhere the caller can actually read.
+# A handler that fails cannot change the exit code — it is already captured — and
+# cannot stop the ones behind it.
+declare -a _FIVE_EXIT_STACK=()
+push_exit_handler() { _FIVE_EXIT_STACK+=("$1"); }
+
+# Drained into a local copy and cleared BEFORE anything runs, so a handler that
+# exits (or a second trip through the trap) cannot re-run the chain. The local
+# declaration is also what keeps `${#…[@]}` resolvable inside this function —
+# tests/local_array_unbound_default_unit.sh arm G resolves a read only against
+# what its own function creates, and the array above is file-scope.
+_five_run_exit_handlers() {
+  local -a stack=("${_FIVE_EXIT_STACK[@]+"${_FIVE_EXIT_STACK[@]}"}")
+  _FIVE_EXIT_STACK=()
+  local i
+  for (( i=${#stack[@]} - 1; i >= 0; i-- )); do
+    eval "${stack[$i]}" || true
+  done
+}
+
 # _report_silent_exit <code> — the backstop itself, fired from the EXIT trap.
 _report_silent_exit() {
   local code="${1:-0}"

--- a/src/lib/output.sh
+++ b/src/lib/output.sh
@@ -28,6 +28,61 @@ JSON_MODE=0
 # needing to know how it was reached.
 CURRENT_VERB=""
 
+# ---------------------------------------------------------------------------
+# DIVE-2598 — THE SILENT NON-ZERO, AND WHY IT NEEDS A BACKSTOP AND NOT A FIX.
+#
+# `set -euo pipefail` (src/header.sh) is the right default for this script and it
+# is not going away. Its cost is that ANY unguarded command failure terminates the
+# process AT THAT LINE — before the handler reaches its own error path, so nothing
+# is printed on stdout OR stderr and the caller gets a bare exit code with no
+# reason attached to it. Twice in one release that was a `var=$(<probe>)` around a
+# pipeline ending in `grep`, which exits 1 on no-match: DIVE-2566 killed `5dive
+# push`, DIVE-2603 killed `5dive task done` for every caller whose result text
+# named no branch. Both were found by `bash -x` on the installed binary, because
+# the product itself said nothing at all.
+#
+# Each of those got its own `|| var=""`. That is the correct fix for the line, and
+# it is not a fix for the CLASS: the next unguarded substitution is a normal thing
+# to write and will present identically. What is missing is not another guard, it
+# is a REPORTER — the property that this CLI never exits non-zero silently,
+# whatever killed it.
+#
+# WHY A FILE AND NOT A VARIABLE. `fail()` runs inside command substitutions and
+# `flock` subshells, whose variable writes are invisible to the parent that will
+# actually exit and fire the EXIT trap. A marker file is written by the subshell
+# and read by the trap. `$$` (deliberately, not `$BASHPID`) is the same value in
+# every subshell of one invocation and different in a nested `5dive` child, so the
+# path is exactly per-invocation. Cleared at load, so a stale file from a
+# same-pid predecessor can only make us MISS a report — never invent one.
+FIVE_REPORTED_FLAG="${TMPDIR:-/tmp}/.5dive-reported.$(id -u 2>/dev/null || echo x).$$"
+rm -f "$FIVE_REPORTED_FLAG" 2>/dev/null || true
+
+# mark_reported — "this exit already told the caller why". Called by fail(), which
+# every reported error in this CLI funnels through (including policy_refuse). Any
+# other deliberate non-zero exit that prints its own reason first — the
+# `<verb>_usage; exit "$E_USAGE"` sites — calls it too.
+mark_reported() { : > "$FIVE_REPORTED_FLAG" 2>/dev/null || true; }
+
+# _report_silent_exit <code> — the backstop itself, fired from the EXIT trap.
+_report_silent_exit() {
+  local code="${1:-0}"
+  if (( code == 0 )) || [[ -e "$FIVE_REPORTED_FLAG" ]]; then
+    rm -f "$FIVE_REPORTED_FLAG" 2>/dev/null || true
+    return 0
+  fi
+  # 130/143 are Ctrl-C and SIGTERM. A signal is not an unreported failure — the
+  # person who sent it knows why it died, and `watch`/`supervisor` exit this way
+  # by design.
+  (( code == 130 || code == 143 )) && return 0
+  local verb="${CURRENT_VERB:-}"
+  local msg="5dive${verb:+ $verb} exited $code without reporting a reason. This is a bug in the CLI, not a refusal: a command failed under \`set -euo pipefail\` and ended the run before any error path could print. The command did NOT run to completion and its effect is UNKNOWN — re-read the object (\`5dive task show\`, \`5dive agent list\`) before retrying. To locate it: \`bash -x \$(command -v 5dive) ${verb:-<verb>} ...\` and read the last line before the exit. Please file it: \`5dive bug\`."
+  if (( JSON_MODE )); then
+    jq -cn --argjson c "$code" --arg m "$msg" \
+      '{ok:false, error:{code:$c, class:"generic", message:$m}}' 2>/dev/null || true
+  fi
+  echo "error: $msg" >&2
+}
+
 # fail <code> <message>
 # Always exits. In JSON mode, prints envelope on stdout AND a plain line on
 # stderr (for logs). In text mode, prints prose on stderr only. Exit status
@@ -72,6 +127,11 @@ fail() {
   if [[ "$code" == "${E_GENERIC:-1}" ]]; then
     echo "hint: run '5dive bug --verb=\"${CURRENT_VERB:-unknown}\" --exit=$code' to preview a diagnostic bug report (allowlisted fields only; nothing is filed until you add --file)" >&2
   fi
+  # DIVE-2598: this exit carries a reason, so the EXIT-trap backstop stays quiet
+  # for it. Set AFTER the message is emitted, never before — the flag asserts "the
+  # caller WAS told", and claiming it earlier would silence the backstop for a
+  # death between the claim and the print.
+  mark_reported
   exit "$code"
 }
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -360,7 +360,7 @@ main() {
   done
   set -- "${rest[@]+"${rest[@]}"}"
 
-  [[ $# -gt 0 ]] || { usage; exit "$E_USAGE"; }
+  [[ $# -gt 0 ]] || { usage; mark_reported; exit "$E_USAGE"; }
   local top="$1"; shift
   # DIVE-2323: the one place that sees every dispatch, so fail()'s E_GENERIC
   # hint can name the verb that broke. Set unconditionally, even for a $top
@@ -468,7 +468,7 @@ main() {
         with_registry_lock cmd_hire "$@"
       fi ;;
     agent)
-      [[ $# -gt 0 ]] || { usage; exit "$E_USAGE"; }
+      [[ $# -gt 0 ]] || { usage; mark_reported; exit "$E_USAGE"; }
       local sub="$1"; shift
       case "$sub" in
         -h|--help|help) usage ;;

--- a/tests/silent_nonzero_exit_backstop_unit.sh
+++ b/tests/silent_nonzero_exit_backstop_unit.sh
@@ -68,14 +68,14 @@
 # cmd_watch.sh, which build.sh ships verbatim) out of the census. Re-run all three
 # when this file is touched — the population is what drifts, not the mechanism.
 #
-# MUTATION GRADE — RUN, not asserted. RE-TAKEN AT 1b50763 (this branch rebased onto
-# 089f7d2), twice: once before the rebase and once after, identical both times.
-# Re-taken because iteration 2 changed src/ and the previous table's
+# MUTATION GRADE — RUN, not asserted. RE-TAKEN AT 6c35c00, on the branch merged with
+# main (8412b71). Re-taken because iteration 2 changed src/, so the previous table's
 # "`git diff a2c41bf HEAD -- src/` is EMPTY" no longer held — a mutation score
-# transfers only while the graded tree is the shipped one, and a rebase moves the
-# tree. Nothing after 1b50763 touches src/ (only this comment block), so
-# `git diff 1b50763 HEAD -- src/` is empty and the graded mechanism is the shipped
-# one. Eight mutations, each applied to the committed tree and reverted
+# transfers only while the graded tree is the shipped one. Taken three times in all
+# (pre-merge, on a rebase that was abandoned to keep the PR fast-forward, and here)
+# with identical results. Nothing after 6c35c00 touches src/ (only this comment
+# block), so `git diff 6c35c00 HEAD -- src/` is empty and the graded mechanism is
+# the shipped one. Eight mutations, each applied to the committed tree and reverted
 # after (`git checkout -- src/`, tree verified clean at the end); every one turns
 # this file red, on the arms named. Baseline 15/0, 1.7s on the dev box.
 #   * `push_exit_handler() { : ; }`                -> 14/1 (arm 10)

--- a/tests/silent_nonzero_exit_backstop_unit.sh
+++ b/tests/silent_nonzero_exit_backstop_unit.sh
@@ -50,9 +50,10 @@
 #
 # MUTATION GRADE — RUN, not asserted. Six mutations against the committed tree at
 # a2c41bf (rebased onto b64b6da), each reverted after; every one turns this file
-# red, and on the arms named. Baseline 11/0. Later commits on this branch touch
-# only this header — `git diff a2c41bf HEAD -- src/` is EMPTY, so the graded
-# mechanism is the shipped one.
+# red, and on the arms named. Baseline 11/0. Re-taken unchanged after the induction
+# moved from a stubbed `sqlite3` to the injection above. Later commits on this
+# branch touch only this file — `git diff a2c41bf HEAD -- src/` is EMPTY, so the
+# graded mechanism is the shipped one.
 #   * `mark_reported() { : ; }`                    -> 8/3  (arms 3, 4, 7)
 #   * drop `mark_reported` from fail()             -> 9/2  (arms 3, 7)
 #   * drop `mark_reported` from the usage sites    -> 10/1 (arm 4)
@@ -92,28 +93,34 @@ if ! BUILD_OUT="$BIN" bash build.sh >"$TMP/build.log" 2>&1; then
   printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"; exit 1
 fi
 
-# THE MUTANT: the same bundle with the backstop's body replaced by `:`. This is
-# the pre-DIVE-2598 CLI, built from THIS tree, so arm 2 measures the difference
-# the change makes rather than asserting a remembered fact about an old release.
-MUT="$TMP/5dive-mutant"
-awk '
-  /^_report_silent_exit\(\) \{/ { print "_report_silent_exit() { : ; }"; skip=1; next }
-  skip && /^\}/                 { skip=0; next }
-  skip                          { next }
-  { print }
-' "$BIN" > "$MUT"
-chmod +x "$MUT"
-if ! grep -q '^_report_silent_exit() { : ; }' "$MUT"; then
-  bad_t 'build the neutered-backstop mutant' 'the awk rewrite did not take — arm 2 would grade nothing'
-fi
-
-# `sqlite3` dead on PATH is the induction: every store read in this CLI goes
-# through it, and an unguarded one dies exactly the DIVE-2598 way. Chosen over
-# patching a source line so the arm cannot be satisfied by a guard added to one
-# call site.
-mkdir -p "$TMP/bin"
-printf '#!/bin/sh\nexit 1\n' > "$TMP/bin/sqlite3"; chmod +x "$TMP/bin/sqlite3"
-DEADPATH="$TMP/bin:$PATH"
+# THE INDUCTION, AND WHY IT IS NOT A STORE-READING VERB. The first version of this
+# harness killed `task ls` by stubbing `sqlite3` dead on PATH. It passed here and
+# FAILED in CI: a fresh runner has no tasks store, so `task ls` refuses early and
+# correctly ("tasks store not initialised", rc=10, through fail()) and never reaches
+# sqlite3 at all. The arm was measuring a death that only happens on a provisioned
+# host. So the death is now INJECTED into the built bundle instead — one unguarded
+# `var=$(… | grep <no-match>)` at the top of a handler, which is the DIVE-2598
+# mechanism exactly: grep exits 1 on no-match, pipefail promotes it, `set -e` ends
+# the run before anything prints. `whoami` is the carrier because it needs no host
+# state beyond /etc/passwd, and CURRENT_VERB is already set by the time it runs, so
+# the report can be checked for the verb it names.
+inject() {  # inject <src-bundle> <dst> [extra-awk-rewrite]
+  awk -v extra="${3:-}" '
+    /^cmd_whoami\(\) \{/ {
+      print; print "  _dive2598_induced=$(printf %s \"\" | grep -m1 zzz-no-match)"; next
+    }
+    extra == "neuter" && /^_report_silent_exit\(\) \{/ { print "_report_silent_exit() { : ; }"; skip=1; next }
+    skip && /^\}/ { skip=0; next }
+    skip { next }
+    { print }
+  ' "$1" > "$2"
+  chmod +x "$2"
+}
+INJ="$TMP/5dive-injected"; inject "$BIN" "$INJ"
+MUT="$TMP/5dive-injected-nobackstop"; inject "$BIN" "$MUT" neuter
+grep -q 'zzz-no-match' "$INJ" && grep -q 'zzz-no-match' "$MUT" \
+  && grep -q '^_report_silent_exit() { : ; }' "$MUT" \
+  || bad_t 'build the injected bundles' 'an awk rewrite did not take — arms 1, 2 and 6 would grade nothing'
 
 RC=0; OUT=""; ERR=""
 run() {  # run <bin> [args...] — captures rc, stdout (OUT), stderr (ERR) separately
@@ -122,23 +129,22 @@ run() {  # run <bin> [args...] — captures rc, stdout (OUT), stderr (ERR) separ
   OUT=$("$bin" "$@" 2>"$TMP/err.txt") || RC=$?
   ERR=$(cat "$TMP/err.txt")
 }
-run_dead() { local bin="$1"; shift; PATH="$DEADPATH" run "$bin" "$@"; }
 
 # --- 1. THE DEFECT, REPRODUCED AND REPORTED ----------------------------------
-# `task ls` is READ-ONLY, so AUDIT_CMD is unset for it: this arm also proves the
+# `whoami` is READ-ONLY, so AUDIT_CMD is unset for it: this arm also proves the
 # report is not hung off the audit subsystem's early return.
-run_dead "$BIN" task ls
+run "$INJ" whoami
 if [[ $RC -ne 0 && "$ERR" =~ $BACKSTOP_RE ]]; then
   ok_t "an induced set -e death exits non-zero AND says so (DIVE-2598 shape, read-only verb)"
 else
   bad_t 'induced silent death must be reported' "rc=$RC stdout=${#OUT}B stderr=[${ERR:0:200}]"
 fi
-[[ "$ERR" == *"5dive task"* && "$ERR" == *"5dive bug"* ]] \
+[[ "$ERR" == *"5dive whoami"* && "$ERR" == *"5dive bug"* ]] \
   && ok_t 'the report names the verb that died and where to file it' \
   || bad_t 'report should name verb + 5dive bug' "stderr=[${ERR:0:300}]"
 
 # --- 2. THE DIFFERENTIAL: the same run, backstop neutered --------------------
-run_dead "$MUT" task ls
+run "$MUT" whoami
 if [[ $RC -ne 0 && -z "$OUT" && -z "$ERR" ]]; then
   ok_t "non-vacuity: with the backstop neutered the SAME run is rc=$RC with zero bytes on both streams"
 else
@@ -173,7 +179,7 @@ run "$BIN" --version
 # A silent death under --json is WORSE than in text mode: the caller is parsing
 # stdout, and an empty stdout with a bare rc is indistinguishable from a crash of
 # the pipeline itself.
-run_dead "$BIN" --json task ls
+run "$INJ" --json whoami
 if [[ $RC -ne 0 ]] && jq -e '.ok == false and (.error.message | test("without reporting a reason"))' <<<"$OUT" >/dev/null 2>&1; then
   ok_t '--json emits {ok:false,error:{...}} on stdout instead of nothing'
 else

--- a/tests/silent_nonzero_exit_backstop_unit.sh
+++ b/tests/silent_nonzero_exit_backstop_unit.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# DIVE-2598 — THE CLI MUST NEVER EXIT NON-ZERO WITHOUT SAYING WHY.
+#
+# THE INCIDENT. `5dive task done DIVE-2597 --result="plain text no refs"` exited 1
+# with ZERO bytes on stdout AND stderr, and left the row open. Nothing printed,
+# nothing the caller could act on; a caller that reads only output saw success.
+# It cost the reporter three attempts and a `bash -x` of the installed binary.
+# The line was an unguarded `_br_cands=$(_gate_branch_refs_from_text ...)` whose
+# pipeline ends in `grep` — exit 1 on no-match, promoted by `pipefail`, fatal
+# under `set -e` BEFORE any handler could print. DIVE-2603 guarded that line, and
+# `tests/task_merge_gate_branch_in_result_unit.sh` pins it.
+#
+# WHAT THIS FILE GRADES IS THE OTHER HALF, AND IT IS NOT THE SAME HALF. DIVE-2566
+# was the identical shape in `5dive push` one file over, in the same release. Two
+# per-line guards do not make a third unguarded substitution any less likely — an
+# unguarded `$( )` is a normal thing to write. The property that has to hold is
+# that WHATEVER kills this CLI, the exit carries a reason. So the backstop is
+# graded here against a REAL induced death in a REAL built bundle, not against the
+# one line that happened to cause it: stub `sqlite3` to exit 1 on PATH and any
+# db-reading verb dies exactly the DIVE-2598 way. The mutant arm proves the
+# hazard is live in this tree and that the green arm is not green by vacuity.
+#
+# THE FALSE-POSITIVE HALF IS AS LOAD-BEARING AS THE TRUE ONE. A backstop that
+# fires after an error that DID print appends "no reason was given" to a message
+# that gave one — the report would then be wrong exactly when the CLI was right.
+# So every reported-exit shape gets an arm: fail()'s own path, the
+# `<verb>_usage; exit "$E_USAGE"` sites that never reach fail(), and success.
+#
+# MUTATION GRADE (by hand, each must turn this file red):
+#   * `mark_reported() { :; }`            -> arms 3/4 FAIL (backstop fires after a
+#                                            message that was printed).
+#   * drop `mark_reported` from fail()    -> arm 3 FAILS.
+#   * drop `mark_reported` from the usage sites -> arm 4 FAILS.
+#   * `_report_silent_exit() { :; }`      -> arms 1/6/7/9 FAIL (this is arm 2's
+#                                            mutant, made permanent).
+#   * move `_report_silent_exit` BELOW the `[[ -n "$AUDIT_CMD" ]]` return in
+#     on_exit_audit -> arms 1 and 9 FAIL (read-only verbs go silent again).
+#   * drop the 130/143 suppression       -> arm 8's first half FAILS.
+#
+# Runs the SHIPPED artifact: builds a throwaway bundle via BUILD_OUT (43ms) and
+# executes it. The only verbs it runs are read-only (`task ls`, `--version`) or
+# argument errors that never reach the store, and the db-reading ones are run
+# with `sqlite3` stubbed dead so they cannot touch the live tasks.db at all.
+# Run: bash tests/silent_nonzero_exit_backstop_unit.sh   (no root, no network.)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+. "$(dirname "${BASH_SOURCE[0]}")/lib/env_isolation.sh" 2>/dev/null || true
+declare -F _five_env_isolate >/dev/null && _five_env_isolate
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/silent-nonzero-backstop.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+BACKSTOP_RE='without reporting a reason'
+
+BIN="$TMP/5dive"
+if ! BUILD_OUT="$BIN" bash build.sh >"$TMP/build.log" 2>&1; then
+  bad_t 'build a throwaway bundle to grade' "$(tail -3 "$TMP/build.log")"
+  printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"; exit 1
+fi
+
+# THE MUTANT: the same bundle with the backstop's body replaced by `:`. This is
+# the pre-DIVE-2598 CLI, built from THIS tree, so arm 2 measures the difference
+# the change makes rather than asserting a remembered fact about an old release.
+MUT="$TMP/5dive-mutant"
+awk '
+  /^_report_silent_exit\(\) \{/ { print "_report_silent_exit() { : ; }"; skip=1; next }
+  skip && /^\}/                 { skip=0; next }
+  skip                          { next }
+  { print }
+' "$BIN" > "$MUT"
+chmod +x "$MUT"
+if ! grep -q '^_report_silent_exit() { : ; }' "$MUT"; then
+  bad_t 'build the neutered-backstop mutant' 'the awk rewrite did not take — arm 2 would grade nothing'
+fi
+
+# `sqlite3` dead on PATH is the induction: every store read in this CLI goes
+# through it, and an unguarded one dies exactly the DIVE-2598 way. Chosen over
+# patching a source line so the arm cannot be satisfied by a guard added to one
+# call site.
+mkdir -p "$TMP/bin"
+printf '#!/bin/sh\nexit 1\n' > "$TMP/bin/sqlite3"; chmod +x "$TMP/bin/sqlite3"
+DEADPATH="$TMP/bin:$PATH"
+
+RC=0; OUT=""; ERR=""
+run() {  # run <bin> [args...] — captures rc, stdout (OUT), stderr (ERR) separately
+  local bin="$1"; shift
+  RC=0
+  OUT=$("$bin" "$@" 2>"$TMP/err.txt") || RC=$?
+  ERR=$(cat "$TMP/err.txt")
+}
+run_dead() { local bin="$1"; shift; PATH="$DEADPATH" run "$bin" "$@"; }
+
+# --- 1. THE DEFECT, REPRODUCED AND REPORTED ----------------------------------
+# `task ls` is READ-ONLY, so AUDIT_CMD is unset for it: this arm also proves the
+# report is not hung off the audit subsystem's early return.
+run_dead "$BIN" task ls
+if [[ $RC -ne 0 && "$ERR" =~ $BACKSTOP_RE ]]; then
+  ok_t "an induced set -e death exits non-zero AND says so (DIVE-2598 shape, read-only verb)"
+else
+  bad_t 'induced silent death must be reported' "rc=$RC stdout=${#OUT}B stderr=[${ERR:0:200}]"
+fi
+[[ "$ERR" == *"5dive task"* && "$ERR" == *"5dive bug"* ]] \
+  && ok_t 'the report names the verb that died and where to file it' \
+  || bad_t 'report should name verb + 5dive bug' "stderr=[${ERR:0:300}]"
+
+# --- 2. THE DIFFERENTIAL: the same run, backstop neutered --------------------
+run_dead "$MUT" task ls
+if [[ $RC -ne 0 && -z "$OUT" && -z "$ERR" ]]; then
+  ok_t "non-vacuity: with the backstop neutered the SAME run is rc=$RC with zero bytes on both streams"
+else
+  bad_t 'the mutant must reproduce the silent exit' "rc=$RC stdout=${#OUT}B stderr=${#ERR}B — if this is not silent, arm 1 is grading nothing"
+fi
+
+# --- 3. NO FALSE POSITIVE: an error that fail() already reported -------------
+run "$BIN" zzznotacommand
+if [[ $RC -ne 0 && "$ERR" == *"unknown command"* && ! "$ERR" =~ $BACKSTOP_RE ]]; then
+  ok_t 'an error printed by fail() is NOT also reported as unexplained'
+else
+  bad_t 'fail() path must suppress the backstop' "rc=$RC stderr=[${ERR:0:300}]"
+fi
+
+# --- 4. NO FALSE POSITIVE: a usage exit that never reaches fail() ------------
+# `{ _task_usage; exit "$E_USAGE"; }` prints its reason and exits directly, so it
+# has to mark itself reported or the backstop calls a printed usage page silent.
+run "$BIN" task
+if [[ $RC -ne 0 && -n "$ERR$OUT" && ! "$ERR" =~ $BACKSTOP_RE ]]; then
+  ok_t 'a verb usage page + direct exit is NOT reported as unexplained'
+else
+  bad_t 'usage-exit sites must mark themselves reported' "rc=$RC stderr=[${ERR:0:200}]"
+fi
+
+# --- 5. NO FALSE POSITIVE: success ------------------------------------------
+run "$BIN" --version
+[[ $RC -eq 0 && ! "$ERR" =~ $BACKSTOP_RE ]] \
+  && ok_t 'a successful command reports nothing' \
+  || bad_t 'success must stay quiet' "rc=$RC stderr=[${ERR:0:200}]"
+
+# --- 6. --json: stdout must still carry a parseable envelope -----------------
+# A silent death under --json is WORSE than in text mode: the caller is parsing
+# stdout, and an empty stdout with a bare rc is indistinguishable from a crash of
+# the pipeline itself.
+run_dead "$BIN" --json task ls
+if [[ $RC -ne 0 ]] && jq -e '.ok == false and (.error.message | test("without reporting a reason"))' <<<"$OUT" >/dev/null 2>&1; then
+  ok_t '--json emits {ok:false,error:{...}} on stdout instead of nothing'
+else
+  bad_t '--json must emit an error envelope' "rc=$RC stdout=[${OUT:0:300}]"
+fi
+
+# --- 7-9. PROPERTIES REACHABLE ONLY FROM INSIDE ------------------------------
+# Sourced from the same src/ files the bundle above was built from.
+rig() {  # rig <body> — runs <body> under set -euo pipefail with the real primitives
+  bash -c '
+    set -euo pipefail
+    . "$1/lib/error_codes.sh" 2>/dev/null || true
+    . "$1/lib/output.sh"
+    AUDIT_CMD=""; declare -a AUDIT_ARGS=()
+    . "$1/lib/audit.sh" 2>/dev/null || true
+    eval "$2"
+  ' _ "$PWD/$SRC" "$1" 2>&1
+}
+
+# 7. fail() inside a command substitution. Its `mark_reported` runs in a SUBSHELL,
+#    whose variable writes the exiting parent can never see — which is why the
+#    marker is a file. If this regresses, every subshell error prints twice: its
+#    real message and a backstop claiming there wasn't one.
+out=$(rig 'trap on_exit_audit EXIT; x=$(fail 5 "boom in a subshell"); echo "unreachable: $x"')
+if [[ "$out" == *"boom in a subshell"* && "$out" != *"without reporting a reason"* ]]; then
+  ok_t 'fail() in a command substitution marks the parent reported (file marker, not a variable)'
+else
+  bad_t 'subshell fail() must suppress the parent backstop' "out=[${out:0:300}]"
+fi
+
+# 8. Signals are not unreported failures — and the liveness half proves the
+#    suppression is a case, not the whole function being dead.
+out=$(rig '_report_silent_exit 130; echo "END"')
+[[ "$out" == "END" ]] \
+  && ok_t 'exit 130 (Ctrl-C) is not reported as an unexplained failure' \
+  || bad_t 'signal exits must be suppressed' "out=[${out:0:200}]"
+out=$(rig '_report_silent_exit 1; echo "END"')
+[[ "$out" == *"without reporting a reason"* ]] \
+  && ok_t 'liveness pair: the same function DOES report a plain rc=1' \
+  || bad_t 'the reporter must fire on a non-signal code' "out=[${out:0:200}]"
+
+# 9. The report runs ahead of the AUDIT_CMD early-return.
+out=$(rig 'trap on_exit_audit EXIT; AUDIT_CMD=""; false; :')
+[[ "$out" == *"without reporting a reason"* ]] \
+  && ok_t 'a read-only command (AUDIT_CMD unset) is still reported' \
+  || bad_t 'the report must precede the audit early-return' "out=[${out:0:200}]"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/silent_nonzero_exit_backstop_unit.sh
+++ b/tests/silent_nonzero_exit_backstop_unit.sh
@@ -26,16 +26,42 @@
 # So every reported-exit shape gets an arm: fail()'s own path, the
 # `<verb>_usage; exit "$E_USAGE"` sites that never reach fail(), and success.
 #
-# MUTATION GRADE (by hand, each must turn this file red):
-#   * `mark_reported() { :; }`            -> arms 3/4 FAIL (backstop fires after a
-#                                            message that was printed).
-#   * drop `mark_reported` from fail()    -> arm 3 FAILS.
-#   * drop `mark_reported` from the usage sites -> arm 4 FAILS.
-#   * `_report_silent_exit() { :; }`      -> arms 1/6/7/9 FAIL (this is arm 2's
-#                                            mutant, made permanent).
+# HOW THE POPULATION WAS ENUMERATED, because reading did not find it. The backstop
+# has to stay quiet for every deliberate non-zero exit that prints its own reason
+# and never routes through fail(). Reading src/ found the seven
+# `<verb>_usage; exit "$E_USAGE"` sites and cmd_account's in-use refusal. It MISSED
+# `cmd_whoami.sh`'s UNMEASURABLE refusal, which builds its own
+# `{ok:false,…,data:{…}}` envelope (fail() cannot carry `data`) — the core tier
+# caught that one red, which is the only reason the count is not still wrong.
+# So the set is enumerated by OPERATION over the BUILT bundle, not by inspection:
+#
+#   grep -nE '(^|[;&|[:space:]])exit[[:space:]]+("?\$[A-Za-z_]\w*"?|[1-9][0-9]*)' 5dive
+#   grep -rn 'ok:false' src/ | grep -v src/lib/output.sh      # the whoami shape
+#
+# 35 hits, classified: 10 marked in-process sites (fail() itself, cmd_account,
+# cmd_whoami, 7 usage exits) + 2 `trap '… exit 130' INT TERM` (covered by the
+# signal rule) + 2 `_tasks_alarm …; exit 3` inside a `( flock 9 )` SUBSHELL, which
+# cannot double-report because a `( )` subshell does not run the parent's EXIT trap
+# (measured, bash 5.2) + 12 inside heredoc'd `bash -s` installers that are a
+# DIFFERENT PROCESS and never reach our trap + 9 that are comments, awk programs or
+# JS. The second grep answers "what else builds its own envelope": exactly two,
+# cmd_account and cmd_whoami, both marked. Re-run both greps when this file is
+# touched — the population is the thing that drifts, not the mechanism.
+#
+# MUTATION GRADE — RUN, not asserted. Six mutations against the committed tree at
+# a2c41bf (rebased onto b64b6da), each reverted after; every one turns this file
+# red, and on the arms named. Baseline 11/0. Later commits on this branch touch
+# only this header — `git diff a2c41bf HEAD -- src/` is EMPTY, so the graded
+# mechanism is the shipped one.
+#   * `mark_reported() { : ; }`                    -> 8/3  (arms 3, 4, 7)
+#   * drop `mark_reported` from fail()             -> 9/2  (arms 3, 7)
+#   * drop `mark_reported` from the usage sites    -> 10/1 (arm 4)
+#   * `_report_silent_exit() { return 0; }`        -> 6/5  (arms 1, 1b, 6, 8-liveness, 9)
 #   * move `_report_silent_exit` BELOW the `[[ -n "$AUDIT_CMD" ]]` return in
-#     on_exit_audit -> arms 1 and 9 FAIL (read-only verbs go silent again).
-#   * drop the 130/143 suppression       -> arm 8's first half FAILS.
+#     on_exit_audit                                -> 7/4  (arms 1, 1b, 6, 9)
+#   * drop the 130/143 suppression                 -> 10/1 (arm 8, first half)
+# Arm 7 survives the reporter being dead ON PURPOSE — it asserts the real message
+# is still printed and the backstop stays quiet, so only the marker can move it.
 #
 # Runs the SHIPPED artifact: builds a throwaway bundle via BUILD_OUT (43ms) and
 # executes it. The only verbs it runs are read-only (`task ls`, `--version`) or

--- a/tests/silent_nonzero_exit_backstop_unit.sh
+++ b/tests/silent_nonzero_exit_backstop_unit.sh
@@ -35,32 +35,77 @@
 # caught that one red, which is the only reason the count is not still wrong.
 # So the set is enumerated by OPERATION over the BUILT bundle, not by inspection:
 #
-#   grep -nE '(^|[;&|[:space:]])exit[[:space:]]+("?\$[A-Za-z_]\w*"?|[1-9][0-9]*)' 5dive
+#   grep -nE '(^|[;&|[:space:]])exit[[:space:]]+("?\$\{?[A-Za-z_][A-Za-z0-9_]*(:-[^}]*)?\}?"?|[1-9][0-9]*)' 5dive
 #   grep -rn 'ok:false' src/ | grep -v src/lib/output.sh      # the whoami shape
+#   grep -nE "trap[[:space:]]+.*[[:space:]]EXIT([[:space:]]|$)" 5dive   # arm 11
 #
-# 35 hits, classified: 10 marked in-process sites (fail() itself, cmd_account,
-# cmd_whoami, 7 usage exits) + 2 `trap '… exit 130' INT TERM` (covered by the
-# signal rule) + 2 `_tasks_alarm …; exit 3` inside a `( flock 9 )` SUBSHELL, which
-# cannot double-report because a `( )` subshell does not run the parent's EXIT trap
-# (measured, bash 5.2) + 12 inside heredoc'd `bash -s` installers that are a
-# DIFFERENT PROCESS and never reach our trap + 9 that are comments, awk programs or
-# JS. The second grep answers "what else builds its own envelope": exactly two,
-# cmd_account and cmd_whoami, both marked. Re-run both greps when this file is
-# touched — the population is the thing that drifts, not the mechanism.
+# THE THIRD GREP IS THE ITERATION-1 GAP, and it is why exit sites are not the whole
+# population. A property hung off a trap can be switched off by a line that contains
+# no `exit` at all: `trap '_watch_teardown' EXIT` in cmd_watch REPLACED
+# `trap on_exit_audit EXIT` for the rest of the process. The exit-site census
+# classified those two verbs correctly and still could not see it. Arm 11 pins the
+# trap population; arm 10/10b grade the behaviour. Re-run all THREE when this file
+# is touched.
 #
-# MUTATION GRADE — RUN, not asserted. Six mutations against the committed tree at
-# a2c41bf (rebased onto b64b6da), each reverted after; every one turns this file
-# red, and on the arms named. Baseline 11/0. Re-taken unchanged after the induction
-# moved from a stubbed `sqlite3` to the injection above. Later commits on this
-# branch touch only this file — `git diff a2c41bf HEAD -- src/` is EMPTY, so the
-# graded mechanism is the shipped one.
-#   * `mark_reported() { : ; }`                    -> 8/3  (arms 3, 4, 7)
-#   * drop `mark_reported` from fail()             -> 9/2  (arms 3, 7)
-#   * drop `mark_reported` from the usage sites    -> 10/1 (arm 4)
-#   * `_report_silent_exit() { return 0; }`        -> 6/5  (arms 1, 1b, 6, 8-liveness, 9)
-#   * move `_report_silent_exit` BELOW the `[[ -n "$AUDIT_CMD" ]]` return in
-#     on_exit_audit                                -> 7/4  (arms 1, 1b, 6, 9)
-#   * drop the 130/143 suppression                 -> 10/1 (arm 8, first half)
+# CENSUS A — 37 hits on a fresh bundle at this tree, classified: 10 marked
+# in-process sites (fail() itself, cmd_account, cmd_whoami, 7 usage exits) + 2
+# `trap '… exit 130' INT TERM` (covered by the signal rule) + 2 `_tasks_alarm …;
+# exit 3` inside a `( flock 9 )` SUBSHELL, which cannot double-report because a
+# `( )` subshell does not run the parent's EXIT trap (measured, bash 5.2) + 12
+# inside heredoc'd `bash -s` installers that are a DIFFERENT PROCESS and never
+# reach our trap + 10 that are comments, awk programs or JS + 1 `exit
+# "${E_PERMISSION:-13}"` in lib/tasks_db.sh. That last one is the BRACED form the
+# first version of this regex could not see: harmless (the branch only runs with
+# `fail` undefined, i.e. output.sh unsourced and no trap installed) but it was a
+# hole in the instrument, so the regex above now spans `${…}` and `${…:-…}` and
+# the count moved 35 → 36 (a comment, found on a re-count) → 37.
+#
+# CENSUS B answers "what else builds its own envelope": exactly two, cmd_account
+# and cmd_whoami, both marked. CENSUS C is arm 11's expected set — 3 lines, one
+# `trap on_exit_audit EXIT` and two identical `trap 'rm -rf "$TMPDIR"' EXIT` in
+# heredoc'd installers. Its `([[:space:]]|$)` tail is load-bearing: it is what
+# keeps the two PROSE mentions of the old clobbering line (in lib/output.sh and
+# cmd_watch.sh, which build.sh ships verbatim) out of the census. Re-run all three
+# when this file is touched — the population is what drifts, not the mechanism.
+#
+# MUTATION GRADE — RUN, not asserted. RE-TAKEN AT 1b50763 (this branch rebased onto
+# 089f7d2), twice: once before the rebase and once after, identical both times.
+# Re-taken because iteration 2 changed src/ and the previous table's
+# "`git diff a2c41bf HEAD -- src/` is EMPTY" no longer held — a mutation score
+# transfers only while the graded tree is the shipped one, and a rebase moves the
+# tree. Nothing after 1b50763 touches src/ (only this comment block), so
+# `git diff 1b50763 HEAD -- src/` is empty and the graded mechanism is the shipped
+# one. Eight mutations, each applied to the committed tree and reverted
+# after (`git checkout -- src/`, tree verified clean at the end); every one turns
+# this file red, on the arms named. Baseline 15/0, 1.7s on the dev box.
+#   * `push_exit_handler() { : ; }`                -> 14/1 (arm 10)
+#   * drop the `_five_run_exit_handlers` call from on_exit_audit  -> 14/1 (arm 10)
+#   * cmd_watch back to `trap '_watch_teardown' EXIT`            -> 14/1 (arm 11)
+#   * cmd_supervisor back to its raw `trap … EXIT`               -> 14/1 (arm 11)
+#   * `mark_reported() { : ; }`                    -> 12/3 (arms 3, 4, 7)
+#   * drop `mark_reported` from fail()             -> 13/2 (arms 3, 7)
+#   * `_report_silent_exit() { return 0; }`        -> 9/6  (arms 1, 1b, 6, 8-liveness, 9, 10)
+#   * drop the 130/143 suppression                 -> 14/1 (arm 8, first half)
+# The last four are the iteration-1 table re-run unchanged in shape; the counts
+# moved only because the baseline grew from 11 arms to 15. Note what the third and
+# fourth mutations do NOT red: arms 10/10b, which inject into `whoami`. Restoring
+# the clobbering line in a REAL verb is caught by the CENSUS and by nothing else
+# in this file — which is the whole reason arm 11 exists, and why the real-verb
+# behaviour is measured by hand in the ground-truth note below rather than here
+# (it needs a TTY, so it cannot be a CI arm).
+#
+# GROUND TRUTH ON THE REAL VERB, because arms 10/10b carry the property on `whoami`
+# (which needs no TTY) and a harness that only ever grades its own injection can be
+# right about a shape and wrong about the shipped verb. Two arms on one built
+# bundle, differing ONLY in whether cmd_watch registers its teardown via
+# `push_exit_handler` or the old `trap '_watch_teardown' EXIT`, each with a bare
+# `false` injected on the line after, run as `sudo script -qec "<bundle> watch"
+# /dev/null` (a TTY is required or both arms die at the `-t 1` gate and agree):
+#   push_exit_handler  -> rc=1, 476 bytes, full diagnostic naming verb `watch`,
+#                         and the alt-screen escapes come FIRST — the teardown ran
+#                         before the message, so it lands on a restored terminal
+#   trap … EXIT        -> rc=1,  18 bytes, terminal-reset escapes only, no report
+# That is the iteration-1 measurement reproduced and then reversed.
 # Arm 7 survives the reporter being dead ON PURPOSE — it asserts the real message
 # is still printed and the backstop stays quiet, so only the marker can move it.
 #
@@ -107,7 +152,11 @@ fi
 inject() {  # inject <src-bundle> <dst> [extra-awk-rewrite]
   awk -v extra="${3:-}" '
     /^cmd_whoami\(\) \{/ {
-      print; print "  _dive2598_induced=$(printf %s \"\" | grep -m1 zzz-no-match)"; next
+      print
+      if (extra == "chain")   { print "  _dive2598_teardown() { printf teardown-ran >&2; }"; print "  push_exit_handler _dive2598_teardown" }
+      if (extra == "clobber") { print "  _dive2598_teardown() { printf teardown-ran >&2; }"; print "  trap '\''_dive2598_teardown'\'' EXIT" }
+      print "  _dive2598_induced=$(printf %s \"\" | grep -m1 zzz-no-match)"
+      next
     }
     extra == "neuter" && /^_report_silent_exit\(\) \{/ { print "_report_silent_exit() { : ; }"; skip=1; next }
     skip && /^\}/ { skip=0; next }
@@ -226,6 +275,65 @@ out=$(rig 'trap on_exit_audit EXIT; AUDIT_CMD=""; false; :')
 [[ "$out" == *"without reporting a reason"* ]] \
   && ok_t 'a read-only command (AUDIT_CMD unset) is still reported' \
   || bad_t 'the report must precede the audit early-return' "out=[${out:0:200}]"
+
+# --- 10. A VERB THAT NEEDS ITS OWN CLEANUP DOES NOT DISABLE THE BACKSTOP -----
+# The iteration-1 gap. `watch` and `supervisor --watch` each wrote
+# `trap '<teardown>' EXIT`; bash traps REPLACE, so that line discarded
+# `trap on_exit_audit EXIT` for the rest of the process — no report, no audit
+# record — and no census of exit SITES could see it, because the line contains no
+# `exit`. Graded on `whoami` rather than the real verbs so it needs no TTY.
+CHAIN="$TMP/5dive-injected-chain"; inject "$BIN" "$CHAIN" chain
+CLOB="$TMP/5dive-injected-clobber"; inject "$BIN" "$CLOB" clobber
+grep -q 'push_exit_handler _dive2598_teardown' "$CHAIN" \
+  && grep -q "trap '_dive2598_teardown' EXIT" "$CLOB" \
+  || bad_t 'build the exit-handler bundles' 'an awk rewrite did not take — arms 10 and 10b would grade nothing'
+
+run "$CHAIN" whoami
+if [[ $RC -ne 0 && "$ERR" == *"teardown-ran"* && "$ERR" =~ $BACKSTOP_RE ]]; then
+  ok_t 'a verb registering cleanup via push_exit_handler keeps the backstop AND runs its teardown'
+else
+  bad_t 'push_exit_handler must chain, not replace' "rc=$RC stderr=[${ERR:0:300}]"
+fi
+
+# 10b. NON-VACUITY, and the reason the helper exists rather than a review rule:
+#      the same teardown installed the obvious way still runs and still kills the
+#      report. If this ever stops being silent, arm 10 is proving nothing.
+run "$CLOB" whoami
+if [[ $RC -ne 0 && "$ERR" == *"teardown-ran"* && ! "$ERR" =~ $BACKSTOP_RE ]]; then
+  ok_t "non-vacuity: the same teardown as a raw \`trap ... EXIT\` still runs and silences the report (rc=$RC)"
+else
+  bad_t 'the clobbering shape must reproduce the silent exit' "rc=$RC stderr=[${ERR:0:300}] — if this reports, arm 10 grades nothing"
+fi
+
+# --- 11. THE POPULATION: exactly one EXIT trap in the shipped bundle ---------
+# A property hung off a trap has a second population beside the exit sites, and
+# arm 10 only covers the two verbs we already know about. This is the arm that
+# catches the NEXT cmd_* to write the obvious thing: any EXIT trap in the bundle
+# other than the classified set below reds here and has to be justified.
+#   * `trap on_exit_audit EXIT`      — main.sh, the one process-wide trap
+#   * `trap 'rm -rf "$TMPDIR"' EXIT` — TWICE (cmd_skill.sh, lib/agent_setup.sh),
+#     both inside heredoc'd `bash -s` installers that are a DIFFERENT PROCESS and
+#     never see ours; identical text, so `sort -u` folds them to one line.
+census_traps() {  # census_traps <bundle> — distinct EXIT-trap installs, C-collated
+  grep -oE "trap[[:space:]]+('[^']*'|\"[^\"]*\"|[A-Za-z_][A-Za-z0-9_]*)[[:space:]]+EXIT([[:space:]]|$)" "$1" \
+    | sed 's/[[:space:]]*$//' | LC_ALL=C sort -u
+}
+EXPECTED_TRAPS=$'trap \'rm -rf "$TMPDIR"\' EXIT\ntrap on_exit_audit EXIT'
+FOUND_TRAPS=$(census_traps "$BIN")
+if [[ "$FOUND_TRAPS" == "$EXPECTED_TRAPS" ]]; then
+  ok_t 'the built bundle installs no EXIT trap beyond the classified set (nothing can clobber the backstop)'
+else
+  bad_t 'unclassified EXIT trap in the bundle' "found:
+$FOUND_TRAPS
+expected:
+$EXPECTED_TRAPS
+A new \`trap ... EXIT\` REPLACES on_exit_audit. Use push_exit_handler, or classify it here."
+fi
+# Liveness for the arm above: a clean census is worthless unless the same census
+# reds on a bundle that HAS the extra trap. $CLOB is exactly that bundle.
+[[ "$(census_traps "$CLOB")" != "$EXPECTED_TRAPS" ]] \
+  && ok_t 'liveness pair: the same census DOES flag a bundle carrying an extra EXIT trap' \
+  || bad_t 'the census must detect an added EXIT trap' "census of the clobber bundle matched the expected set — the arm above cannot fail"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## The defect

`5dive task done DIVE-XXXX --result="plain text no refs"` exited **1** with zero bytes on
stdout *and* stderr, and left the row open. A caller that pipes to `head` and reads `$?` gets
a number with no message attached to it; one that reads only output sees success. It took a
`bash -x` of the installed binary to find, which is the tell — the product itself said nothing.

The line was an unguarded `_br_cands=$(_gate_branch_refs_from_text …)`. That pipeline ends in
`grep`, which exits 1 when it matches nothing — the normal case, since most results name no
branch. `pipefail` promotes it, and under `set -euo pipefail` a bare `var=$(…)` takes the
process down **before any handler runs**.

**That half is already fixed and is not in this PR.** #402 (DIVE-2603) guarded the line and
ships in 0.18.6; `tests/task_merge_gate_branch_in_result_unit.sh` pins it. DIVE-2566 was the
identical shape in `5dive push` one file over, in the same release.

This PR is the other half the report asked for: *"a close that refuses must print why."*

## Not a third guard — the property

Two per-line guards do not make the third unguarded substitution less likely; writing
`var=$(…)` is normal. So:

- `fail()` — which every reported error funnels through, `policy_refuse()` included — marks
  the exit **reported**, after it prints.
- The `EXIT` trap reports anything else: verb, code, that the command did **not** run to
  completion so its effect is unknown, how to locate it (`bash -x $(command -v 5dive) …`), and
  `5dive bug`. Under `--json` it emits a real `{ok:false,error:{…}}` envelope — an empty
  stdout is worse for a parser than for a person.
- It runs **before** the `AUDIT_CMD` early-return in `on_exit_audit`, or every read-only verb
  stays silent (`AUDIT_CMD` is only set for mutating verbs).
- Signals (130/143) are not unreported failures and stay quiet.

**The marker is a FILE, not a variable, and that is the load-bearing decision.** A variable is
tidier and it is wrong: `fail()` runs inside command substitutions and `flock` subshells, so a
variable set there dies with the subshell and the parent's `EXIT` trap would report an
already-reported failure as unreported — two messages for every subshell error, the real one
and a backstop claiming there wasn't one. Keyed on `$$` (not `$BASHPID`): identical in every
subshell of one invocation, different in a nested child. Cleared at load, so a stale same-pid
file can only make us MISS a report, never invent one.

## How the exit-site population was enumerated — by operation, because reading missed one

The backstop must stay quiet for every deliberate non-zero exit that prints its own reason and
never routes through `fail()`. **Reading `src/` found the seven `<verb>_usage; exit "$E_USAGE"`
sites and `cmd_account`'s in-use refusal. It missed `cmd_whoami`'s UNMEASURABLE refusal** —
which builds its own `{ok:false,…,data:{…}}` envelope because `fail()` cannot carry `data`.
The core tier caught that one red (`whoami_sealed_actor_unit.sh` T12), and a second envelope on
stdout is not JSON, so a *correct* refusal parsed as nothing at all. The only reason the count
is not still wrong is that a test disagreed with the enumeration.

So the set is enumerated by operation over the **built bundle**, not by inspection:

```sh
grep -nE '(^|[;&|[:space:]])exit[[:space:]]+("?\$[A-Za-z_]\w*"?|[1-9][0-9]*)' 5dive
grep -rn 'ok:false' src/ | grep -v src/lib/output.sh      # "what else builds its own envelope"
```

**35 hits, classified:**

| bucket | n | disposition |
|---|---|---|
| in-process, bypass `fail()` | 10 | **marked**: `fail()` itself, `cmd_account`, `cmd_whoami`, 7 usage exits |
| `trap '… exit 130' INT TERM` | 2 | covered by the signal rule |
| `_tasks_alarm …; exit 3` in a `( flock 9 )` **subshell** | 2 | a `( )` subshell does not run the parent's `EXIT` trap (measured, bash 5.2) |
| inside heredoc'd `bash -s` installers | 12 | a **different process**; never reaches our trap |
| comments, `awk` programs, JS | 9 | not exits |

The second grep answers "what else builds its own envelope": exactly two, `cmd_account` and
`cmd_whoami`, both marked. Both greps are recorded in the harness header — the population is
the thing that drifts, not the mechanism.

## Evidence

`tests/silent_nonzero_exit_backstop_unit.sh` — 11 arms, ~1.2s, core tier.

Graded against a **real induced death in a real built bundle**: `sqlite3` stubbed to `exit 1`
on `PATH` kills any store-reading verb exactly this way — chosen over patching a source line so
the arm cannot be satisfied by a guard added to one call site. The differential is the **same
bundle with the backstop neutered**: mutant is rc 1 with **zero bytes on both streams**,
patched is rc 1 plus the diagnostic. Control and test differ in the mechanism under test and
nothing else.

Six mutations against the committed tree, each red on the named arms (baseline 11/0):

| mutation | result |
|---|---|
| `mark_reported() { : ; }` | 8/3 |
| drop `mark_reported` from `fail()` | 9/2 |
| drop `mark_reported` from the usage sites | 10/1 |
| `_report_silent_exit() { return 0; }` | 6/5 |
| move the report BELOW the `AUDIT_CMD` return | 7/4 |
| drop the 130/143 suppression | 10/1 |

Core tier: **0 harness failures**.

## Also settled, and it removes a defect from the backlog rather than adding a fix

The report carried a second arm — "fails both WITH and WITHOUT a gh token in the environment",
honestly flagged as reproduced-but-not-traced. There is no second arm. `_gate_gh_token`
resolves from four sources and every agent account falls through to
`sudo -n -u claude gh auth token`, so unsetting the variable never produced a tokenless run.
Both arms were one code path and one guard closed both; measured after the fix,
`env -u GH_TOKEN -u GITHUB_TOKEN 5dive task done` succeeds identically. Building a guard for
the phantom would have looked like diligence. *To negate a capability, negate its **resolver**,
not the one input you know about.*

Wiki: `a-cli-that-exits-non-zero-without-a-reason` (new), plus that rule appended to
`test-harness-credential-reach-and-transcript-durability`.
