### PR TITLE
feat(gate): record WHY a gate has the tier it has (DIVE-2615)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## Unreleased — feat(gate): a gate now records WHY it has the tier it has (DIVE-2615)
+
+lodar was interrupted three times in ten minutes on 2026-08-03 by gates that were not
+his to answer. The first question anyone asks about that — *how many of these did the
+tier-2 floor over-fire on?* — turned out to be unanswerable from the store.
+
+`gate_history.floor_provenance` existed on the live box and was **NULL on all 79 rows**:
+a column with no writer, no migration and no reference anywhere in `src/` or `tests/`.
+Every input to the tier decision is computed in `cmd_task_need` and then thrown away, so
+the split had to be reconstructed by building a bundle, stripping its `main` call,
+sourcing it, and re-running the CLI's own predicates over asks read back out of the
+store. **Two attempts at that were void** — one built from a dirty feature branch that
+contained no DIVE-2629, one ran the bare per-field predicate instead of
+`_gate_floor_axis`, which is what the filing path actually calls.
+
+The tier decision is now written on the **same statement that writes the tier**, in six
+values that each name whose decision it was:
+
+| value | who decided |
+|---|---|
+| `axis=pinned` | the FILER passed `--tier=2`; the floor was never consulted |
+| `axis=type-default` | manual/secret/access — 2 is the type's default and nobody chose |
+| `axis=secret-type` | filed below tier 2 and forced up by its type |
+| `axis=ask` | the floor fired on the ask |
+| `axis=title` | term in the title only — **not** floored, routed to the lead (DIVE-2224) |
+| `axis=title-fallback` | floored on the title because the ask states nothing of its own |
+| `axis=none` | the floor ran and did not fire |
+
+plus `;term=<t>` wherever a term is what fired, so *"floored on `publish`"* is a stored
+fact rather than something a reader re-derives with a regex.
+
+**`NULL` and `axis=none` are deliberately different facts.** NULL means this build never
+recorded it; `axis=none` means the floor ran and found nothing. An empty cell meaning
+both is precisely what made the pre-existing column measure nothing, so a writer that
+emitted NULL on a clean gate would have reproduced the defect while looking like a fix.
+
+`pinned` vs `type-default` reads `tier_arg`, not `tier`: by that line the type default
+has already been applied and the effective tier cannot tell a filer's choice from a
+type's default — the same distinction DIVE-1182 captured `tier_arg` for, two lines up.
+
+Schema is additive on both tables, declared in the fresh-store CREATE **and** in the
+migration: a fresh box never runs the migration, and the create-if-absent block never
+reaches a `gate_history` that already exists, so either one alone leaves a live box
+without the column.
+
+`tests/gate_floor_provenance_unit.sh` — 19 arms. Two were written asserting the wrong
+thing and the harness said so: a plain `secret` gate is a *type-default*, not a
+type-floor (the default lands before the floor block), and a migration fixture holding
+only `gate_history` takes the fresh-create path, so it proved nothing until it carried a
+`tasks` table.
+
 ## Unreleased — fix(gate): the tier-2 destructive floor graded the BRANCH NAME in a push-for-review ask (DIVE-2629)
 
 `approve delegated push for review of branch dive-2613-teardown-outcomes-hetzner-only`

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -1002,7 +1002,12 @@ cmd_task_show() {
                       CASE WHEN need_options IS NOT NULL THEN '  options: '||need_options ELSE '' END||
                       CASE WHEN recommend IS NOT NULL THEN x'0a'||'recommend: '||recommend ELSE '' END||
                       CASE WHEN precedent_ref IS NOT NULL
-                           THEN x'0a'||'precedent: '||COALESCE((SELECT ident FROM tasks p WHERE p.id=tasks.precedent_ref),'#'||precedent_ref) ELSE '' END||x'0a'||
+                           THEN x'0a'||'precedent: '||COALESCE((SELECT ident FROM tasks p WHERE p.id=tasks.precedent_ref),'#'||precedent_ref) ELSE '' END||
+                      -- DIVE-2615: why this gate has this tier. Absent on rows filed
+                      -- before this shipped, which is a real distinction and not a
+                      -- rendering gap — see the NULL-vs-axis=none note in cmd_task_need.
+                      CASE WHEN floor_provenance IS NOT NULL AND floor_provenance <> ''
+                           THEN x'0a'||'tier set by: '||floor_provenance ELSE '' END||x'0a'||
                       'ask:  '||COALESCE(ask,'')||
                       CASE WHEN need_answered_at IS NOT NULL
                            THEN x'0a'||'answer: '||CASE WHEN need_type='secret' THEN '(provided — loaded out-of-band)' ELSE COALESCE(need_answer,'') END||'  ('||need_answered_at||')'
@@ -5609,6 +5614,10 @@ cmd_task_need() {
               secret_key=NULL, connector=NULL, secret_oob=NULL, ask_shape=NULL,
               precedent_ref=NULL, precedent_kind=NULL, routed_reviewer=NULL,
               needs_capability=NULL,
+              -- DIVE-2615: a withdrawn gate has no tier, so it must not keep
+              -- reporting why it had one. The archive above already copied this
+              -- value onto the history row, which is where it belongs afterwards.
+              floor_provenance=NULL,
               need_asked_at=NULL, gate_pinged_at=NULL, gate_filed_by=NULL
         WHERE id=${id};
         UPDATE tasks SET status='todo'
@@ -5798,13 +5807,48 @@ cmd_task_need() {
   fi
   local tier_floored=0
   local _floored_by_title=0 _floor_axis=none _ft_title=""   # DIVE-2224
+  # DIVE-2615: WHY this gate has the tier it has, recorded at the moment it is
+  # decided. Every input below is computed here and then thrown away, so the store
+  # could say a gate was tier 2 and never say what made it tier 2 — floor_provenance
+  # was NULL on all 79 gate_history rows because nothing has ever written it.
+  # Answering "how many of tonight's human pings were the floor over-firing?" needed
+  # a bundle rig sourcing this file's predicates against asks re-read from the store,
+  # two of my attempts at which were void. That is a question the store should
+  # answer, and after this it does.
+  #
+  # NULL vs 'axis=none' IS THE WHOLE POINT and they are not the same fact. NULL means
+  # this build never recorded it (a pre-DIVE-2615 row). 'axis=none' means the floor
+  # RAN and did not fire. Conflating them is exactly what made the existing column
+  # unusable — an empty value that means both "no data" and "no hit" measures nothing.
+  local _floor_prov=""
+  if [[ "$tier" == "2" ]]; then
+    # Tier 2 BEFORE the floor is consulted, and the two ways of getting there are
+    # different facts about different people, so they get different values.
+    # `pinned` is the caller's explicit --tier=2 — a LARGE population (12 of the 48
+    # tier-2 gates that pinged the human in the 7 days to 2026-08-03) and invisible
+    # from the row today, which makes the filer's own choice read as the
+    # classifier's doing. `type-default` is manual/secret/access, where 2 is the
+    # type's default and nobody chose anything. Reading `tier_arg`, not `tier`, is
+    # what separates them: by this line the type default has already been applied,
+    # so the effective tier cannot tell them apart — the same distinction DIVE-1182
+    # captured `tier_arg` for two lines above.
+    if [[ "$tier_arg" == "2" ]]; then _floor_prov="axis=pinned"; else _floor_prov="axis=type-default"; fi
+  fi
   if [[ "$tier" != "2" ]]; then
     if [[ "$type" == "secret" ]]; then
       tier=2; tier_floored=1
+      _floor_prov="axis=secret-type"
     else
       local ttl_title; ttl_title=$(db "SELECT COALESCE(title,'') FROM tasks WHERE id=${id};")
       # DIVE-2224: per-field, never the join; and the ASK is the subject (answer A).
       _floor_axis=$(_gate_floor_axis "$ask" "$ttl_title")
+      local _floor_term=""
+      case "$_floor_axis" in
+        ask)  _floor_term=$(_gate_tier2_floor_term "$ask" 2>/dev/null) || _floor_term="" ;;
+        title|title-fallback)
+          _floor_term=$(_gate_tier2_floor_term "$ttl_title" 2>/dev/null) || _floor_term="" ;;
+      esac
+      _floor_prov="axis=${_floor_axis}${_floor_term:+;term=${_floor_term}}"
       case "$_floor_axis" in
         ask) tier=2; tier_floored=1 ;;
         title-fallback)
@@ -6256,6 +6300,9 @@ cmd_task_need() {
             ask_shape=$(sqlq_or_null "$ask_shape"),
             precedent_ref=${precedent_ref:-NULL},
             precedent_kind=$(sqlq_or_null "$precedent_kind"),
+            -- DIVE-2615: why this gate has this tier. Written on the SAME statement
+            -- that writes the tier, so the two can never disagree about one filing.
+            floor_provenance=$(sqlq_or_null "$_floor_prov"),
             -- DIVE-2241: the capability the filer DECLARED, recorded verbatim —
             -- including one that resolved to nothing. What was claimed is the
             -- provenance; whether it resolved is recomputable from the sealed

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -225,6 +225,12 @@ CREATE TABLE IF NOT EXISTS tasks (
   -- the one case a developer with a working board never exercises. Caught by
   -- council_schedule_e2e, whose rig starts from an empty dir.
   derived_actor TEXT,
+  -- DIVE-2615: why this gate has this tier — axis=pinned|type-default|secret-type
+  -- |ask|title|title-fallback|none, plus ;term=<t> where a term is what fired.
+  -- Declared HERE as well as in _tasks_db_migrate: a fresh store takes this CREATE
+  -- and never runs the migration, so the array entry alone left the column missing
+  -- on exactly the boxes that have no history to migrate.
+  floor_provenance TEXT,
   parent_id   INTEGER REFERENCES tasks(id) ON DELETE CASCADE,
   created_at  TEXT NOT NULL DEFAULT (datetime('now')),
   started_at  TEXT,
@@ -673,7 +679,8 @@ CREATE TABLE IF NOT EXISTS gate_history (
   need_answer_sig   TEXT,
   human_nonce_hash  TEXT,
   retired_by        TEXT NOT NULL,
-  retired_at        TEXT NOT NULL DEFAULT (datetime('now'))
+  retired_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  floor_provenance  TEXT
 );
 CREATE INDEX IF NOT EXISTS gate_history_task_idx ON gate_history(task_id, id);
 
@@ -1071,7 +1078,8 @@ _tasks_db_migrate() {
            'originated_by_objective INTEGER' 'originated_cycle INTEGER' \
            'verify_unavailable INTEGER' 'last_skipped_at TEXT' \
            'human_evidence TEXT' \
-           'derived_actor TEXT'; do
+           'derived_actor TEXT' \
+           'floor_provenance TEXT'; do
     # DIVE-2418: herestring, NOT a pipe. `printf | grep -q` lets grep exit on its
     # first match while printf is still writing, and printf then takes SIGPIPE and
     # emits "write error: Broken pipe" on stderr. This runs from tasks_db_init on
@@ -1346,10 +1354,28 @@ CREATE TABLE IF NOT EXISTS gate_history (
   need_answer_sig   TEXT,
   human_nonce_hash  TEXT,
   retired_by        TEXT NOT NULL,
-  retired_at        TEXT NOT NULL DEFAULT (datetime('now'))
+  retired_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  floor_provenance  TEXT
 );
 CREATE INDEX IF NOT EXISTS gate_history_task_idx ON gate_history(task_id, id);
 MIG
+  fi
+
+  # DIVE-2615 — additive floor_provenance on an ALREADY-CREATED gate_history. The
+  # block above only runs when the table is ABSENT, so on every store that already
+  # has one (i.e. every box that has ever filed a gate) a new column in the CREATE
+  # reaches nothing. Same one-shot pragma check the tasks columns use.
+  #
+  # This box is the reason the check is a pragma read and not a bare ALTER: it
+  # already carries `floor_provenance TEXT`, added out-of-band by something that
+  # left no trace in this repo — the column existed with no writer, no migration
+  # and no reference in src/ or tests/, which is why it read NULL on all 79 rows.
+  local has_gh_floorprov
+  has_gh_floorprov=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
+    "SELECT 1 FROM pragma_table_info('gate_history') WHERE name='floor_provenance' LIMIT 1;" 2>/dev/null)
+  if [[ "$has_gh_floorprov" != "1" ]]; then
+    sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
+      "ALTER TABLE gate_history ADD COLUMN floor_provenance TEXT;" >/dev/null 2>&1 || true
   fi
 
   # DIVE-748 — additive scorecard column on already-created loop_runs tables.
@@ -1893,11 +1919,11 @@ _gate_archive_and_clear_sql() {
     "INSERT INTO gate_history (task_id, ident, need_type, ask, need_options, recommend," \
     "                          tier, need_asked_at, need_answer, need_answered_at," \
     "                          need_answered_by, need_answered_uid, need_answer_sig," \
-    "                          human_nonce_hash, retired_by)" \
+    "                          human_nonce_hash, retired_by, floor_provenance)" \
     "  SELECT id, ident, need_type, ask, need_options, recommend," \
     "         tier, need_asked_at, need_answer, need_answered_at," \
     "         need_answered_by, need_answered_uid, need_answer_sig," \
-    "         human_nonce_hash, $(sqlq "$verb")" \
+    "         human_nonce_hash, $(sqlq "$verb"), floor_provenance" \
     "    FROM tasks" \
     "   WHERE (${pred})" \
     "     AND (need_type IS NOT NULL OR need_answer IS NOT NULL" \

--- a/tests/gate_floor_provenance_unit.sh
+++ b/tests/gate_floor_provenance_unit.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# DIVE-2615 — A GATE MUST RECORD WHY IT HAS THE TIER IT HAS.
+#
+# THE INCIDENT, and it is a measurement incident rather than a behaviour one.
+# lodar was interrupted three times in ten minutes on 2026-08-03 by gates that were
+# not his to answer. Answering the first question anyone asks about that — "how many
+# of these did the tier-2 floor over-fire on?" — turned out to be unanswerable from
+# the store. `gate_history.floor_provenance` existed on the live box and was NULL on
+# all 79 rows, because it had NO writer, NO migration and no reference anywhere in
+# src/ or tests/: a column added out-of-band that nothing ever filled.
+#
+# So the split had to be reconstructed by building a bundle, stripping its `main`
+# call, sourcing it, and re-running this file's own predicates over asks re-read
+# from the store. Two attempts at that were VOID (one built from a dirty feature
+# branch with no DIVE-2629 in it; one ran the bare predicate per field instead of
+# `_gate_floor_axis`, which is what the filing path actually calls). Every input to
+# the tier decision is computed in `cmd_task_need` and then discarded. This file
+# grades that they are kept.
+#
+# THE DISTINCTION THAT MAKES THE COLUMN WORTH ANYTHING, and arm 6 exists only for
+# it: NULL and `axis=none` are DIFFERENT FACTS. NULL means this build never recorded
+# it — every row filed before this ships. `axis=none` means the floor RAN and did
+# not fire. An empty value that means both "no data" and "no hit" is what made the
+# pre-existing column measure nothing, so a writer that emits NULL on a clean gate
+# would reproduce the defect while looking like a fix. Arm 6 and arm 11 are a pair:
+# 6 asserts the clean gate says `none`, 11 asserts a row the writer never touched
+# stays NULL, and only both together pin the distinction.
+#
+# THE SIX VALUES, and each is a different actor's decision:
+#   axis=pinned        the FILER passed --tier=2. The floor was never consulted.
+#                      12 of the 48 tier-2 gates that pinged the human in the 7 days
+#                      to 2026-08-03 — the largest single population, and invisible
+#                      from the row before this, which made the filer's own choice
+#                      read as the classifier's doing.
+#   axis=type-default  manual/secret/access, where 2 is the type default and nobody
+#                      chose anything. Read off `tier_arg`, not `tier` — by that line
+#                      the default has been applied and the effective tier cannot
+#                      tell the two apart (the distinction DIVE-1182 captured
+#                      `tier_arg` for, two lines above).
+#   axis=secret-type   type=secret, floored by type without consulting the floor.
+#   axis=ask           the floor fired on the ask. THE tier-2 gate.
+#   axis=title-fallback the floor fired on the title because the ask states nothing
+#                      of its own — floored, deliberately, failing closed.
+#   axis=none          the floor ran and did not fire.
+# plus `;term=<t>` wherever a term is what fired, so "floored on 'publish'" is a
+# stored fact and not something a reader re-derives with a regex.
+#
+# WHAT THIS FILE DOES NOT CLAIM. It does not grade the floor's verdicts — that is
+# tests/gate_floor_branch_name_unit.sh and the classifiers' own harnesses. It grades
+# that whatever the floor decided is WRITTEN DOWN, on the same statement that writes
+# the tier, and that it survives into gate_history when the gate is retired.
+#
+# Run: bash tests/gate_floor_provenance_unit.sh   (no root, no network.)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+. "$(dirname "${BASH_SOURCE[0]}")/lib/env_isolation.sh" 2>/dev/null || true
+declare -F _five_env_isolate >/dev/null && _five_env_isolate
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/gate-floor-prov.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+GATE_PROOF_KEY="$STATE_DIR/gate-proof.key"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"; set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+tasks_db_init
+task_need_notify() { :; }              # no DM on filing
+_task_human_send_allowed() { return 0; }
+audit_log() { :; }
+
+seed() { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ($(sqlq "$1"),$(sqlq "$2"),'todo','main');"; }
+prov() { db "SELECT COALESCE(floor_provenance,'<NULL>') FROM tasks WHERE ident=$(sqlq "$1");"; }
+tier_of() { db "SELECT COALESCE(tier,'') FROM tasks WHERE ident=$(sqlq "$1");"; }
+
+# --- 0. the column exists at all, on a store this build created -----------------
+# The pre-existing live column proves nothing about a fresh box: it was added
+# out-of-band. This asserts our OWN schema carries it, on both tables.
+for t in tasks gate_history; do
+  [[ "$(db "SELECT 1 FROM pragma_table_info('$t') WHERE name='floor_provenance';")" == "1" ]] \
+    && ok_t "schema: $t.floor_provenance exists on a freshly-initialised store" \
+    || bad_t "$t must carry floor_provenance" "a fresh store built by tasks_db_init has no such column"
+done
+
+# --- 1. axis=pinned — the filer chose it ---------------------------------------
+seed DIVE-9001 'ordinary title'
+( cmd_task_need DIVE-9001 --type=decision --ask="pick a lane" --options="A|B" --recommend=A --tier=2 >/dev/null 2>&1 )
+[[ "$(prov DIVE-9001)" == "axis=pinned" && "$(tier_of DIVE-9001)" == "2" ]] \
+  && ok_t 'an explicit --tier=2 records axis=pinned (the filer chose the human, not the floor)' \
+  || bad_t 'explicit --tier=2 must record axis=pinned' "got [$(prov DIVE-9001)] tier=$(tier_of DIVE-9001)"
+
+# --- 2. axis=type-default — nobody chose anything -------------------------------
+# `manual` defaults to tier 2. The effective tier is identical to arm 1's; only
+# tier_arg separates them, which is the whole reason this value is distinct.
+seed DIVE-9002 'ordinary title'
+( cmd_task_need DIVE-9002 --type=manual --ask="do the thing by hand" >/dev/null 2>&1 )
+[[ "$(prov DIVE-9002)" == "axis=type-default" && "$(tier_of DIVE-9002)" == "2" ]] \
+  && ok_t 'a type-defaulted tier 2 is recorded as type-default, NOT as pinned' \
+  || bad_t 'type-default must not be reported as a filer choice' "got [$(prov DIVE-9002)] tier=$(tier_of DIVE-9002)"
+[[ "$(prov DIVE-9001)" != "$(prov DIVE-9002)" ]] \
+  && ok_t 'differential: two gates at the SAME effective tier 2 record different causes' \
+  || bad_t 'pinned and type-default must be distinguishable' 'both read the same — tier_arg is not being consulted'
+
+# --- 3. axis=ask + term — the floor fired on the ask ----------------------------
+seed DIVE-9003 'ordinary title'
+( cmd_task_need DIVE-9003 --type=decision --ask="approve the spend on a bigger volume" --options="A|B" --recommend=A >/dev/null 2>&1 )
+[[ "$(prov DIVE-9003)" == "axis=ask;term=spend" && "$(tier_of DIVE-9003)" == "2" ]] \
+  && ok_t 'a floored ask records the axis AND the term that fired' \
+  || bad_t 'axis=ask must carry the term' "got [$(prov DIVE-9003)] tier=$(tier_of DIVE-9003)"
+
+# --- 4. axis=title — floored on nothing, routed by kind ------------------------
+# DIVE-2224: a category term in the TITLE with a substantive ask does NOT floor.
+# The row must still say so — "not floored, and here is the term I saw" is exactly
+# the fact a reviewer needs, and it is the bucket 4 of tonight's 48 fell into.
+seed DIVE-9004 'delete the old customer records table'
+( cmd_task_need DIVE-9004 --type=decision --ask="which of the two rendering libraries should the panel use, A or B" --options="A|B" --recommend=A >/dev/null 2>&1 )
+[[ "$(prov DIVE-9004)" == "axis=title;term=delete" ]] \
+  && ok_t 'a title-only category term records axis=title with its term' \
+  || bad_t 'axis=title must be recorded' "got [$(prov DIVE-9004)]"
+[[ "$(tier_of DIVE-9004)" == "1" ]] \
+  && ok_t 'liveness pair: that gate is NOT floored — provenance records a term WITHOUT a tier change' \
+  || bad_t 'a title-axis term must not floor the gate' "tier=$(tier_of DIVE-9004) — if this is 2, arm 4 is recording the wrong thing"
+
+# --- 5. axis=title-fallback — the ask states nothing of its own -----------------
+seed DIVE-9005 'delete the old customer records table'
+( cmd_task_need DIVE-9005 --type=decision --ask="?" --options="A|B" --recommend=A >/dev/null 2>&1 )
+[[ "$(prov DIVE-9005)" == "axis=title-fallback;term=delete" && "$(tier_of DIVE-9005)" == "2" ]] \
+  && ok_t 'an insubstantial ask floors on the title and records title-fallback' \
+  || bad_t 'title-fallback must be recorded and must floor' "got [$(prov DIVE-9005)] tier=$(tier_of DIVE-9005)"
+
+# --- 6. axis=none — the floor RAN and did not fire ------------------------------
+seed DIVE-9006 'panel rendering library choice'
+( cmd_task_need DIVE-9006 --type=decision --ask="which of the two rendering libraries should the panel use, A or B" --options="A|B" --recommend=A >/dev/null 2>&1 )
+[[ "$(prov DIVE-9006)" == "axis=none" ]] \
+  && ok_t 'a clean gate records axis=none — "ran, no hit", not an empty cell' \
+  || bad_t 'a non-floored gate must still record that the floor ran' "got [$(prov DIVE-9006)] — NULL here reproduces the defect this ticket exists to fix"
+
+# --- 7. secret: type-default vs secret-type are DIFFERENT ROUTES to tier 2 ------
+# Written to assert `secret-type` on a plain `--type=secret`, which was WRONG and
+# this arm caught it. `secret` defaults to tier 2, so the default is applied BEFORE
+# the floor block and a plain secret gate never reaches the type-floor at all — it
+# is a type-default like any other. `secret-type` is reachable only when the filer
+# asks for a LOWER tier and the type forces it back up, which is a different event
+# and deserves a different value. Both are graded so neither can quietly become the
+# other.
+#
+# --secret-key and --connector are required TOGETHER. Given wrong, cmd_task_need
+# calls fail(), which under a SOURCED harness exits the whole suite here and takes
+# arms 8-11 with it — silently, since the tail then prints no total. Every
+# cmd_task_need below is run for its EFFECT and asserted from the store, never
+# trusted to return.
+seed DIVE-9007 'ordinary title'
+( cmd_task_need DIVE-9007 --type=secret --ask="the deploy key" --secret-key=DEPLOY_KEY --connector=github >/dev/null 2>&1 )
+[[ "$(prov DIVE-9007)" == "axis=type-default" && "$(tier_of DIVE-9007)" == "2" ]] \
+  && ok_t 'a plain secret gate is a type-default — the type floor is never consulted' \
+  || bad_t 'plain secret must record type-default' "got [$(prov DIVE-9007)] tier=$(tier_of DIVE-9007)"
+seed DIVE-9012 'ordinary title'
+( cmd_task_need DIVE-9012 --type=secret --tier=1 --ask="the deploy key" --secret-key=DEPLOY_KEY --connector=github >/dev/null 2>&1 )
+[[ "$(prov DIVE-9012)" == "axis=secret-type" && "$(tier_of DIVE-9012)" == "2" ]] \
+  && ok_t 'a secret filed at tier 1 is forced up BY TYPE and says so (secret-type)' \
+  || bad_t 'a down-tiered secret must record secret-type' "got [$(prov DIVE-9012)] tier=$(tier_of DIVE-9012)"
+
+# --- 8. it survives into gate_history when the gate is retired -----------------
+# The archive is the only durable record once a row is re-filed or withdrawn, and
+# the reconstruction that motivated this ticket read gate_history, not tasks.
+seed DIVE-9008 'ordinary title'
+( cmd_task_need DIVE-9008 --type=decision --ask="approve the spend on a bigger volume" --options="A|B" --recommend=A >/dev/null 2>&1 )
+( cmd_task_need DIVE-9008 --type=decision --ask="which rendering library, A or B" --options="A|B" --recommend=A >/dev/null 2>&1 )
+hist=$(db "SELECT COALESCE(floor_provenance,'<NULL>') FROM gate_history WHERE ident='DIVE-9008' ORDER BY id LIMIT 1;")
+[[ "$hist" == "axis=ask;term=spend" ]] \
+  && ok_t 'the archived gate keeps its provenance in gate_history' \
+  || bad_t 'gate_history must carry floor_provenance' "got [$hist]"
+[[ "$(prov DIVE-9008)" == "axis=none" ]] \
+  && ok_t 'and the re-filed gate on the same row records its OWN, different cause' \
+  || bad_t 're-file must overwrite provenance' "got [$(prov DIVE-9008)]"
+
+# --- 9. withdraw clears it -----------------------------------------------------
+# A row with no gate must not keep reporting why it had a tier. The value is not
+# lost — arm 8 is why: the archive took a copy on the way out.
+seed DIVE-9009 'ordinary title'
+( cmd_task_need DIVE-9009 --type=decision --ask="approve the spend on a bigger volume" --options="A|B" --recommend=A >/dev/null 2>&1 )
+( cmd_task_need DIVE-9009 --withdraw >/dev/null 2>&1 )
+[[ "$(prov DIVE-9009)" == "<NULL>" ]] \
+  && ok_t 'withdraw clears the provenance off the task row' \
+  || bad_t 'a withdrawn gate must not keep its floor provenance' "got [$(prov DIVE-9009)]"
+[[ -n "$(db "SELECT floor_provenance FROM gate_history WHERE ident='DIVE-9009';")" ]] \
+  && ok_t 'liveness pair: the withdrawn gate kept its provenance in history (cleared, not destroyed)' \
+  || bad_t 'withdraw must archive before it clears' 'history row has no provenance — the clear ran ahead of the copy'
+
+# --- 10. the ADDITIVE migration, on a store that predates the column -----------
+# The CREATE only runs when gate_history is ABSENT, so on every box that has ever
+# filed a gate a new column in the CREATE reaches nothing. This builds that store
+# on purpose: table present, column missing.
+#
+# THE FIXTURE HAS TO CARRY A `tasks` TABLE or it proves nothing: tasks_db_init runs
+# the migration ONLY when `tasks` already exists, so a fixture holding gate_history
+# alone takes the fresh-store path, the CREATE runs, and the arm passes for the one
+# reason it must not — it never exercised the migration. Written that way first;
+# it read before=0 after=0 and that is what exposed it. So: build a REAL store,
+# then put gate_history back the way a pre-DIVE-2615 box has it.
+OLD="$TMP/old"; mkdir -p "$OLD/tasks"
+( STATE_DIR="$OLD"; TASKS_DIR="$OLD/tasks"; TASKS_DB="$OLD/tasks/tasks.db"; tasks_db_init >/dev/null 2>&1 )
+sqlite3 "$OLD/tasks/tasks.db" "DROP TABLE gate_history; CREATE TABLE gate_history (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id INTEGER NOT NULL, retired_by TEXT NOT NULL);" 2>/dev/null
+before=$(sqlite3 "$OLD/tasks/tasks.db" "SELECT COUNT(*) FROM pragma_table_info('gate_history') WHERE name='floor_provenance';")
+[[ "$(sqlite3 "$OLD/tasks/tasks.db" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='tasks';")" == "1" ]] \
+  && ok_t 'migration fixture: the store has a tasks table, so init takes the MIGRATE path (not fresh-create)' \
+  || bad_t 'the fixture must look like an existing store' 'no tasks table — init would fresh-create and the next arm would be vacuous'
+( STATE_DIR="$OLD"; TASKS_DIR="$OLD/tasks"; TASKS_DB="$OLD/tasks/tasks.db"; tasks_db_init >/dev/null 2>&1 )
+after=$(sqlite3 "$OLD/tasks/tasks.db" "SELECT COUNT(*) FROM pragma_table_info('gate_history') WHERE name='floor_provenance';")
+[[ "$before" == "0" && "$after" == "1" ]] \
+  && ok_t "migration: a pre-existing gate_history gains the column (before=$before after=$after)" \
+  || bad_t 'the additive migration must reach an existing gate_history' "before=$before after=$after — before must be 0 or this arm proves nothing"
+
+# --- 11. NULL still means "never recorded" -------------------------------------
+# The other half of arm 6. A row the writer has not touched must read NULL, so the
+# two facts stay separable on a store that spans the release boundary.
+seed DIVE-9011 'ordinary title'
+[[ "$(prov DIVE-9011)" == "<NULL>" ]] \
+  && ok_t 'a row with no gate reads NULL — distinguishable from a gate whose floor found nothing' \
+  || bad_t 'an ungated row must be NULL, not axis=none' "got [$(prov DIVE-9011)]"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/gate_floor_provenance_unit.sh
+++ b/tests/gate_floor_provenance_unit.sh
@@ -50,6 +50,24 @@
 # that whatever the floor decided is WRITTEN DOWN, on the same statement that writes
 # the tier, and that it survives into gate_history when the gate is retired.
 #
+# MUTATION GRADE — RUN against the committed tree at efd1fa9, each reverted after
+# (`git checkout -- src/`, tree verified clean at the end). Baseline 19/0, 2.4s.
+#   * drop `floor_provenance=` from the filing UPDATE   -> 7/12
+#   * read `tier` instead of `tier_arg` for pinned      -> 16/3  (arms 2, 2-diff, 7)
+#   * drop the `;term=` suffix                          -> 13/6
+#   * emit NULL instead of `axis=none`                  -> 17/2  (arms 6, 8b)
+#   * drop the withdraw clear                           -> 18/1  (arm 9)
+#   * drop floor_provenance from the gate_history INSERT-> 17/2  (arms 8, 9-liveness)
+#   * drop the additive gate_history ALTER              -> 18/1  (arm 10)
+#   * drop the column from the fresh `tasks` CREATE     -> 18/1  (arm 0)
+# The NULL-vs-none mutation was TAKEN TWICE. Written first as a regex over the
+# assignment, it reddened six arms — more than it should, because the rewrite
+# mangled the whole expression rather than the one case, so it graded "the writer is
+# broken" and not "the distinction is gone". Re-taken surgically (append one line
+# blanking `_floor_prov` when the axis is `none`, every other path untouched) it
+# reds exactly arms 6 and 8b, which is the claim. A mutation that reds too much is
+# not a stronger result, it is a different experiment.
+#
 # Run: bash tests/gate_floor_provenance_unit.sh   (no root, no network.)
 set -uo pipefail
 


### PR DESCRIPTION
Adds `floor_provenance` — the stored reason a gate carries the tier it carries. The column existed on the live store with **no writer, no migration and no reference anywhere in src/ or tests/**, so it read NULL on all 79 `gate_history` rows and "why is this gate tier 2" was not a stored fact.

Seven values, each naming whose decision it was: `axis=pinned` (the filer passed `--tier=2`), `type-default`, `secret-type`, `ask`, `title`, `title-fallback`, `none` — plus `;term=<t>` naming what fired. Written on the same statement that writes the tier, carried into `gate_history` on archive, cleared on withdraw *after* the archive takes its copy, and surfaced in `task show` as `tier set by:`.

NULL and `axis=none` are deliberately different facts: NULL is "no build recorded this", `axis=none` is "the floor ran and found nothing". An empty cell meaning both is what made the pre-existing column measure nothing. Not backfilled — the causal split is honest from today forward, not retroactively.

Schema is additive and declared in **both** the fresh-store CREATE and the migration: a fresh box never runs the migration, and the create-if-absent block never reaches a `gate_history` that already exists — either one alone leaves a live box without the column.

## Verification (olivia, verifier)

Graded at branch tip `c66f986`; merge-base with `origin/main` is `089f7d2` = main's tip, so no stale base.

- `tests/gate_floor_provenance_unit.sh` — 19/0 green in a fresh detached worktree
- **Five independent mutations** by the verifier, each reddening distinctly: drop the write statement (7/12F), collapse `axis=none` to empty (17/2F), drop it from the archive SELECT (17/2F), delete the `gate_history` ALTER (18/1F), collapse pinned-vs-type-default by reading `tier` instead of `tier_arg` (16/3F). Tree clean after revert, baseline re-green.
- Blast radius on the schema change: `schema_sync_unit` 12 in sync / 0 diverged; `gate_floor_branch_name_unit` 35/0

Non-blocking nit for a later pass: on a gate where the floor finds a term in the TITLE and deliberately does *not* floor (`axis=title`, DIVE-2224 answer A), `task show` still renders it under the label `tier set by:` on a tier-1 row whose tier was not in fact set by the title. Stored value is honest; only the label over-claims, and it cannot mislead on a tier-2 row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)