### PR TITLE
fix(broker): gate-verdict regex reads the first NON-BLANK line, as a whole word (DIVE-2614)

### DIFF
--- a/src/lib/broker.sh
+++ b/src/lib/broker.sh
@@ -129,7 +129,15 @@ broker_gate_check() {
   # falls through the reject check below (no verdict word to match).
   local gverdict
   gverdict=$(printf '%s\n' "$ganswer" | grep -m1 -v '^[[:space:]]*$') || gverdict=""
-  if printf '%s' "$gverdict" | grep -qiE '^\s*(no|reject|rejected|deny|denied|block)\b'; then
+  # Every stem's inflected forms are enumerated explicitly (reject/rejected,
+  # deny/denied, block/blocked) rather than matched with an ending like
+  # `(reject|deny|block)(ed|ing)?\b` — `\b` alone doesn't extend a bare stem
+  # to its inflections ("block" has no boundary inside "blocked"), and a
+  # collapsed `(ed|ing)?` re-admits "Blocking issues: none" and "Rejecting
+  # the null hypothesis" as false positives (main, DIVE-2614 review). Any new
+  # stem added here needs its own inflected forms added too, deliberately —
+  # this list is maintained by hand, not enforced by the pattern.
+  if printf '%s' "$gverdict" | grep -qiE '^\s*(no|reject|rejected|deny|denied|block|blocked)\b'; then
     audit_log "${surface} gate" error "$E_VALIDATION" -- "ident=${ident}" "line=${gverdict}"
     fail "$E_VALIDATION" "gate on ${ident} was REJECTED ('${ganswer}') — ${noun} refused."
   fi

--- a/src/lib/broker.sh
+++ b/src/lib/broker.sh
@@ -108,7 +108,19 @@ broker_gate_check() {
   if [[ -z "$gansweredat" ]]; then
     fail "$E_VALIDATION" "gate on ${ident} is OPEN (unanswered ${gtype}) — ${noun} refused until it clears (5dive task answer ${ident} ...)."
   fi
-  if printf '%s' "$ganswer" | grep -qiE '^\s*(no|reject|deny|denied|block)'; then
+  # DIVE-2614: the verdict word is read off the FIRST LINE ONLY, as a whole
+  # word (`\b`). Either half of the old check alone still misreads real
+  # approvals — `grep -qiE` with no `-z`/`^` scope is line-based, so a verdict
+  # word on ANY later line of a multi-line answer tripped it (an approval whose
+  # line 3 says "BLOCKING NOTHING, BUT FIX BEFORE MERGE" inverted); and with no
+  # word boundary the five stems are prefixes, so "Note:", "Nothing", "None",
+  # "Not", "non-agent", "Blocking", "Rejecting" all matched too. Both fixes are
+  # required together: line-scoping alone still prefix-matches a first line
+  # that opens with "Nothing to fix.", and a word boundary alone still reads a
+  # later "Blocking issues: none" as the verdict.
+  local gverdict; gverdict=$(printf '%s\n' "$ganswer" | head -n1)
+  if printf '%s' "$gverdict" | grep -qiE '^\s*(no|reject|deny|denied|block)\b'; then
+    audit_log "${surface} gate" error "$E_VALIDATION" -- "ident=${ident}" "line=${gverdict}"
     fail "$E_VALIDATION" "gate on ${ident} was REJECTED ('${ganswer}') — ${noun} refused."
   fi
   [[ "$gby" == human:* ]] && authorized=1

--- a/src/lib/broker.sh
+++ b/src/lib/broker.sh
@@ -108,8 +108,8 @@ broker_gate_check() {
   if [[ -z "$gansweredat" ]]; then
     fail "$E_VALIDATION" "gate on ${ident} is OPEN (unanswered ${gtype}) — ${noun} refused until it clears (5dive task answer ${ident} ...)."
   fi
-  # DIVE-2614: the verdict word is read off the FIRST LINE ONLY, as a whole
-  # word (`\b`). Either half of the old check alone still misreads real
+  # DIVE-2614: the verdict word is read off the FIRST NON-BLANK LINE, as a
+  # whole word (`\b`). Either half of the old check alone still misreads real
   # approvals — `grep -qiE` with no `-z`/`^` scope is line-based, so a verdict
   # word on ANY later line of a multi-line answer tripped it (an approval whose
   # line 3 says "BLOCKING NOTHING, BUT FIX BEFORE MERGE" inverted); and with no
@@ -118,8 +118,18 @@ broker_gate_check() {
   # required together: line-scoping alone still prefix-matches a first line
   # that opens with "Nothing to fix.", and a word boundary alone still reads a
   # later "Blocking issues: none" as the verdict.
-  local gverdict; gverdict=$(printf '%s\n' "$ganswer" | head -n1)
-  if printf '%s' "$gverdict" | grep -qiE '^\s*(no|reject|deny|denied|block)\b'; then
+  # NOT `head -n1`: "the first line" and "line 1" diverge the moment line 1 is
+  # blank/whitespace-only (main, 2026-08-04) — `head -n1` on
+  # $'\nNo — rejected' reads as '', which cleared the gate on a genuine
+  # rejection. `grep -m1 -v` skips blank lines to find the first one that
+  # actually has content.
+  # Guarded: under `set -euo pipefail`, an all-blank $ganswer makes grep exit
+  # 1 (no non-blank line found) and pipefail promotes that to the whole
+  # substitution, which would kill this function. An empty gverdict correctly
+  # falls through the reject check below (no verdict word to match).
+  local gverdict
+  gverdict=$(printf '%s\n' "$ganswer" | grep -m1 -v '^[[:space:]]*$') || gverdict=""
+  if printf '%s' "$gverdict" | grep -qiE '^\s*(no|reject|rejected|deny|denied|block)\b'; then
     audit_log "${surface} gate" error "$E_VALIDATION" -- "ident=${ident}" "line=${gverdict}"
     fail "$E_VALIDATION" "gate on ${ident} was REJECTED ('${ganswer}') — ${noun} refused."
   fi

--- a/tests/broker_surface_unit.sh
+++ b/tests/broker_surface_unit.sh
@@ -353,6 +353,30 @@ out=$(run broker_gate_check push 7 DIVE-7)
 want "'Rejected' (inflected) still refuses, not just bare 'Reject'" \
      '[[ "$out" == *"REJECTED"* && "$out" == *"rc=9" ]]'
 
+# main (2026-08-04, second review pass): "block" was left bare while
+# reject/rejected and deny/denied were both split — with the word boundary,
+# "block" no longer prefix-matches "blocked" ('k' then 'e', both word chars,
+# no boundary), the exact same inflection gap as "rejected". "Blocked —
+# needs a rebase first" is how a reviewer actually refuses, not an exotic
+# phrasing, and it's on the cmd_deploy.sh path.
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]="Blocked — needs a rebase first"; ROW[need_answered_by]="human:lodar"
+out=$(run broker_gate_check push 7 DIVE-7)
+want "'Blocked' (inflected) still refuses, not just bare 'Block'" \
+     '[[ "$out" == *"REJECTED"* && "$out" == *"rc=9" ]]'
+# ...and it trips on nothing else it shouldn't: the false positives this row
+# exists to fix stay fixed with 'blocked' added to the alternation.
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]="Blocking issues: none"; ROW[need_answered_by]="human:lodar"
+out=$(run broker_gate_check push 7 DIVE-7)
+want "adding 'blocked' didn't re-admit 'Blocking issues: none'" '[[ "$out" == "rc=0" ]]'
+
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]="Denied for now"; ROW[need_answered_by]="human:lodar"
+out=$(run broker_gate_check push 7 DIVE-7)
+want "'Denied' still refuses (existing stem, non-regression check)" \
+     '[[ "$out" == *"REJECTED"* && "$out" == *"rc=9" ]]'
+
 # An answer that is nothing but blank lines must not crash broker_gate_check
 # under set -euo pipefail (the real caller's mode, per header.sh — `run()`
 # above does not set -e, so this needs its own subshell to actually exercise

--- a/tests/broker_surface_unit.sh
+++ b/tests/broker_surface_unit.sh
@@ -121,6 +121,13 @@ db() {
 }
 _gate_closure_verify() { return "${CLOSURE_RC:-0}"; }
 _gate_agent_for_uid()  { printf '%s' "${UID_AGENT:-}"; }
+# DIVE-2614: broker_gate_check now audit_logs the rejected-gate refusal before
+# fail()ing. This harness doesn't source lib/audit.sh, so stub it. `run()`
+# below exercises broker_gate_check in a subshell (to contain fail()'s exit),
+# so a plain array wouldn't survive back to the parent shell — a file does.
+AUDIT_LOG_CALLS="$TMP/audit_log_calls"
+: > "$AUDIT_LOG_CALLS"
+audit_log() { printf '%s\n' "$*" >> "$AUDIT_LOG_CALLS"; }
 
 # shellcheck source=../src/lib/broker.sh
 . "$ROOT/src/lib/broker.sh"
@@ -273,6 +280,68 @@ _seen=$(for _t in "$ROOT"/tests/*.sh; do
         done | grep -c x)
 want "non-vacuity: the harness sweep inspected at least 15 harnesses (saw $_seen)" \
      '[[ "$_seen" -ge 15 ]]'
+
+echo
+echo "== 8. DIVE-2614: verdict is read off the FIRST LINE ONLY, as a WHOLE WORD"
+# Each case is authorized (human:lodar) so a rc=0 unambiguously means the
+# reject-check let it through; these are direct broker_gate_check calls, not
+# the old/new differential above — the pinned baseline still carries the bug,
+# so diffing against it here would assert the fix never happened.
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]=$'approve — ship it.\nNote: this line used to trip the prefix list.'
+ROW[need_answered_by]="human:lodar"
+out=$(run broker_gate_check push 7 DIVE-7)
+want "a later line beginning 'Note:' no longer inverts a first-line approval" '[[ "$out" == "rc=0" ]]'
+
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]="Nothing blocks this"; ROW[need_answered_by]="human:lodar"
+out=$(run broker_gate_check push 7 DIVE-7)
+want "'Nothing' no longer prefix-matches 'no'" '[[ "$out" == "rc=0" ]]'
+
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]="Blocking issues: none"; ROW[need_answered_by]="human:lodar"
+out=$(run broker_gate_check push 7 DIVE-7)
+want "'Blocking' no longer prefix-matches 'block'" '[[ "$out" == "rc=0" ]]'
+
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]="non-agent, same sha: exit 0, 12 arms"; ROW[need_answered_by]="human:lodar"
+out=$(run broker_gate_check push 7 DIVE-7)
+want "'non-agent' no longer prefix-matches 'no'" '[[ "$out" == "rc=0" ]]'
+
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]="Reject as-is — rebase first"; ROW[need_answered_by]="human:lodar"
+out=$(run broker_gate_check push 7 DIVE-7)
+want "a genuine first-line reject ('Reject as-is') still refuses" \
+     '[[ "$out" == *"REJECTED"* && "$out" == *"rc=9" ]]'
+
+# "not" was never one of the five stems (no|reject|deny|denied|block) — it only
+# ever tripped via the OLD "no" prefix bug, the same bug that caught "Note"/
+# "Nothing"/"None". Required property #2 in DIVE-2614 names "Not" explicitly
+# among the words that must stop reading as a veto, so this is the intended
+# behavior change, not a miss — though it means a real reject that opens with
+# a bare "Not ..." (DIVE-2577's "NOT AS-IS — rebase first" is exactly this
+# shape) now needs "no"/"reject"/"deny"/"denied"/"block" as its actual first
+# word to be caught. Flagged, not silently resolved: see the DIVE-2614 result.
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]="Not a blocker"; ROW[need_answered_by]="human:lodar"
+out=$(run broker_gate_check push 7 DIVE-7)
+want "'Not' alone no longer prefix-matches 'no' (required property #2)" '[[ "$out" == "rc=0" ]]'
+
+echo
+echo "== 9. DIVE-2614: the rejected-gate refusal is audit-logged"
+: > "$AUDIT_LOG_CALLS"
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t; ROW[need_answer]="no, not yet"
+run broker_gate_check push 7 DIVE-7 >/dev/null
+want "exactly one audit_log call fired on the reject path" \
+     '[[ "$(wc -l < "$AUDIT_LOG_CALLS")" -eq 1 ]]'
+want "the audit call names the surface and ident" \
+     '[[ "$(cat "$AUDIT_LOG_CALLS")" == *"push gate"* && "$(cat "$AUDIT_LOG_CALLS")" == *"ident=DIVE-7"* ]]'
+
+: > "$AUDIT_LOG_CALLS"
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]="Nothing blocks this"; ROW[need_answered_by]="human:lodar"
+run broker_gate_check push 7 DIVE-7 >/dev/null
+want "no audit_log call on a clean approval" '[[ "$(wc -l < "$AUDIT_LOG_CALLS")" -eq 0 ]]'
 
 echo
 echo "broker surface unit: ${PASS} passed, ${FAIL} failed"

--- a/tests/broker_surface_unit.sh
+++ b/tests/broker_surface_unit.sh
@@ -327,6 +327,43 @@ ROW[need_answer]="Not a blocker"; ROW[need_answered_by]="human:lodar"
 out=$(run broker_gate_check push 7 DIVE-7)
 want "'Not' alone no longer prefix-matches 'no' (required property #2)" '[[ "$out" == "rc=0" ]]'
 
+# main (2026-08-04, reviewing this same fix): `head -n1` reads "line 1", not
+# "the first line" — the moment line 1 is blank/whitespace, a genuine
+# rejection on a LATER line cleared the gate. A false APPROVE is worse than
+# the false REJECT this row exists to fix, and it lands on cmd_deploy.sh too.
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]=$'\nNo — rejected'; ROW[need_answered_by]="human:lodar"
+out=$(run broker_gate_check push 7 DIVE-7)
+want "a leading blank line no longer hides a rejection on line 2" \
+     '[[ "$out" == *"REJECTED"* && "$out" == *"rc=9" ]]'
+
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]=$'  \nrejected, do not push'; ROW[need_answered_by]="human:lodar"
+out=$(run broker_gate_check push 7 DIVE-7)
+want "a whitespace-only line 1 no longer hides 'rejected' on line 2" \
+     '[[ "$out" == *"REJECTED"* && "$out" == *"rc=9" ]]'
+
+# "rejected" needs its own stem, same as deny/denied already had — with a
+# word boundary, "reject" (no trailing \b match into "...ed") no longer
+# prefix-matches "rejected", so the inflected form would silently stop
+# tripping without this entry.
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]="Rejected — needs another pass"; ROW[need_answered_by]="human:lodar"
+out=$(run broker_gate_check push 7 DIVE-7)
+want "'Rejected' (inflected) still refuses, not just bare 'Reject'" \
+     '[[ "$out" == *"REJECTED"* && "$out" == *"rc=9" ]]'
+
+# An answer that is nothing but blank lines must not crash broker_gate_check
+# under set -euo pipefail (the real caller's mode, per header.sh — `run()`
+# above does not set -e, so this needs its own subshell to actually exercise
+# it): gverdict's `grep -m1 -v` finds no non-blank line and exits 1, and
+# pipefail promotes that to the whole substitution unless it's guarded.
+reset_row; ROW[need_type]=approval; ROW[need_answered_at]=t
+ROW[need_answer]=$'   \n   '; ROW[need_answered_by]="human:lodar"
+out=$(( set -euo pipefail; broker_gate_check push 7 DIVE-7 ) 2>/dev/null; printf 'rc=%s' "$?")
+want "a wholly-blank answer doesn't crash the guarded gverdict assignment under set -e" \
+     '[[ "$out" == "rc=0" ]]'
+
 echo
 echo "== 9. DIVE-2614: the rejected-gate refusal is audit-logged"
 : > "$AUDIT_LOG_CALLS"


### PR DESCRIPTION
Closes DIVE-2614.

`broker_gate_check`'s reject-detection was both **line-unscoped** and **boundary-free**:

```bash
grep -qiE '^\s*(no|reject|deny|denied|block)'
```

`grep` is line-based and `^` anchors *per line*, so a verdict word on **any** line of a multi-line answer could flip a first-line approval into a refusal. With no word boundary the stems were **prefixes**, so `Note:`, `Nothing`, `None`, `Not`, `Blocking`, `Rejecting` all read as vetoes. Both halves had to be fixed together — line-scoping alone still prefix-matches a first line opening `Nothing to fix.`, and a boundary alone still reads a later `Blocking issues: none` as the verdict.

This matters beyond push: `broker_gate_check` is also on the `cmd_deploy.sh` path, where a false reject refuses a production deploy with an approval sitting in the record.

## Review rounds

Two fail-opens were caught in review, both of which would have **inverted** the defect — trading a noisy failure for a silent one, in the direction that costs more:

1. **`head -n1` is not "the first line"** — it is line 1 *even when line 1 is blank*. An answer beginning with a newline yielded `''`, so a genuine rejection cleared the gate. Now takes the first non-blank line via `grep -m1 -v '^[[:space:]]*$'`, guarded with `|| gverdict=""` so a wholly-blank answer cannot trip `set -euo pipefail`.
2. **Inflections must be enumerated** — with `\b`, `blocked` cannot match `block\b` (same reason `rejected` needed re-adding alongside `reject`). `Blocked — needs a rebase` is ordinary reviewer prose and was passing as an approval. All three pairs are now explicit.

`(reject|deny|block)(ed|ing)?\b` was considered and **rejected**: it re-admits `Blocking issues: none` and `Rejecting the null hypothesis`, both real approval prose from our own gate history. Enumeration is deliberate.

Also logs the refusal (surface, ident, matched line) via `audit_log` before `fail()` — nothing previously recorded whether a rejected-gate refusal actually consumed a push/deploy attempt, so the historical count could never be split into consumed vs. unconsumed.

## Verification

52/52 in `tests/broker_surface_unit.sh`, push_unit 94/94, deploy_unit 34/34. Reviewer re-ran a 12-case matrix independently against the artefact — all 6 rejections detected, all 6 approvals (including the original `Nothing to fix.` / `Not a blocker` symptoms) correctly passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)