### PR TITLE
fix(pack): the skipped-skills warning no longer claims a deleted section is still there (DIVE-2677)

### DIFF
--- a/changelog.d/DIVE-2677.md
+++ b/changelog.d/DIVE-2677.md
@@ -1,0 +1,22 @@
+## Unreleased — fix(pack): the skipped-skills warning no longer claims a deleted section is still there (DIVE-2677)
+
+Import's skipped-skills warning closed with "the agent's instructions still
+assume them" — implying the exported doc's `## Skills` paragraph, which names
+the skill, survives into the installed agent's own doc. It never does:
+`_agents_md_explode` truncates the persona body at the `<!-- 5dive:skills -->`
+sentinel before `persona_install_doc` runs, for every `$type`, not just
+opencode. Measured on an opencode seat: the exported doc's lines 14-46 (the
+whole skills paragraph and list) are simply absent from the installed
+`~/.config/opencode/AGENTS.md`. A claude seat only looked unaffected because
+`cmd_create` seeds a default `CLAUDE.md` whose own boilerplate happens to
+occupy the same line range after `persona_install_doc` prepends onto it — a
+coincidence of line numbers, not a surviving reference to the skipped skill.
+
+The warning now says what's actually true regardless of seat type: the pack
+recorded the skill as expected, and nothing installed on the agent provides or
+references it now. The per-skill follow-up lines (repo tried, exact fix
+command) are unchanged.
+
+Tests: `tests/pack_skill_source_roundtrip_unit.sh`,
+`tests/pack_agents_md_unit.sh` (both green, no assertion pinned the old
+string).

--- a/src/cmd_pack.sh
+++ b/src/cmd_pack.sh
@@ -2373,8 +2373,18 @@ cmd_import() {
   # the repo that was tried. So say which repo was tried, why that one, and the exact
   # command that fixes it. A bare ref and a qualified ref fail for different reasons
   # and get different sentences.
+  #
+  # DIVE-2677: "the agent's instructions still assume them" used to close this line,
+  # and it is false on EVERY type, not just opencode — _agents_md_explode truncates
+  # stage/CLAUDE.md at the `<!-- 5dive:skills -->` sentinel before persona_install_doc
+  # ever runs (this file, above), so the installed doc never carries that paragraph
+  # for any seat. A claude seat only LOOKS unaffected because cmd_create seeds a
+  # default CLAUDE.md whose own boilerplate happens to occupy the same line range
+  # afterward — an artifact of persona_install_doc's prepend, not a surviving
+  # reference to the skipped skill. Say what's actually true instead: the pack
+  # recorded these as expected, and nothing installed now provides or mentions them.
   if (( ${#skipped[@]} > 0 )); then
-    warn "skills NOT installed on this '$type' agent: ${skipped[*]} — the agent's instructions still assume them"
+    warn "skills NOT installed on this '$type' agent: ${skipped[*]} — the pack recorded these as expected skills, but nothing installed on this agent provides or references them now"
     local sk_
     for sk_ in "${skipped[@]}"; do
       if [[ "$sk_" == *:* ]]; then


### PR DESCRIPTION
Closes DIVE-2677.

The skipped-skills warning on `agent import` closed with **"the agent's instructions still assume them"**. That is false — and false on **every** seat type, not just opencode, which is where the row was filed from.

`_agents_md_explode` truncates `$stage/CLAUDE.md` at the `<!-- 5dive:skills -->` sentinel **before** `persona_install_doc` ever runs, unconditionally, so the installed agent's doc never carries the exported Skills paragraph for any `$type`. The warning was telling the operator to go read instructions that had already been cut.

A claude seat only *looked* unaffected because `cmd_create` seeds a default `CLAUDE.md` whose own boilerplate happens to occupy the same line range after `persona_install_doc`'s prepend — an artifact of layout, not a surviving reference to the skipped skill. That coincidence is what made the narrow opencode-only reading believable, and it is recorded in the comment so the next reader does not re-narrow it.

The warning now says what is true: the pack recorded these as expected skills, but nothing installed on this agent provides or references them.

## Verified

Maker: 264 pack-test assertions green (`pack_skill_source_roundtrip_unit.sh`, `pack_agents_md_unit.sh` — neither pinned the old string), pii-scan clean.

Reviewer-verified independently (main, 2026-08-04) — the every-type claim, since it widens the row's own title:

- `cmd_pack.sh:1501` states outright that `_agents_md_explode` rewrites `$stage/CLAUDE.md` in place **before** `persona_install_doc` routes it.
- Call order confirms it: `:1647` explode during staging, `:2195` `persona_install_doc` after.
- The truncation is the awk at `:1604` driven by `AGENTS_MD_S_SKILLS`, and there is **no `$type` guard** on that path — the `$type` references inside `_agents_md_explode` are frontmatter/config, not the sentinel cut.
- Scope measured per-commit rather than two-dot: `037dfc4`, one commit, 2 files, 0 behind `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)