### PR TITLE
DIVE-2682: refuse a close whose delivery binding predates the current loop iteration

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -2895,6 +2895,34 @@ _task_status_cmd() {
     if [[ -z "$_dref" ]]; then
       _branch=$(_push_branch_from_body "$_body")
     fi
+    # DIVE-2682 (implements the DIVE-2671 design call): a binding can OUTLIVE the
+    # iteration it was made for. The gate below asks "did the bound PR land"; it
+    # never asks "did the sha the verifier graded land", and a maker→verifier loop
+    # separates those two by design. DIVE-2057 is the clean instance: bound to #45
+    # at first delivery, #45 was REJECTED, the fix landed in a new PR #51, and the
+    # row still pointed at #45 — a credential-holding close would have greened off
+    # a PR that does not contain the passed work.
+    #
+    # Keyed on ITERATION, not on the graded sha and not on timestamps. The sha
+    # variant is refuted: we squash-merge, so a graded head is NEVER an ancestor
+    # of main and every squash-merged PR would false-RED. The timestamp variant is
+    # refuted too — DIVE-2057's binding legitimately predates its latest ACK.
+    #
+    # This check is PURELY LOCAL. No token, no API, no rail — so unlike every
+    # GitHub-query arm below it, it cannot vary by caller, which is the exact
+    # failure mode that made a missing credential do the work of a control.
+    #
+    # NULL is not stale: rows bound before this column existed cannot be judged,
+    # and a gate that refuses on "I do not know" is a false red.
+    if [[ -n "$_dref" ]]; then
+      local _bind_iter _cur_iter
+      _bind_iter=$(db "SELECT COALESCE(CAST(delivery_ref_iteration AS TEXT),'') FROM tasks WHERE id=${id};")
+      _cur_iter=$(db "SELECT COALESCE(iteration,0) FROM tasks WHERE id=${id};")
+      if [[ -n "$_bind_iter" ]] && (( _bind_iter < _cur_iter )); then
+        policy_refuse "$E_CONFLICT" done-with-stale-delivery-binding DIVE-2682 "$ident" \
+          "$ident cannot close: its delivery binding ${_dref} was recorded at loop iteration ${_bind_iter}, and the loop is now at ${_cur_iter}. The work bounced back to the maker and was re-delivered after that PR was bound, so closing here would grade a PR that does not contain the re-delivered work (DIVE-2057 is the clean instance of that). Re-point the binding to the PR carrying the CURRENT iteration — \`task deliver $ident --pr=https://github.com/<owner>/<repo>/pull/N\` — then \`task done\`."
+      fi
+    fi
     if [[ -n "$_dref" || -n "$_branch" ]]; then
       _mg_had_subject=1     # a declared delivery IS something to verify
       if ! command -v gh >/dev/null 2>&1; then
@@ -3738,7 +3766,9 @@ cmd_task_deliver() {
   _asignee=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=${id};")
   if [[ -n "$_vfier" && "$_vfier" != "$_asignee" ]]; then
     # Hand off to the verifier exactly like a maker's `task done` (DIVE-477).
-    _task_route_to_verifier "$id" "$_vfier" "$_asignee" "$result" "$want_result"
+    # DIVE-2682: the trailing 1 stamps delivery_ref_iteration alongside the bump —
+    # this verb, and only this verb, just wrote delivery_ref above.
+    _task_route_to_verifier "$id" "$_vfier" "$_asignee" "$result" "$want_result" 1
     return
   fi
   # No distinct verifier: record the delivery but do NOT close — a verifier must
@@ -3887,9 +3917,22 @@ cmd_task_merge_audit() {
 # in their queue (no heartbeat change needed). No status='done' is written: the
 # work is not closed until the verifier signs off.
 _task_route_to_verifier() {
-  local id="$1" vfier="$2" maker="$3" result="$4" want_result="$5"
+  local id="$1" vfier="$2" maker="$3" result="$4" want_result="$5" stamp_binding="${6:-0}"
   local set_result=""
   (( want_result )) && set_result=", result=$(sqlq_or_null "$result")"
+  # DIVE-2682: stamp the binding's iteration in the SAME UPDATE that bumps the
+  # counter, never in a second statement. Both right-hand sides evaluate against
+  # the PRE-update row, so delivery_ref_iteration and iteration land on the same
+  # number — which is the whole point. Reading the counter at two different
+  # moments is what would false-REFUSE the well-behaved maker who re-points the
+  # binding and delivers in one breath.
+  #
+  # Only cmd_task_deliver passes 1: it is the sole writer of delivery_ref, so it
+  # is the only caller that just (re)pointed the binding. A plain `task done`
+  # re-delivery passes 0 and deliberately leaves the stamp behind at its old
+  # iteration — that gap IS the signal the gate reads.
+  local set_binding_iter=""
+  (( stamp_binding )) && set_binding_iter=", delivery_ref_iteration=COALESCE(iteration,0)+1"
   # DIVE-1416 (gap#2): stamp handoff_delivered_at fresh on EVERY delivery (incl.
   # a re-delivery after a reject/bounce-back) — the dedicated clock the stall
   # sweep uses to detect a delivery sitting unacknowledged too long. Clear any
@@ -3927,7 +3970,7 @@ _task_route_to_verifier() {
               ELSE COALESCE(iteration,0) END,
             handoff_rejected_at=NULL,
             started_at=NULL, handoff_ack_at=NULL,
-            handoff_delivered_at=datetime('now'), handoff_stale_pinged_at=NULL${set_result}
+            handoff_delivered_at=datetime('now'), handoff_stale_pinged_at=NULL${set_result}${set_binding_iter}
       WHERE id=${id};"
   local iter; iter=$(db "SELECT iteration FROM tasks WHERE id=${id};")
   local iter_note=""

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -3945,7 +3945,18 @@ _task_route_to_verifier() {
   # re-delivery passes 0 and deliberately leaves the stamp behind at its old
   # iteration — that gap IS the signal the gate reads.
   local set_binding_iter=""
-  (( stamp_binding )) && set_binding_iter=", delivery_ref_iteration=COALESCE(iteration,0)+1"
+  # DIVE-2682 + DIVE-2601 interaction, found by rebasing onto 8051cb1: the counter's
+  # bump became CONDITIONAL ("re-delivery of the same pass, not rework" — it only
+  # increments on a first delivery or after a reject). An unconditional +1 here then
+  # stamped the binding at iteration+1 while `iteration` itself stayed put, leaving
+  # bind > iter on every same-pass re-delivery — a state the guard's own predicate
+  # (bind < iter) can never flag, so it fails SILENTLY rather than loudly. The stamp
+  # must mirror the counter's CASE exactly, or the two answers are read from
+  # different moments again, which is the hazard this row's body opens with.
+  (( stamp_binding )) && set_binding_iter=", delivery_ref_iteration=CASE
+              WHEN handoff_delivered_at IS NULL OR handoff_rejected_at IS NOT NULL
+              THEN COALESCE(iteration,0)+1
+              ELSE COALESCE(iteration,0) END"
   # DIVE-1416 (gap#2): stamp handoff_delivered_at fresh on EVERY delivery (incl.
   # a re-delivery after a reject/bounce-back) — the dedicated clock the stall
   # sweep uses to detect a delivery sitting unacknowledged too long. Clear any

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -3760,7 +3760,20 @@ cmd_task_deliver() {
   fi
   # Record the delivery ref + timestamp before the handoff, so the merge-gate can
   # see it regardless of where the task lands next.
-  db "UPDATE tasks SET delivery_ref=$(sqlq "$pr"), delivered_at=datetime('now') WHERE id=${id};"
+  # DIVE-2682 (dev's reject, iteration 1): stamp the binding's iteration HERE, beside
+  # the delivery_ref write, so BOTH deliver arms record it. The routing arm below
+  # overwrites this with iteration+1 inside the same UPDATE that bumps the counter.
+  # The non-routing arm (verifier == assignee) previously stamped NOTHING — and that
+  # is exactly the arm a maker lands in when it follows the refusal's own printed
+  # remedy, because the gate fires on a VERIFIER's close, when assignee IS the
+  # verifier. So `task deliver --pr=<new>` re-pointed the binding for real while the
+  # stamp stayed behind, and the next close refused again naming the CORRECT new PR
+  # as recorded at the old iteration: a false refuse on a correctly-bound row, which
+  # is the hazard class this row exists to prevent.
+  # CURRENT iteration, never a bump: re-pointing is the legitimate act the gate
+  # demands, so recording it cannot weaken the gate — the stamp still only ever
+  # equals an iteration at which a PR was actually named.
+  db "UPDATE tasks SET delivery_ref=$(sqlq "$pr"), delivered_at=datetime('now'), delivery_ref_iteration=COALESCE(iteration,0) WHERE id=${id};"
   local _vfier _asignee
   _vfier=$(db "SELECT COALESCE(verifier,'')  FROM tasks WHERE id=${id};")
   _asignee=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=${id};")

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -3945,7 +3945,7 @@ _task_route_to_verifier() {
   # re-delivery passes 0 and deliberately leaves the stamp behind at its old
   # iteration — that gap IS the signal the gate reads.
   local set_binding_iter=""
-  # DIVE-2682 + DIVE-2601 interaction, found by rebasing onto 8051cb1: the counter's
+  # DIVE-2682 + DIVE-2624 interaction, found by rebasing onto 8051cb1: the counter's
   # bump became CONDITIONAL ("re-delivery of the same pass, not rework" — it only
   # increments on a first delivery or after a reject). An unconditional +1 here then
   # stamped the binding at iteration+1 while `iteration` itself stayed put, leaving

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -1099,7 +1099,7 @@ _tasks_db_migrate() {
            'ask_shape TEXT' 'precedent_ref INTEGER' 'precedent_kind TEXT' \
            'needs_capability TEXT' \
            'shipped_flag_at TEXT' 'routed_reviewer TEXT' \
-           'delivery_ref TEXT' 'delivered_at TEXT' \
+           'delivery_ref TEXT' 'delivered_at TEXT' 'delivery_ref_iteration INTEGER' \
            'originated_by_objective INTEGER' 'originated_cycle INTEGER' \
            'verify_unavailable INTEGER' 'last_skipped_at TEXT' \
            'human_evidence TEXT' \

--- a/tests/task_deliver_merge_gate_unit.sh
+++ b/tests/task_deliver_merge_gate_unit.sh
@@ -429,6 +429,28 @@ out=$( actor_seam_as dev; cmd_task_done DIVE-261 2>&1 ); rc=$?
   && ok_t "Tgb close on a RE-POINTED binding is ACCEPTED and the task closes" \
   || bad_t "Tgb accepted" "rc=$rc status=$(statusof DIVE-261) out=$out"
 
+# ARM (d) — THE REMEDY ARM, and it INHERITS arm (a)'s refused row rather than
+# re-seeding one that resembles it. dev's reject (iteration 1) found that arm (b),
+# though an honest control, re-seeds assignee='main' BEFORE re-pointing, which puts
+# it on the ROUTING deliver arm. A real maker reading the refusal is not there: the
+# gate fires on a VERIFIER's close, so at that instant assignee IS the verifier and
+# `task deliver --pr=<new>` takes the NON-routing arm. That arm stamped nothing, so
+# the remedy the refusal printed re-pointed the binding for real and then refused
+# again, naming the CORRECT new PR as "recorded at loop iteration 1".
+# A refusal that prints an instruction has made a testable claim about reachability.
+# This arm runs that instruction VERBATIM, from the state the refusal left behind.
+[[ "$(assigneeof DIVE-260)" == "dev" && "$(iterof DIVE-260)" == "2" && "$(binditerof DIVE-260)" == "1" ]] \
+  && ok_t "Tgd inherits arm (a)'s refused row (assignee=verifier, iter=2, bind=1)" \
+  || bad_t "Tgd wrong start state" "assignee=$(assigneeof DIVE-260) iter=$(iterof DIVE-260) bind=$(binditerof DIVE-260)"
+( actor_seam_as main; cmd_task_deliver DIVE-260 --pr="$PR2" ) >/dev/null 2>&1
+[[ "$(iterof DIVE-260)" == "2" && "$(binditerof DIVE-260)" == "2" ]] \
+  && ok_t "Tgd the printed remedy stamps the binding at the CURRENT iteration, no bump" \
+  || bad_t "Tgd remedy did not move the stamp" "iter=$(iterof DIVE-260) bind=$(binditerof DIVE-260)"
+out=$( actor_seam_as dev; cmd_task_done DIVE-260 2>&1 ); rc=$?
+[[ $rc -eq 0 && "$(statusof DIVE-260)" == "done" ]] \
+  && ok_t "Tgd following the refusal's OWN remedy makes the close succeed" \
+  || bad_t "Tgd remedy is inert — false refuse on a correctly-bound row" "rc=$rc status=$(statusof DIVE-260) out=$out"
+
 # ARM (c): a row bound BEFORE this column existed has a NULL stamp. NULL is not
 # stale — "I cannot judge" must never become a refusal, or the gate false-REDs
 # every legacy row on the board the moment it ships.

--- a/tests/task_deliver_merge_gate_unit.sh
+++ b/tests/task_deliver_merge_gate_unit.sh
@@ -376,7 +376,69 @@ out=$(cmd_task_done DIVE-265 --result="PASS. graded-sha: $OTHER_SHA" 2>&1); rc=$
 [[ -z "$(_gate_graded_sha "graded-sha: nothex")" ]] \
   && ok_t "Te9d extractor ignores a non-hex label value" \
   || bad_t "Te9d" "got=$(_gate_graded_sha "graded-sha: nothex")"
+# --- Tg: DIVE-2682 — a binding that PREDATES the current loop iteration is stale,
+#     and a close on it is refused. Graded by mutation, both arms, because a fix
+#     that only ever refuses passes the refusing arm trivially. ------------------
+iterof()  { db "SELECT COALESCE(iteration,0) FROM tasks WHERE ident='$1';"; }
+binditerof() { db "SELECT COALESCE(CAST(delivery_ref_iteration AS TEXT),'NULL') FROM tasks WHERE ident='$1';"; }
+PR2="https://github.com/5dive-ai/5dive/pull/1000"
 
+# The well-behaved delivery first: deliver stamps the binding's iteration in the
+# SAME update that bumps the counter, so the two agree. If these ever disagree at
+# this point the ordering hazard is live and every arm below is meaningless.
+seed_task DIVE-260 main dev
+cmd_task_deliver DIVE-260 --pr="$PR" >/dev/null 2>&1
+[[ "$(iterof DIVE-260)" == "1" && "$(binditerof DIVE-260)" == "1" ]] \
+  && ok_t "Tg0 deliver stamps binding-iteration == iteration (no two-moment read)" \
+  || bad_t "Tg0 stamp/bump agree" "iter=$(iterof DIVE-260) bind=$(binditerof DIVE-260)"
+
+# ARM (a): the loop bounces and the maker re-delivers WITHOUT re-pointing the
+# binding — `task done` from the maker routes to the verifier again and bumps the
+# counter, leaving the binding behind at iteration 1. The close must REFUSE.
+db "UPDATE tasks SET assignee='main', status='in_progress' WHERE ident='DIVE-260';"   # verifier rejected → back to maker
+( actor_seam_as main; cmd_task_done DIVE-260 --result="fixed, re-delivering" ) >/dev/null 2>&1
+[[ "$(iterof DIVE-260)" == "2" && "$(binditerof DIVE-260)" == "1" ]] \
+  && ok_t "Tga re-delivery bumps the counter and leaves the binding at its old iteration" \
+  || bad_t "Tga stale gap created" "iter=$(iterof DIVE-260) bind=$(binditerof DIVE-260)"
+export GH_STUB_STATE="MERGED" GH_STUB_MERGED="2026-08-04T00:00:00Z"
+out=$( actor_seam_as dev; cmd_task_done DIVE-260 2>&1 ); rc=$?
+[[ $rc -eq $E_CONFLICT ]] \
+  && ok_t "Tga close on a STALE binding is REFUSED even though the PR is MERGED" \
+  || bad_t "Tga refused rc" "rc=$rc (want $E_CONFLICT) out=$out"
+[[ "$out" == *"DIVE-2682"* || "$out" == *"iteration"* ]] \
+  && ok_t "Tga the refusal names the iteration mismatch, not the merge state" \
+  || bad_t "Tga refusal message" "out=$out"
+[[ "$(statusof DIVE-260)" != "done" ]] \
+  && ok_t "Tga the task did NOT close" \
+  || bad_t "Tga task closed anyway" "status=$(statusof DIVE-260)"
+
+# ARM (b) — THE CONTROL, and the one that catches the ordering hazard. Same loop,
+# but the maker RE-POINTS the binding with `task deliver --pr=<new>`. The stamp
+# and the bump happen in one update, so they agree, and the close is ACCEPTED.
+# Without this arm a fix that refuses unconditionally would pass arm (a) and look
+# correct while blocking every legitimate close on the board.
+seed_task DIVE-261 main dev
+cmd_task_deliver DIVE-261 --pr="$PR" >/dev/null 2>&1
+db "UPDATE tasks SET assignee='main', status='in_progress' WHERE ident='DIVE-261';"   # rejected → back to maker
+( actor_seam_as main; cmd_task_deliver DIVE-261 --pr="$PR2" ) >/dev/null 2>&1
+[[ "$(iterof DIVE-261)" == "2" && "$(binditerof DIVE-261)" == "2" ]] \
+  && ok_t "Tgb re-pointing the binding stamps it at the NEW iteration (no false refuse)" \
+  || bad_t "Tgb re-point stamp" "iter=$(iterof DIVE-261) bind=$(binditerof DIVE-261)"
+out=$( actor_seam_as dev; cmd_task_done DIVE-261 2>&1 ); rc=$?
+[[ $rc -eq 0 && "$(statusof DIVE-261)" == "done" ]] \
+  && ok_t "Tgb close on a RE-POINTED binding is ACCEPTED and the task closes" \
+  || bad_t "Tgb accepted" "rc=$rc status=$(statusof DIVE-261) out=$out"
+
+# ARM (c): a row bound BEFORE this column existed has a NULL stamp. NULL is not
+# stale — "I cannot judge" must never become a refusal, or the gate false-REDs
+# every legacy row on the board the moment it ships.
+seed_task DIVE-262 main dev
+cmd_task_deliver DIVE-262 --pr="$PR" >/dev/null 2>&1
+db "UPDATE tasks SET delivery_ref_iteration=NULL, iteration=7 WHERE ident='DIVE-262';"
+out=$( actor_seam_as dev; cmd_task_done DIVE-262 2>&1 ); rc=$?
+[[ $rc -eq 0 && "$(statusof DIVE-262)" == "done" ]] \
+  && ok_t "Tgc a NULL binding-iteration (legacy row) is NOT treated as stale" \
+  || bad_t "Tgc legacy row false-refused" "rc=$rc status=$(statusof DIVE-262) out=$out"
 echo "-----"
 printf 'task_deliver_merge_gate_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/tests/task_deliver_merge_gate_unit.sh
+++ b/tests/task_deliver_merge_gate_unit.sh
@@ -395,7 +395,7 @@ cmd_task_deliver DIVE-260 --pr="$PR" >/dev/null 2>&1
 # ARM (a): the loop bounces and the maker re-delivers WITHOUT re-pointing the
 # binding — `task done` from the maker routes to the verifier again and bumps the
 # counter, leaving the binding behind at iteration 1. The close must REFUSE.
-db "UPDATE tasks SET assignee='main', status='in_progress' WHERE ident='DIVE-260';"   # verifier rejected → back to maker
+db "UPDATE tasks SET assignee='main', status='in_progress', handoff_rejected_at=datetime('now') WHERE ident='DIVE-260';"   # verifier rejected → back to maker
 ( actor_seam_as main; cmd_task_done DIVE-260 --result="fixed, re-delivering" ) >/dev/null 2>&1
 [[ "$(iterof DIVE-260)" == "2" && "$(binditerof DIVE-260)" == "1" ]] \
   && ok_t "Tga re-delivery bumps the counter and leaves the binding at its old iteration" \
@@ -419,7 +419,7 @@ out=$( actor_seam_as dev; cmd_task_done DIVE-260 2>&1 ); rc=$?
 # correct while blocking every legitimate close on the board.
 seed_task DIVE-261 main dev
 cmd_task_deliver DIVE-261 --pr="$PR" >/dev/null 2>&1
-db "UPDATE tasks SET assignee='main', status='in_progress' WHERE ident='DIVE-261';"   # rejected → back to maker
+db "UPDATE tasks SET assignee='main', status='in_progress', handoff_rejected_at=datetime('now') WHERE ident='DIVE-261';"   # rejected → back to maker
 ( actor_seam_as main; cmd_task_deliver DIVE-261 --pr="$PR2" ) >/dev/null 2>&1
 [[ "$(iterof DIVE-261)" == "2" && "$(binditerof DIVE-261)" == "2" ]] \
   && ok_t "Tgb re-pointing the binding stamps it at the NEW iteration (no false refuse)" \
@@ -450,6 +450,28 @@ out=$( actor_seam_as dev; cmd_task_done DIVE-260 2>&1 ); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-260)" == "done" ]] \
   && ok_t "Tgd following the refusal's OWN remedy makes the close succeed" \
   || bad_t "Tgd remedy is inert — false refuse on a correctly-bound row" "rc=$rc status=$(statusof DIVE-260) out=$out"
+
+# ARM (e) — THE SAME-PASS RE-DELIVERY, and it exists because the first version of
+# this fix was UNGRADED. DIVE-2601 made the counter's bump CONDITIONAL ("re-delivery
+# of the same pass, not rework": iteration moves only on a first delivery or after a
+# reject). The stamp was still an unconditional +1, so a same-pass re-delivery left
+# bind = iter+1 — a state the guard's predicate (bind < iter) can NEVER flag, i.e. it
+# fails SILENTLY. Every other arm here bounces via handoff_rejected_at, which takes
+# the +1 branch and makes the two forms identical, so mutating the CASE back to +1
+# scored 41/0 and proved nothing. This arm is the one that reds it.
+seed_task DIVE-263 main dev
+cmd_task_deliver DIVE-263 --pr="$PR" >/dev/null 2>&1
+# Re-deliver with NO reject in between: assignee back to the maker, handoff_rejected_at
+# left NULL — the "same pass" state.
+db "UPDATE tasks SET assignee='main', status='in_progress' WHERE ident='DIVE-263';"
+( actor_seam_as main; cmd_task_deliver DIVE-263 --pr="$PR2" ) >/dev/null 2>&1
+[[ "$(iterof DIVE-263)" == "$(binditerof DIVE-263)" ]] \
+  && ok_t "Tge same-pass re-delivery keeps stamp == counter (no silent bind>iter)" \
+  || bad_t "Tge stamp outran the counter" "iter=$(iterof DIVE-263) bind=$(binditerof DIVE-263)"
+out=$( actor_seam_as dev; cmd_task_done DIVE-263 2>&1 ); rc=$?
+[[ $rc -eq 0 && "$(statusof DIVE-263)" == "done" ]] \
+  && ok_t "Tge and the close is ACCEPTED (bind>iter would have been unflaggable, not refused)" \
+  || bad_t "Tge same-pass close" "rc=$rc status=$(statusof DIVE-263) out=$out"
 
 # ARM (c): a row bound BEFORE this column existed has a NULL stamp. NULL is not
 # stale — "I cannot judge" must never become a refusal, or the gate false-REDs

--- a/tests/task_deliver_merge_gate_unit.sh
+++ b/tests/task_deliver_merge_gate_unit.sh
@@ -386,48 +386,48 @@ PR2="https://github.com/5dive-ai/5dive/pull/1000"
 # The well-behaved delivery first: deliver stamps the binding's iteration in the
 # SAME update that bumps the counter, so the two agree. If these ever disagree at
 # this point the ordering hazard is live and every arm below is meaningless.
-seed_task DIVE-260 main dev
-cmd_task_deliver DIVE-260 --pr="$PR" >/dev/null 2>&1
-[[ "$(iterof DIVE-260)" == "1" && "$(binditerof DIVE-260)" == "1" ]] \
-  && ok_t "Tg0 deliver stamps binding-iteration == iteration (no two-moment read)" \
-  || bad_t "Tg0 stamp/bump agree" "iter=$(iterof DIVE-260) bind=$(binditerof DIVE-260)"
+seed_task DIVE-270 main dev
+cmd_task_deliver DIVE-270 --pr="$PR" >/dev/null 2>&1
+[[ "$(iterof DIVE-270)" == "1" && "$(binditerof DIVE-270)" == "1" ]] \
+  && ok_t "Tg0 ROUTING deliver stamps binding-iteration == iteration (no two-moment read)" \
+  || bad_t "Tg0 stamp/bump agree" "iter=$(iterof DIVE-270) bind=$(binditerof DIVE-270)"
 
 # ARM (a): the loop bounces and the maker re-delivers WITHOUT re-pointing the
 # binding — `task done` from the maker routes to the verifier again and bumps the
 # counter, leaving the binding behind at iteration 1. The close must REFUSE.
-db "UPDATE tasks SET assignee='main', status='in_progress', handoff_rejected_at=datetime('now') WHERE ident='DIVE-260';"   # verifier rejected → back to maker
-( actor_seam_as main; cmd_task_done DIVE-260 --result="fixed, re-delivering" ) >/dev/null 2>&1
-[[ "$(iterof DIVE-260)" == "2" && "$(binditerof DIVE-260)" == "1" ]] \
+db "UPDATE tasks SET assignee='main', status='in_progress', handoff_rejected_at=datetime('now') WHERE ident='DIVE-270';"   # verifier rejected → back to maker
+( actor_seam_as main; cmd_task_done DIVE-270 --result="fixed, re-delivering" ) >/dev/null 2>&1
+[[ "$(iterof DIVE-270)" == "2" && "$(binditerof DIVE-270)" == "1" ]] \
   && ok_t "Tga re-delivery bumps the counter and leaves the binding at its old iteration" \
-  || bad_t "Tga stale gap created" "iter=$(iterof DIVE-260) bind=$(binditerof DIVE-260)"
+  || bad_t "Tga stale gap created" "iter=$(iterof DIVE-270) bind=$(binditerof DIVE-270)"
 export GH_STUB_STATE="MERGED" GH_STUB_MERGED="2026-08-04T00:00:00Z"
-out=$( actor_seam_as dev; cmd_task_done DIVE-260 2>&1 ); rc=$?
+out=$( actor_seam_as dev; cmd_task_done DIVE-270 2>&1 ); rc=$?
 [[ $rc -eq $E_CONFLICT ]] \
   && ok_t "Tga close on a STALE binding is REFUSED even though the PR is MERGED" \
   || bad_t "Tga refused rc" "rc=$rc (want $E_CONFLICT) out=$out"
 [[ "$out" == *"DIVE-2682"* || "$out" == *"iteration"* ]] \
   && ok_t "Tga the refusal names the iteration mismatch, not the merge state" \
   || bad_t "Tga refusal message" "out=$out"
-[[ "$(statusof DIVE-260)" != "done" ]] \
+[[ "$(statusof DIVE-270)" != "done" ]] \
   && ok_t "Tga the task did NOT close" \
-  || bad_t "Tga task closed anyway" "status=$(statusof DIVE-260)"
+  || bad_t "Tga task closed anyway" "status=$(statusof DIVE-270)"
 
 # ARM (b) — THE CONTROL, and the one that catches the ordering hazard. Same loop,
 # but the maker RE-POINTS the binding with `task deliver --pr=<new>`. The stamp
 # and the bump happen in one update, so they agree, and the close is ACCEPTED.
 # Without this arm a fix that refuses unconditionally would pass arm (a) and look
 # correct while blocking every legitimate close on the board.
-seed_task DIVE-261 main dev
-cmd_task_deliver DIVE-261 --pr="$PR" >/dev/null 2>&1
-db "UPDATE tasks SET assignee='main', status='in_progress', handoff_rejected_at=datetime('now') WHERE ident='DIVE-261';"   # rejected → back to maker
-( actor_seam_as main; cmd_task_deliver DIVE-261 --pr="$PR2" ) >/dev/null 2>&1
-[[ "$(iterof DIVE-261)" == "2" && "$(binditerof DIVE-261)" == "2" ]] \
+seed_task DIVE-271 main dev
+cmd_task_deliver DIVE-271 --pr="$PR" >/dev/null 2>&1
+db "UPDATE tasks SET assignee='main', status='in_progress', handoff_rejected_at=datetime('now') WHERE ident='DIVE-271';"   # rejected → back to maker
+( actor_seam_as main; cmd_task_deliver DIVE-271 --pr="$PR2" ) >/dev/null 2>&1
+[[ "$(iterof DIVE-271)" == "2" && "$(binditerof DIVE-271)" == "2" ]] \
   && ok_t "Tgb re-pointing the binding stamps it at the NEW iteration (no false refuse)" \
-  || bad_t "Tgb re-point stamp" "iter=$(iterof DIVE-261) bind=$(binditerof DIVE-261)"
-out=$( actor_seam_as dev; cmd_task_done DIVE-261 2>&1 ); rc=$?
-[[ $rc -eq 0 && "$(statusof DIVE-261)" == "done" ]] \
+  || bad_t "Tgb re-point stamp" "iter=$(iterof DIVE-271) bind=$(binditerof DIVE-271)"
+out=$( actor_seam_as dev; cmd_task_done DIVE-271 2>&1 ); rc=$?
+[[ $rc -eq 0 && "$(statusof DIVE-271)" == "done" ]] \
   && ok_t "Tgb close on a RE-POINTED binding is ACCEPTED and the task closes" \
-  || bad_t "Tgb accepted" "rc=$rc status=$(statusof DIVE-261) out=$out"
+  || bad_t "Tgb accepted" "rc=$rc status=$(statusof DIVE-271) out=$out"
 
 # ARM (d) — THE REMEDY ARM, and it INHERITS arm (a)'s refused row rather than
 # re-seeding one that resembles it. dev's reject (iteration 1) found that arm (b),
@@ -439,50 +439,50 @@ out=$( actor_seam_as dev; cmd_task_done DIVE-261 2>&1 ); rc=$?
 # again, naming the CORRECT new PR as "recorded at loop iteration 1".
 # A refusal that prints an instruction has made a testable claim about reachability.
 # This arm runs that instruction VERBATIM, from the state the refusal left behind.
-[[ "$(assigneeof DIVE-260)" == "dev" && "$(iterof DIVE-260)" == "2" && "$(binditerof DIVE-260)" == "1" ]] \
+[[ "$(assigneeof DIVE-270)" == "dev" && "$(iterof DIVE-270)" == "2" && "$(binditerof DIVE-270)" == "1" ]] \
   && ok_t "Tgd inherits arm (a)'s refused row (assignee=verifier, iter=2, bind=1)" \
-  || bad_t "Tgd wrong start state" "assignee=$(assigneeof DIVE-260) iter=$(iterof DIVE-260) bind=$(binditerof DIVE-260)"
-( actor_seam_as main; cmd_task_deliver DIVE-260 --pr="$PR2" ) >/dev/null 2>&1
-[[ "$(iterof DIVE-260)" == "2" && "$(binditerof DIVE-260)" == "2" ]] \
+  || bad_t "Tgd wrong start state" "assignee=$(assigneeof DIVE-270) iter=$(iterof DIVE-270) bind=$(binditerof DIVE-270)"
+( actor_seam_as main; cmd_task_deliver DIVE-270 --pr="$PR2" ) >/dev/null 2>&1
+[[ "$(iterof DIVE-270)" == "2" && "$(binditerof DIVE-270)" == "2" ]] \
   && ok_t "Tgd the printed remedy stamps the binding at the CURRENT iteration, no bump" \
-  || bad_t "Tgd remedy did not move the stamp" "iter=$(iterof DIVE-260) bind=$(binditerof DIVE-260)"
-out=$( actor_seam_as dev; cmd_task_done DIVE-260 2>&1 ); rc=$?
-[[ $rc -eq 0 && "$(statusof DIVE-260)" == "done" ]] \
+  || bad_t "Tgd remedy did not move the stamp" "iter=$(iterof DIVE-270) bind=$(binditerof DIVE-270)"
+out=$( actor_seam_as dev; cmd_task_done DIVE-270 2>&1 ); rc=$?
+[[ $rc -eq 0 && "$(statusof DIVE-270)" == "done" ]] \
   && ok_t "Tgd following the refusal's OWN remedy makes the close succeed" \
-  || bad_t "Tgd remedy is inert — false refuse on a correctly-bound row" "rc=$rc status=$(statusof DIVE-260) out=$out"
+  || bad_t "Tgd remedy is inert — false refuse on a correctly-bound row" "rc=$rc status=$(statusof DIVE-270) out=$out"
 
 # ARM (e) — THE SAME-PASS RE-DELIVERY, and it exists because the first version of
-# this fix was UNGRADED. DIVE-2601 made the counter's bump CONDITIONAL ("re-delivery
+# this fix was UNGRADED. DIVE-2701 made the counter's bump CONDITIONAL ("re-delivery
 # of the same pass, not rework": iteration moves only on a first delivery or after a
 # reject). The stamp was still an unconditional +1, so a same-pass re-delivery left
 # bind = iter+1 — a state the guard's predicate (bind < iter) can NEVER flag, i.e. it
 # fails SILENTLY. Every other arm here bounces via handoff_rejected_at, which takes
 # the +1 branch and makes the two forms identical, so mutating the CASE back to +1
 # scored 41/0 and proved nothing. This arm is the one that reds it.
-seed_task DIVE-263 main dev
-cmd_task_deliver DIVE-263 --pr="$PR" >/dev/null 2>&1
+seed_task DIVE-273 main dev
+cmd_task_deliver DIVE-273 --pr="$PR" >/dev/null 2>&1
 # Re-deliver with NO reject in between: assignee back to the maker, handoff_rejected_at
 # left NULL — the "same pass" state.
-db "UPDATE tasks SET assignee='main', status='in_progress' WHERE ident='DIVE-263';"
-( actor_seam_as main; cmd_task_deliver DIVE-263 --pr="$PR2" ) >/dev/null 2>&1
-[[ "$(iterof DIVE-263)" == "$(binditerof DIVE-263)" ]] \
+db "UPDATE tasks SET assignee='main', status='in_progress' WHERE ident='DIVE-273';"
+( actor_seam_as main; cmd_task_deliver DIVE-273 --pr="$PR2" ) >/dev/null 2>&1
+[[ "$(iterof DIVE-273)" == "$(binditerof DIVE-273)" ]] \
   && ok_t "Tge same-pass re-delivery keeps stamp == counter (no silent bind>iter)" \
-  || bad_t "Tge stamp outran the counter" "iter=$(iterof DIVE-263) bind=$(binditerof DIVE-263)"
-out=$( actor_seam_as dev; cmd_task_done DIVE-263 2>&1 ); rc=$?
-[[ $rc -eq 0 && "$(statusof DIVE-263)" == "done" ]] \
+  || bad_t "Tge stamp outran the counter" "iter=$(iterof DIVE-273) bind=$(binditerof DIVE-273)"
+out=$( actor_seam_as dev; cmd_task_done DIVE-273 2>&1 ); rc=$?
+[[ $rc -eq 0 && "$(statusof DIVE-273)" == "done" ]] \
   && ok_t "Tge and the close is ACCEPTED (bind>iter would have been unflaggable, not refused)" \
-  || bad_t "Tge same-pass close" "rc=$rc status=$(statusof DIVE-263) out=$out"
+  || bad_t "Tge same-pass close" "rc=$rc status=$(statusof DIVE-273) out=$out"
 
 # ARM (c): a row bound BEFORE this column existed has a NULL stamp. NULL is not
 # stale — "I cannot judge" must never become a refusal, or the gate false-REDs
 # every legacy row on the board the moment it ships.
-seed_task DIVE-262 main dev
-cmd_task_deliver DIVE-262 --pr="$PR" >/dev/null 2>&1
-db "UPDATE tasks SET delivery_ref_iteration=NULL, iteration=7 WHERE ident='DIVE-262';"
-out=$( actor_seam_as dev; cmd_task_done DIVE-262 2>&1 ); rc=$?
-[[ $rc -eq 0 && "$(statusof DIVE-262)" == "done" ]] \
+seed_task DIVE-272 main dev
+cmd_task_deliver DIVE-272 --pr="$PR" >/dev/null 2>&1
+db "UPDATE tasks SET delivery_ref_iteration=NULL, iteration=7 WHERE ident='DIVE-272';"
+out=$( actor_seam_as dev; cmd_task_done DIVE-272 2>&1 ); rc=$?
+[[ $rc -eq 0 && "$(statusof DIVE-272)" == "done" ]] \
   && ok_t "Tgc a NULL binding-iteration (legacy row) is NOT treated as stale" \
-  || bad_t "Tgc legacy row false-refused" "rc=$rc status=$(statusof DIVE-262) out=$out"
+  || bad_t "Tgc legacy row false-refused" "rc=$rc status=$(statusof DIVE-272) out=$out"
 echo "-----"
 printf 'task_deliver_merge_gate_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/tests/task_deliver_merge_gate_unit.sh
+++ b/tests/task_deliver_merge_gate_unit.sh
@@ -452,7 +452,7 @@ out=$( actor_seam_as dev; cmd_task_done DIVE-270 2>&1 ); rc=$?
   || bad_t "Tgd remedy is inert — false refuse on a correctly-bound row" "rc=$rc status=$(statusof DIVE-270) out=$out"
 
 # ARM (e) — THE SAME-PASS RE-DELIVERY, and it exists because the first version of
-# this fix was UNGRADED. DIVE-2701 made the counter's bump CONDITIONAL ("re-delivery
+# this fix was UNGRADED. DIVE-2624 made the counter's bump CONDITIONAL ("re-delivery
 # of the same pass, not rework": iteration moves only on a first delivery or after a
 # reject). The stamp was still an unconditional +1, so a same-pass re-delivery left
 # bind = iter+1 — a state the guard's predicate (bind < iter) can NEVER flag, i.e. it


### PR DESCRIPTION
Implements the DIVE-2671 design call.

## The gap

The DIVE-1830 merge gate asks *"did the bound PR land"*. It never asks *"did the sha the verifier graded land"* — and a maker→verifier loop separates those two by design.

**DIVE-2057 is the clean instance:** bound to #45 at first delivery, #45 was **REJECTED**, the fix landed in a new PR #51, and the row still pointed at #45. A credential-holding `task done` today greens off #45 and closes the ticket while the graded work sits elsewhere.

## Why iteration, and not the two obvious alternatives

| approach | verdict |
|---|---|
| bind the graded **sha**, test ancestry | **refuted** — we squash-merge, so a graded head is never an ancestor of main; every squash-merged PR would false-RED |
| compare **timestamps** | **refuted** — DIVE-2057's binding legitimately predates its latest ACK |
| **iteration-at-binding vs current iteration** | ✅ purely local — no token, no API, no rail, so it cannot vary by caller |

That last property matters more than it looks: a missing credential doing the work of a control is exactly how the DIVE-2057 false close was *accidentally* avoided.

## The ordering hazard — the whole risk of this change

The counter is bumped **inside** the same handoff that delivers. Stamping the binding in a second statement would read the counter at a different moment and **false-REFUSE the well-behaved maker**. So `delivery_ref_iteration` is set in the *same* `UPDATE` as the bump, where both right-hand sides evaluate against the pre-update row and land on the same number. Only `cmd_task_deliver` passes `stamp=1` — it is the sole writer of `delivery_ref`.

**NULL is not stale.** Rows bound before the column existed cannot be judged, and a gate that refuses on "I do not know" is a false red.

## Graded by mutation, not by a green run

Disabling the refusal (`if false; then`) **reds three arms** — so Tga gates a regression rather than merely existing.

- **Tg0** — deliver stamps binding-iteration == iteration (no two-moment read)
- **Tga** — re-deliver *without* re-pointing → close **REFUSED even though the PR is MERGED**
- **Tgb** — re-deliver *with* `task deliver --pr=<new>` → close **ACCEPTED** ← the control; a fix that only ever refuses passes Tga trivially
- **Tgc** — a legacy NULL stamp is **not** treated as stale

23/23 in `task_deliver_merge_gate_unit.sh`, plus 8 related harnesses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)