### PR TITLE
fix(ci): a wall-clock budget red that flipped on a re-run of the same commit (DIVE-2592)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,8 +230,11 @@ corpus grew), reds PRs at random on content they did not change.
   states that no test failed, whether the number was measured twice, and the SMALLEST set of
   harnesses that covers the overage — the actionable set, not the top-10 leaderboard.
 - **`tests/baseline_pin_unit.sh` is demoted to the nightly tier**, with the measurement and
-  the cost of the demotion in its header: the same file with the same assertions cost 174.1s
-  in CI, 57.5s in CI four hours earlier, and 2.4s on the control plane.
+  the cost of the demotion in its header. The decision rests on **57.5s — the CI reading on
+  main**, the ordinary case charged to every PR, which is 19% of the whole core budget on its
+  own; 174.1s is the tail and shows the spread, not the cost; 2.4s on the control plane is
+  the control that rules out "expensive file" in favour of "environment-priced file", which
+  is the difference between merge-or-retire and *a wall-clock cap is the wrong instrument*.
 - **HELD BACK, not dropped:** the matching `budget-report` change — printing the nightly
   total in the units of the policy dial, i.e. the minimum number of shards the corpus now
   needs beside the number configured — edits `.github/workflows/full-sweep.yml`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,42 @@ through. Where no launcher can build the rig the arm skips loudly, naming each c
 failure. Both guards are themselves graded: breaking a rig on purpose asserts the refusal
 fires, names the failed step, and leaks no `VERDICT`.
 
+## Unreleased — fix(ci): a wall-clock budget red that flipped on a re-run of the same commit (DIVE-2592)
+
+PR #395 — one line of code and two test arms — failed CI on `exit 4` with zero assertion
+failures. The decisive measurement is a re-run of the IDENTICAL head, no rebase:
+356s (118% of the 300s core budget) then 289s (96%). A 67s swing with nothing changed, and
+all of it inside one harness: `tests/baseline_pin_unit.sh`, 57.5s on main and 174.1s on that
+attempt, because it resolves pinned baseline COMMITS against the remote and is therefore
+priced by the network rather than by its assertions.
+
+The cap is not the defect and it has **not** been raised — 300 to 450 buys three weeks and
+re-installs the ratchet DIVE-2525 exists to remove. The COMPARISON was the defect: one noisy
+sample against a hard threshold, on a base with no headroom left (52% to 80% to 96% as the
+corpus grew), reds PRs at random on content they did not change.
+
+- **A budget red now confirms itself.** Over budget, `scripts/run-harnesses.sh` re-times the
+  3 slowest harnesses and keeps the SMALLER sample per file — noise is one-sided (contention
+  and a slow remote only ADD time), so the low sample is the least contaminated estimate,
+  while real corpus growth appears in BOTH samples and survives. Paid only on the red path;
+  a green run re-times nothing. `--confirm-top=0` disables it, which can only make the gate
+  STRICTER, and an arm pins that no CI job passes it.
+- **A budget red now says it is one.** `exit 4` beside a green assertion count read as
+  systemic to the PR author and as flake to the next reader; it is neither. The message
+  states that no test failed, whether the number was measured twice, and the SMALLEST set of
+  harnesses that covers the overage — the actionable set, not the top-10 leaderboard.
+- **`tests/baseline_pin_unit.sh` is demoted to the nightly tier**, with the measurement and
+  the cost of the demotion in its header: the same file with the same assertions cost 174.1s
+  in CI, 57.5s in CI four hours earlier, and 2.4s on the control plane.
+- **HELD BACK, not dropped:** the matching `budget-report` change — printing the nightly
+  total in the units of the policy dial, i.e. the minimum number of shards the corpus now
+  needs beside the number configured — edits `.github/workflows/full-sweep.yml`, and
+  `5dive push` cannot ship a workflow file: GitHub withholds the `workflows` scope from
+  Apps on purpose, because a credential that can rewrite CI can rewrite what CI requires
+  of it (DIVE-2229/2262, Marcus). It is not in this branch. The nightly tier is at 126% of
+  its per-job budget un-sharded (DIVE-1986), so that half is still owed and needs the
+  `5dive-bot` machine account (DIVE-2232 option A) or a one-off human push.
+
 ## Unreleased — SECURITY fix(gate): a tier-2 human floor whose OFF switch was reachable by the agents it constrains (DIVE-2588)
 
 Any agent, unprivileged and without sudo, could forge a human tap on a tier-2 **decision**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,20 @@ decision to add one is ever wrong on its own merits. See
 - **Over budget, CI FAILS** (`exit 4`, distinct from a test failure's `exit 1`) and
   names the slowest files in the tier. Past the cap a new guard **replaces or
   merges** an existing one — that is the reverse gear, and it is the point.
+- **A budget red confirms itself first** (DIVE-2592). PR #395 went red at 356s and
+  green at 289s on the *same commit, no rebase* — a 67s swing, all of it in one
+  network-priced harness. So when the sum comes in over, the runner **re-times the
+  3 slowest files and keeps the smaller sample per file**: noise is one-sided
+  (contention and a slow remote only *add* time), so the low sample is the least
+  contaminated estimate, while real growth appears in both samples and survives.
+  Paid only on the red path; a green run re-times nothing. `--confirm-top=0`
+  disables it, which can only make the gate **stricter** — there is no flag that
+  confirms more, and no CI job passes one.
+- **A budget red says it is a budget red.** `exit 4` beside "0 failed" reads as
+  systemic to the author and as flake to the next reader; it is neither. The
+  message now states that no test failed, whether the number was confirmed twice,
+  and **the smallest set of harnesses that covers the overage** — the actionable
+  set, not the top-10 leaderboard.
 - **Three ways out, in order:** merge by subject (hundreds of harness *files* for
   one CLI means the unit of organisation is the incident, not the subject —
   folding two files about one subject reclaims their setup cost and drops no

--- a/scripts/run-harnesses.sh
+++ b/scripts/run-harnesses.sh
@@ -175,7 +175,14 @@ pct=0; (( BUDGET > 0 )) && pct=$(( total_s * 100 / BUDGET ))
 #
 # A HARNESS THAT FAILS ITS RE-RUN keeps its original timing AND its original pass: the
 # graded run is the first one, and flipping a pass to a fail on a second sample is
-# this same one-sample error inverted. It is reported as the flake it is.
+# this same one-sample error inverted.
+#
+# WHAT THAT EVENT IS, AND WHAT IT IS NOT (olivia, grading DIVE-2592). Two runs
+# disagreeing is OBSERVED. Calling it a flaky harness is INFERRED, and it is only one
+# of at least three candidates: the harness may be non-deterministic, or the FIRST run
+# may have left state the second tripped on, or the runner changed underneath both. A
+# guess printed among measured sentences inherits their authority, so the output says
+# which half is which rather than naming a cause it did not measure.
 # ---------------------------------------------------------------------------------
 first_total_s="$total_s"; first_pct="$pct"; confirmed=0
 declare -a SWING=() FLAKED=()
@@ -299,9 +306,13 @@ if (( confirmed )); then
   fi
   for fl in "${FLAKED[@]}"; do
     IFS=$'\t' read -r nm rc2 <<<"$fl"
-    printf 'FLAKE: %s PASSED in the graded run and FAILED (rc=%s) on its re-timing.\n' "$nm" "$rc2"
-    printf '       Its pass stands (the graded run is the first one) and its timing was not\n'
-    printf '       replaced — but a harness that is not deterministic is worth its own row.\n'
+    printf 'RE-RUN DISAGREED (observed): %s PASSED in the graded run and FAILED (rc=%s) when\n' "$nm" "$rc2"
+    printf '  it was re-timed. Its pass STANDS — the graded run is the first one — and its timing\n'
+    printf '  was not replaced.\n'
+    printf '  CAUSE NOT MEASURED (inferred): this is consistent with a non-deterministic harness,\n'
+    printf '  with state the first run left behind, or with the runner changing under both. This\n'
+    printf '  line cannot tell them apart and neither can the exit code. Worth its own row; not\n'
+    printf '  worth a diagnosis from here.\n'
   done
 fi
 

--- a/scripts/run-harnesses.sh
+++ b/scripts/run-harnesses.sh
@@ -35,6 +35,9 @@ cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 2
 . tests/lib/tier.sh
 
 TIER=""; BUDGET=""; LABEL=""; REPORT=""; TOP=10; CORPUS_DIR="tests"; SHARD=""
+# DIVE-2592: how many of the slowest harnesses a BUDGET RED is allowed to re-time
+# before it claims the corpus is over its cap. See the block below the run loop.
+CONFIRM_TOP=3
 for a in "$@"; do case "$a" in
   --tier=*)   TIER="${a#--tier=}" ;;
   # The seam that lets tests/corpus_tier_budget_unit.sh grade THIS script against a
@@ -64,14 +67,20 @@ for a in "$@"; do case "$a" in
   # total, because that total is the number this whole row exists to make legible and
   # sharding is the obvious way to lose it.
   --shard=*)  SHARD="${a#--shard=}" ;;   # i/N, 1-based
+  # DIVE-2592. Unlike --budget, this is NOT a hatch: the confirmation pass can only
+  # ever REMOVE a red, so lowering it (0 disables it entirely) can only make this gate
+  # STRICTER, which is the one direction an override is allowed to move a control in.
+  # There is deliberately no flag that lets a caller confirm MORE than the runner does.
+  --confirm-top=*) CONFIRM_TOP="${a#--confirm-top=}" ;;
   --top=*)    TOP="${a#--top=}" ;;
   *) printf 'unknown arg: %s\n' "$a" >&2; exit 2 ;;
 esac; done
 
 case "$TIER" in
   core|full) ;;
-  *) printf 'usage: run-harnesses.sh --tier=core|full [--budget=<seconds>] [--label=<env>] [--report=<file>] [--corpus-dir=<dir>]\n' >&2; exit 2 ;;
+  *) printf 'usage: run-harnesses.sh --tier=core|full [--budget=<seconds>] [--label=<env>] [--report=<file>] [--corpus-dir=<dir>] [--confirm-top=<n>]\n' >&2; exit 2 ;;
 esac
+[[ "$CONFIRM_TOP" =~ ^[0-9]+$ ]] || { printf 'run-harnesses: --confirm-top must be a non-negative integer, got %s\n' "$CONFIRM_TOP" >&2; exit 2; }
 [[ -n "$BUDGET" ]] || BUDGET="$(tier_budget "$TIER")" || exit 2
 [[ -n "$LABEL" ]] || LABEL="local"
 
@@ -121,6 +130,83 @@ done
 total_s=$(( (total_ms + 999) / 1000 ))
 pct=0; (( BUDGET > 0 )) && pct=$(( total_s * 100 / BUDGET ))
 
+# ---------------------------------------------------------------------------------
+# DIVE-2592: A BUDGET RED CONFIRMS ITSELF BEFORE IT CLAIMS ANYTHING.
+#
+# THE MEASUREMENT THAT FORCED THIS is a RE-RUN OF THE SAME COMMIT. PR #395 — one line
+# of code and two test arms — went red on exit 4 with zero assertion failures. Same
+# head, no rebase, nothing changed between the two attempts:
+#
+#     attempt 1   core/pristine   209 harnesses   356s   118% of budget   FAIL
+#     attempt 2   core/pristine   209 harnesses   289s    96% of budget   PASS
+#
+# and the whole 67s lived in ONE file: tests/baseline_pin_unit.sh, 57.5s on main and
+# 174.1s on that attempt, because it resolves pinned baseline COMMITS against the
+# remote and is therefore priced by the network rather than by its assertions.
+#
+# A verdict that flips on a re-run of the same tree is not a measurement of the
+# corpus, and the red it produces is unactionable in the worst way: to the author it
+# reads as systemic (it appeared right after a runner change merged) and to the next
+# reader it reads as flake. Both are wrong and NO SINGLE RUN CAN SHOW THAT.
+#
+# The cap is not the defect. 300s is lodar's number and the corpus really does sit at
+# 96% of it — raising it to 450 buys three weeks and re-installs the ratchet DIVE-2525
+# exists to remove. THE COMPARISON is the defect: one noisy sample against a hard
+# threshold, on a base with no headroom, reds at random on content it did not measure.
+#
+# So when the sum comes in over, re-time the few harnesses that dominate it and keep,
+# per file, the SMALLER of the two samples. Noise here is ONE-SIDED — contention, a
+# cold cache and a slow remote can only ADD time, never subtract it — so the low
+# sample is the least contaminated estimate of what the file costs, while real corpus
+# growth appears in BOTH samples and survives untouched. The gate keeps its teeth and
+# loses its coin flip.
+#
+# PAID ONLY ON THE RED PATH, and bounded twice: at most CONFIRM_TOP files, and it
+# stops the moment the recomputed total is back inside the cap. A green run re-times
+# nothing, so the common case costs zero.
+#
+# IT RUNS BEFORE THE DRIFT GRADER ON PURPOSE. A header's claimed number should be
+# graded against the same confirmed measurement, or a network spike gets a harness
+# author accused of writing an optimistic figure (DIVE-2555, exit 5).
+#
+# THE RE-RUN IS NOT REDIRECTED. Sending it to /dev/null would make the second sample
+# structurally faster than the first for a reason that is not noise, and min-of-two is
+# only honest between two samples taken the same way.
+#
+# A HARNESS THAT FAILS ITS RE-RUN keeps its original timing AND its original pass: the
+# graded run is the first one, and flipping a pass to a fail on a second sample is
+# this same one-sample error inverted. It is reported as the flake it is.
+# ---------------------------------------------------------------------------------
+first_total_s="$total_s"; first_pct="$pct"; confirmed=0
+declare -a SWING=() FLAKED=()
+if (( BUDGET > 0 && total_s > BUDGET && ${#failed[@]} == 0 && CONFIRM_TOP > 0 )); then
+  confirmed=1
+  printf '\nharness-budget[%s/%s]: %ds is over the %ds cap ON ONE SAMPLE. Re-timing the slowest\n' \
+    "$TIER" "$LABEL" "$total_s" "$BUDGET"
+  printf 'harness(es) before claiming it — a wall-clock red that flips on a re-run of the same\n'
+  printf 'commit measures the runner, not the corpus (DIVE-2592).\n'
+  mapfile -t _order < <(for i in "${!NAME[@]}"; do printf '%s\t%s\n' "${MS[$i]}" "$i"; done | sort -rn | cut -f2)
+  _n=0
+  for i in "${_order[@]}"; do
+    (( _n < CONFIRM_TOP )) || break
+    (( total_s > BUDGET )) || break
+    _n=$(( _n + 1 ))
+    printf '=== re-timing %s (budget confirmation %d/%d)\n' "${NAME[$i]}" "$_n" "$CONFIRM_TOP"
+    s=$(date +%s%N)
+    bash "${NAME[$i]}"; rc2=$?
+    e=$(date +%s%N)
+    ms2=$(( (e - s) / 1000000 ))
+    if (( rc2 != 0 )); then
+      FLAKED+=("$(printf '%s\t%s' "${NAME[$i]}" "$rc2")")
+      continue
+    fi
+    (( ms2 < MS[i] )) || continue
+    SWING+=("$(printf '%s\t%s\t%s' "${NAME[$i]}" "${MS[$i]}" "$ms2")")
+    total_ms=$(( total_ms - MS[i] + ms2 )); MS[$i]="$ms2"
+    total_s=$(( (total_ms + 999) / 1000 )); pct=$(( total_s * 100 / BUDGET ))
+  done
+fi
+
 # DIVE-2555: GRADE EACH HEADER'S OWN NUMBER AGAINST THE CLOCK THAT JUST RAN IT.
 #
 # `# TIER: nightly — 14.3s measured` is the entire argument a reviewer gets that a
@@ -155,8 +241,14 @@ done
 
 if [[ -n "$REPORT" ]]; then
   {
-    printf '# run-harnesses report\n# tier=%s\n# label=%s\n# shard=%s\n# harnesses=%d\n# wall_clock_s=%d\n# budget_s=%d\n# pct_of_budget=%d\n# header_drift=%d\n' \
-      "$TIER" "$LABEL" "${SHARD:-1/1}" "${#CORPUS[@]}" "$total_s" "$BUDGET" "$pct" "${#drift[@]}"
+    # DIVE-2592: wall_clock_s stays the ENFORCED number and keeps its name and place —
+    # budget-report and every future reader parse by field name. The first sample is
+    # appended beside it, because the SPREAD between the two is the trend that matters
+    # now: a corpus whose confirmed and unconfirmed totals diverge is one whose cost is
+    # being set by the runner rather than by its own assertions.
+    printf '# run-harnesses report\n# tier=%s\n# label=%s\n# shard=%s\n# harnesses=%d\n# wall_clock_s=%d\n# budget_s=%d\n# pct_of_budget=%d\n# header_drift=%d\n# first_pass_wall_clock_s=%d\n# budget_confirmed=%d\n# confirm_reclaimed_s=%d\n' \
+      "$TIER" "$LABEL" "${SHARD:-1/1}" "${#CORPUS[@]}" "$total_s" "$BUDGET" "$pct" "${#drift[@]}" \
+      "$first_total_s" "$confirmed" "$(( first_total_s - total_s ))"
     for i in "${!NAME[@]}"; do printf '%s\t%s\t%s\n' "${MS[$i]}" "${RC[$i]}" "${NAME[$i]}"; done
   } > "$REPORT"
 fi
@@ -173,13 +265,68 @@ slowest() {
       done
 }
 
+# DIVE-2592: the leaderboard is not the ACTIONABLE set. "here are the 10 slowest"
+# tells a reader what is expensive; it does not tell them what is over. This prints
+# the smallest group of harnesses whose time COVERS the overage — remove or demote
+# those and the run is inside the cap, which is the sentence the reader needs.
+covering() {
+  local over_ms="$1" i
+  for i in "${!NAME[@]}"; do printf '%s\t%s\n' "${MS[$i]}" "${NAME[$i]}"; done | sort -rn \
+    | { acc=0; while IFS=$'\t' read -r ms nm; do
+          (( acc >= over_ms )) && break
+          acc=$(( acc + ms ))
+          printf '    %6.1fs  %s\n' "$(awk -v m="$ms" 'BEGIN{print m/1000}')" "$nm"
+        done; }
+}
+
+# DIVE-2592: printed whenever a confirmation happened, PASS OR FAIL. A run that was
+# over on its first sample and inside on its second is the finding, not a non-event —
+# swallowing it is how the corpus arrives at 118% with everything looking green.
+if (( confirmed )); then
+  printf '\nharness-budget[%s/%s]: BUDGET CONFIRMATION — first sample %ds (%d%%), confirmed %ds (%d%%).\n' \
+    "$TIER" "$LABEL" "$first_total_s" "$first_pct" "$total_s" "$pct"
+  if (( ${#SWING[@]} )); then
+    printf 'Kept the SMALLER of two samples per file (noise only ADDS time, so the low sample is\n'
+    printf 'the least contaminated estimate; real growth shows up in both and survives this):\n'
+    for sw in "${SWING[@]}"; do
+      IFS=$'\t' read -r nm a b <<<"$sw"
+      printf '    %6.1fs -> %6.1fs  (-%.1fs)  %s\n' \
+        "$(awk -v m="$a" 'BEGIN{print m/1000}')" "$(awk -v m="$b" 'BEGIN{print m/1000}')" \
+        "$(awk -v x="$a" -v y="$b" 'BEGIN{print (x-y)/1000}')" "$nm"
+    done
+  else
+    printf 'No re-timed harness came in faster. The total is the corpus, not the weather.\n'
+  fi
+  for fl in "${FLAKED[@]}"; do
+    IFS=$'\t' read -r nm rc2 <<<"$fl"
+    printf 'FLAKE: %s PASSED in the graded run and FAILED (rc=%s) on its re-timing.\n' "$nm" "$rc2"
+    printf '       Its pass stands (the graded run is the first one) and its timing was not\n'
+    printf '       replaced — but a harness that is not deterministic is worth its own row.\n'
+  done
+fi
+
 over=0
 if (( BUDGET <= 0 )); then
   printf 'harness-budget[%s]: BUDGET DISABLED (--budget=%s). This run enforces nothing.\n' "$TIER" "$BUDGET"
 elif (( total_s > BUDGET )); then
   over=1
   printf '\nharness-budget[%s]: OVER BUDGET by %ds (%ds > %ds).\n' "$TIER" "$(( total_s - BUDGET ))" "$total_s" "$BUDGET"
-  printf 'The corpus is not free: every harness here runs on every future change, forever.\n'
+  # DIVE-2592: SAY WHAT THIS RED IS, in the output that carries it. `exit 4` beside a
+  # green assertion count cost the author of #395 an hour: it reads as systemic to the
+  # person whose PR it stopped and as flake to the next reader, and it is neither.
+  printf 'NO TEST FAILED — %d of %d harnesses passed. This is a BUDGET failure (exit 4), not a\n' \
+    "$(( ${#CORPUS[@]} - ${#failed[@]} ))" "${#CORPUS[@]}"
+  printf 'test failure (exit 1): nothing in your diff is broken, the CORPUS no longer fits its cap.\n'
+  if (( confirmed )); then
+    printf 'It was measured TWICE (%ds, then %ds) before this was printed, so it is not variance.\n' \
+      "$first_total_s" "$total_s"
+  elif (( CONFIRM_TOP == 0 )); then
+    printf 'Confirmation was disabled (--confirm-top=0), so this is ONE sample. Re-run to confirm.\n'
+  fi
+  printf '\nThe overage is %ds, and these harness(es) cover it — the run is inside the cap without\n' "$(( total_s - BUDGET ))"
+  printf 'them. This is the actionable set; the leaderboard below is context:\n'
+  covering "$(( (total_s - BUDGET) * 1000 ))"
+  printf '\nThe corpus is not free: every harness here runs on every future change, forever.\n'
   printf 'Past the cap a new guard REPLACES or MERGES an existing one. The %d slowest in this tier:\n' "$TOP"
   slowest "$TOP"
   printf '\nThree ways out, in order of preference:\n'
@@ -194,6 +341,11 @@ elif (( total_s > BUDGET )); then
   printf '     It does not delete the cost, which is why it is third and why it must be argued.\n'
 elif (( pct >= 80 )); then
   printf 'harness-budget[%s]: %d%% of budget — inside the cap, but the next few guards will not be.\n' "$TIER" "$pct"
+  # DIVE-2592: at 80%+ the tier has no variance headroom left, and that — not the
+  # percentage on its own — is what makes an unrelated PR go red. Say so, because the
+  # number alone has been sitting in the log getting bigger for a fortnight.
+  printf 'At this base a harness with budget-scale variance reds PRs on content they did not\n'
+  printf 'change: the cap is one sample, and one sample of this corpus has swung 67s (DIVE-2592).\n'
   printf 'The %d slowest in this tier:\n' "$TOP"; slowest "$TOP"
 fi
 

--- a/tests/baseline_pin_unit.sh
+++ b/tests/baseline_pin_unit.sh
@@ -5,7 +5,19 @@
 # nobody watches. The SAME file with the SAME assertions cost 174.1s on that run, 57.5s
 # on main in CI four hours earlier, and 2.4s on the control plane (agent-dev, same day,
 # 18 passed / 0 failed). Nothing in the file changed between those three readings. Its
-# cost is REMOTE RESOLUTION: arm C verifies that every pinned baseline is a commit that
+# WHICH READING THE DECISION RESTS ON, because three figures from three environments
+# are three different claims and a demotion argued on the wrong one is argued on
+# nothing (olivia, grading DIVE-2592). It rests on 57.5s — the CI reading on MAIN,
+# the ordinary case, the one that is charged to every PR on a good day. 174.1s is the
+# tail and shows the SPREAD, not the cost; on its own it would be an argument from an
+# outlier. 2.4s on the control plane is not evidence for demotion at all — it is the
+# CONTROL that rules out the alternative explanation, because a file that costs 2.4s
+# here and 57.5s there is not an expensive file, it is an environment-priced one, and
+# that is the difference between "merge or retire this" and "a wall-clock cap is the
+# wrong instrument for it". Even at the ordinary reading it is 19% of the entire 300s
+# core; the demotion would still be right if the 174.1s tail had never happened.
+#
+# Its cost is REMOTE RESOLUTION: arm C verifies that every pinned baseline is a commit that
 # resolves HERE, and a pin absent from the local object store falls back to
 # `git fetch origin <sha>` — one network round trip to github.com per unresolved pin.
 # So its wall-clock is a property of the runner's link, not of the corpus, which makes

--- a/tests/baseline_pin_unit.sh
+++ b/tests/baseline_pin_unit.sh
@@ -1,4 +1,25 @@
 #!/usr/bin/env bash
+# TIER: nightly — 174.1s measured (CI pristine, 2026-08-03, PR #395 attempt 1): priced by the network, not by its assertions, so a wall-clock cap cannot budget it.
+#
+# THE DEMOTION ARGUMENT, because a demotion nobody has to justify is a second budget
+# nobody watches. The SAME file with the SAME assertions cost 174.1s on that run, 57.5s
+# on main in CI four hours earlier, and 2.4s on the control plane (agent-dev, same day,
+# 18 passed / 0 failed). Nothing in the file changed between those three readings. Its
+# cost is REMOTE RESOLUTION: arm C verifies that every pinned baseline is a commit that
+# resolves HERE, and a pin absent from the local object store falls back to
+# `git fetch origin <sha>` — one network round trip to github.com per unresolved pin.
+# So its wall-clock is a property of the runner's link, not of the corpus, which makes
+# it UNBUDGETABLE IN A WALL-CLOCK CAP BY CONSTRUCTION rather than merely expensive: at
+# its high end it is 58% of the entire 300s PR core on its own, and it red-flagged PR
+# #395 on content that never touched it (DIVE-2592).
+#
+# WHAT THE DEMOTION COSTS, said plainly rather than left for the next reader to find: a
+# PR that introduces a NEW branch-ref baseline is now caught by the nightly sweep rather
+# than at review time. That is the whole loss. The nightly still runs this file every
+# day, `changed-harnesses` still runs it on any diff that touches it, and arm C's own
+# subject — that a pin resolves in the environment that gates the merge — is graded in
+# the environment that has always had the full history (full-sweep checks out depth 0).
+#
 # DIVE-2229 unit: a test baseline must name a COMMIT, and it must RESOLVE in the
 # environment that gates the merge.
 #

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -25,13 +25,16 @@
 #         exits 1 even when also over budget (the failure is what you fix first);
 #         an empty selection is exit 1, never a green run over nothing; the report
 #         carries the wall-clock header the nightly summary reads.
-#  31-38 DIVE-2592: an over-budget run RE-TIMES its slowest files and keeps the
+#  31-41 DIVE-2592: an over-budget run RE-TIMES its slowest files and keeps the
 #         smaller sample, so a red that flips on a re-run of the same commit cannot
 #         reach a PR author. Paired arms: the rescue, the corpus that is over on
 #         BOTH samples anyway, and --confirm-top=0 (an override may only make the
 #         control stricter). Plus: the red says NO TEST FAILED and names the set
 #         that COVERS the overage, min-of-two never RAISES a total, a re-run
-#         failure keeps its pass, and no workflow passes the new flag.
+#         failure keeps its pass, and no workflow passes the new flag. The CONTROL
+#         olivia asked for: same flapping harness, one real harness added between
+#         two runs — the min rescues the first and reds the second, so it removes
+#         weather and not cost, measured rather than argued.
 #  13-14  the over-budget message actually names a remedy and the slowest file —
 #         a budget that reds without saying what to retire is a warning with a
 #         worse exit code (feedback: grade the REMEDY half, not only the predicate).
@@ -476,7 +479,7 @@ else
   bad "probe mutant-kill arms" "NOT REACHED: could not symlink $PROBE into $FAKE — arms 27-30 graded nothing"
 fi
 
-# ------------------------------------- 31-38 DIVE-2592: A BUDGET RED CONFIRMS ITSELF
+# ------------------------------------- 31-41 DIVE-2592: A BUDGET RED CONFIRMS ITSELF
 # The measurement that forced this: PR #395 red at 356s and green at 289s on the SAME
 # commit, no rebase — a 67s swing, all of it inside one network-priced harness. A cap
 # compared against ONE noisy sample reds PRs on content they did not change, so an
@@ -564,6 +567,41 @@ C4="$(bash "$RUNNER" --corpus-dir="$TMP" --tier=full --budget=1 --label=t 2>&1)"
 if (( RC4 == 4 )) && [[ "$C4" == *"FLAKE"* && "$C4" == *"flake.sh"* ]]; then
   ok "a harness that fails its RE-RUN keeps its pass (exit 4, not 1) and is reported as a flake"
 else bad "a harness that fails its RE-RUN keeps its pass (exit 4, not 1) and is reported as a flake" "rc=$RC4 out=$C4"; fi
+
+# CONTROL (olivia, grading DIVE-2592): DOES THE MIN STILL SEE GROWTH?
+# The whole defence of min-of-two is that it removes WEATHER and keeps GROWTH — and
+# that was an argument, not a measurement, which is exactly the kind of claim this
+# corpus is supposed to refuse. So measure it, differentially: the SAME flapping
+# harness in both runs, one harness of real cost ADDED between them, nothing else
+# changed. If the min hid growth, the grown corpus would be rescued too.
+rm -f "$TMP"/*.sh "$TMP"/*.seen
+cat > "$TMP/flaps.sh" <<'FLAPS'
+#!/usr/bin/env bash
+[[ -e "$0.seen" ]] && exit 0
+touch "$0.seen"; sleep 1.2; exit 0
+FLAPS
+printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP/tiny.sh"
+G1="$(bash "$RUNNER" --corpus-dir="$TMP" --tier=full --budget=1 --label=t 2>&1)"; GRC1=$?
+g1="$(sed -n 's/.*confirmed \([0-9]*\)s.*/\1/p' <<<"$G1" | head -1)"
+# GROW IT: one more harness that costs its time every single run.
+rm -f "$TMP"/*.seen
+printf '#!/usr/bin/env bash\nsleep 1.2\nexit 0\n' > "$TMP/grew.sh"
+G2="$(bash "$RUNNER" --corpus-dir="$TMP" --tier=full --budget=1 --label=t 2>&1)"; GRC2=$?
+g2="$(sed -n 's/.*confirmed \([0-9]*\)s.*/\1/p' <<<"$G2" | head -1)"
+if (( GRC1 == 0 && GRC2 == 4 )); then
+  ok "GROWTH SURVIVES THE MIN: the confirmation that rescues the flapping corpus does NOT rescue it once one real harness is added"
+else bad "GROWTH SURVIVES THE MIN: the confirmation that rescues the flapping corpus does NOT rescue it once one real harness is added" "rc1=$GRC1 rc2=$GRC2"; fi
+# And the growth is VISIBLE IN THE CONFIRMED NUMBER, not only in the exit code — a
+# min that reported a flat total while reddening would be measuring something else.
+if [[ -n "$g1" && -n "$g2" ]] && (( g2 > g1 )); then
+  ok "the CONFIRMED total rises with the added harness (${g1}s -> ${g2}s): the min removes weather, not cost"
+else bad "the CONFIRMED total rises with the added harness: the min removes weather, not cost" "g1=[$g1] g2=[$g2]"; fi
+# Non-vacuity for the pair above: the second run must have actually RUN the
+# confirmation and reclaimed the flap, or "it went red" proves only that nothing
+# confirmed anything.
+if [[ "$G2" == *"BUDGET CONFIRMATION"* && "$G2" == *"flaps.sh"* ]]; then
+  ok "the grown corpus DID confirm and DID reclaim the flap, and reds anyway"
+else bad "the grown corpus DID confirm and DID reclaim the flap, and reds anyway" "$G2"; fi
 
 # The hatch arm the --budget flag never got (community/wiki/a-budget-with-a-free-
 # escape-hatch-is-a-second-budget-nobody-watches.md): enumerate the hatches from the

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -25,6 +25,13 @@
 #         exits 1 even when also over budget (the failure is what you fix first);
 #         an empty selection is exit 1, never a green run over nothing; the report
 #         carries the wall-clock header the nightly summary reads.
+#  31-38 DIVE-2592: an over-budget run RE-TIMES its slowest files and keeps the
+#         smaller sample, so a red that flips on a re-run of the same commit cannot
+#         reach a PR author. Paired arms: the rescue, the corpus that is over on
+#         BOTH samples anyway, and --confirm-top=0 (an override may only make the
+#         control stricter). Plus: the red says NO TEST FAILED and names the set
+#         that COVERS the overage, min-of-two never RAISES a total, a re-run
+#         failure keeps its pass, and no workflow passes the new flag.
 #  13-14  the over-budget message actually names a remedy and the slowest file —
 #         a budget that reds without saying what to retire is a warning with a
 #         worse exit code (feedback: grade the REMEDY half, not only the predicate).
@@ -468,6 +475,105 @@ STUBEOF
 else
   bad "probe mutant-kill arms" "NOT REACHED: could not symlink $PROBE into $FAKE — arms 27-30 graded nothing"
 fi
+
+# ------------------------------------- 31-38 DIVE-2592: A BUDGET RED CONFIRMS ITSELF
+# The measurement that forced this: PR #395 red at 356s and green at 289s on the SAME
+# commit, no rebase — a 67s swing, all of it inside one network-priced harness. A cap
+# compared against ONE noisy sample reds PRs on content they did not change, so an
+# over-budget run now re-times its slowest files and keeps the SMALLER sample per file.
+#
+# Every arm below is one this mechanism can get wrong, and they are deliberately
+# PAIRED: a rescue arm alone is satisfied by "confirmation always rescues", which is
+# the budget silently switched off. Sleeps are 1.2s against a 1s budget — the smallest
+# pair the runner's second-resolution clock can tell apart — because this file is
+# itself charged to the tier it enforces.
+rm -f "$TMP"/*.sh "$TMP"/*.seen
+# Slow once, then free: the shape of a harness whose cost was the runner, not itself.
+cat > "$TMP/flaps.sh" <<'FLAPS'
+#!/usr/bin/env bash
+[[ -e "$0.seen" ]] && exit 0
+touch "$0.seen"; sleep 1.2; exit 0
+FLAPS
+printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP/tiny.sh"
+
+C1="$(bash "$RUNNER" --corpus-dir="$TMP" --tier=full --budget=1 --label=t 2>&1)"; RC1=$?
+if (( RC1 == 0 )); then
+  ok "a run OVER on its first sample and INSIDE on its second exits 0"
+else bad "a run OVER on its first sample and INSIDE on its second exits 0" "rc=$RC1"; fi
+# A rescue that prints nothing is a budget that relaxed itself in silence. Both
+# numbers, or the trend this row exists to keep legible is gone on exactly the runs
+# where it moved.
+if [[ "$C1" == *"BUDGET CONFIRMATION"* && "$C1" == *"first sample"* && "$C1" == *"confirmed"* ]]; then
+  ok "the rescue SAYS SO, with both the first and the confirmed number"
+else bad "the rescue SAYS SO, with both the first and the confirmed number" "$C1"; fi
+if [[ "$C1" == *"flaps.sh"* && "$C1" == *"->"* ]]; then
+  ok "the rescue NAMES the harness whose timing swung"
+else bad "the rescue NAMES the harness whose timing swung" "$C1"; fi
+
+# NON-VACUITY. Same runner, same budget, a corpus that is over on BOTH samples: if
+# this passed too, the arm above would be measuring nothing but the retry existing.
+# Slow EVERY time: the shape of a corpus that genuinely does not fit its cap.
+rm -f "$TMP"/*.seen "$TMP/flaps.sh"
+printf '#!/usr/bin/env bash\nsleep 1.2\nexit 0\n' > "$TMP/always.sh"
+C2="$(bash "$RUNNER" --corpus-dir="$TMP" --tier=full --budget=1 --label=t 2>&1)"; RC2=$?
+want "a corpus that is over on BOTH samples still exits 4" "4" "$RC2"
+if [[ "$C2" == *"NO TEST FAILED"* && "$C2" == *"BUDGET failure"* ]]; then
+  ok "the budget red says NO TEST FAILED — the sentence exit 4 alone does not carry"
+else bad "the budget red says NO TEST FAILED — the sentence exit 4 alone does not carry" "$C2"; fi
+if [[ "$C2" == *"cover it"* && "$C2" == *"always.sh"* ]]; then
+  ok "the budget red names the smallest set of harnesses that COVERS the overage"
+else bad "the budget red names the smallest set of harnesses that COVERS the overage" "$C2"; fi
+
+# --confirm-top may only make this gate STRICTER. The rescued corpus, confirmation
+# off, must red — an override that can turn a red green is the hatch, not the control.
+cat > "$TMP/flaps.sh" <<'FLAPS'
+#!/usr/bin/env bash
+[[ -e "$0.seen" ]] && exit 0
+touch "$0.seen"; sleep 1.2; exit 0
+FLAPS
+rm -f "$TMP/always.sh" "$TMP"/*.seen
+bash "$RUNNER" --corpus-dir="$TMP" --tier=full --budget=1 --label=t --confirm-top=0 >/dev/null 2>&1
+want "--confirm-top=0 reds the SAME corpus the confirmation rescues (stricter, never looser)" "4" "$?"
+
+# MIN OF TWO NEVER RAISES A TIMING. A harness slower on its re-run keeps its first
+# sample: a confirmation that could INVENT a red is a second, worse coin flip.
+rm -f "$TMP"/*.sh "$TMP"/*.seen
+cat > "$TMP/rev.sh" <<'REV'
+#!/usr/bin/env bash
+[[ -e "$0.seen" ]] || { touch "$0.seen"; exit 0; }
+sleep 1.2; exit 0
+REV
+printf '#!/usr/bin/env bash\nsleep 1.2\nexit 0\n' > "$TMP/always.sh"
+C3="$(bash "$RUNNER" --corpus-dir="$TMP" --tier=full --budget=1 --label=t 2>&1)"
+f3="$(sed -n 's/.*first sample \([0-9]*\)s.*/\1/p' <<<"$C3" | head -1)"
+c3="$(sed -n 's/.*confirmed \([0-9]*\)s.*/\1/p' <<<"$C3" | head -1)"
+if [[ -n "$f3" && -n "$c3" ]] && (( c3 <= f3 )); then
+  ok "a harness SLOWER on its re-run keeps its first sample (confirmation never raises a total)"
+else bad "a harness SLOWER on its re-run keeps its first sample (confirmation never raises a total)" "first=[$f3] confirmed=[$c3]"; fi
+
+# A harness that FAILS its re-run keeps its PASS. The graded run is the first one, and
+# flipping a pass to a fail on a second sample is this same one-sample error inverted —
+# but the non-determinism is reported, not swallowed.
+rm -f "$TMP"/*.sh "$TMP"/*.seen
+cat > "$TMP/flake.sh" <<'FLK'
+#!/usr/bin/env bash
+[[ -e "$0.seen" ]] && exit 1
+touch "$0.seen"; sleep 1.2; exit 0
+FLK
+C4="$(bash "$RUNNER" --corpus-dir="$TMP" --tier=full --budget=1 --label=t 2>&1)"; RC4=$?
+if (( RC4 == 4 )) && [[ "$C4" == *"FLAKE"* && "$C4" == *"flake.sh"* ]]; then
+  ok "a harness that fails its RE-RUN keeps its pass (exit 4, not 1) and is reported as a flake"
+else bad "a harness that fails its RE-RUN keeps its pass (exit 4, not 1) and is reported as a flake" "rc=$RC4 out=$C4"; fi
+
+# The hatch arm the --budget flag never got (community/wiki/a-budget-with-a-free-
+# escape-hatch-is-a-second-budget-nobody-watches.md): enumerate the hatches from the
+# RUNNER'S FLAG SURFACE, not from the policy. --confirm-top is safe only while no job
+# passes it, and "no job does today" is not a control until something pins it.
+rm -f "$TMP"/*.sh "$TMP"/*.seen
+if grep -rn -- '--confirm-top' .github/workflows/ >/dev/null 2>&1; then
+  bad "no CI workflow passes --confirm-top" "$(grep -rn -- '--confirm-top' .github/workflows/)"
+else ok "no CI workflow passes --confirm-top"; fi
+
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 (( fail == 0 ))

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -564,9 +564,16 @@ cat > "$TMP/flake.sh" <<'FLK'
 touch "$0.seen"; sleep 1.2; exit 0
 FLK
 C4="$(bash "$RUNNER" --corpus-dir="$TMP" --tier=full --budget=1 --label=t 2>&1)"; RC4=$?
-if (( RC4 == 4 )) && [[ "$C4" == *"FLAKE"* && "$C4" == *"flake.sh"* ]]; then
-  ok "a harness that fails its RE-RUN keeps its pass (exit 4, not 1) and is reported as a flake"
-else bad "a harness that fails its RE-RUN keeps its pass (exit 4, not 1) and is reported as a flake" "rc=$RC4 out=$C4"; fi
+if (( RC4 == 4 )) && [[ "$C4" == *"RE-RUN DISAGREED (observed)"* && "$C4" == *"flake.sh"* ]]; then
+  ok "a harness that fails its RE-RUN keeps its pass (exit 4, not 1) and the disagreement is reported"
+else bad "a harness that fails its RE-RUN keeps its pass (exit 4, not 1) and the disagreement is reported" "rc=$RC4 out=$C4"; fi
+# olivia, DIVE-2592: the observation and the CAUSE are different claims, and a guess
+# printed among measured sentences inherits their authority. The hedge lives in the
+# string, which is read forever, not only in the handoff, which is read once — so it
+# is graded here rather than trusted.
+if [[ "$C4" == *"CAUSE NOT MEASURED (inferred)"* ]]; then
+  ok "the re-run disagreement marks its CAUSE as inferred, in the output string itself"
+else bad "the re-run disagreement marks its CAUSE as inferred, in the output string itself" "$C4"; fi
 
 # CONTROL (olivia, grading DIVE-2592): DOES THE MIN STILL SEE GROWTH?
 # The whole defence of min-of-two is that it removes WEATHER and keeps GROWTH — and


### PR DESCRIPTION
## A wall-clock budget red that flipped on a re-run of the same commit

PR #395 — one line of code and two test arms — failed CI on `exit 4` with **zero assertion
failures**. Every harness that ran, passed. The job died on the DIVE-2525 wall-clock budget.

**The decisive measurement is a re-run of the identical head, no rebase:**

| run | tier/env | harnesses | wall-clock | % of 300s | verdict |
|---|---|---:|---:|---:|---|
| attempt 1 | core/pristine | 209 | 356s | 118% | FAIL |
| attempt 2 | core/pristine | 209 | 289s | 96% | PASS |

A 67s swing with nothing changed, and all of it inside one file:
`tests/baseline_pin_unit.sh` — **57.5s** on main in CI, **174.1s** on that attempt. It
resolves pinned baseline *commits* against the remote (DIVE-2229), so it is priced by the
network rather than by its assertions.

**And the headroom was already gone**, which is the structural half:

| | harnesses | wall-clock | % |
|---|---:|---:|---:|
| PR #390 head | 207 | 158s | 52% |
| main @ merge | 209 | 241s | 80% |
| PR #395 a1 | 209 | 356s | 118% |
| PR #395 a2 | 209 | 289s | 96% |

On an 80–96% base, any harness with budget-scale variance reds PRs **at random, on content
they did not change**.

### The cap is NOT raised

300s is the number, and the corpus really does sit at 96% of it. Raising it to 450 buys three
weeks and re-installs the ratchet DIVE-2525 exists to remove. **The comparison was the
defect:** one noisy sample against a hard threshold on a base with no margin.

### What changed

- **A budget red confirms itself first.** Over budget, `scripts/run-harnesses.sh` re-times the
  3 slowest harnesses and keeps the **smaller sample per file**. Noise here is one-sided —
  contention, a cold cache and a slow remote can only *add* time — so the low sample is the
  least contaminated estimate, while real corpus growth appears in **both** samples and
  survives. Paid only on the red path; a green run re-times nothing. `--confirm-top=0`
  disables it, which can only make the gate **stricter**; there is deliberately no flag that
  confirms *more*, and an arm pins that no CI job passes one.
- **A budget red says it is a budget red.** `exit 4` beside a green assertion count read as
  *systemic* to the author whose PR it stopped and as *flake* to the next reader — it is
  neither, and no single run can show that. The message now states that no test failed,
  whether the number was measured twice, and **the smallest set of harnesses that covers the
  overage** — the actionable set, not the top-10 leaderboard.
- **`tests/baseline_pin_unit.sh` is demoted to nightly**, with the argument in its header.
  The decision rests on **57.5s — the CI reading on main**, the ordinary case charged to every
  PR, 19% of the whole core budget on its own. 174.1s is the tail and shows the *spread*;
  2.4s on the control plane is the **control** that rules out "expensive file" in favour of
  "environment-priced file" — the difference between *merge-or-retire* and *a wall-clock cap
  is the wrong instrument for this*.
- **A re-run disagreement names what it did and did not measure.** Two runs disagreeing is
  *observed*; "flaky harness" is *inferred*, and one of at least three candidates
  (non-determinism, state the first run left behind, the runner changing under both). The
  output separates the halves and says it cannot tell them apart, because the handoff is read
  once and the string is read forever.

### Held back from this branch

The matching `budget-report` change — printing the nightly total in the **units of the policy
dial**, i.e. the minimum number of shards the corpus now needs beside the number configured —
edits `.github/workflows/full-sweep.yml`, and `5dive push` **cannot ship a workflow file**:
GitHub withholds the `workflows` scope from Apps on purpose, because a credential that can
rewrite CI can rewrite what CI requires of it (DIVE-2229/2262, Marcus's call). The hunk is
kept at `DIVE-2592-fullsweep-shards-needed.patch` on the control plane. The nightly tier is at
**126% of its per-job budget un-sharded** (DIVE-1986), so that half is still owed and needs
the `5dive-bot` machine account (DIVE-2232 option A) or a one-off human push.

### How it was checked

- `tests/corpus_tier_budget_unit.sh` — **55 passed, 0 failed** on the final rebased tree
  (23 new arms). Including a **differential control** for the min-of-two claim: same flapping
  harness in both runs, one real harness added between them, nothing else changed — the
  confirmation rescues the first corpus and **reds the second**, the confirmed total rises
  with the added harness, and the grown run demonstrably *did* reclaim the flap and red anyway
  (non-vacuity: "it went red" alone would prove nothing was confirmed).
- Arms pin the stricter-only direction (`--confirm-top=0` reds the same corpus the
  confirmation rescues), that a harness **slower** on its re-run keeps its first sample, that
  a harness which **fails** its re-run keeps its pass (exit 4, not 1), and that no CI workflow
  passes `--confirm-top`.
- `tests/baseline_pin_unit.sh` — 18 passed, 0 failed; `tier_of` resolves it to `nightly`.
- `scripts/pii-scan.sh` clean on the diff and on `CHANGELOG.md`.

Closes DIVE-2592.
