### PR TITLE
DIVE-2582: conflict-free changelog entries via changelog.d/ fragments

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -442,6 +442,16 @@ jobs:
           sed -i -E "s/^readonly FIVE_VERSION=\"[^\"]+\"/readonly FIVE_VERSION=\"${version}\"/" src/header.sh
           [ "$(grep -m1 -oE '^readonly FIVE_VERSION="[^"]+"' src/header.sh)" = "readonly FIVE_VERSION=\"${version}\"" ] \
             || { echo "::error::could not write FIVE_VERSION=${version} into src/header.sh (the 'readonly FIVE_VERSION=' anchor drifted?) — refusing to cut ${tag} rather than publish the sentinel"; exit 1; }
+          # DIVE-2582: FOLD changelog.d/*.md FRAGMENTS into CHANGELOG.md's top,
+          # BEFORE the stamp below — same detached-commit-only rule (never main),
+          # so stamp-changelog.sh sees the folded headings same as a manually-typed
+          # one. Not fatal for the same reason the stamp isn't: a cut must not die
+          # because a fragment drifted from the expected format.
+          if _folded=$(bash scripts/fold-changelog-fragments.sh 2>&1); then
+            echo "changelog.d fragments folded for ${tag}: ${_folded} (DIVE-2582)"
+          else
+            echo "::warning::changelog.d fragments could not be folded for ${tag} (${_folded}) — publishing anyway"
+          fi
           # DIVE-2452: STAMP THE CHANGELOG onto this release commit, same rule as the
           # FIVE_VERSION write above — the detached release tree only, never main
           # (DIVE-2247 removed this job's ability to push a protected branch, and the
@@ -477,6 +487,10 @@ jobs:
           # a pathspec that matches nothing, and the stamp is explicitly non-fatal —
           # a cut must not die because a repo has no CHANGELOG.md.
           if [ -f CHANGELOG.md ]; then git add -f CHANGELOG.md; fi
+          # DIVE-2582: the fold step above deletes any folded changelog.d/
+          # fragments from the working tree — stage that removal too, same guard
+          # shape (dir may legitimately not exist).
+          if [ -d changelog.d ]; then git add -A -f changelog.d; fi
           git -c user.name=lodar -c user.email=markounik@gmail.com \
               commit -q -m "release ${tag}: assign ${version} + built bundle (DIVE-2091 bundle-at-tag-time, DIVE-2247 version-at-tag-time)"
           # DIVE-2433: `sha` is about to stop meaning "the commit whose check-runs we

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,11 @@ caught.
   at tag time (DIVE-2091) and are not tracked on `main`; `bundle-drift` CI
   checks that `build.sh` is reproducible from `src/`, not that a committed
   bundle matches.
+- Changelog entry: editing the top of `CHANGELOG.md` directly still works, but
+  every PR that does it collides with every other open PR touching the same
+  spot (DIVE-2582). Prefer adding `changelog.d/<ident>.md` instead — see
+  `changelog.d/README.md` — it never conflicts, and folds into `CHANGELOG.md`
+  automatically at the next release cut.
 
 ## Reporting bugs / requesting features
 

--- a/changelog.d/DIVE-2582.md
+++ b/changelog.d/DIVE-2582.md
@@ -1,0 +1,23 @@
+## Unreleased — feat(changelog): conflict-free entries via changelog.d/ fragments (DIVE-2582)
+
+Every PR that inserted a new `## Unreleased` section at the top of
+`CHANGELOG.md` collided with every other open PR doing the same — measured
+five times in one session on 2026-08-03, on five unrelated branches, all
+mechanical, none with any semantic content. Measured, not assumed, that the
+two cheaper-looking fixes don't actually work: appending at the bottom instead
+of the top conflicts identically under both `git merge` and `git rebase` (a
+pure insertion at a shared anchor conflicts regardless of which end of the
+file the anchor is at), and a `.gitattributes merge=union` driver resolves a
+*local* git merge but is not honored by GitHub's server-side PR merge at all
+(github.com/orgs/community/discussions/9288) — which is the actual thing that
+shows a PR as CONFLICTING and blocks CI here.
+
+`changelog.d/*.md` gives every entry its own file — two PRs adding distinct
+files never conflict, by construction, the same argument DIVE-2091 made for
+the bundle. `scripts/fold-changelog-fragments.sh` folds pending fragments into
+`CHANGELOG.md`'s top at release-cut time, in the same detached-release-commit
+step `stamp-changelog.sh` already runs in (never main, matching DIVE-2247).
+Purely additive: editing `CHANGELOG.md` directly still works unchanged, so no
+already-open PR needs to do anything differently.
+
+Tests: `tests/fold_changelog_fragments_unit.sh`.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,33 @@
+# changelog.d/ — conflict-free changelog entries (DIVE-2582)
+
+Editing the top of `CHANGELOG.md` directly still works exactly as before — this
+is an *additional*, optional path, not a replacement.
+
+**Why it exists:** every PR that inserts a new section at the top of
+`CHANGELOG.md` collides with every other open PR that also did — measured five
+times in one session on 2026-08-03. Two PRs each adding a *different file* here
+never collide, because there is no shared line range for git to conflict on.
+
+**How to use it:** instead of editing `CHANGELOG.md`, add one file:
+
+```
+changelog.d/<ident>.md      # e.g. changelog.d/DIVE-2582.md
+```
+
+containing exactly what you would otherwise have typed at the top of
+`CHANGELOG.md` — the file's first non-blank line must be a heading of the form:
+
+```
+## Unreleased — <type>(<scope>): <headline> (<ident>)
+```
+
+(a bare `## Unreleased` with no dash is also accepted), followed by the body
+prose, same as today's convention.
+
+**What happens to it:** `scripts/fold-changelog-fragments.sh` runs at release-cut
+time (same place `scripts/stamp-changelog.sh` runs — the detached release
+commit, never main), folds every fragment here into `CHANGELOG.md`'s top
+(newest filename first), and removes the folded files *from that commit's
+tree only*. Fragments are not deleted from main by this step — same
+"Unreleased never clears off main" property `CHANGELOG.md` itself already has
+(see the header of `scripts/stamp-changelog.sh`); this is not a new limitation.

--- a/scripts/fold-changelog-fragments.sh
+++ b/scripts/fold-changelog-fragments.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# fold-changelog-fragments.sh — fold changelog.d/*.md fragments into CHANGELOG.md
+# (DIVE-2582).
+#
+# THE PROBLEM. main's CHANGELOG.md format is a single prose `## Unreleased —
+# <headline>` H2 inserted at the TOP of the file. Every PR that adds one inserts
+# at the same offset, so every merge conflicts with every other open PR that also
+# added one — measured five times in one session on 2026-08-03, on five unrelated
+# branches. Verified empirically (not assumed): appending at the BOTTOM instead of
+# the top does NOT avoid this — a pure git 3-way merge/rebase test with two
+# branches each adding a distinct block at the same anchor (top OR bottom)
+# conflicts either way, because both sides insert at the identical position
+# relative to a shared, unmoved context. A `.gitattributes merge=union` driver
+# does resolve it for a LOCAL git merge, but GitHub's PR merge (the actual thing
+# that shows a PR as CONFLICTING and blocks CI here) is server-side and does not
+# honor gitattributes merge drivers at all — confirmed against
+# github.com/orgs/community/discussions/9288. So neither of the two "no new
+# convention" options actually fixes the reported problem.
+#
+# THE FIX: give every entry its OWN FILE. Two PRs each adding a distinct
+# `changelog.d/<ident>.md` never conflict — there is no shared line range to
+# collide on, by construction, the same argument DIVE-2091 made for the bundle.
+#
+# PURELY ADDITIVE — this does not replace or require migrating the existing
+# convention. An agent can keep editing CHANGELOG.md directly (today's habit,
+# and still supported) or drop a fragment in changelog.d/ (new, zero-conflict
+# path) — both land in the same place by release time. No open PR needs to
+# change anything to keep working.
+#
+# WHERE THIS RUNS: same place and same rule as scripts/stamp-changelog.sh — the
+# detached release commit only, never main (DIVE-2247: a github.token push to a
+# protected branch is rejected, so nothing here needs to push one). Consequence,
+# stated so it reads as accepted rather than missed: changelog.d/ fragments are
+# consumed (deleted) in the release commit's tree, not on main, so main's
+# changelog.d/ keeps whatever was there — exactly the same "Unreleased never
+# clears on main" property CHANGELOG.md already has today (see stamp-changelog.sh's
+# header). Not a new limitation; matched to the existing one on purpose.
+#
+# FRAGMENT FORMAT: a fragment's first non-blank line MUST be a
+# `## Unreleased — <headline>` (or bare `## Unreleased`) heading — the exact text
+# that would otherwise have been typed at the top of CHANGELOG.md, so authoring a
+# fragment is not a new format to learn, only a new file to put it in.
+#
+# Usage: fold-changelog-fragments.sh [changelog-path] [fragments-dir]
+#        folds newest-fragment-first (by filename, descending) to the TOP of
+#        changelog-path, deletes the folded fragments, prints the number folded.
+#        0 fragments is success (prints 0) — a cut with nothing pending is normal.
+set -uo pipefail
+
+changelog="${1:-CHANGELOG.md}"
+fragdir="${2:-changelog.d}"
+
+if [[ ! -f "$changelog" ]]; then
+  echo "fold-changelog-fragments: ${changelog} does not exist" >&2
+  exit 2
+fi
+
+if [[ ! -d "$fragdir" ]]; then
+  echo 0
+  exit 0
+fi
+
+# Newest-first by filename (ticket idents sort roughly chronologically), README
+# and dotfiles excluded — this is a docs/convention file, not an entry.
+mapfile -t frags < <(find "$fragdir" -maxdepth 1 -type f -name '*.md' ! -iname 'readme.md' -printf '%f\n' | sort -r)
+
+if [[ ${#frags[@]} -eq 0 ]]; then
+  echo 0
+  exit 0
+fi
+
+folded=0
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+for f in "${frags[@]}"; do
+  path="${fragdir}/${f}"
+  # First non-blank line must anchor a well-formed heading, same pattern
+  # stamp-changelog.sh anchors on — a fragment that drifted from the format is
+  # reported and skipped, never silently folded as prose.
+  first_content_line="$(grep -m1 -v '^[[:space:]]*$' "$path" || true)"
+  if [[ ! "$first_content_line" =~ ^##[[:space:]]+Unreleased([[:space:]]|$) ]]; then
+    echo "fold-changelog-fragments: ${path} does not start with '## Unreleased' — skipping (not folded, not deleted)" >&2
+    continue
+  fi
+  cat "$path" >> "$tmp"
+  printf '\n' >> "$tmp"
+  rm -f "$path"
+  folded=$((folded + 1))
+done
+
+if [[ "$folded" -gt 0 ]]; then
+  # Splice the folded block in right after the `# Changelog` title line (line 1)
+  # so it lands exactly where a manual top-of-file edit would have gone.
+  {
+    head -n1 "$changelog"
+    echo
+    cat "$tmp"
+    tail -n +2 "$changelog" | sed '/./,$!d'
+  } > "${changelog}.new"
+  mv "${changelog}.new" "$changelog"
+fi
+
+echo "$folded"

--- a/tests/fold_changelog_fragments_unit.sh
+++ b/tests/fold_changelog_fragments_unit.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# DIVE-2582 unit harness for scripts/fold-changelog-fragments.sh — the
+# conflict-free changelog.d/ path. Covers:
+#   - two fragments fold in, newest filename first, above the existing content
+#   - README.md in changelog.d/ is never treated as a fragment
+#   - a missing changelog.d/ folds 0, exit 0 (not an error — nothing pending)
+#   - a fragment that doesn't start with '## Unreleased' is reported and
+#     skipped: not folded into CHANGELOG.md, not deleted from changelog.d/
+#   - a bare '## Unreleased' (no em-dash headline) is accepted
+# Run: bash tests/fold_changelog_fragments_unit.sh   (no root, no network)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.." || exit 1
+SCRIPT="$(pwd)/scripts/fold-changelog-fragments.sh"
+
+TMP="$(mktemp -d /tmp/fold-changelog-unit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+R="$TMP/repo"
+mkdir -p "$R/changelog.d"
+
+cat > "$R/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## Unreleased — fix(old): existing entry
+
+Body of the existing entry.
+EOF
+
+cat > "$R/changelog.d/DIVE-9001.md" <<'EOF'
+## Unreleased — feat(x): fragment one (DIVE-9001)
+
+Body of fragment one.
+EOF
+
+cat > "$R/changelog.d/DIVE-9002.md" <<'EOF'
+## Unreleased — feat(y): fragment two (DIVE-9002)
+
+Body of fragment two.
+EOF
+
+cat > "$R/changelog.d/README.md" <<'EOF'
+convention doc, not an entry
+EOF
+
+out=$(cd "$R" && bash "$SCRIPT" 2>"$TMP/err"); rc=$?
+[[ $rc -eq 0 && "$out" == "2" ]] \
+  && ok_t "folds two fragments, reports count=2 (rc=0)" \
+  || bad_t "folds two fragments, reports count=2" "rc=$rc out=$out err=$(cat "$TMP/err")"
+
+body="$(cat "$R/CHANGELOG.md")"
+[[ "$body" == *"fragment two"*"fragment one"*"existing entry"* ]] \
+  && ok_t "folded content: newest fragment first, above pre-existing content" \
+  || bad_t "folded content order" "$body"
+
+[[ -f "$R/changelog.d/README.md" && ! -f "$R/changelog.d/DIVE-9001.md" && ! -f "$R/changelog.d/DIVE-9002.md" ]] \
+  && ok_t "folded fragments deleted, README.md untouched" \
+  || bad_t "post-fold changelog.d/ contents" "$(ls "$R/changelog.d" 2>&1)"
+
+# --- no changelog.d/ at all: 0 folded, not an error ------------------------
+R2="$TMP/repo2"
+mkdir -p "$R2"
+printf '# Changelog\n' > "$R2/CHANGELOG.md"
+out2=$(cd "$R2" && bash "$SCRIPT" 2>"$TMP/err2"); rc2=$?
+[[ $rc2 -eq 0 && "$out2" == "0" ]] \
+  && ok_t "missing changelog.d/: folds 0, exit 0" \
+  || bad_t "missing changelog.d/" "rc=$rc2 out=$out2 err=$(cat "$TMP/err2")"
+
+# --- malformed fragment: reported, not folded, not deleted -----------------
+R3="$TMP/repo3"
+mkdir -p "$R3/changelog.d"
+printf '# Changelog\n' > "$R3/CHANGELOG.md"
+cat > "$R3/changelog.d/DIVE-9003.md" <<'EOF'
+not a heading, just prose
+EOF
+out3=$(cd "$R3" && bash "$SCRIPT" 2>"$TMP/err3"); rc3=$?
+[[ $rc3 -eq 0 && "$out3" == "0" ]] \
+  && ok_t "malformed fragment: folds 0, exit 0 (non-fatal)" \
+  || bad_t "malformed fragment fold count" "rc=$rc3 out=$out3"
+[[ -f "$R3/changelog.d/DIVE-9003.md" ]] \
+  && ok_t "malformed fragment left in place, not deleted" \
+  || bad_t "malformed fragment survives" "$(ls "$R3/changelog.d" 2>&1)"
+grep -q "DIVE-9003.md" "$TMP/err3" \
+  && ok_t "malformed fragment reported on stderr" \
+  || bad_t "malformed fragment stderr report" "$(cat "$TMP/err3")"
+
+# --- bare '## Unreleased' (no em-dash headline) is accepted -----------------
+R4="$TMP/repo4"
+mkdir -p "$R4/changelog.d"
+printf '# Changelog\n' > "$R4/CHANGELOG.md"
+cat > "$R4/changelog.d/DIVE-9004.md" <<'EOF'
+## Unreleased
+
+Bare heading body.
+EOF
+out4=$(cd "$R4" && bash "$SCRIPT" 2>"$TMP/err4"); rc4=$?
+[[ $rc4 -eq 0 && "$out4" == "1" ]] \
+  && ok_t "bare '## Unreleased' heading (no em-dash) is accepted" \
+  || bad_t "bare heading fold count" "rc=$rc4 out=$out4 err=$(cat "$TMP/err4")"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Authored by **dev2** (commit `fb14757`). Pushed and opened by main because the delegated-push path cannot ship workflow-file changes — `5dive push` 422s with *"permissions requested are not granted to this installation"* when a branch touches `.github/workflows/`, since it defensively requests `workflows:write` the App installation does not hold. That is the still-open **DIVE-2262** gap, not a defect in this branch.

## The problem

Every merge conflicts every open PR on `CHANGELOG.md` — one file, one hot top section, every branch appending to it. Same shape as DIVE-2091's serialised-merge-queue, one file down.

## The fix

Entries become per-ticket fragments under `changelog.d/`, folded into `CHANGELOG.md` at **release-cut time** rather than on every merge. Two branches touching different fragments no longer touch the same file.

- `scripts/fold-changelog-fragments.sh` — the fold, with its own harness (8/8)
- `release-cut.yml` — folds **before** the DIVE-2452 stamp, same detached-commit-only rule (never main), and **non-fatal** for the same reason the stamp is: a cut must not die because a fragment drifted from the expected format
- the fold deletes folded fragments; the removal is staged under the same dir-may-not-exist guard

## Verified before pushing, not taken on trust

- `scripts/actionlint-scan.sh` → **rc=0**. Checked deliberately: `release-cut.yml` is the only writer of a version in this repo and an Actions expression inside a `run:` comment made it unparseable for 45 minutes on 2026-08-02 (DIVE-2539). The added hunks use shell variables only — no expression delimiter in the `run:` block.
- `tests/fold_changelog_fragments_unit.sh` → **8 passed, 0 failed**
- Branch was cut from `25891e2`; main has moved a long way since, so main is merged in for the up-to-date-branch policy.

dev2 runs `task deliver --pr=` against this once it is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)