### PR TITLE
fix(gate): the T2 floor reads the ACTION, not the branch name (DIVE-2629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## Unreleased — fix(gate): the tier-2 destructive floor graded the BRANCH NAME in a push-for-review ask (DIVE-2629)
+
+`approve delegated push for review of branch dive-2613-teardown-outcomes-hetzner-only`
+filed as a **tier-2 human-only** gate. Delete the single word `teardown` from that
+branch name and the identical ask filed tier-1. Graft it onto an unrelated branch and
+that one floored too.
+
+The floor exists to catch **destructive actions**. The action here is "push a feature
+branch to a remote for review" — no merge, no prod touch, reversible, destroys nothing.
+What was destructive-sounding is the **subject of the code on the branch**. The floor was
+reading what the work is *about* and grading it as what the gate *does*, so the better a
+branch name described the work, the likelier it floored: the naming convention we want is
+the one that tripped it.
+
+**Why that was a ratchet, not one extra tap.** A tier-2 approval is filed with no
+`routed_reviewer`, and `cmd_task_answer`'s designated-reviewer exception requires
+`actor == routed_reviewer`. Once floored, **no agent could ever clear it** — not the filer,
+not their lead, not the org coordinator — and no agent action handed it back. DIVE-2613 was
+one of six engineering gates that reached the paired human on 2026-08-03, and dev2 stayed
+blocked behind it.
+
+The fix **scopes the match, not the verdict**: when — and only when — the text is recognised
+as an *inert* push-for-review, the git branch identifier is removed before the floor reads
+it. A branch name is a label, never a statement of the action a gate authorises. Everything
+else in the ask is still read unchanged, so a push ask that **also** names a spend, a secret,
+a publish or a customer email still floors on its own prose.
+
+Three narrowings, all biased toward keeping the floor on:
+
+- **Not the whole eng-ship class.** `merge`, `deploy`, roll-to-fleet and push-to-`main` touch
+  prod and keep flooring on their subject matter.
+- **Only branch-*shaped* tokens are redacted** — a slash (`feat/x`), a ticket prefix
+  (`dive-2613-…`), or two-plus hyphens. Hyphenated prose like `auto-teardown` is a word, not
+  a ref, and still floors.
+- **Applied at the single match site**, so the filing floor, the approval/manual routing arm
+  and `cmd_goal`'s low-risk check all inherit the same verdict from the same inputs.
+
+`tests/gate_floor_branch_name_unit.sh` (33 arms) grades both directions, and four mutations
+are documented in its header — removing the redaction, dropping the not-inert guard, widening
+the slug shape to any hyphen, and un-mirroring the reporter each redden a named arm.
+
 ## Unreleased — fix(init): the `codex` recipe asked nvm which node it SELECTED, not npm where it INSTALLED (DIVE-2596)
 
 `sudo 5dive agent create --type=codex` aborted with

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -4578,6 +4578,103 @@ _gate_needs_human() {
   [[ " $_GATE_HUMAN_CAPABILITIES " == *" $c "* ]]
 }
 
+# DIVE-2629: THE FLOOR MUST READ THE ACTION, NOT THE SUBJECT MATTER OF THE CODE.
+#
+# THE DEFECT, measured by main 2026-08-03 by running _gate_tier2_floor_hit on four
+# ask strings that differ by ONE token:
+#
+#   'approve delegated push for review of branch dive-2613-teardown-outcomes-...'  -> T2
+#   'approve delegated push for review of branch dive-2613-outcomes-hetzner-only'  -> T1
+#   'approve delegated push for review of branch dive-XXXX-teardown-foo'           -> T2
+#   'approve delegated push for review of branch dive-2592-budget-variance'        -> T1
+#
+# The word 'teardown' appearing ONLY inside a git branch NAME forces tier 2. The
+# floor exists to catch DESTRUCTIVE ACTIONS; the action here is "push a feature
+# branch to a remote for review" — inert by construction, no merge, no prod touch,
+# reversible. What is destructive-sounding is the SUBJECT of the code on the
+# branch. The floor was reading what the work is ABOUT and grading it as what the
+# gate DOES, so the better a branch name describes the work the likelier it floors:
+# the naming convention we WANT is the one that trips it.
+#
+# WHY THAT IS A RATCHET AND NOT ONE EXTRA TAP. A tier-2 approval is filed with NO
+# routed_reviewer, and cmd_task_answer's designated-reviewer exception requires
+# actor == routed_reviewer. So NO agent can ever clear it — not the filer, not
+# their lead, not the org coordinator — and no agent action hands it back. It is
+# permanently the human's. DIVE-2613 is one of the six eng gates lodar objected to
+# on 2026-08-03 ("can you stop pinging me for dev stuff") and dev2 stayed blocked
+# behind it. The floor's usual "a false positive costs one tap" bias does not hold
+# on this path, because there is no tap that gives it back.
+#
+# THE FIX SCOPES THE MATCH, NOT THE VERDICT (main's shape, adopted). Exempting the
+# individual words would be the tempting non-fix — it keeps the wrong question and
+# tidies the answer, the same way stripping +suffix was the non-fix on DIVE-2594.
+# Instead: when — and only when — the text is recognised as an INERT
+# push-for-review, the git branch IDENTIFIER is removed before the floor reads it.
+# A branch name is a label, never a statement of the action a gate authorises.
+# Everything else in the ask is still read, unchanged: a push ask that ALSO names a
+# spend, a secret or a publish still floors, because those words are in the prose.
+#
+# THREE NARROWINGS, all deliberate, all biased toward KEEPING the floor:
+#
+#   1. NOT the whole eng-ship class. _gate_eng_ship_hit also covers merge, deploy,
+#      roll-to-fleet and push-to-main — those TOUCH PROD and are not inert, so they
+#      must keep flooring on their subject matter. _GATE_PUSH_NOT_INERT_RX kicks
+#      the text back out of this exemption the moment it names one of them, which
+#      is why "push branch X for review, then merge to main" is unchanged.
+#   2. Only BRANCH-SHAPED tokens are redacted, not every hyphenated word. A slug
+#      qualifies on a slash (feat/x), a ticket prefix (dive-2613-...), or two or
+#      more hyphens (a-b-c). So 'auto-teardown' in prose survives and still floors:
+#      one hyphen and no ticket prefix is a WORD, and when the shape is ambiguous
+#      the floor stays on.
+#   3. Applied HERE, at the single match site, so every consumer — cmd_task_need's
+#      filing floor, the approval/manual routing arm, and cmd_goal's low-risk
+#      check — inherits the same verdict from the same inputs, which is the
+#      property _gate_floor_axis exists to preserve.
+#
+# NOT ATTEMPTED, and it is a separate ticket: DIVE-2592 routed to olivia when its
+# filer dev reports_to main. That is _gate_route_reviewer, not the floor, and main
+# explicitly did not diagnose it — do not fold it in here.
+_GATE_PUSH_FOR_REVIEW_RX='delegated push|push[- ]for[- ]review|5dive push|push[^.]*(for review|for a pr|for code review|branch)'
+_GATE_PUSH_NOT_INERT_RX='\bmerg(e|es|ed|ing)\b|deploy|redeploy|\brelease\b|roll ?out|\broll(ing|ed)? out\b|roll[^.]*fleet|fleet[- ]?roll|push(es|ed|ing)? to (main|prod|production)|\bland (the|it|this)\b'
+
+# 0 iff the text describes an INERT push-for-review: a feature branch going to a
+# remote for PR review. Fails closed — anything that also names a prod-touching
+# verb is NOT inert and gets no exemption.
+_gate_push_for_review_hit() {
+  local text; text=$(printf '%s' "${1-}" | tr '[:upper:]' '[:lower:]')
+  [[ "$text" =~ $_GATE_PUSH_FOR_REVIEW_RX ]] || return 1
+  [[ "$text" =~ $_GATE_PUSH_NOT_INERT_RX ]] && return 1
+  return 0
+}
+
+# 0 iff $1 (already lowercased, punctuation trimmed) has the shape of a git ref.
+# Three qualifying shapes; a single-hyphen word with no ticket prefix does NOT
+# qualify, because that is how English compounds are written.
+_gate_branch_slug_token() {
+  local w="${1-}" hy
+  [[ "$w" =~ ^[a-z0-9._/-]+$ ]] || return 1
+  [[ "$w" == */* ]] && return 0
+  [[ "$w" =~ ^[a-z]+-[0-9]+(-|$) ]] && return 0
+  hy=${w//[^-]/}
+  (( ${#hy} >= 2 )) && return 0
+  return 1
+}
+
+# Drop branch-identifier tokens from $1. Globbing is disabled around the split so
+# a ref containing * or ? cannot expand against the cwd.
+_gate_redact_branch_refs() {
+  local out="" w core noglob=0
+  [[ $- == *f* ]] || { noglob=1; set -f; }
+  for w in ${1-}; do
+    core="$w"
+    [[ "$w" =~ ^[^a-z0-9]*([a-z0-9._/-]+)[^a-z0-9]*$ ]] && core="${BASH_REMATCH[1]}"
+    _gate_branch_slug_token "$core" && continue
+    out+="$w "
+  done
+  (( noglob )) && set +f
+  printf '%s' "$out"
+}
+
 _GATE_T2_FLOOR_RX='spend|billing|invoice|charge|payment|refund|subscription|price|pricing|\$[0-9]|€[0-9]|publish|public post|announce|launch post|press|customer email|email customers|newsletter|blast|secret|credential|api key|token|password|delete|destroy|teardown|wipe|purge|drop[^.]{0,20}table|truncate|irreversible|revoke|dns|domain transfer'
 _gate_tier2_floor_hit() {
   local text floor_rx="$_GATE_T2_FLOOR_RX" loaded_rx="" constitution_path="" ere_rc=0
@@ -4645,6 +4742,14 @@ _gate_tier2_floor_hit() {
   # keep matching (revoked, truncated, charges, pressing). Containment inside an
   # unrelated STEM is the defect; containment at the start of a longer word
   # (pressure, deleterious) still fires and is the accepted cost of that choice.
+  #
+  # DIVE-2629: an inert push-for-review ask NAMES A GIT BRANCH, and the branch name
+  # is the subject of the work, not the action being authorised. Redact refs before
+  # matching so the floor grades what the gate DOES. Scoped, not exempted — the
+  # rest of the ask is read exactly as before. Full rationale at the RX above.
+  if _gate_push_for_review_hit "$text"; then
+    text=$(_gate_redact_branch_refs "$text")
+  fi
   [[ "$text" =~ (^|[^[:alnum:]_])($floor_rx) ]]
 }
 
@@ -5286,6 +5391,14 @@ _gate_tier2_floor_term() {
   # term the floor no longer matches. BASH_REMATCH[0] now carries the boundary
   # character too (" press"), so the TERM is group 2; reporting [0] would print a
   # leading space into the warn line and into the gate record.
+  #
+  # DIVE-2629: and that invariant is exactly why the branch-ref redaction has to be
+  # mirrored here. Without it this helper would keep reporting 'teardown' — a term
+  # read out of a git branch name — for a text the floor itself no longer floors,
+  # which is the drift the paragraph above forbids.
+  if _gate_push_for_review_hit "$text"; then
+    text=$(_gate_redact_branch_refs "$text")
+  fi
   [[ "$text" =~ (^|[^[:alnum:]_])($rx) ]] && printf '%s' "${BASH_REMATCH[2]}"
 }
 

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -4635,7 +4635,16 @@ _gate_needs_human() {
 # filer dev reports_to main. That is _gate_route_reviewer, not the floor, and main
 # explicitly did not diagnose it — do not fold it in here.
 _GATE_PUSH_FOR_REVIEW_RX='delegated push|push[- ]for[- ]review|5dive push|push[^.]*(for review|for a pr|for code review|branch)'
-_GATE_PUSH_NOT_INERT_RX='\bmerg(e|es|ed|ing)\b|deploy|redeploy|\brelease\b|roll ?out|\broll(ing|ed)? out\b|roll[^.]*fleet|fleet[- ]?roll|push(es|ed|ing)? to (main|prod|production)|\bland (the|it|this)\b'
+# The DESTINATION clause is `\bto\b … (main|master|prod)`, NOT `push to (main|…)`.
+# Found by the pre-land corpus sweep, and it is the one arm the fix got wrong on
+# first writing: DIVE-1940's real ask is "Push branch dive-1940-token-ux @ 3d9851a0
+# to 5dive-frontend MAIN". The adjacent form `push to main` cannot see a repo name
+# sitting between the verb and its destination, so a push to a repo's default
+# branch was inheriting the inert-push exemption. It floored before this change
+# only by accident — on the word 'token' inside the branch name — so the sweep is
+# what caught it, not the defect it was sweeping for. Bounded distance is safe here
+# in a way DIVE-2224 forbids across a seam: this matches inside ONE field.
+_GATE_PUSH_NOT_INERT_RX='\bmerg(e|es|ed|ing)\b|deploy|redeploy|\brelease\b|roll ?out|\broll(ing|ed)? out\b|roll[^.]*fleet|fleet[- ]?roll|\bto\b[^.]{0,60}\b(main|master|prod|production|trunk)\b|\bland (the|it|this)\b'
 
 # 0 iff the text describes an INERT push-for-review: a feature branch going to a
 # remote for PR review. Fails closed — anything that also names a prod-touching

--- a/tests/gate_floor_branch_name_unit.sh
+++ b/tests/gate_floor_branch_name_unit.sh
@@ -26,15 +26,31 @@
 # fails against exempting the whole _gate_eng_ship_hit class instead of the inert
 # push-for-review subset.
 #
-# MUTATION GRADE (all four run, all four go red where stated):
+# MUTATION GRADE (all five run, all five go red where stated):
 #   M1  remove the `if _gate_push_for_review_hit` block from _gate_tier2_floor_hit
 #       -> T1/T2 red (the fix is gone).
 #   M2  drop the _GATE_PUSH_NOT_INERT_RX check from _gate_push_for_review_hit
 #       -> T6 red (a merge/deploy ask would inherit the exemption).
+#   M2b write the not-inert destination clause as the ADJACENT `push to (main|...)`
+#       instead of `\bto\b … (main|master|prod)` -> T6f/T6g red. This is the one
+#       the fix got WRONG on first writing, and T6f is the live DIVE-1940 ask that
+#       caught it: an adjacent pattern cannot see a repo name sitting between the
+#       verb and its destination ("push branch X to 5dive-frontend MAIN").
 #   M3  redact every token containing a hyphen (drop the slug-shape test)
 #       -> T5 red ('auto-teardown' in prose would stop flooring).
 #   M4  omit the mirrored redaction in _gate_tier2_floor_term
 #       -> T7 red (the helper reports a term the floor did not use).
+#
+# PRE-LAND CORPUS SWEEP (main's condition on the ticket: "how many rows are floored
+# this way, and would any legitimately-destructive gate be downgraded"). Ran
+# _gate_floor_axis over all 435 gate rows in the live store (tasks + gate_history),
+# old code vs new. THREE change, all `ask` -> `title` — meaning they become
+# LEAD-ROUTED with floored_by=title, not unfloored: DIVE-2613 and DIVE-2034 (both
+# `…-teardown-…` in the branch name, both inert push-or-PR asks) and DIVE-2068
+# (`…-secret-gate-shipflag`). The 2068 variant that says "Open PR + MERGE" is NOT
+# among them — it still floors, which is M2's guard doing its job on real data.
+# A fourth row, DIVE-1940, changed on the first draft and does NOT change now; it
+# is T6f.
 #
 # TIER: core — 0.6s measured on the 5dive control-plane host (bash, no root, no
 # network): source-and-call only, no DB writes beyond tasks_db_init.
@@ -149,6 +165,14 @@ floors "T6c roll to the fleet is not inert" \
   'approve delegated push for branch dive-2613-teardown-foo and roll to the fleet'
 floors "T6d push to prod is not inert" \
   'approve push to prod of branch dive-2613-teardown-foo'
+# T6f/T6g are the REAL DIVE-1940 ask, verbatim from the live corpus, and they are
+# the arm the fix failed on first writing: an adjacent `push to main` pattern
+# cannot see a repo name between the verb and the destination. Caught by the
+# pre-land sweep, not by the ticket. Commit sha is a public repo ref, not PII.
+floors "T6f push to a REPO's main is not inert (DIVE-1940, verbatim)" \
+  'Push branch dive-1940-token-ux @ 3d9851a0 to 5dive-frontend main? I have no push creds; the work is built and verified.'
+floors "T6g push to master is not inert" \
+  'approve delegated push of branch dive-2613-teardown-foo to the app repo master'
 if _gate_eng_ship_hit 'approve deploy of branch dive-2613-teardown-outcomes-hetzner-only'; then
   ok_t "T6e the T6b text IS eng-ship, so T6b proves the exemption is narrower than eng-ship"
 else

--- a/tests/gate_floor_branch_name_unit.sh
+++ b/tests/gate_floor_branch_name_unit.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# DIVE-2629 isolated unit harness: the tier-2 category floor must grade the ACTION
+# a gate authorises, not the SUBJECT MATTER named in a git branch name.
+#
+# THE DEFECT (measured by main 2026-08-03, reproduced verbatim in T1/T2 below).
+# 'approve delegated push for review of branch dive-2613-teardown-outcomes-hetzner-only'
+# floored to tier 2 on the single word 'teardown', which appears ONLY inside the
+# branch name. Delete that one token from the same sentence and it drops to tier 1;
+# add it to an unrelated branch name and that one floors too. The action being
+# authorised is "push a feature branch to a remote for review" — inert, reversible,
+# destroys nothing.
+#
+# WHY THIS IS NOT "one extra human tap", which is the floor's usual accepted cost.
+# A tier-2 approval carries NO routed_reviewer, and cmd_task_answer's
+# designated-reviewer exception requires actor == routed_reviewer, so once floored
+# NO agent can ever clear it — not the filer, not their lead, not the coordinator.
+# It is a RATCHET: permanently the human's, with no agent action that hands it
+# back. DIVE-2613 sat there while dev2 stayed blocked behind it.
+#
+# T3-T8 ARE THE ARM THAT MATTERS, and they are the reason this file is not just
+# "assert the false positive is gone". A suite that only asserts T1/T2 is satisfied
+# by DELETING 'teardown' from the floor, or by exempting every push ask wholesale —
+# both of which would let a genuinely destructive or spend-bearing ask through. T3
+# fails against a wholesale "push asks are never floored" implementation. T5 fails
+# against redacting every hyphenated word rather than branch-SHAPED tokens. T6
+# fails against exempting the whole _gate_eng_ship_hit class instead of the inert
+# push-for-review subset.
+#
+# MUTATION GRADE (all four run, all four go red where stated):
+#   M1  remove the `if _gate_push_for_review_hit` block from _gate_tier2_floor_hit
+#       -> T1/T2 red (the fix is gone).
+#   M2  drop the _GATE_PUSH_NOT_INERT_RX check from _gate_push_for_review_hit
+#       -> T6 red (a merge/deploy ask would inherit the exemption).
+#   M3  redact every token containing a hyphen (drop the slug-shape test)
+#       -> T5 red ('auto-teardown' in prose would stop flooring).
+#   M4  omit the mirrored redaction in _gate_tier2_floor_term
+#       -> T7 red (the helper reports a term the floor did not use).
+#
+# TIER: core — 0.6s measured on the 5dive control-plane host (bash, no root, no
+# network): source-and-call only, no DB writes beyond tasks_db_init.
+#
+# Isolation matches the sibling harnesses: source src/ libs, throwaway STATE_DIR —
+# the live shared tasks.db is NEVER touched. Run:
+#   bash tests/gate_floor_branch_name_unit.sh
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/gate-floor-branch-name-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+GATE_PROOF_KEY="$STATE_DIR/gate-proof.key"
+GATE_PROOF_ENFORCE="$STATE_DIR/gate-proof.enforce"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"; set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+tasks_db_init
+task_need_notify() { :; }
+audit_log() { :; }
+
+no_floor() {  # <label> <text> -- asserts the floor does NOT fire
+  if _gate_tier2_floor_hit "$2"; then
+    bad_t "$1" "floored on term='$(_gate_tier2_floor_term "$2")' -- text: $2"
+  else
+    ok_t "$1"
+  fi
+}
+floors() {    # <label> <text> -- asserts the floor DOES fire
+  if _gate_tier2_floor_hit "$2"; then
+    ok_t "$1 (term='$(_gate_tier2_floor_term "$2")')"
+  else
+    bad_t "$1" "did NOT floor -- text: $2"
+  fi
+}
+
+# --- T1: main's MEASURED pair. The two that floored are the defect; the two that
+#     did not are the control, and they must be UNCHANGED by this fix. -----------
+no_floor "T1a teardown in the branch name no longer floors" \
+  'approve delegated push for review of branch dive-2613-teardown-outcomes-hetzner-only'
+no_floor "T1b same ask without 'teardown' is unchanged (control)" \
+  'approve delegated push for review of branch dive-2613-outcomes-hetzner-only'
+no_floor "T1c teardown grafted onto an unrelated branch no longer floors" \
+  'approve delegated push for review of branch dive-XXXX-teardown-foo'
+no_floor "T1d unrelated branch is unchanged (control)" \
+  'approve delegated push for review of branch dive-2592-budget-variance'
+
+# --- T2: the same exemption across the other ways a push ask is phrased, and
+#     across the other destructive terms a branch name plausibly carries. --------
+no_floor "T2a push-for-review, delete in the slug" \
+  'approve push-for-review of branch dive-2700-delete-orphan-rows'
+no_floor "T2b 5dive push, purge in the slug" \
+  'please approve 5dive push for branch feat/purge-stale-cache'
+no_floor "T2c branch slug with a trailing period" \
+  'approve delegated push for review of branch dive-2613-teardown-outcomes.'
+no_floor "T2d slug with two hyphens and no ticket prefix" \
+  'approve delegated push for review of branch fix-token-refresh-loop'
+
+# --- T3: THE ASK'S OWN PROSE IS STILL READ. A push gate that ALSO names money, a
+#     secret, or a publish is a human call and must still floor. This arm fails
+#     against a wholesale "push asks are never floored" exemption. ---------------
+floors "T3a push ask that also names a spend" \
+  'approve delegated push for review of branch dive-2613-foo, and approve $500 for the ads run'
+floors "T3b push ask that also rotates a credential" \
+  'approve delegated push for review of branch dive-2613-foo and provision a new api key'
+floors "T3c push ask that also publishes" \
+  'approve delegated push for review of branch dive-2613-foo then publish the launch post'
+floors "T3d push ask that also emails customers" \
+  'approve delegated push for review of branch dive-2613-foo and email customers about it'
+
+# --- T4: a genuinely destructive ask that is NOT a push-for-review is untouched. -
+floors "T4a bare teardown ask still floors" \
+  'approve the teardown of the hetzner box'
+floors "T4b delete ask still floors" \
+  'confirm we delete the orphaned agent accounts'
+floors "T4c the word branch alone buys no exemption" \
+  'approve the branch teardown of the staging fleet'
+
+# --- T5: HYPHENATED PROSE IS NOT A BRANCH NAME. One hyphen and no ticket prefix
+#     is how English compounds are written, so the floor STAYS ON. Fails against
+#     "redact every hyphenated token". ------------------------------------------
+floors "T5a auto-teardown in prose still floors" \
+  'approve delegated push for review of the auto-teardown fix'
+floors "T5b re-publish in prose still floors" \
+  'approve delegated push for review of the re-publish path'
+
+# --- T6: NOT THE WHOLE ENG-SHIP CLASS. merge / deploy / roll-to-fleet / push-to-
+#     main TOUCH PROD and keep flooring on their subject matter. Fails against an
+#     exemption keyed on _gate_eng_ship_hit. ------------------------------------
+floors "T6a push for review THEN merge to main is not inert" \
+  'approve delegated push for review of branch dive-2613-teardown-outcomes then merge to main'
+floors "T6b deploy is not inert" \
+  'approve deploy of branch dive-2613-teardown-outcomes-hetzner-only'
+floors "T6c roll to the fleet is not inert" \
+  'approve delegated push for branch dive-2613-teardown-foo and roll to the fleet'
+floors "T6d push to prod is not inert" \
+  'approve push to prod of branch dive-2613-teardown-foo'
+if _gate_eng_ship_hit 'approve deploy of branch dive-2613-teardown-outcomes-hetzner-only'; then
+  ok_t "T6e the T6b text IS eng-ship, so T6b proves the exemption is narrower than eng-ship"
+else
+  bad_t "T6e T6b text is eng-ship" "classifier changed; T6b no longer discriminates"
+fi
+
+# --- T7: the reporter must never name a term the floor did not use. -------------
+_t7=$(_gate_tier2_floor_term 'approve delegated push for review of branch dive-2613-teardown-outcomes-hetzner-only')
+if [[ -z "$_t7" ]]; then
+  ok_t "T7 _gate_tier2_floor_term reports nothing where the floor does not fire"
+else
+  bad_t "T7 floor_term agrees with the floor" "reported '$_t7' for a text that does not floor"
+fi
+_t7b=$(_gate_tier2_floor_term 'approve the teardown of the hetzner box')
+if [[ "$_t7b" == "teardown" ]]; then
+  ok_t "T7b floor_term still names the term on a real hit"
+else
+  bad_t "T7b floor_term names the term" "expected 'teardown', got '$_t7b'"
+fi
+
+# --- T8: the redactor itself. Shape classification, and no cwd globbing. --------
+for _s in 'dive-2613-teardown-foo' 'feat/purge-cache' 'a-b-c' 'dive-2613'; do
+  _gate_branch_slug_token "$_s" \
+    && ok_t "T8 '$_s' reads as a branch ref" \
+    || bad_t "T8 '$_s' reads as a branch ref" "not classified as a slug"
+done
+for _s in 'auto-teardown' 'teardown' 're-publish' 'e-mail'; do
+  if _gate_branch_slug_token "$_s"; then
+    bad_t "T8 '$_s' is NOT a branch ref" "wrongly classified as a slug"
+  else
+    ok_t "T8 '$_s' is NOT a branch ref"
+  fi
+done
+_g=$(cd "$TMP" && touch zz-glob-canary.txt && _gate_redact_branch_refs 'approve branch dive-1-a *')
+case "$_g" in
+  *zz-glob-canary*) bad_t "T8 redactor does not glob against the cwd" "expanded: $_g" ;;
+  *)                ok_t  "T8 redactor does not glob against the cwd" ;;
+esac
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
The tier-2 destructive floor read the whole ask, so `approve delegated push for review of branch dive-2613-teardown-outcomes-hetzner-only` floored to human-only. Approving a branch push is inert; the branch is merely *about* teardown code. Because a tier-2 gate gets no `routed_reviewer`, and the clearance exception requires `actor == routed_reviewer`, **no agent could ever take it back** — it was permanently the human's.

Scopes the MATCH, not the verdict. When and only when an ask is recognised as an inert push-for-review, git branch identifiers are redacted before the floor reads it. The rest of the ask is read unchanged, so a push ask that also names a spend, secret, publish or customer email still floors on its own prose.

Three narrowings, all biased toward keeping the floor ON:

- NOT the whole eng-ship class — merge, deploy, roll-to-fleet and push-to-main keep flooring.
- Only branch-SHAPED tokens (a slash, a ticket prefix, or 2+ hyphens), so hyphenated prose like `auto-teardown` is a word and still floors.
- Applied at the single match site, so the filing floor, the routing arm and `cmd_goal` inherit one verdict. Mirrored into `_gate_tier2_floor_term` so the reporter never names a term the floor no longer uses.

## The sweep caught a defect the ticket did not

`_gate_floor_axis` over all **435** gate rows in the live store, old vs new: exactly **three** change (DIVE-2613, DIVE-2034, DIVE-2068), all ask→title — i.e. still floored, by the title instead of the ask. **Zero rows are unfloored.**

A fourth changed on the first draft: DIVE-1940, real ask *"Push branch dive-1940-token-ux @ 3d9851a0 to 5dive-frontend MAIN"* — a push to a repo default branch that must keep flooring, missed because the guard was written as the adjacent `push to (main|prod)`, which cannot see a repo name between verb and destination. It had floored before only by accident, on `token` in the branch name. Rewritten as `\bto\b[^.]{0,60}\b(main|master|prod|production|trunk)\b`.

## Verification

35 arms both directions; five mutations each reddening a named arm. Independently reproduced at review: removing the redaction at both call sites takes the harness 35/0 → **28 passed, 7 failed**, restored to 35/0 with an md5 match.

Behaviourally, in both directions, sourced from the branch:

```
T1  approve delegated push ... branch dive-2613-teardown-outcomes-hetzner-only   (the symptom, was T2)
T1  approve delegated push ... branch dive-2592-budget-variance
T2  Push branch dive-1940-token-ux @ 3d9851a0 to 5dive-frontend MAIN
T2  approve the auto-teardown of the customer fleet
T2  approve a volume resize (spend) on the control plane
```

Pre-fix `origin/main` returns T2 for the first line and T1 for `merge branch X into main` — the latter unchanged by this diff, so it is pre-existing and out of scope.

## Known limitation, stated rather than implied

The filing path reads `_gate_hit_either "$ask" "$title"`. DIVE-2613's **title** is *"Two webhook.ts teardown sites surface only hetzner"*, which still floors — so the motivating row would still be human-only after this change. That is the same defect one field over (a title names the work's subject, not the action being authorised) and is tracked separately. This diff fixes the ask axis and does not claim the title axis.

Authored by olivia, verified and merged by main (olivia holds no push credential, and `5dive push` refuses without the very gate this fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
