### PR TITLE
fix(heartbeat): surface a recurring instance that was never started (DIVE-2693)

### DIFF
--- a/changelog.d/DIVE-2693.md
+++ b/changelog.d/DIVE-2693.md
@@ -1,0 +1,36 @@
+## Unreleased — fix(heartbeat): surface a recurring instance that was never started (DIVE-2693)
+
+The stall sweep keys on `handoff_delivered_at`. A materialized recurring instance
+that is simply **never picked up** has none — it was never delivered to anyone —
+so nothing watched it.
+
+That matters more than one late task, because the materializer is **skip-if-open**:
+while an instance sits open the template's next slot is suppressed. One unworked
+instance does not delay a beat, it **deletes every subsequent occurrence** for as
+long as it sits.
+
+It stayed invisible because the recovery is clean. Downstream producers check their
+own preconditions, decline to act, and emit nothing — so the only symptom is a
+green-looking no-op a day or two later. **A fault whose recovery is correct is a
+fault nobody reports.**
+
+New sweep, sibling of the DIVE-1416 gap#2 one, deliberately **not keyed to any
+ident**: any `kind='standard'` row with `from_template_id`, `status='todo'`,
+`started_at IS NULL`, unparked, not gate-blocked, older than
+`HEARTBEAT_RECURRING_STALL_HOURS` (default 24). It pings the assignee with the
+two exits (start it, or cancel it to let the schedule re-fire) and the coordinator
+with the suppression consequence, then stamps `recurring_stall_pinged_at` so it
+says it once.
+
+**Found two live stalls on its first dry run against the real board**, on templates
+nobody had connected to this defect: `DIVE-2479` (Daily GH branch/PR hygiene sweep,
+from `DIVE-1430`) unstarted 4 days, and `DIVE-2550` (Daily version loop, from
+`DIVE-1699`) unstarted 2 days. Both assigned to `main`. The row was filed from two
+DIVE-1237 instances; hardcoding that ident would have shipped a watchdog blind to
+both of these.
+
+Tests: `tests/heartbeat_recurring_stall_unit.sh`, 13 assertions, core. The
+predicate is **extracted from `cmd_heartbeat.sh`** rather than retyped, so it
+cannot grade a query that no longer exists. Carries a non-vacuity anchor (eight
+exclusion arms all pass against a predicate returning nothing) and a mutation arm
+that asserts it applied before trusting it.

--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -86,6 +86,12 @@ _HB_GATE_SHIPPED_REF="${HEARTBEAT_GATE_SHIPPED_REF:-origin/main}"
 # escape-hatch pattern as _HB_GATE_ESCALATE_DAYS.
 _HB_VERIFY_STALE_MIN="${HEARTBEAT_VERIFY_STALE_MIN:-60}"
 [[ "$_HB_VERIFY_STALE_MIN" =~ ^[0-9]+$ ]] || _HB_VERIFY_STALE_MIN=60
+# DIVE-2693: how long a materialized RECURRING instance may sit todo-and-never-
+# started before the sweep surfaces it. Hours, not minutes: a daily beat is
+# allowed to be worked late in its own day, and only becomes a fault once it has
+# outlived its own cadence and started suppressing the NEXT slot.
+_HB_RECURRING_STALL_HOURS="${HEARTBEAT_RECURRING_STALL_HOURS:-24}"
+[[ "$_HB_RECURRING_STALL_HOURS" =~ ^[0-9]+$ ]] || _HB_RECURRING_STALL_HOURS=24
 _HB_STALL_MIN_MINUTES="${HEARTBEAT_STALL_MIN_MINUTES:-30}"
 [[ "$_HB_STALL_MIN_MINUTES" =~ ^[0-9]+$ ]] || _HB_STALL_MIN_MINUTES=30
 # Orphan reclaim. An in_progress task whose claiming claude session is GONE — the
@@ -2282,6 +2288,50 @@ _hb_stall_sweep() {
                  AND handoff_delivered_at IS NOT NULL
                  AND NOT (need_type IS NOT NULL AND need_answered_at IS NULL)
                  AND handoff_delivered_at <= datetime('now','-${_HB_VERIFY_STALE_MIN} minutes');")
+
+  # (a2) DIVE-2693 — a materialized RECURRING instance that was never STARTED.
+  #
+  # WHY THIS IS NOT COVERED BY (a) ABOVE, which is the whole reason it needed its
+  # own predicate: gap#2 keys on handoff_delivered_at, and a plain never-started
+  # todo has none — it was never delivered to anyone, it was simply never picked
+  # up. The two stall shapes are disjoint and a query for one cannot see the other.
+  #
+  # WHY IT MATTERS MORE THAN ONE LATE TASK: the materializer is skip-if-open, so
+  # while an instance sits open the template's NEXT slot is suppressed. One
+  # unworked instance therefore does not delay a beat, it DELETES every subsequent
+  # occurrence of it for as long as it sits. Measured twice on DIVE-1237: DIVE-2026
+  # ate 07-27..07-28, DIVE-2403 ate 07-31..08-04 (five slots, nothing shipped).
+  #
+  # WHY IT STAYED INVISIBLE BOTH TIMES: the downstream producer's own precondition
+  # check absorbs the stall correctly — it declines to activate, so nothing errors
+  # and the only symptom is a green-looking no-op a day or two later. A fault whose
+  # recovery is clean is a fault nobody reports.
+  #
+  # NOT KEYED TO ANY IDENT. DIVE-1237 is only where we noticed it; the defect is a
+  # property of skip-if-open dedup on ANY template, and DIVE-1155/DIVE-1236 sit on
+  # the same mechanism and would fail identically and just as quietly.
+  local rrow rid rident rasg rcreated rtmpl rhours
+  while IFS= read -r rrow; do
+    [[ -n "$rrow" ]] || continue
+    IFS=$'\x1f' read -r rid rident rasg rcreated rtmpl <<<"$rrow"
+    [[ -n "$rid" ]] || continue
+    rhours=$(( ($(date -u +%s) - $(date -u -d "$rcreated" +%s 2>/dev/null || date -u +%s)) / 3600 ))
+    if [[ -n "$rasg" ]]; then
+      ( cmd_send "$rasg" --from="task-engine" \
+          --message="⏳ ${rident} is a RECURRING instance you have never started — ${rhours}h old. While it sits open the schedule's next slot is SUPPRESSED (skip-if-open), so the beat is not late, it is not happening. Work it or close it: \`5dive task start ${rident}\`, or \`5dive task cancel ${rident} --result=...\` to let the schedule re-fire." ) >/dev/null 2>&1 || true
+    fi
+    ( cmd_send "main" --from="task-engine" \
+        --message="⏳ Recurring beat stalled: ${rident} (from template ${rtmpl}) has sat todo and never-started for ${rhours}h, assignee '${rasg:-unassigned}' — every slot since is suppressed by skip-if-open (DIVE-2693)." ) >/dev/null 2>&1 || true
+    db "UPDATE tasks SET recurring_stall_pinged_at=datetime('now') WHERE id=${rid};"
+    _hb_log "[recurring-stall] ${rident} never-started ${rhours}h (template ${rtmpl}) -> surfaced"
+  done < <(db "SELECT t.id||x'1f'||COALESCE(t.ident,'DIVE-'||t.id)||x'1f'||COALESCE(t.assignee,'')||x'1f'||t.created_at||x'1f'||COALESCE(p.ident,'DIVE-'||t.from_template_id)
+               FROM tasks t LEFT JOIN tasks p ON p.id=t.from_template_id
+               WHERE t.kind='standard' AND t.from_template_id IS NOT NULL
+                 AND t.status='todo' AND t.started_at IS NULL
+                 AND t.recurring_stall_pinged_at IS NULL
+                 AND NOT (t.need_type IS NOT NULL AND t.need_answered_at IS NULL)
+                 AND t.parked_at IS NULL
+                 AND t.created_at <= datetime('now','-${_HB_RECURRING_STALL_HOURS} hours');")
 
   # (b) GAP#3 core — fleet-idle-while-actionable-work-is-open, persisting.
   local in_prog running_loops stranded_todo open_gates total_stranded

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -376,6 +376,16 @@ CREATE TABLE IF NOT EXISTS tasks (
   handoff_delivered_at    TEXT,
   handoff_stale_pinged_at TEXT,
   handoff_rejected_at     TEXT,
+  -- DIVE-2693: recurring_stall_pinged_at throttles the recurring-instance stall
+  -- sweep to one surface-ping per instance (same shipped_flag_at pattern as
+  -- handoff_stale_pinged_at above). A materialized instance that is never STARTED
+  -- has no handoff_delivered_at, so gap#2's sweep cannot see it — and skip-if-open
+  -- dedup means the template's next slot is suppressed for as long as it sits, so
+  -- one unworked instance silently eats every subsequent occurrence of the beat.
+  -- Measured twice on DIVE-1237 (the OpenAgent drip): DIVE-2026 ate 07-27..07-28,
+  -- DIVE-2403 ate 07-31..08-04. Both recovered cleanly downstream, which is exactly
+  -- what kept the fault quiet.
+  recurring_stall_pinged_at TEXT,
   -- DIVE-891: risk-tiered gates (adopted design DIVE-861). tier is set when the
   -- gate is filed: 0 = auto-clear (rec applies immediately, digest line only),
   -- 1 = agent-clearable + 48h TTL auto-applies the recommendation, 2 = hard
@@ -1082,6 +1092,7 @@ _tasks_db_migrate() {
            'iteration INTEGER' 'maker_agent TEXT' 'handoff_ack_at TEXT' 'task_budget TEXT' \
            'handoff_delivered_at TEXT' 'handoff_stale_pinged_at TEXT' \
            'handoff_rejected_at TEXT' \
+           'recurring_stall_pinged_at TEXT' \
            'tier INTEGER' 'need_asked_at TEXT' 'gate_pinged_at TEXT' 'wake_at TEXT' \
            'gate_filed_by TEXT' \
            'secret_key TEXT' 'connector TEXT' 'secret_oob TEXT' 'human_nonce_hash TEXT' \

--- a/tests/heartbeat_recurring_stall_unit.sh
+++ b/tests/heartbeat_recurring_stall_unit.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# TIER: core
+#
+# DIVE-2693 — the recurring-instance stall sweep's PREDICATE.
+#
+# What this grades and why it is a predicate test rather than an end-to-end one:
+# the sweep's whole value is which rows it selects. Everything after the SELECT is
+# two cmd_send calls and an UPDATE, and booting a heartbeat to observe those costs
+# a registry, a tmux pane and a clock. The selection is the part that can be wrong
+# in a way nobody notices — a stall sweep that silently selects nothing looks
+# exactly like a fleet with no stalls, which is the defect this row exists to fix.
+#
+# THE QUERY IS EXTRACTED FROM THE SOURCE, NOT RETYPED. A retyped copy grades a
+# query that no longer exists the moment someone edits the real one, and it would
+# keep passing while doing so. Same reasoning as tests that derive a table from its
+# call sites instead of pinning a literal.
+set -euo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source.
+# NOTE the absence of `2>/dev/null`. Redirecting the source's stderr would also
+# swallow the helper's own stderr line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+SRC="$ROOT/src/cmd_heartbeat.sh"
+
+PASS=0; FAIL=0
+ok_t()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS+1)); }
+bad_t() { printf 'FAIL - %s\n' "$1"; [ -n "${2:-}" ] && printf '   %s\n' "$2"; FAIL=$((FAIL+1)); }
+
+command -v sqlite3 >/dev/null 2>&1 || { echo "SKIP: sqlite3 not present"; exit 0; }
+
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+DB="$TMP/t.db"
+
+# ---------------------------------------------------------------------------
+# 1. EXTRACT the live predicate. If this fails the test fails loudly rather than
+#    falling back to a hand-copy — a fallback here would silently grade nothing.
+# ---------------------------------------------------------------------------
+QUERY=$(awk '/SELECT t\.id\|\|x.1f.\|\|COALESCE\(t\.ident/,/hours.\);"\)/' "$SRC" \
+        | sed -e 's/^ *//' -e '1s/^.*db "//' -e 's/;")$/;/')
+if [[ -z "$QUERY" || "$QUERY" != *"from_template_id"* ]]; then
+  bad_t "extract the live predicate from $SRC" "awk matched nothing, or the match does not mention from_template_id — the sweep query moved or was renamed; this test is now blind and must be re-anchored, NOT deleted"
+  printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"; exit 1
+fi
+ok_t "the sweep's SELECT is extracted from cmd_heartbeat.sh, not retyped here"
+
+# The threshold is interpolated by the shell in the real caller; bind the default.
+QUERY="${QUERY//\$\{_HB_RECURRING_STALL_HOURS\}/24}"
+case "$QUERY" in
+  *'${'*) bad_t "predicate has no unbound shell expansions left" "still contains \${...}: $QUERY" ;;
+  *)      ok_t  "predicate has no unbound shell expansions left" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 2. Fixture. One row per behaviour, each differing from the SURFACED row in
+#    exactly one column, so a red arm names its own cause.
+# ---------------------------------------------------------------------------
+sqlite3 "$DB" <<'SQL'
+CREATE TABLE tasks (
+  id INTEGER PRIMARY KEY, ident TEXT, title TEXT, status TEXT, assignee TEXT,
+  kind TEXT NOT NULL DEFAULT 'standard', created_at TEXT, started_at TEXT,
+  from_template_id INTEGER, parked_at TEXT, need_type TEXT, need_answered_at TEXT,
+  recurring_stall_pinged_at TEXT, schedule TEXT
+);
+-- the template itself
+INSERT INTO tasks (id,ident,status,kind,schedule,created_at) VALUES
+  (100,'DIVE-1237','todo','recurring','0 4 * * *',datetime('now','-30 days'));
+-- SURFACED: never-started instance, older than the window
+INSERT INTO tasks (id,ident,status,kind,assignee,created_at,from_template_id) VALUES
+  (1,'DIVE-2403','todo','standard','dev',datetime('now','-5 days'),100);
+-- NOT surfaced, one column different each:
+INSERT INTO tasks (id,ident,status,kind,assignee,created_at,from_template_id) VALUES
+  (2,'DIVE-2694','todo','standard','dev',datetime('now','-1 hours'),100);      -- too young
+INSERT INTO tasks (id,ident,status,kind,assignee,created_at,started_at,from_template_id) VALUES
+  (3,'DIVE-2695','todo','standard','dev',datetime('now','-5 days'),datetime('now','-4 days'),100); -- started
+INSERT INTO tasks (id,ident,status,kind,assignee,created_at,from_template_id) VALUES
+  (4,'DIVE-2696','todo','standard','dev',datetime('now','-5 days'),NULL);      -- not from a template
+INSERT INTO tasks (id,ident,status,kind,assignee,created_at,from_template_id,recurring_stall_pinged_at) VALUES
+  (5,'DIVE-2697','todo','standard','dev',datetime('now','-5 days'),100,datetime('now','-1 days')); -- already pinged
+INSERT INTO tasks (id,ident,status,kind,assignee,created_at,from_template_id,parked_at) VALUES
+  (6,'DIVE-2698','todo','standard','dev',datetime('now','-5 days'),100,datetime('now','-2 days')); -- parked
+INSERT INTO tasks (id,ident,status,kind,assignee,created_at,from_template_id,need_type) VALUES
+  (7,'DIVE-2699','todo','standard','dev',datetime('now','-5 days'),100,'decision'); -- open human gate
+INSERT INTO tasks (id,ident,status,kind,assignee,created_at,from_template_id) VALUES
+  (8,'DIVE-2700','done','standard','dev',datetime('now','-5 days'),100);       -- closed
+SQL
+
+run_predicate() { sqlite3 "$DB" "$(printf '%s' "$QUERY")" 2>/dev/null | cut -d$'\x1f' -f2 | sort | tr '\n' ' '; }
+
+GOT=$(run_predicate)
+if [[ "$GOT" == "DIVE-2403 " ]]; then
+  ok_t "surfaces EXACTLY the never-started, over-age recurring instance"
+else
+  bad_t "surfaces EXACTLY the never-started, over-age recurring instance" "got: [$GOT] want: [DIVE-2403 ]"
+fi
+
+# Each exclusion asserted by NAME, so a future predicate that drops one arm reds
+# the arm that owns it rather than one uninformative aggregate.
+for spec in "DIVE-2694:younger than the window" \
+            "DIVE-2695:already started" \
+            "DIVE-2696:not materialized from a template" \
+            "DIVE-2697:already surfaced once (no re-ping)" \
+            "DIVE-2698:parked with a wake date" \
+            "DIVE-2699:blocked on an unanswered human gate" \
+            "DIVE-2700:already closed" \
+            "DIVE-1237:the recurring TEMPLATE itself"; do
+  id="${spec%%:*}"; why="${spec#*:}"
+  case " $GOT " in
+    *" $id "*) bad_t "excludes $id — $why" "it was surfaced; got: [$GOT]" ;;
+    *)         ok_t  "excludes $id — $why" ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# 3. NON-VACUITY. Every exclusion above also passes on a predicate that returns
+#    NOTHING, so they cannot distinguish "correctly filtered" from "broken and
+#    silent". This arm is what makes the eight above mean anything.
+# ---------------------------------------------------------------------------
+if [[ -n "${GOT// /}" ]]; then
+  ok_t "ANCHOR: the predicate returns a non-empty set (the exclusions are not vacuous)"
+else
+  bad_t "ANCHOR: the predicate returns a non-empty set" "empty result — every exclusion arm above is passing for free"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. MUTATION. Drop the started_at conjunct and row 3 must appear. Asserts the
+#    mutation APPLIED before trusting the arm — a no-op mutant is otherwise
+#    indistinguishable from a killed one.
+# ---------------------------------------------------------------------------
+MUT="${QUERY/AND t.started_at IS NULL/}"
+if [[ "$MUT" == "$QUERY" ]]; then
+  bad_t "MUTATION applies: the started_at conjunct is present to remove" "anchor 'AND t.started_at IS NULL' not found — the mutant reverted nothing and this arm graded NOTHING"
+else
+  MGOT=$(sqlite3 "$DB" "$(printf '%s' "$MUT")" 2>/dev/null | cut -d$'\x1f' -f2 | sort | tr '\n' ' ')
+  case " $MGOT " in
+    *" DIVE-2695 "*) ok_t "MUTATION: dropping the started_at conjunct lets the started row through (the conjunct is load-bearing)" ;;
+    *)               bad_t "MUTATION: dropping the started_at conjunct lets the started row through" "got: [$MGOT] — the conjunct is NOT what excludes it, so the real cause is unknown" ;;
+  esac
+fi
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes DIVE-2693.

The DIVE-1416 gap#2 stall sweep keys on `handoff_delivered_at`. A materialized recurring instance that is simply **never picked up** has none — it was never delivered to anyone — so nothing watched it. **The two stall shapes are disjoint, and a query for one cannot see the other.**

That matters more than one late task, because the materializer is **skip-if-open**: while an instance sits open, the template's next slot is suppressed. One unworked instance does not delay a beat, it **deletes every subsequent occurrence** for as long as it sits. Measured twice on `DIVE-1237`: `DIVE-2026` ate 07-27..07-28, `DIVE-2403` ate 07-31..08-04 with nothing shipped in between.

**Why it stayed invisible both times:** the downstream producer's own precondition check absorbs the stall *correctly* — it declines to activate, nothing errors, and the only symptom is a green-looking no-op a day or two later. A fault whose recovery is clean is a fault nobody reports.

## Not keyed to any ident — and that decision paid immediately

The row was filed from two `DIVE-1237` instances. The defect is a property of skip-if-open dedup on **any** template, so the predicate keys on schedule-descent and row state, never an ident list.

**The first dry run against the live board found two stalls nobody had connected to this:**

| instance | template | title | unstarted |
|---|---|---|---|
| `DIVE-2479` | `DIVE-1430` | Daily GH branch/PR hygiene sweep | 4 days |
| `DIVE-2550` | `DIVE-1699` | Daily version loop | 2 days |

Both assigned to `main`. A watchdog hardcoded to `DIVE-1237` would have shipped blind to both.

## Behaviour

Any `kind='standard'` row with `from_template_id`, `status='todo'`, `started_at IS NULL`, unparked, not blocked on an unanswered gate, older than `HEARTBEAT_RECURRING_STALL_HOURS` (default 24). Pings the assignee with the two real exits — start it, or cancel it so the schedule re-fires — and the coordinator with the suppression consequence. Then stamps `recurring_stall_pinged_at`, so it says it once.

One additive nullable column, same migration pattern as every other field on that table.

## Tests

`tests/heartbeat_recurring_stall_unit.sh` — 13 assertions, core, hermetic (temp sqlite, no registry, no clock).

- **The predicate is extracted from `cmd_heartbeat.sh`, not retyped.** A retyped copy grades a query that stops existing the moment someone edits the real one, and keeps passing while it does. If the extraction fails, the test fails loudly rather than falling back to a hand-copy.
- Eight exclusion arms, each differing from the surfaced row in exactly one column, asserted **by name** so a red arm states its own cause.
- **Non-vacuity anchor**: all eight exclusions also pass against a predicate returning nothing, so an explicit arm asserts the result set is non-empty. Without it a silently-broken sweep reads as a clean fleet — which is this row's own failure mode, rebuilt inside its own detector.
- **Mutation arm** that asserts the mutation *applied* before trusting the verdict, so a no-op mutant is distinguishable from a killed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)