### PR TITLE
fix(pack): record skill provenance on the CREATE path, and resolve defaults without a manifest (DIVE-2678)

### DIFF
--- a/changelog.d/DIVE-2678.md
+++ b/changelog.d/DIVE-2678.md
@@ -1,0 +1,33 @@
+## Unreleased — fix(pack): export carries a skill's source, and a skip says why (DIVE-2678)
+
+Two fresh seats imported from one exported AGENTS.md both reported `Skills
+added: 4, skipped: 18`, identical name-for-name on claude and opencode. That
+reads as a broken importer on a foreign harness; it is neither broken nor
+harness-specific.
+
+`agent export` recorded skills as the bare directory NAMES under the agent's
+skills dir. Import re-resolves a bare name through `parse_skill_spec`, which
+defaults it to `<org>/skills` and tries nothing else — so a skill installed
+from any other repo left the export with its provenance stripped, and the
+importer could only skip it. The skip was correct: all 18 skipped names were
+checked against `5dive-ai/skills` by fetch and none are published there (the
+same fetch returns 200 for the four that did install, so the check is not
+vacuous).
+
+The origin was never missing, only unread. `.skills-manifest.json`, written
+beside the skills by `agent skill add`, already records the source each skill
+resolved from. Export now reads it (`_pack_skill_refs`) and emits the
+qualified `<owner/repo>:<id>` form when the source is known and is not the
+default repo, keeping the short bare form when it is — so a round-trip
+reinstalls third-party skills, and the common case plus the human-readable
+AGENTS.md rendering are unchanged. A skill with no manifest entry (hand-seeded,
+or bundled by an earlier import) still exports bare, because there is no fact
+to carry.
+
+That case is now stated rather than counted. The import warning names, per
+skill, which repo was tried and why it failed: a qualified ref names the repo
+that did not serve it, and a bare ref says no source was recorded, names the
+one repo that was therefore tried, and prints the exact `agent skill add
+--source=` command that finishes the job by hand.
+
+Tests: `tests/pack_skill_source_roundtrip_unit.sh`.

--- a/changelog.d/DIVE-2678.md
+++ b/changelog.d/DIVE-2678.md
@@ -9,25 +9,61 @@ harness-specific.
 skills dir. Import re-resolves a bare name through `parse_skill_spec`, which
 defaults it to `<org>/skills` and tries nothing else — so a skill installed
 from any other repo left the export with its provenance stripped, and the
-importer could only skip it. The skip was correct: all 18 skipped names were
-checked against `5dive-ai/skills` by fetch and none are published there (the
-same fetch returns 200 for the four that did install, so the check is not
-vacuous).
+importer could only skip it.
 
-The origin was never missing, only unread. `.skills-manifest.json`, written
-beside the skills by `agent skill add`, already records the source each skill
-resolved from. Export now reads it (`_pack_skill_refs`) and emits the
-qualified `<owner/repo>:<id>` form when the source is known and is not the
-default repo, keeping the short bare form when it is — so a round-trip
-reinstalls third-party skills, and the common case plus the human-readable
-AGENTS.md rendering are unchanged. A skill with no manifest entry (hand-seeded,
-or bundled by an earlier import) still exports bare, because there is no fact
-to carry.
+Export now carries the source and emits the qualified `<owner/repo>:<id>` form
+when it is known and is not the default repo, keeping the short bare form when
+it is — so a round-trip reinstalls the skill, and the common case plus the
+human-readable AGENTS.md rendering are unchanged. Where a skill genuinely
+cannot be reinstalled, the import warning names, per skill, which repo was
+tried and why, and prints the exact `agent skill add --source=` command that
+finishes the job by hand.
 
-That case is now stated rather than counted. The import warning names, per
-skill, which repo was tried and why it failed: a qualified ref names the repo
-that did not serve it, and a bare ref says no source was recorded, names the
-one repo that was therefore tried, and prints the exact `agent skill add
---source=` command that finishes the job by hand.
+### The correction that matters, and it changes the scope of the fix
 
-Tests: `tests/pack_skill_source_roundtrip_unit.sh`.
+An earlier draft of this entry said *"the origin was never missing, only
+unread"* — that `.skills-manifest.json`, written beside the skills by `agent
+skill add`, already held every answer and export merely had to read it. **That
+was wrong on every seat that exists.** Measured 2026-08-04, `find /home -name
+.skills-manifest.json` returns **zero** across the whole fleet, including
+`agent-creative` — the very seat whose export produced the reported numbers.
+
+The writer is not new (live since DIVE-2282), so the reason is not that it had
+not landed yet. It is that **`agent skill add` is not how skills reach a seat.**
+They arrive through `install_default_skill_for_agent` on the create path, which
+installed the body and recorded nothing. A manifest-reading fix therefore
+reached no seat at all, including the one in the report. Both halves are now
+fixed:
+
+- **The create path records provenance.** All three arms — npx, manual
+  git-clone, and the already-present arm — now write the manifest entry. The
+  already-present arm makes re-running preseed a **backfill** for seats that
+  predate this, rather than a fix only for seats created from now on.
+- **Provenance no longer depends on a manifest existing.** For the 5dive
+  defaults, `skill_default_source` resolves the repo with no network and no
+  manifest. This is what recovers **`find-skills`** — installed on *every* seat
+  of *every* type from `vercel-labs/skills`, and one of the 18 skipped names.
+  A manifest entry still wins when present, since it carries third-party
+  sources the table cannot know.
+
+### Honest scope: this recovers 1 of the 18, and that is the ceiling
+
+Re-probed 2026-08-04 against both candidate repos under both layouts, exactly
+one of the 18 skipped names is published anywhere reachable: `find-skills`, in
+`vercel-labs/skills` under `skills/find-skills`. The other 17 (`animejs`,
+`gsap`, the `hyperframes` family, `lodar-voice`, and the rest) 404 everywhere,
+so they are genuinely local-only and **skipping them stays correct** — no table
+and no probe can reinstall a skill that was never published. Those still export
+bare, and the per-skill warning is what carries them across.
+
+So the reported seat does not become 22 of 22. It becomes 5 of 22 automatically,
+with the remaining 17 named individually alongside the command to seed each one.
+The `find-skills` half generalises well beyond this report, because that skill
+is on every seat and its export has been lossy for every seat.
+
+Tests: `tests/pack_skill_source_roundtrip_unit.sh` (41 assertions, 0.28s, core).
+Section 5 deliberately grades a fixture with **no manifest at all** — the shape
+every real seat has. The earlier sections build their own manifest, and a
+fixture that supplies the precondition can never discover that the precondition
+is never met in production; that is exactly how the first cut passed while
+fixing nothing.

--- a/src/cmd_pack.sh
+++ b/src/cmd_pack.sh
@@ -104,15 +104,34 @@ _marketplace_fetch_pack() {
 # came out of an export unresolvable and the importer could only skip it. Measured on
 # two fresh seats from one exported AGENTS.md: 4 of 22 installed, and all 18 skipped
 # were third-party (none published in 5dive-ai/skills — verified by fetching each).
-# The provenance was never missing, only unread: `.skills-manifest.json`, written by
-# cmd_skill_add next to the skills themselves, records the source each was installed
-# from. Emit the qualified `<owner/repo>:<id>` form when the source is known and is not
-# the default repo; keep the bare form otherwise, so the common case and the
+# Provenance comes from `.skills-manifest.json`, written beside the skills by
+# cmd_skill_add. Emit the qualified `<owner/repo>:<id>` form when the source is known
+# and is not the default repo; keep the bare form otherwise, so the common case and the
 # human-readable AGENTS.md rendering are unchanged.
 #
-# A skill with no manifest entry (hand-seeded, or bundled by an earlier import) still
-# comes out bare — there is no fact to carry. That is the case the import-side warning
-# now names out loud instead of folding into a count.
+# ITERATION 3 CORRECTS THE CLAIM ABOVE THIS LINE. The first cut said "the provenance was
+# never missing, only unread". On this fleet it IS missing: MEASURED 2026-08-04,
+# `find /home -name .skills-manifest.json` returns ZERO — not one seat has one, including
+# agent-creative, the very seat whose export produced "added 4, skipped 18". The writer
+# has been live since DIVE-2282/PR #291, so the reason is not that it is new: it lives
+# only in `agent skill add`, and that is not how skills reach a seat. The create path
+# (install_default_skill_for_agent) installed and recorded NOTHING. Reading a manifest
+# therefore reached zero seats and could not have fixed the case it was filed against.
+#
+# So provenance is recovered in two tiers, and the fleet runs on the second:
+#   1. the manifest, when there is one (authoritative — it carries third-party sources
+#      this table cannot know). The create path now writes it, so new seats have one.
+#   2. skill_default_source, for the 5dive defaults. No network, no manifest. This is
+#      what recovers find-skills — installed on EVERY seat from vercel-labs/skills, and
+#      one of the 18 skipped names on the measured export.
+#
+# HONEST SCOPE, because the fix is partial and the shape of the remainder matters:
+# re-probed 2026-08-04, of those 18 exactly ONE (find-skills) is published anywhere
+# reachable — `vercel-labs/skills` serves it under `skills/find-skills`. The other 17
+# (animejs, gsap, the hyperframes family, lodar-voice, ...) 404 in both candidate repos
+# under both layouts, so they are genuinely local-only and skipping them stays correct;
+# no table or probe can reinstall a skill that is not published. Those keep exporting
+# bare, and the import warning names each one with the command to seed it by hand.
 _pack_skill_refs() {
   local sdir="$1"
   [[ -d "$sdir" ]] || { echo '[]'; return 0; }
@@ -123,11 +142,19 @@ _pack_skill_refs() {
   fi
   # Skills install as real dirs OR symlinks (per-agent skill layout), so match
   # both — -type d alone misses the symlinked majority.
-  find "$sdir" -maxdepth 1 -mindepth 1 \( -type d -o -type l \) -printf '%f\n' 2>/dev/null \
-    | sort | jq -R . \
-    | jq -cs --argjson m "$mf" --arg def "$(gh_org)/skills" '
+  local ids
+  ids=$(find "$sdir" -maxdepth 1 -mindepth 1 \( -type d -o -type l \) -printf '%f\n' 2>/dev/null | sort)
+  # Tier 2, built only for the ids actually present: {"find-skills":"vercel-labs/skills"}.
+  local defs='{}' id src
+  while IFS= read -r id; do
+    [[ -n "$id" ]] || continue
+    src=$(skill_default_source "$id") || continue
+    defs=$(jq -c --arg k "$id" --arg v "$src" '.[$k] = $v' <<<"$defs" 2>/dev/null) || defs='{}'
+  done <<<"$ids"
+  printf '%s\n' "$ids" | sed '/^$/d' | jq -R . \
+    | jq -cs --argjson m "$mf" --argjson d "$defs" --arg def "$(gh_org)/skills" '
         map(. as $id
-            | (($m[$id].source // "") | tostring) as $s
+            | (($m[$id].source // $d[$id] // "") | tostring) as $s
             | if ($s == "" or $s == $def) then $id else ($s + ":" + $id) end)' 2>/dev/null \
     || echo '[]'
 }

--- a/src/cmd_pack.sh
+++ b/src/cmd_pack.sh
@@ -96,6 +96,42 @@ _marketplace_fetch_pack() {
   rm -rf "$dl"; echo "$out"
 }
 
+# _pack_skill_refs <skills-dir> -> JSON array of skill specs for the manifest.
+#
+# DIVE-2678. Export used to emit the bare directory names here. That is lossy in the
+# one way that matters: import re-resolves a bare name through parse_skill_spec, which
+# defaults to `<org>/skills` and tries NOTHING else, so a skill from any other repo
+# came out of an export unresolvable and the importer could only skip it. Measured on
+# two fresh seats from one exported AGENTS.md: 4 of 22 installed, and all 18 skipped
+# were third-party (none published in 5dive-ai/skills — verified by fetching each).
+# The provenance was never missing, only unread: `.skills-manifest.json`, written by
+# cmd_skill_add next to the skills themselves, records the source each was installed
+# from. Emit the qualified `<owner/repo>:<id>` form when the source is known and is not
+# the default repo; keep the bare form otherwise, so the common case and the
+# human-readable AGENTS.md rendering are unchanged.
+#
+# A skill with no manifest entry (hand-seeded, or bundled by an earlier import) still
+# comes out bare — there is no fact to carry. That is the case the import-side warning
+# now names out loud instead of folding into a count.
+_pack_skill_refs() {
+  local sdir="$1"
+  [[ -d "$sdir" ]] || { echo '[]'; return 0; }
+  local mf='{}'
+  if [[ -f "$sdir/.skills-manifest.json" ]]; then
+    mf=$(jq -c 'if type == "object" then . else {} end' "$sdir/.skills-manifest.json" 2>/dev/null) || mf='{}'
+    [[ -n "$mf" ]] || mf='{}'
+  fi
+  # Skills install as real dirs OR symlinks (per-agent skill layout), so match
+  # both — -type d alone misses the symlinked majority.
+  find "$sdir" -maxdepth 1 -mindepth 1 \( -type d -o -type l \) -printf '%f\n' 2>/dev/null \
+    | sort | jq -R . \
+    | jq -cs --argjson m "$mf" --arg def "$(gh_org)/skills" '
+        map(. as $id
+            | (($m[$id].source // "") | tostring) as $s
+            | if ($s == "" or $s == $def) then $id else ($s + ":" + $id) end)' 2>/dev/null \
+    || echo '[]'
+}
+
 # Install a bundled skill (a local <dir>/SKILL.md) directly into the agent's
 # skills dir — used on import when the pack carries the skill body.
 _install_bundled_skill() {
@@ -1632,14 +1668,20 @@ cmd_export() {
   if [[ -f "$cdir/avatar.png" ]]; then
     cp "$cdir/avatar.png" "$stage/avatar.png" 2>/dev/null && has_avatar=1
   fi
-  # Skills as source refs (reuse the skills spec; import re-adds them) — names only.
-  local skills='[]'
-  if [[ -d "$cdir/skills" ]]; then
-    # Skills install as real dirs OR symlinks (per-agent skill layout), so match
-    # both — -type d alone misses the symlinked majority.
-    skills=$(find "$cdir/skills" -maxdepth 1 -mindepth 1 \( -type d -o -type l \) -printf '%f\n' 2>/dev/null \
-             | sort | jq -R . | jq -cs '.' 2>/dev/null || echo '[]')
-  fi
+  # Skills as source refs (reuse the skills spec; import re-adds them).
+  #
+  # DIVE-2678: this used to emit the skills DIRECTORY NAMES and nothing else, which
+  # throws away the one fact import needs. A bare name is re-resolved by
+  # parse_skill_spec against `<org>/skills` and NOWHERE else, so every skill that came
+  # from any other repo became unresolvable the moment it was exported — the importer
+  # then correctly, and silently-by-design, skipped it. Measured on two fresh seats:
+  # 4 of 22 installed, the other 18 all third-party (none of them exist in
+  # 5dive-ai/skills, verified by fetch). The skill's origin is not lost data: the
+  # per-agent `.skills-manifest.json` already records the source cmd_skill_add
+  # resolved it from. Carry it as the qualified `<owner/repo>:<id>` form whenever it
+  # is NOT the default repo, and keep the short bare form when it is — so an
+  # AGENTS.md stays readable and the common case is unchanged.
+  local skills; skills=$(_pack_skill_refs "$cdir/skills")
   # Hooks subset from settings (structure only; if a hook command embeds a
   # secret that is on the operator — we copy the hooks block verbatim from
   # settings, which by convention holds no tokens).
@@ -2170,8 +2212,23 @@ cmd_import() {
 
   # DIVE-2565: a silent skill drop is the bad outcome the single-file format was
   # explicitly not allowed to have. Name them, on every harness.
+  #
+  # DIVE-2678: naming them was not enough. "Skills added: 4, skipped: 18" reads as a
+  # broken importer, and the reader's next move (re-run it, file a bug) is the wrong
+  # one in both cases — the skip is CORRECT, the skill genuinely is not fetchable from
+  # the repo that was tried. So say which repo was tried, why that one, and the exact
+  # command that fixes it. A bare ref and a qualified ref fail for different reasons
+  # and get different sentences.
   if (( ${#skipped[@]} > 0 )); then
     warn "skills NOT installed on this '$type' agent: ${skipped[*]} — the agent's instructions still assume them"
+    local sk_
+    for sk_ in "${skipped[@]}"; do
+      if [[ "$sk_" == *:* ]]; then
+        warn "  '${sk_#*:}' — '${sk_%%:*}' did not serve it (missing, private, or unreachable from this host)"
+      else
+        warn "  '$sk_' — no source recorded in the pack, so only '$(gh_org)/skills' was tried and it is not published there; re-add it by hand: 5dive agent skill $as add --source=<owner/repo> --skill=$sk_"
+      fi
+    done
   fi
 
   rm -rf "$stage"

--- a/src/header.sh
+++ b/src/header.sh
@@ -515,6 +515,32 @@ declare -A SKILLS_INSTALL_DIR=(
   [grok]=".grok/skills"
 )
 
+# skill_default_source <id> -> the repo a 5dive DEFAULT skill is installed from,
+# or non-zero for any id that is not one of ours.
+#
+# DIVE-2678 iteration 3. The manifest is the authoritative provenance record, but
+# it only ever describes skills that arrived via `agent skill add` — and MEASURED
+# 2026-08-04, zero seats on this fleet carry one, because the create path
+# (install_default_skill_for_agent) never wrote it. So on every seat that exists
+# today the manifest answers nothing, and a default skill installed from a repo
+# that is NOT <org>/skills exported bare and came back unresolvable.
+#
+# find-skills is exactly that case and it is not an edge: it ships on EVERY seat
+# of every type, from vercel-labs/skills, and it was in the 18 skipped names on
+# the measured export. This table is what lets provenance be recovered for a
+# skill installed before the writer existed, with no network and no manifest.
+#
+# It must agree with the install_default_skill_for_agent call sites in
+# agent_setup.sh; tests/pack_skill_source_roundtrip_unit.sh asserts that it does,
+# so adding a default skill there without adding it here reds the suite.
+skill_default_source() {
+  case "$1" in
+    find-skills) echo "vercel-labs/skills" ;;
+    5dive-cli|compile-knowledge|openagent) echo "$(gh_org)/skills" ;;
+    *) return 1 ;;
+  esac
+}
+
 # skills_install_dir <type> -> the $HOME-relative dir an installed skill body
 # lands in for that type. THE resolver: this is the expression cmd_pack.sh's
 # import path, cmd_skill add/list/rm and agent_setup.sh each spell by hand, and

--- a/src/lib/agent_setup.sh
+++ b/src/lib/agent_setup.sh
@@ -451,6 +451,39 @@ _skill_needs_manual_install() {
   esac
 }
 
+# _skill_manifest_note <user> <home> <install_dir> <skill> <source>
+#
+# DIVE-2678 iteration 3 — THE HOLE THAT MADE THE MANIFEST FICTION. `.skills-manifest.json`
+# has been written by cmd_skill_add since DIVE-2282/PR #291, and yet MEASURED 2026-08-04
+# not one seat on this fleet has one. The reason is not that the writer is new or broken:
+# it is that `agent skill add` is not how skills get onto a seat. Every default arrives
+# through install_default_skill_for_agent below, which installed the body and recorded
+# nothing — so export had no provenance to read on any seat that exists.
+#
+# Best-effort by construction: a manifest write must never fail an install. Every failure
+# path swallows, exactly as the cmd_skill_add block does.
+_skill_manifest_note() {
+  local user="$1" home="$2" install_dir="$3" skill="$4" source="$5"
+  sudo -u "$user" -H env INSTALL_DIR="$install_dir" SKILL="$skill" SOURCE="$source" \
+    bash -s >/dev/null 2>&1 <<'MANIFEST_NOTE' || true
+set -uo pipefail
+[ -d "$HOME/$INSTALL_DIR/$SKILL" ] || exit 0
+MANIFEST="$HOME/$INSTALL_DIR/.skills-manifest.json"
+if ! /usr/bin/jq -e . "$MANIFEST" >/dev/null 2>&1; then echo '{}' > "$MANIFEST" 2>/dev/null || true; fi
+# Same hash recipe as cmd_skill_add: relative paths + sorted, so a tree installed by
+# either path hashes identically and `skill add --force` change-detection stays honest.
+CONTENT_SHA=$(cd "$HOME/$INSTALL_DIR/$SKILL" && find . -type f -print0 | sort -z | xargs -0 -r /usr/bin/sha256sum | /usr/bin/sha256sum | cut -d' ' -f1) || CONTENT_SHA=""
+if /usr/bin/jq --arg k "$SKILL" --arg s "$SOURCE" --arg c "$CONTENT_SHA" \
+     --arg t "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+     '.[$k] = {source:$s, resolved_sha:"", content_sha256:$c, installed_at:$t}' \
+     "$MANIFEST" > "$MANIFEST.tmp" 2>/dev/null; then
+  mv "$MANIFEST.tmp" "$MANIFEST"
+else
+  rm -f "$MANIFEST.tmp"
+fi
+MANIFEST_NOTE
+}
+
 # Install one skill into an agent user's per-type skills dir. Routes through
 # `npx skills add --agent <id>` for upstream-supported types, and falls back
 # to a direct git-clone + cp -r for types upstream rejects (see
@@ -473,6 +506,10 @@ install_default_skill_for_agent() {
   [[ -d "$home" ]] || return 1
   id -u "$user" &>/dev/null || return 1
   if sudo -u "$user" test -d "$home/$install_dir/$skill"; then
+    # Already installed — but on a seat created before the write above existed, that
+    # body has no manifest entry. Record it here too, so re-running preseed BACKFILLS
+    # provenance onto existing seats instead of only fixing seats created from now on.
+    _skill_manifest_note "$user" "$home" "$install_dir" "$skill" "$source"
     return 0
   fi
   if _skill_needs_manual_install "$type"; then
@@ -502,6 +539,7 @@ skill_target_within "$HOME/$INSTALL_DIR" "$SKILL" \
 cp -r "$SRC_DIR" "$HOME/$INSTALL_DIR/$SKILL"
 echo "manual-installed $SKILL → $HOME/$INSTALL_DIR/$SKILL"
 MANUAL_SKILL
+    _skill_manifest_note "$user" "$home" "$install_dir" "$skill" "$source"
     return 0
   fi
   sudo -u "$user" -H env SOURCE="$source" SKILL="$skill" AGENT_ID="$agent_id" bash -s >&2 <<'DEFAULT_SKILL' \
@@ -515,6 +553,7 @@ export PATH="/home/claude/.local/bin:$PATH"
 cd "$HOME"
 timeout 180 npx -y skills add "https://github.com/$SOURCE" --skill "$SKILL" --agent "$AGENT_ID" --yes 2>&1 | tail -15
 DEFAULT_SKILL
+  _skill_manifest_note "$user" "$home" "$install_dir" "$skill" "$source"
 }
 
 # Install a claude-plugins-official channel plugin into the agent user's

--- a/tests/pack_skill_source_roundtrip_unit.sh
+++ b/tests/pack_skill_source_roundtrip_unit.sh
@@ -142,5 +142,89 @@ has "$IMPORT_ARM" 'did not serve it' "cmd_import still distinguishes a qualified
 STAGE_ARM=$(grep -c '_pack_skill_refs "\$cdir/skills"' "$SRC/cmd_pack.sh")
 check "export calls the helper (not an inlined copy)" "$STAGE_ARM" "1"
 
+printf '\n5. NO MANIFEST AT ALL — the shape every real seat actually has\n'
+# THE LESSON THIS SECTION EXISTS FOR. Sections 1-4 build their own fixture manifest,
+# so they pass on a precondition that does not hold anywhere in production: measured
+# 2026-08-04, `find /home -name .skills-manifest.json` returns ZERO across the fleet,
+# including the seat whose export produced the reported "added 4, skipped 18". A
+# fixture that SUPPLIES the precondition can never discover that the precondition is
+# never met — so this section removes it and grades the fleet-real shape.
+NOMAN="$TMP/noman/skills"
+mkdir -p "$NOMAN"/{find-skills,5dive-cli,animejs}
+for s in find-skills 5dive-cli animejs; do printf '# %s\n' "$s" > "$NOMAN/$s/SKILL.md"; done
+check "the fixture really has no manifest" "$([[ -e "$NOMAN/.skills-manifest.json" ]] && echo yes || echo no)" "no"
+
+NREFS=$(_pack_skill_refs "$NOMAN")
+has "$NREFS" '"vercel-labs/skills:find-skills"' \
+  "find-skills resolves with NO manifest — the default table carries it"
+check "and it round-trips to the repo that actually serves it" \
+  "$(rt "vercel-labs/skills:find-skills")" "vercel-labs/skills|find-skills"
+has "$NREFS" '"5dive-cli"' "a default-repo default stays bare"
+has "$NREFS" '"animejs"' "an unpublished local-only skill still exports bare"
+hasnt "$NREFS" '"vercel-labs/skills:animejs"' \
+  "the table never INVENTS a source for a skill it does not know"
+
+# Precedence: a manifest is authoritative because it can carry third-party sources the
+# table cannot know. If the table won instead, a relocated skill would silently export
+# the wrong repo.
+mkdir -p "$TMP/prec/skills/find-skills"; printf '# f\n' > "$TMP/prec/skills/find-skills/SKILL.md"
+jq -n '{"find-skills":{source:"example-org/tools"}}' > "$TMP/prec/skills/.skills-manifest.json"
+has "$(_pack_skill_refs "$TMP/prec/skills")" '"example-org/tools:find-skills"' \
+  "an explicit manifest entry OVERRIDES the default table"
+
+printf '\n6. the default table cannot drift from the installer that seeds it\n'
+# skill_default_source is a second spelling of the install_default_skill_for_agent call
+# sites. Two spellings of one fact drift, so derive the truth from agent_setup.sh and
+# compare — adding a default skill there without adding it here reds this.
+DRIFT=0
+while read -r src_ skill_; do
+  [[ -n "$skill_" ]] || continue
+  got=$(skill_default_source "$skill_" 2>/dev/null) || got="<unknown>"
+  if [[ "$got" != "$src_" ]]; then
+    bad_ "skill_default_source $skill_ -> want [$src_] got [$got]"; DRIFT=1
+  fi
+done < <(grep -oE 'install_default_skill_for_agent "\$name" [a-z]+ (vercel-labs/skills|"\$\(gh_org\)/skills") [a-z0-9-]+' \
+           "$SRC/lib/agent_setup.sh" \
+         | sed -E 's/.* (vercel-labs\/skills|"\$\(gh_org\)\/skills") ([a-z0-9-]+)$/\1 \2/' \
+         | sed 's|"\$(gh_org)/skills"|5dive-ai/skills|' | sort -u)
+[[ $DRIFT -eq 0 ]] && ok_ "every installer default is known to skill_default_source"
+# Non-vacuity: the loop above must actually have read call sites.
+SITES=$(grep -cE 'install_default_skill_for_agent "\$name" [a-z]+ ' "$SRC/lib/agent_setup.sh")
+if [[ "$SITES" -ge 8 ]]; then ok_ "the drift check read $SITES real call sites"
+else bad_ "drift check read only $SITES call sites — it is not reaching agent_setup.sh"; fi
+check "an id that is not a 5dive default is rejected" \
+  "$(skill_default_source not-a-5dive-skill >/dev/null 2>&1; echo $?)" "1"
+
+printf '\n7. the create path RECORDS provenance (why no seat had a manifest)\n'
+# The writer existed in cmd_skill_add since DIVE-2282/PR #291 and still no seat had a
+# manifest, because installs do not go through `agent skill add` — they go through
+# install_default_skill_for_agent, which recorded nothing. Assert every arm now notes.
+SETUP=$(sed -n '/^install_default_skill_for_agent()/,/^}/p' "$SRC/lib/agent_setup.sh")
+NOTES=$(grep -c '_skill_manifest_note "\$user" "\$home" "\$install_dir" "\$skill" "\$source"' <<<"$SETUP")
+check "all three install arms record the source (npx, manual, already-present)" "$NOTES" "3"
+has "$SETUP" 'BACKFILLS' "the already-present arm is documented as the backfill it is"
+# The note helper must write the key export reads. Grade the shape, not the prose.
+NOTE_FN=$(sed -n '/^_skill_manifest_note()/,/^}/p' "$SRC/lib/agent_setup.sh")
+has "$NOTE_FN" '.skills-manifest.json' "the helper writes the file export reads"
+has "$NOTE_FN" 'source:$s' "the helper records the SOURCE field _pack_skill_refs consumes"
+has "$NOTE_FN" '|| true' "a manifest write can never fail an install"
+
+# Behavioural: run the helper's body against a throwaway HOME and read the result back
+# through _pack_skill_refs. Source-level greps above say the call sites exist; this says
+# the thing they call produces a manifest export can actually use.
+NHOME="$TMP/nhome"; mkdir -p "$NHOME/.claude/skills/find-skills"
+printf '# f\n' > "$NHOME/.claude/skills/find-skills/SKILL.md"
+( sed -n '/^_skill_manifest_note()/,/^}/p' "$SRC/lib/agent_setup.sh" \
+    | sed -n '/<<.MANIFEST_NOTE./,/^MANIFEST_NOTE$/p' | sed '1d;$d' \
+    | HOME="$NHOME" INSTALL_DIR=".claude/skills" SKILL="find-skills" \
+      SOURCE="vercel-labs/skills" bash -s ) >/dev/null 2>&1
+check "the helper body actually wrote a manifest" \
+  "$([[ -s "$NHOME/.claude/skills/.skills-manifest.json" ]] && echo yes || echo no)" "yes"
+check "and it recorded the source export needs" \
+  "$(jq -r '."find-skills".source // "<none>"' "$NHOME/.claude/skills/.skills-manifest.json" 2>/dev/null)" \
+  "vercel-labs/skills"
+has "$(_pack_skill_refs "$NHOME/.claude/skills")" '"vercel-labs/skills:find-skills"' \
+  "a seat seeded by the create path now exports its source"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/tests/pack_skill_source_roundtrip_unit.sh
+++ b/tests/pack_skill_source_roundtrip_unit.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# DIVE-2678 isolated unit harness — a skill's SOURCE survives export, and a skill
+# that cannot survive it says why.
+#
+# The incident: two fresh seats imported from one exported AGENTS.md and both
+# reported "Skills added: 4, skipped: 18", identical name-for-name. It reads as a
+# broken importer. It is not. Export emitted the skills DIRECTORY NAMES, and a bare
+# name is re-resolved by parse_skill_spec against `<org>/skills` and nowhere else, so
+# every skill from any other repo left the export unresolvable. All 18 skipped names
+# were checked against 5dive-ai/skills by fetch: none are published there, so the
+# skip was CORRECT and the fix belongs on the export side (carry the source) plus the
+# message (say which repo was tried and how to finish the job by hand).
+#
+# Graded BEHAVIOURALLY, both halves — the first cut of the second section grepped
+# cmd_import for the warning text and a disabled branch killed nothing, the standing
+# lesson in pack_cross_harness_unit.sh. _pack_skill_refs is called for real against a
+# real fixture tree; the message arm executes the shipped `for` body.
+# Run: bash tests/pack_skill_source_roundtrip_unit.sh
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/skill-source-roundtrip.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Pin the org so gh_org never probes the network from a unit harness — and so the
+# "default repo" the assertions talk about is a value this file states, not one the
+# host happens to resolve to.
+export GH_ORG=5dive-ai
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+# shellcheck source=/dev/null
+source "$SRC/cmd_skill.sh"   # parse_skill_spec — the resolver the refs are aimed at
+# shellcheck source=/dev/null
+source "$SRC/cmd_pack.sh"
+
+JSON_MODE=1
+set +e   # header.sh enabled `set -e`; tests deliberately probe non-zero paths
+
+PASS=0; FAIL=0
+ok_()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad_()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+check() { if [[ "$2" == "$3" ]]; then ok_ "$1"; else bad_ "$1 (want [$3] got [$2])"; fi; }
+has()   { if grep -qF -- "$2" <<<"$1"; then ok_ "$3"; else bad_ "$3 (missing [$2])"; fi; }
+hasnt() { if grep -qF -- "$2" <<<"$1"; then bad_ "$3 (unexpectedly present: [$2])"; else ok_ "$3"; fi; }
+
+# ---------------------------------------------------------------- fixtures ---
+# A seat carrying the three shapes that behave differently. Reserved fakes only
+# (host CLAUDE.md rule): no real third-party repo slug is named.
+SDIR="$TMP/skills"
+mkdir -p "$SDIR"/{5dive-cli,widgets,handseeded}
+for s in 5dive-cli widgets handseeded; do printf '# %s\n' "$s" > "$SDIR/$s/SKILL.md"; done
+# A symlinked skill — the per-agent layout the -type l arm exists for.
+mkdir -p "$TMP/elsewhere/linked"; printf '# linked\n' > "$TMP/elsewhere/linked/SKILL.md"
+ln -s "$TMP/elsewhere/linked" "$SDIR/linked"
+jq -n '{
+  "5dive-cli": { source: "5dive-ai/skills",   resolved_sha: "deadbeef", content_sha256: "aaa" },
+  "widgets":   { source: "example-org/tools", resolved_sha: "deadbeef", content_sha256: "bbb" },
+  "linked":    { source: "example-org/tools", resolved_sha: "deadbeef", content_sha256: "ccc" }
+}' > "$SDIR/.skills-manifest.json"
+
+printf '\n1. export carries the source ref (_pack_skill_refs)\n'
+
+REFS=$(_pack_skill_refs "$SDIR")
+check "refs are a JSON array" "$(jq -r 'type' <<<"$REFS" 2>/dev/null)" "array"
+check "every installed skill is represented" "$(jq -r 'length' <<<"$REFS" 2>/dev/null)" "4"
+has "$REFS" '"example-org/tools:widgets"' "third-party skill exports QUALIFIED"
+has "$REFS" '"example-org/tools:linked"' "a SYMLINKED third-party skill exports qualified too"
+has "$REFS" '"5dive-cli"' "default-repo skill stays bare (readable AGENTS.md)"
+hasnt "$REFS" '"5dive-ai/skills:5dive-cli"' "default repo is not spelled out redundantly"
+has "$REFS" '"handseeded"' "a skill with no manifest entry still exports (bare)"
+# The manifest file itself is not a skill.
+hasnt "$REFS" '.skills-manifest' "the manifest file is never emitted as a skill"
+
+printf '\n2. the ref is what the IMPORT resolver actually consumes\n'
+# The point of section 1 is only true if parse_skill_spec — the function import feeds
+# these strings to — splits them back to the source they were exported from. Assert
+# the round-trip, not the string shape.
+rt() { local pair; pair=$(parse_skill_spec "$1"); printf '%s|%s' "${pair% *}" "${pair#* }"; }
+check "qualified ref round-trips to its own repo" \
+  "$(rt "$(jq -r '.[] | select(startswith("example-org/tools:widgets"))' <<<"$REFS")")" \
+  "example-org/tools|widgets"
+check "bare ref resolves to the default repo, as before" "$(rt 5dive-cli)" "5dive-ai/skills|5dive-cli"
+# The pre-fix behaviour, stated as the thing that must no longer happen: a bare
+# "widgets" would have been aimed at the WRONG repo, which is the whole defect.
+check "the pre-fix bare form aimed at the wrong repo" "$(rt widgets)" "5dive-ai/skills|widgets"
+
+printf '\n3. degenerate inputs do not take the export down\n'
+check "missing skills dir -> empty array" "$(_pack_skill_refs "$TMP/nope")" "[]"
+mkdir -p "$TMP/empty/skills"
+check "empty skills dir -> empty array" "$(_pack_skill_refs "$TMP/empty/skills")" "[]"
+mkdir -p "$TMP/garbage/skills/one"; printf '# one\n' > "$TMP/garbage/skills/one/SKILL.md"
+printf 'not json at all\n' > "$TMP/garbage/skills/.skills-manifest.json"
+check "unparseable manifest degrades to bare names, never empty" \
+  "$(_pack_skill_refs "$TMP/garbage/skills")" '["one"]'
+printf '[1,2,3]\n' > "$TMP/garbage/skills/.skills-manifest.json"
+check "a manifest of the wrong TYPE degrades the same way" \
+  "$(_pack_skill_refs "$TMP/garbage/skills")" '["one"]'
+
+printf '\n4. a skip states its reason, per skill (DIVE-2678 messaging)\n'
+# Execute the shipped arm rather than grepping for its text: the same `for` body, over
+# the same two ref shapes, with warn captured. A branch someone disables to false must
+# take these assertions down with it.
+skip_report() {
+  local as="newseat"; local -a skipped=("$@"); local sk_ out
+  # warn writes to STDERR, so the redirect has to be INSIDE the substitution — a
+  # trailing `2>&1` on the assignment redirects the assignment, not the subshell,
+  # and every `has` below then passes/fails against an empty string.
+  out=$( {
+    for sk_ in "${skipped[@]}"; do
+      if [[ "$sk_" == *:* ]]; then
+        warn "  '${sk_#*:}' — '${sk_%%:*}' did not serve it (missing, private, or unreachable from this host)"
+      else
+        warn "  '$sk_' — no source recorded in the pack, so only '$(gh_org)/skills' was tried and it is not published there; re-add it by hand: 5dive agent skill $as add --source=<owner/repo> --skill=$sk_"
+      fi
+    done
+  } 2>&1 )
+  printf '%s' "$out"
+}
+REPORT=$(skip_report "example-org/tools:widgets" "handseeded")
+has "$REPORT" "example-org/tools" "a qualified skip names the repo that did not serve it"
+has "$REPORT" "no source recorded" "a bare skip says the provenance was missing"
+has "$REPORT" "5dive-ai/skills" "a bare skip names the ONLY repo that was tried"
+has "$REPORT" "5dive agent skill newseat add --source=<owner/repo> --skill=handseeded" \
+  "a bare skip hands over the exact command that finishes the job"
+hasnt "$REPORT" "'example-org/tools:widgets' — no source recorded" \
+  "a qualified skip does not claim its source was missing"
+
+# The shipped call site must be the same shape as the arm graded above — a helper
+# graded in isolation is worth nothing if cmd_import stopped calling it.
+IMPORT_ARM=$(sed -n '/DIVE-2565: a silent skill drop/,/^  rm -rf "\$stage"/p' "$SRC/cmd_pack.sh")
+has "$IMPORT_ARM" 'no source recorded in the pack' "cmd_import still emits the per-skill reason"
+has "$IMPORT_ARM" 'did not serve it' "cmd_import still distinguishes a qualified failure"
+STAGE_ARM=$(grep -c '_pack_skill_refs "\$cdir/skills"' "$SRC/cmd_pack.sh")
+check "export calls the helper (not an inlined copy)" "$STAGE_ARM" "1"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Closes DIVE-2678. Iteration 3, after a reviewer reject of iteration 2.

## What iteration 2 got right, and what it missed

Iteration 2 established — and the reviewer re-verified — that the **skip was correct**: all 18 skipped names 404 in `5dive-ai/skills`, while the same API lists the published dirs, so the control was not vacuous. The loss is on the **export** side.

Its remedy read `.skills-manifest.json`, on the stated premise that *"the origin was never missing, only unread."* **It was missing.** Zero such files existed anywhere under `/home` — including `agent-creative`, the exact seat whose export produced `added 4, skipped 18`. The fix reached no seat.

## Root cause of that, which is the new finding

The manifest writer lived **only** in `cmd_skill_add`. Skills actually reach a seat via `install_default_skill_for_agent` on the **create** path, which installed the skill body and recorded nothing. That is why no seat had a manifest despite the writer shipping in PR #291.

## Both halves fixed

1. **The create path now records provenance.** All three arms call `_skill_manifest_note`; the already-present arm makes a preseed re-run a **backfill** for existing seats.
2. **Export no longer depends on a manifest existing.** `skill_default_source` resolves the 5dive defaults with no manifest and no network, so the common case works on seats that predate any of this.

## Honest ceiling — this does not make it 22 of 22

Both candidate repos were re-probed under both layouts. **Exactly 1 of the 18** is published anywhere reachable: `find-skills`, at `vercel-labs/skills` under `skills/find-skills`. The other 17 404 everywhere, are genuinely local-only, and stay **correctly** skipped.

So the reported seat goes **4 → 5 of 22**, not 4 → 22. But the `find-skills` half reaches **every seat of every type**, since that skill ships on all of them and its export has been lossy for all of them.

## Verified

Maker: 23 → 41 assertions, 0.28s, core. Section 5 grades a fixture with **no manifest** — the exact vacuity the reject named. Section 6 derives the defaults table from `agent_setup.sh` call sites so it cannot drift. Mutation-graded three ways (drop table fallback / drop one note call site / point `find-skills` at a wrong repo) reddening 1, 1 and 2 assertions.

Reviewer-verified independently (main, 2026-08-04):

- **The ceiling claim**: `vercel-labs/skills/skills/find-skills` returns `SKILL.md`; spot-checked `animejs`, `gsap`, `lottie`, `hyperframes` → all 404 there; `lodar-voice` 404 as it must be, since it is deliberately never published.
- **The create-path writer**: `_skill_manifest_note` defined at `agent_setup.sh:465`, called at :512, :542, :556 — the three arms, as claimed.
- **Harness**: 41 passed, 0 failed, rc=0, run by the reviewer. Section 5 is titled *"NO MANIFEST AT ALL — the shape every real seat actually has."*
- **Scope**: three-dot `origin/main...773d4ad` is 5 files.
- **The pre-existing red claim**: the diff touches **none** of the four harnesses named, and `ledger_unit` reproduces red (16/1) on **pristine origin/main in a clean control worktree** sharing nothing with the maker's tree.

**Stated limit, not hidden:** no live export→import round-trip was run on `agent-creative`. The 5-of-22 figure is inference from the verified published ref plus a `parse_skill_spec` round-trip, not an e2e run. Neither maker nor reviewer closed that hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)