### PR TITLE
feat(doctor): report marketplace clone freshness per AGENT (DIVE-2642)

### DIFF
--- a/src/cmd_doctor.sh
+++ b/src/cmd_doctor.sh
@@ -90,6 +90,121 @@ doctor_check_audit_drop_dir() {
     "$dir is a directory with mode 2770 and group $expected_group; lost audit rows can leave a drop marker"
 }
 
+# doctor_marketplace_reference_sha [remote-url] [branch]
+#
+# The PUBLISHED head of the plugin marketplace, read from the remote rather than
+# from any local checkout: a shared clone on this box can sit arbitrarily far
+# behind and would make every reader look current against it. Prints a 40-hex
+# sha, or nothing with rc 1 when it could not be resolved (no network, renamed
+# branch, unauthenticated remote). The caller must treat rc 1 as UNKNOWN.
+doctor_marketplace_reference_sha() {
+  local url="${1:-https://github.com/5dive-ai/5dive-plugins.git}"
+  local branch="${2:-main}" out
+  out=$(git ls-remote --heads "$url" "$branch" 2>/dev/null) || return 1
+  out="${out%%[!0-9a-f]*}"
+  [[ "$out" =~ ^[0-9a-f]{40}$ ]] || return 1
+  printf '%s\n' "$out"
+}
+
+# doctor_check_marketplace_clones [homes-root] [reference-sha] [clone-relpath]
+#
+# DIVE-2642 / DIVE-2621 item (d). The reader of a merged marketplace change is a
+# CLONED AGENT, not a git tree — and the clone lives under each agent's own
+# $HOME, so "is this deployed?" has a DIFFERENT ANSWER PER AGENT. On 2026-08-03
+# one merged commit had five distinct shas live on this box at once and nothing
+# reported it. A boolean would have been a lie: four agents on four shas have no
+# single refresh.
+#
+# So this check reports a POPULATION — N of M, every sha named — and never a
+# yes/no. Three rules it must not break:
+#
+#   1. Never green when it could not run. A missing reference, an unreadable
+#      clone, or a home root with no agents in it reads UNKNOWN. An absence of
+#      complaint is not evidence.
+#   2. Never infer freshness from presence. The sha a clone's HEAD resolves to is
+#      what that agent EXECUTES; a file existing under the clone is not.
+#   3. A path we could not LOOK at is not a path we know is absent. Denial and
+#      absence are indistinguishable from outside the permission boundary, so a
+#      home whose plugins dir we cannot read counts as UNKNOWN, not as "no clone".
+doctor_check_marketplace_clones() {
+  local homes_root="${1:-/home}"
+  local ref_sha="${2:-}"
+  local rel="${3:-.claude/plugins/marketplaces/5dive-plugins}"
+  local home name clone sha behind total msg sev
+  local -a current=() stale=() unknown=() absent=()
+
+  for home in "$homes_root"/*/; do
+    home="${home%/}"
+    name="${home##*/}"
+    [[ -d "$home/.claude" ]] || continue   # not an agent home; not part of M
+    clone="$home/$rel"
+    if [[ ! -d "$clone" ]]; then
+      if [[ -e "$home/.claude/plugins" && ! -r "$home/.claude/plugins" ]]; then
+        unknown+=("$name:unreadable-home")
+      else
+        absent+=("$name")
+      fi
+      continue
+    fi
+    sha=$(git -C "$clone" rev-parse HEAD 2>/dev/null) || sha=""
+    if [[ -z "$sha" ]]; then
+      unknown+=("$name:unreadable-clone")
+    elif [[ -z "$ref_sha" ]]; then
+      unknown+=("$name:${sha:0:7}")
+    elif [[ "$sha" == "$ref_sha" ]]; then
+      current+=("$name:${sha:0:7}")
+    else
+      # Distance is only computable when the published commit is in THIS clone's
+      # object store; a clone that never fetched it can still be graded stale.
+      behind=""
+      if git -C "$clone" cat-file -e "${ref_sha}^{commit}" 2>/dev/null; then
+        behind=$(git -C "$clone" rev-list --count "HEAD..$ref_sha" 2>/dev/null)
+      fi
+      if [[ -n "$behind" ]]; then
+        stale+=("$name:${sha:0:7} (behind by $behind)")
+      else
+        stale+=("$name:${sha:0:7} (distance unknown)")
+      fi
+    fi
+  done
+
+  total=$(( ${#current[@]} + ${#stale[@]} + ${#unknown[@]} + ${#absent[@]} ))
+
+  if (( total == 0 )); then
+    doctor_add plugins marketplace-freshness warn \
+      "UNKNOWN: no agent home found under $homes_root — nothing was measured, which is not the same as fresh"
+    return 0
+  fi
+
+  if [[ -z "$ref_sha" ]]; then
+    doctor_add plugins marketplace-freshness warn \
+      "UNKNOWN: the published marketplace head could not be resolved (git ls-remote), so none of the $total agent clone(s) can be graded — UNKNOWN, not fresh$(doctor_mp_list ' | running:' "${unknown[@]}")"
+    return 0
+  fi
+
+  msg="${#current[@]} of $total agent clones run published main ${ref_sha:0:7}"
+  sev=ok
+  if (( ${#stale[@]} || ${#unknown[@]} )); then
+    sev=warn
+    msg="STALE: $msg"
+  fi
+  msg+="$(doctor_mp_list ' | behind:' "${stale[@]}")"
+  msg+="$(doctor_mp_list ' | UNKNOWN:' "${unknown[@]}")"
+  msg+="$(doctor_mp_list ' | no clone:' "${absent[@]}")"
+  if [[ "$sev" == warn ]]; then
+    msg+=" — a clone's version is per-AGENT, so one refresh does not fix the fleet; each listed clone is its own git checkout under that agent's \$HOME/$rel"
+  fi
+  doctor_add plugins marketplace-freshness "$sev" "$msg"
+}
+
+# doctor_mp_list <label> [item...]  — " label a, b", or "" when there are none.
+doctor_mp_list() {
+  local label="$1"; shift
+  (( $# )) || return 0
+  local IFS=', '
+  printf '%s %s' "$label" "$*"
+}
+
 # doctor_check_reaped_homes [dir]
 #
 # DIVE-2138 quarantines a removed agent's home under REAPED_DIR instead of
@@ -167,11 +282,12 @@ cmd_doctor() {
     # `--category=policy` failed usage for every caller who read the error message
     # and did what it said. Pre-existing; fixed here because this change lands its
     # surface under that category and would otherwise be unreachable by filter.
-    ""|deps|types|auth|creds|registry|shelld|channels|host|memory|policy) ;;
-    *) fail "$E_USAGE" "unknown --category (deps|types|auth|creds|registry|shelld|channels|host|memory|policy)" ;;
+    ""|deps|types|auth|creds|registry|shelld|channels|host|memory|policy|plugins) ;;
+    *) fail "$E_USAGE" "unknown --category (deps|types|auth|creds|registry|shelld|channels|host|memory|policy|plugins)" ;;
   esac
 
   local run_deps=0 run_types=0 run_auth=0 run_creds=0 run_registry=0 run_shelld=0 run_channels=0 run_host=0 run_memory=0 run_policy=0
+  local run_plugins=0
   [[ -z "$filter" || "$filter" == "deps"     ]] && run_deps=1
   [[ -z "$filter" || "$filter" == "types"    ]] && run_types=1
   [[ -z "$filter" || "$filter" == "auth"     ]] && run_auth=1
@@ -182,6 +298,7 @@ cmd_doctor() {
   [[ -z "$filter" || "$filter" == "host"     ]] && run_host=1
   [[ -z "$filter" || "$filter" == "memory"   ]] && run_memory=1
   [[ -z "$filter" || "$filter" == "policy"   ]] && run_policy=1
+  [[ -z "$filter" || "$filter" == "plugins"  ]] && run_plugins=1
 
   # --- deps ---
   if (( run_deps )); then
@@ -758,6 +875,17 @@ cmd_doctor() {
   # store (kept coarse so a rotting store doesn't flood the dashboard with rows);
   # `5dive memory doctor --json` gives the itemized list. Non-fatal: a scan
   # failure (e.g. no python) degrades to a single warn, never aborts doctor.
+  # --- plugins (marketplace clone freshness, DIVE-2642) ---
+  #
+  # Per AGENT, never per host: the clone lives under each agent's own $HOME, so a
+  # single verdict for "this box" cannot exist. The reference is read from the
+  # REMOTE; if that fails the whole check reads UNKNOWN rather than green.
+  if (( run_plugins )); then
+    local _mp_ref=""
+    _mp_ref=$(doctor_marketplace_reference_sha) || _mp_ref=""
+    doctor_check_marketplace_clones /home "$_mp_ref"
+  fi
+
   if (( run_memory )); then
     local mem_roots=() code_root=""
     for d in /home/claude/projects/5dive /home/claude/projects; do

--- a/src/main.sh
+++ b/src/main.sh
@@ -313,7 +313,7 @@ Health:
     create\`, so it lands as 5dive-bot); a TTY also gets an interactive y/N.
     Agents take the same --file flag a human does — no separate unattended path.
 
-  5dive doctor [--fix] [--dry-run] [--category=deps|types|auth|creds|registry|shelld|channels|host|memory]
+  5dive doctor [--fix] [--dry-run] [--category=deps|types|auth|creds|registry|shelld|channels|host|memory|policy|plugins]
     Walks deps (tmux/jq/bun/python3/nvm/node/npm), type bins, live auth
     probes, stale shadow-credential heal (creds), registry integrity, channel
     health (allowlist + dead inbound telegram poller), host safety (needrestart

--- a/tests/doctor_marketplace_freshness_unit.sh
+++ b/tests/doctor_marketplace_freshness_unit.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# DIVE-2642 (split of DIVE-2621 item d) — the marketplace reader is a CLONED
+# AGENT, and the clone lives under each agent's own $HOME. Four agents sat on
+# four distinct shas of one merged commit on 2026-08-03 and no surface reported
+# it, so this harness grades the surface that now does.
+#
+# The accepting evidence is the STALE arm going RED and the CANNOT-RUN arms
+# reading UNKNOWN. A green on a fleet that happens to be current proves nothing,
+# which is why the all-current arm is here only as the non-vacuity control: it
+# shows the check CAN say ok, so the warns above are not a constant.
+#
+# Runs against synthetic homes: no root, no network, no real agent home touched.
+# Run: bash tests/doctor_marketplace_freshness_unit.sh
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+
+TMP="$(mktemp -d /tmp/doctor-mp-freshness.XXXXXX)"
+trap 'chmod -R u+rwX "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1091
+source src/header.sh
+# shellcheck disable=SC1091
+source src/lib/error_codes.sh
+# shellcheck disable=SC1091
+source src/lib/output.sh
+# shellcheck disable=SC1091
+source src/cmd_doctor.sh
+set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+G=(git -c user.email=agent@example.com -c user.name=fixture -c commit.gpgsign=false -c init.defaultBranch=main)
+
+# --- fixture: an upstream marketplace with two commits ---------------------
+UP="$TMP/upstream"
+mkdir -p "$UP"; "${G[@]}" -C "$UP" init -q .
+echo v1 >"$UP/plugin.json"; "${G[@]}" -C "$UP" add -A; "${G[@]}" -C "$UP" commit -qm v1
+OLD_SHA=$("${G[@]}" -C "$UP" rev-parse HEAD)
+echo v2 >"$UP/plugin.json"; "${G[@]}" -C "$UP" add -A; "${G[@]}" -C "$UP" commit -qm v2
+NEW_SHA=$("${G[@]}" -C "$UP" rev-parse HEAD)
+
+REL=".claude/plugins/marketplaces/5dive-plugins"
+HOMES="$TMP/home"
+
+# make_home <name> <current|stale|none|broken|unreadable>
+make_home() {
+  local name="$1" kind="$2"
+  local h="$HOMES/$name"
+  mkdir -p "$h/.claude"
+  case "$kind" in
+    none) ;;
+    broken) mkdir -p "$h/$REL" ;;                        # a directory, but no git
+    unreadable)
+      mkdir -p "$h/$REL"
+      "${G[@]}" clone -q "$UP" "$h/$REL" 2>/dev/null
+      chmod 000 "$h/.claude/plugins" ;;
+    *)
+      "${G[@]}" clone -q "$UP" "$h/$REL"
+      [[ "$kind" == stale ]] && "${G[@]}" -C "$h/$REL" reset -q --hard "$OLD_SHA"
+      ;;
+  esac
+}
+
+run_check() {                                            # run_check <ref-sha>
+  DOCTOR_CHECKS='[]'
+  doctor_check_marketplace_clones "$HOMES" "$1" "$REL" >/dev/null
+  jq -c '.[0]' <<<"$DOCTOR_CHECKS"
+}
+
+assert_row() {                                           # <label> <ref> <sev> <rx>
+  local label="$1" ref="$2" severity="$3" rx="$4" row
+  row=$(run_check "$ref")
+  if jq -e --arg s "$severity" --arg rx "$rx" \
+      '.category == "plugins" and .name == "marketplace-freshness"
+       and .severity == $s and (.message | test($rx))' <<<"$row" >/dev/null; then
+    ok_t "$label"
+  else
+    bad_t "$label" "$row"
+  fi
+}
+
+# 1. THE ACCEPTING ARM. One stale clone among current ones is reported red, by
+#    NAME and sha, with the distance — not as a fleet boolean.
+make_home a-current current
+make_home b-stale   stale
+assert_row "a stale clone reads warn and names agent, sha and distance" \
+  "$NEW_SHA" warn "^STALE: 1 of 2 .*behind: b-stale:${OLD_SHA:0:7} \\(behind by 1\\)"
+
+# 2. Every stale clone is listed. A population, not a first-hit report: four
+#    agents on four shas have no single refresh, so all four must be nameable.
+make_home c-stale stale
+assert_row "a second stale clone is listed too (N of M, not a boolean)" \
+  "$NEW_SHA" warn "^STALE: 1 of 3 .*b-stale:${OLD_SHA:0:7}.*c-stale:${OLD_SHA:0:7}"
+
+# 3. CANNOT-RUN ARM 1: no published reference (ls-remote failed / no network).
+#    The fleet below is unchanged, so ONLY the missing reference moves this.
+assert_row "an unresolvable published head reads UNKNOWN, never fresh" \
+  "" warn "^UNKNOWN: the published marketplace head could not be resolved"
+
+# 4. CANNOT-RUN ARM 2: a clone directory that is not a git checkout is UNKNOWN,
+#    not fresh and not absent. Presence of the directory is not a version.
+rm -rf "${HOMES:?}/b-stale" "${HOMES:?}/c-stale"
+make_home d-broken broken
+assert_row "a non-git clone dir reads UNKNOWN, not fresh" \
+  "$NEW_SHA" warn "UNKNOWN:.*d-broken:unreadable-clone"
+
+# 5. A path we cannot LOOK at is not a path we know is absent.
+rm -rf "${HOMES:?}/d-broken"
+if (( EUID == 0 )); then
+  printf 'SKIP - unreadable-home arm: running as root, chmod 000 does not deny root (arm would be vacuous)\n'
+else
+  make_home e-denied unreadable
+  assert_row "an unreadable home reads UNKNOWN, not 'no clone'" \
+    "$NEW_SHA" warn "UNKNOWN:.*e-denied:unreadable-home"
+  chmod 755 "$HOMES/e-denied/.claude/plugins"
+  rm -rf "${HOMES:?}/e-denied"
+fi
+
+# 6. CANNOT-RUN ARM 3: a home root with no agent homes in it. Nothing measured
+#    is not the same as everything fresh — the emptiest possible green.
+EMPTY="$HOMES"; HOMES="$TMP/emptyroot"; mkdir -p "$HOMES/not-an-agent"
+assert_row "a home root with no agent homes reads UNKNOWN, not fresh" \
+  "$NEW_SHA" warn "^UNKNOWN: no agent home found under"
+HOMES="$EMPTY"
+
+# 7. An agent with no marketplace clone is reported, but is not itself staleness:
+#    it has no reader to be stale. Listed as context on an otherwise-ok row.
+make_home f-noclone none
+assert_row "a home without a clone is listed but does not fabricate staleness" \
+  "$NEW_SHA" ok "^1 of 2 agent clones run published main ${NEW_SHA:0:7}.*no clone: f-noclone"
+
+# 8. NON-VACUITY CONTROL: an all-current fleet is the ONLY shape that says ok,
+#    which is what makes every warn above a real discrimination.
+rm -rf "${HOMES:?}/f-noclone"
+make_home g-current current
+assert_row "an all-current fleet is ok (control: the check can say ok)" \
+  "$NEW_SHA" ok "^2 of 2 agent clones run published main ${NEW_SHA:0:7}$"
+
+# 9. The reference resolver reports FAILURE rather than a bare empty string, so
+#    a caller cannot mistake "could not ask" for "nothing published".
+out=$(doctor_marketplace_reference_sha "file://$TMP/no-such-repo" main 2>/dev/null); rc=$?
+if (( rc != 0 )) && [[ -z "$out" ]]; then
+  ok_t "the reference resolver exits non-zero on an unresolvable remote"
+else
+  bad_t "the reference resolver exits non-zero on an unresolvable remote" "rc=$rc out=$out"
+fi
+
+out=$(doctor_marketplace_reference_sha "file://$UP" main); rc=$?
+if (( rc == 0 )) && [[ "$out" == "$NEW_SHA" ]]; then
+  ok_t "the reference resolver returns the published head sha"
+else
+  bad_t "the reference resolver returns the published head sha" "rc=$rc out=$out"
+fi
+
+# 10. THE WIRING, EXECUTED — not read. A check nobody dispatches is a check that
+#     never runs, and `--category=plugins` failing usage would make the surface
+#     unreachable exactly the way `--category=policy` was (DIVE-2327). Stub the
+#     root requirement and the two workers, then drive the real cmd_doctor.
+require_root() { :; }
+MP_CALLED=""
+doctor_marketplace_reference_sha() { printf 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n'; }
+doctor_check_marketplace_clones() { MP_CALLED="$1|$2"; }
+
+cmd_doctor --category=plugins >/dev/null 2>&1
+if [[ "$MP_CALLED" == "/home|deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" ]]; then
+  ok_t "--category=plugins dispatches the clone check with the resolved reference"
+else
+  bad_t "--category=plugins dispatches the clone check with the resolved reference" "MP_CALLED=$MP_CALLED"
+fi
+
+HOST_CALLED=""
+doctor_check_audit_drop_dir() { HOST_CALLED=yes; }
+MP_CALLED=""
+cmd_doctor --category=plugins >/dev/null 2>&1
+if [[ -n "$MP_CALLED" && -z "$HOST_CALLED" ]]; then
+  ok_t "the filter is real: --category=plugins runs the clone check and not the host ones"
+else
+  bad_t "the filter is real: --category=plugins runs the clone check and not the host ones" "MP_CALLED=$MP_CALLED HOST_CALLED=$HOST_CALLED"
+fi
+
+# A category the parser does not know must still fail usage, and the usage text
+# must NAME plugins — an unlisted-but-dispatched category is unreachable by
+# every caller who reads the error (DIVE-2327).
+usage_out=$( (cmd_doctor --category=definitely-not-a-category) 2>&1 ); usage_rc=$?
+if (( usage_rc != 0 )) && [[ "$usage_out" == *plugins* ]]; then
+  ok_t "an unknown category fails usage and the usage text lists plugins"
+else
+  bad_t "an unknown category fails usage and the usage text lists plugins" "rc=$usage_rc out=$usage_out"
+fi
+
+# 11. A reference that could not be resolved must reach the check as EMPTY, so
+#     the UNKNOWN branch above is the one that fires. Silently substituting a
+#     local checkout here would re-create the defect one layer down.
+MP_CALLED="unset"
+doctor_marketplace_reference_sha() { return 1; }
+cmd_doctor --category=plugins >/dev/null 2>&1
+if [[ "$MP_CALLED" == "/home|" ]]; then
+  ok_t "an unresolvable reference reaches the check as empty (UNKNOWN, not substituted)"
+else
+  bad_t "an unresolvable reference reaches the check as empty (UNKNOWN, not substituted)" "MP_CALLED=$MP_CALLED"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+(( FAIL == 0 ))


### PR DESCRIPTION
Four cloned agents were found running four stale shas with nothing reporting it (DIVE-2621 item d). This adds `5dive doctor --category=plugins`: `doctor_check_marketplace_clones` + `doctor_marketplace_reference_sha` in src/cmd_doctor.sh, wired into the parser allow-list, the run flags, the dispatch, and the main.sh usage line.

IT REPORTS A POPULATION, NEVER A PER-HOST BOOLEAN. The reader is a cloned agent under its own HOME, so N agents on N shas have no single refresh. Every agent and sha is named, with distance in commits where the published commit is in that clone's object store.

The reference head is read from the REMOTE via `git ls-remote`, never from a local checkout that could share the fleet's own lag.

THREE CANNOT-RUN STATES READ UNKNOWN AND NEVER GREEN: reference unresolvable, clone unreadable or not a git checkout, and zero agent homes found. A home whose plugins dir cannot be read is filed UNKNOWN rather than "no clone", because absence measured across a permission boundary is denial, not evidence.

REAL-FLEET READING, run as root from this branch's built bundle at verification:

  STALE: 0 of 17 agent clones run published main 0714bb6
    6040547  community, creative, dev, don, main, marketing, olivia, vesper, warm-mark
    113282f  dev2      036c336  dev3      912ab7c  main2      e59e7a8  quinn
    no clone: andy, codex, ocqa, claude

ZERO of seventeen. The row was filed over four stale clones; the surface's first real reading is that none are current, across five distinct shas. That reading did not exist before this change and could not be produced by any combination of existing commands.

THE DENOMINATOR MOVED WITH THE OBSERVER, which is the finding the compiled page is named for. The maker, unprivileged, saw 14 of 16 homes answer UNKNOWN across the permission boundary. As root the same check sees 13 real clones and 4 genuine absences. Both readings are correct and neither is complete on its own; filing unreadable homes as UNKNOWN rather than absent is what keeps the unprivileged view honest instead of reassuring.

GRADED BY MUTATION, not by a green. The accepting evidence is the STALE arm going red and each cannot-run arm reading UNKNOWN; the all-current arm exists only as a non-vacuity control proving the check CAN say ok. Maker ran six mutants, each red at the arm that owns it. Verifier reproduced two independently, in a writable copy after the first attempt hit permission-denied against the maker's worktree and printed a full green that graded nothing:

  baseline                              14 passed, 0 failed
  UNKNOWN no longer forces non-ok       12 passed, 2 failed
  dispatch removed                      11 passed, 3 failed
  restored                              14 passed, 0 failed

Dispatch and the `--category=plugins` filter are EXECUTED in the harness, not read — a check nobody dispatches is a check that never runs, and a category dispatched but missing from the parser allow-list is unreachable by every caller who reads the usage error.

Authored by dev3, verified and merged by main (dev3 holds no gh credential). Compiled: community/wiki/a-freshness-check-inherits-its-denominator-from-its-own-visibility.md
