### PR TITLE
fix(tests): re-anchor mutant M10 — DIVE-2588 dropped the conjunct it mutates (DIVE-2589)

### DIFF
--- a/tests/gate_channel_session_t2_mutation.sh
+++ b/tests/gate_channel_session_t2_mutation.sh
@@ -140,8 +140,16 @@ grade "M9-form-not-recorded" "CS1 records the form as channel-session" \
 # ── the tier-2 floor itself, which is the ONLY guard on a decision gate ──────
 # The approval/secret/manual evidence block does not run for `decision`, so if the
 # citation stopped raising `human` the decision arms would be the ones to notice.
+#
+# RE-ANCHORED 2026-08-04 (DIVE-2589). DIVE-2588 (#399) dropped the
+# `&& _gate_proof_enforced` conjunct from this floor — it was a rollout envelope the
+# constrained party could switch off — so the anchor stopped matching and this mutant
+# reported "mutation applies to the current source", i.e. it graded NOTHING and said
+# so. That is the harness's own self-check working exactly as its header promises,
+# and it is why the mutation is asserted to apply rather than assumed to: a
+# no-op mutant is otherwise indistinguishable from a killed one.
 grade "M10-floor-provenance" "CS11 the same tier-2 DECISION gate REFUSES" \
-  '  if [[ "$gtier" == "2" ]] && (( ! human )) && _gate_proof_enforced; then' \
+  '  if [[ "$gtier" == "2" ]] && (( ! human )); then' \
   '  if false; then'
 
 # ── the freshness bound, which iteration 1 let the caller set ────────────────


### PR DESCRIPTION
## The base this was cut from, so nobody re-derives it

Cut from `origin/main@be4a880`; `origin/main@c6080e2` (DIVE-2614) merged in afterwards.

**Read this branch with `git show --stat 3ebb55f` or a three-dot `git diff origin/main...HEAD`.**
A two-dot `origin/main..HEAD` renders the *absence* of DIVE-2614's `src/lib/broker.sh` and
`tests/broker_surface_unit.sh` work as 162 deletions on this branch, which reads as a
tests-only PR gutting a security-relevant source file. It is not. The branch is **one file,
+9/-1**. (Merged rather than rebased: `5dive push` is a plain push and the branch was already
on the remote, so a rebase would have needed a force this agent cannot issue.)

## What this changes

One anchor, in `tests/gate_channel_session_t2_mutation.sh`.

DIVE-2588 (#399) correctly dropped the `&& _gate_proof_enforced` conjunct from the tier-2
human floor — it was a rollout envelope the constrained party could switch off, and a control
whose OFF position is reachable by its subject is not a control. Mutant **M10** anchors on that
exact line. So the anchor stopped matching and the mutant reported:

```
FAIL - M10-floor-provenance — mutation applies to the current source
   the anchor is gone or duplicated; this mutant graded NOTHING
```

Re-anchored to the surviving two-conjunct form.

## Why it was invisible until now

The harness is `TIER: nightly`. A `src/` change therefore reds it **after** the PR that caused it
has merged, so DIVE-2588's author never saw it. That is the standing bill for tiering, and it is
the more interesting half of this PR: the PR core is fast because part of the corpus grades
yesterday's merges.

The knock-on is worth stating for the merge decision. `harness-verdict-slow` declares
`needs: full-pristine`, and `full-pristine` runs `run-harnesses.sh --tier=full`, which includes
this harness. While M10's anchor was stale, `full-pristine` reds → the slow lane never runs →
`probe-slow.txt` is never uploaded → `harness-verdict-union` never runs. **The coverage rail has
been dark since DIVE-2588 landed.** This re-anchor turns it back on.

## The property being protected

The harness *asserts its mutation applied* rather than assuming it. That assertion is the only
reason a no-op mutant is distinguishable from a killed one — a mutation grader that cannot tell
"I killed it" from "I never applied it" grades nothing and reports green. It is what caught this,
loudly, and the added comment records why the check exists so the next refactor does not delete it.

## Verified

- `bash tests/gate_channel_session_t2_mutation.sh` → **14 mutants killed, 0 ungraded, rc=0**,
  **395.4s** (control plane, 2026-08-04), re-run **on the merged tree**. The pre-merge run was
  384.6s; the earlier green did not carry, because DIVE-2614 touches `src/lib/broker.sh`, which
  this harness copies and the unit sources.
- M10 now kills the arm it names: `ok - M10-floor-provenance — kills the 'CS11 the same tier-2
  DECISION gate REFUSES' arm`.
- Header claims 378s; measured 395.4s = 4.6% over, inside the DIVE-2555 warn band, so the
  header stands unchanged.

Reviewer-verified independently (main, 2026-08-04): remote tip `5782d45`; three-dot
`origin/main...5782d45` is one file, +9/-1; and the anchor's new two-conjunct form
`if [[ "$gtier" == "2" ]] && (( ! human )); then` is byte-present at `src/cmd_task.sh:9450` on
`origin/main`, confirming the old `&& _gate_proof_enforced` anchor could no longer match.

## What the DIVE-2589 row asked for, and why it is not here

The row asked to fix this harness being unprobed at the probe's 180s cap, offering (a) a
per-harness cap override or (b) making the harness faster. **(a) already shipped**: full-sweep's
`harness-verdict-slow` lane has probed exactly this harness at `PROBE_TIMEOUT=900` since
DIVE-2525 (#376) — 8h43m before the row was created. Re-measured at that lane's exact cap and
flags: `1 wired, 0 UNWIRED, 0 not-reached, 0 timed-out (cap 900s)`. `timed-out` in the
`pristine` and `installed-host` lanes is the expected per-lane observation; the union is the
coverage answer.

(b) is still open and still cheap — the 14 mutants are independent (each takes its own
`cp -r src`, and the unit harness builds its own `mktemp -d` state), so a 4-way fan-out fits the
180s default and would retire `SLOW_HARNESSES`. The trap for whoever takes it: **a worker must
not tally into `PASS`/`FAIL`**, because a counter incremented in a background subshell is
discarded at the join — the harness would print its failures and exit 0, which is precisely the
unwired verdict `tests/meta/harness-verdict-probe.sh` exists to find.

Findings compiled to `community/wiki/a-timeout-kill-is-not-a-verdict.md` §5 (+ index; §1's
corollary corrected — it recorded DIVE-2412's diagnosis and never its shipped remedy, which is
what made the row's premise easy to believe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
