### PR TITLE
fix(release): the changelog.d fold's deletions are part of the release commit (DIVE-2700)

### DIFF
--- a/changelog.d/DIVE-2700.md
+++ b/changelog.d/DIVE-2700.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **release-cut could not complete any cut while a `changelog.d` fragment existed.**
+  DIVE-2582 added the fragment fold to the release commit — it merges `changelog.d/*.md`
+  into `CHANGELOG.md` and deletes the fragments — but `grade-release-commit.sh`'s
+  allowed-path set was never extended, so the inheritance premise reported the
+  deletions as paths "OUTSIDE the release-commit set" and refused. The guard was
+  correct; its premise had gone stale. v0.19.0 was the first cut attempted afterwards
+  and it died on 7 fragment deletions. Patch and minor cuts were equally affected, and
+  the pipeline could not drain itself because the fold is what removes the fragments.
+  The drift check that exists to catch exactly this (`grade_release_commit_unit.sh`
+  section 11) missed it: its census matched the literal string `git add -f`, and the
+  new writer is `git add -A -f changelog.d` behind an `if [ -d ]` guard, so it counted
+  4 of 5 writers and reported none unlisted. Both halves are fixed — the path set now
+  admits `changelog.d/*` (entries are globs), and the census matches any `git add`
+  regardless of flag order or guard shape.

--- a/scripts/grade-release-commit.sh
+++ b/scripts/grade-release-commit.sh
@@ -195,6 +195,12 @@ if [[ -n "$PARENT_SHA" && -z "${GRC_FULL_CORPUS:-}" ]]; then
     exit 2
   fi
   _unexpected=()
+  # Split the pattern list ONCE, with `read -ra` rather than unquoted word splitting.
+  # read does IFS splitting and NO pathname expansion, which is the whole point: a bare
+  # `for _allowed in $GRC_DELTA_PATHS` expands globs against the working directory, and
+  # `changelog.d/*` would resolve to the files that SURVIVE the fold instead of staying
+  # a pattern (DIVE-2700).
+  read -ra _allowed_pats <<< "$GRC_DELTA_PATHS"
   while IFS= read -r _p; do
     [[ -n "$_p" ]] || continue
     _ok=0
@@ -202,8 +208,15 @@ if [[ -n "$PARENT_SHA" && -z "${GRC_FULL_CORPUS:-}" ]]; then
     # removes a whole directory of fragments whose names cannot be enumerated ahead of
     # time. The four literal entries carry no glob metacharacters, so this is inert for
     # them and changes only what a pattern entry can express.
+    #
+    # The patterns come from _allowed_pats, split ONCE by `read -ra` above, and are
+    # expanded QUOTED here. Both halves are load-bearing: an unquoted
+    # `for _allowed in $GRC_DELTA_PATHS` would PATHNAME-EXPAND the list against the
+    # working directory, so `changelog.d/*` would silently become whatever files
+    # survive the fold (changelog.d/README.md does) and the pattern would never reach
+    # this comparison at all.
     # shellcheck disable=SC2053  # glob matching is the point here, not an oversight
-    for _allowed in $GRC_DELTA_PATHS; do [[ "$_p" == $_allowed ]] && { _ok=1; break; }; done
+    for _allowed in "${_allowed_pats[@]}"; do [[ "$_p" == $_allowed ]] && { _ok=1; break; }; done
     (( _ok )) || _unexpected+=("$_p")
   done <<< "$_delta"
   if (( ${#_unexpected[@]} > 0 )); then

--- a/scripts/grade-release-commit.sh
+++ b/scripts/grade-release-commit.sh
@@ -108,11 +108,24 @@ TESTS_GLOB="${GRC_TESTS_GLOB:-tests/*.sh}"
 GRC_TAIL="${GRC_TAIL:-25}"
 
 # Paths a release commit is ALLOWED to differ from its parent by. Derived from the
-# DIVE-2091 release-commit block in release-cut.yml, which is the only writer:
-# src/header.sh (the DIVE-2247 version assignment), the built bundle and its
-# checksum, and the DIVE-2452 CHANGELOG stamp. Anything else and the parent's CI no
+# writers in release-cut.yml's release-commit block: src/header.sh (the DIVE-2247
+# version assignment), the built bundle and its checksum, the DIVE-2452 CHANGELOG
+# stamp, and the DIVE-2582 changelog.d fold. Anything else and the parent's CI no
 # longer describes this tree.
-GRC_DELTA_PATHS="${GRC_DELTA_PATHS:-src/header.sh 5dive 5dive.sha256 CHANGELOG.md}"
+#
+# DIVE-2700: this comment said "which is the only writer" and named only the first
+# four for as long as that was true. DIVE-2582 then added a SECOND writer — the fold
+# at release-cut.yml:450 runs fold-changelog-fragments.sh, which DELETES every
+# changelog.d/*.md it folds into CHANGELOG.md, staged at :493 — and nobody extended
+# this list. The first cut attempted afterwards (v0.19.0, run 30885717462) refused
+# with 7 fragment deletions "OUTSIDE the release-commit set", and every cut, patch or
+# minor, would have refused identically for as long as any fragment existed. The guard
+# was right; its premise had gone stale underneath it.
+#
+# ENTRIES ARE GLOB PATTERNS — see the matcher below. Keep this list and the workflow's
+# writers in sync; tests/grade_release_commit_unit.sh section 11 derives the truth from
+# the workflow and reds here at PR time, which is the only reason a human need not.
+GRC_DELTA_PATHS="${GRC_DELTA_PATHS:-src/header.sh 5dive 5dive.sha256 CHANGELOG.md changelog.d/*}"
 # The path whose presence in the delta proves the cut actually did something. Without
 # it the subset assertion above is vacuous.
 GRC_DELTA_REQUIRED="${GRC_DELTA_REQUIRED:-src/header.sh}"
@@ -185,7 +198,12 @@ if [[ -n "$PARENT_SHA" && -z "${GRC_FULL_CORPUS:-}" ]]; then
   while IFS= read -r _p; do
     [[ -n "$_p" ]] || continue
     _ok=0
-    for _allowed in $GRC_DELTA_PATHS; do [[ "$_p" == "$_allowed" ]] && { _ok=1; break; }; done
+    # RHS deliberately UNQUOTED so entries act as GLOB PATTERNS (DIVE-2700): the fold
+    # removes a whole directory of fragments whose names cannot be enumerated ahead of
+    # time. The four literal entries carry no glob metacharacters, so this is inert for
+    # them and changes only what a pattern entry can express.
+    # shellcheck disable=SC2053  # glob matching is the point here, not an oversight
+    for _allowed in $GRC_DELTA_PATHS; do [[ "$_p" == $_allowed ]] && { _ok=1; break; }; done
     (( _ok )) || _unexpected+=("$_p")
   done <<< "$_delta"
   if (( ${#_unexpected[@]} > 0 )); then

--- a/tests/grade_release_commit_unit.sh
+++ b/tests/grade_release_commit_unit.sh
@@ -212,6 +212,40 @@ ok "UNRESOLVABLE-PARENT: a parent git cannot resolve is UNDETERMINED, not an inh
 ok "UNRESOLVABLE-PARENT: says the inheritance is unproven" \
   "grep -q 'unproven' <<<\"\$OUT\" && grep -q 'NOT a pass' <<<\"\$OUT\""
 
+# DIVE-2700: THE FOLD'S DELETIONS ARE PART OF THE RELEASE COMMIT, AND THEY ARE THE
+# ONLY WRITE IN IT THAT REMOVES A PATH. release-cut.yml:450 runs
+# fold-changelog-fragments.sh, which REMOVES every changelog.d/*.md it folds into
+# CHANGELOG.md, and :493 stages that removal with `git add -A -f changelog.d`. The
+# deletions land in the delta, so delta mode must tolerate them or no cut can complete
+# while a single fragment exists — which is exactly how v0.19.0 died (run 30885717462,
+# 7 fragment deletions reported "OUTSIDE the release-commit set").
+#
+# mk_repo cannot express this: it only ADDS paths on top of the parent, and the shape
+# under test is a path present in the PARENT and absent from the RELEASE commit. Built
+# by hand for that reason.
+rm -rf "$T/repo"; mkdir -p "$T/repo/src" "$T/repo/tests" "$T/repo/changelog.d"
+_git init -q 2>/dev/null || git -C "$T/repo" init -q
+printf 'readonly FIVE_VERSION="0.0.0-dev"\n' > "$T/repo/src/header.sh"
+printf 'x\n' > "$T/repo/CHANGELOG.md"
+printf '### fragment\n' > "$T/repo/changelog.d/DIVE-1.md"
+printf '### fragment\n' > "$T/repo/changelog.d/DIVE-2.md"
+_git add -A >/dev/null; _git commit -qm parent
+PARENT=$(_git rev-parse HEAD)
+# The release commit, exactly as the cut builds it: version assigned, CHANGELOG
+# stamped, fragments folded away.
+printf 'readonly FIVE_VERSION="0.17.11"\n' > "$T/repo/src/header.sh"
+printf 'x\nfolded\n' > "$T/repo/CHANGELOG.md"
+rm -f "$T/repo/changelog.d/DIVE-1.md" "$T/repo/changelog.d/DIVE-2.md"
+_git add -A >/dev/null; _git commit -qm release
+repo_bundle 0.17.11; repo_tests 0
+runr 0.17.11 "$PARENT"
+ok "FOLD-DELTA: DELETED changelog.d fragments are inside the release-commit set and grade 0" \
+  "[[ $RC -eq 0 ]]"
+ok "FOLD-DELTA: no fragment is reported as an offending path" \
+  "! grep -q 'OUTSIDE the release-commit set' <<<\"\$OUT\""
+ok "FOLD-DELTA: still INHERITS rather than silently falling back to the full corpus" \
+  "grep -q 'inheriting the parent' <<<\"\$OUT\""
+
 # ---- 7. THE EXPENSIVE PATH IS THE DEFAULT ----
 # Without a parent there is no premise, so there is nothing to inherit. The arm that
 # matters is the COUNT: delta mode would have run 1, the full corpus runs 3.
@@ -322,11 +356,35 @@ ok "SHIPPED-LIST: the excluded main-tree harness is NAMED in it, so its SKIP sho
 # and fail HERE, at PR time, instead.
 _wf="$_repo/.github/workflows/release-cut.yml"
 _pathset=$(GRC_DELTA_PATHS= bash -c '. /dev/stdin <<< "$(sed -n "/^GRC_DELTA_PATHS=/p" "$1")"; echo "$GRC_DELTA_PATHS"' _ "$GRADE" 2>/dev/null)
-# Every pathspec the cut stages, read out of the `git add -f` lines themselves.
-_staged=$(grep -oE '^\s*(if \[ -f [^]]+\]; then )?git add -f [^;|&]+' "$_wf" 2>/dev/null \
-          | sed -E 's/.*git add -f //' | tr ' ' '\n' | sed '/^$/d' | sort -u)
+# Every pathspec the cut stages, read out of the `git add` lines themselves.
+#
+# DIVE-2700 — THIS CENSUS IS WHY THE DRIFT WENT UNNOTICED, and the PARSER is the
+# defect, not the list. It used to require a literal `git add -f ` optionally behind
+# `if [ -f ...]; then`. DIVE-2582 added a fifth writer phrased two ordinary ways the
+# pattern did not admit: `git add -A -f changelog.d` (a flag inserted BETWEEN `add`
+# and `-f`) behind `if [ -d changelog.d ]` (a DIRECTORY test, not a file test). So the
+# census counted 4 of 5 writers and printed "0 unlisted", and this arm was GREEN on
+# the exact commit whose cut refused. A census that silently under-counts prints the
+# same "none" as one that checked everything.
+#
+# Now: match ANY `git add`, then strip the flags whatever their order. Over-matching
+# here is safe — an extra pathspec can only add a drift complaint at PR time, never
+# suppress one.
+_staged=$(grep -oE 'git add [^;|&]+' "$_wf" 2>/dev/null \
+          | sed -E 's/^git add //' \
+          | tr ' ' '\n' | sed -E '/^-/d; /^$/d' | sort -u)
 _drift=(); _sn=0
-for _s in $_staged; do _sn=$((_sn+1)); grep -qw -- "$_s" <<< "$_pathset" || _drift+=("$_s"); done
+for _s in $_staged; do
+  _sn=$((_sn+1))
+  _hit=0
+  # Entries are GLOBS (DIVE-2700), so compare by pattern. `changelog.d` staged as a
+  # DIRECTORY must be recognised by the `changelog.d/*` entry, which a literal
+  # `grep -w` over the pathset would miss.
+  for _a in $_pathset; do
+    [[ "$_s" == $_a || "$_a" == "$_s"/* ]] && { _hit=1; break; }
+  done
+  (( _hit )) || _drift+=("$_s")
+done
 ok "PATHSET: the workflow's release-commit block was found and stages something" \
   "[[ -f \"\$_wf\" && $_sn -gt 0 ]]"
 ok "PATHSET: every path release-cut.yml stages is ALLOWED by GRC_DELTA_PATHS (${_sn} staged, ${#_drift[@]} unlisted: ${_drift[*]:-none})" \

--- a/tests/grade_release_commit_unit.sh
+++ b/tests/grade_release_commit_unit.sh
@@ -229,6 +229,13 @@ printf 'readonly FIVE_VERSION="0.0.0-dev"\n' > "$T/repo/src/header.sh"
 printf 'x\n' > "$T/repo/CHANGELOG.md"
 printf '### fragment\n' > "$T/repo/changelog.d/DIVE-1.md"
 printf '### fragment\n' > "$T/repo/changelog.d/DIVE-2.md"
+# README.md SURVIVES the fold, and that is not decoration — it is the arm's whole
+# point. An earlier version of this fixture left changelog.d/ EMPTY after the fold, so
+# a `changelog.d/*` entry matched nothing on disk, stayed literal through the
+# pattern-list loop, and the arm passed while the real cut still refused. A surviving
+# file is what makes an accidental pathname expansion of the pattern list resolve to
+# something WRONG instead of harmlessly to itself. Real changelog.d/ has this file.
+printf '# fragments go here\n' > "$T/repo/changelog.d/README.md"
 _git add -A >/dev/null; _git commit -qm parent
 PARENT=$(_git rev-parse HEAD)
 # The release commit, exactly as the cut builds it: version assigned, CHANGELOG


### PR DESCRIPTION
**release-cut has been unable to complete any cut since DIVE-2582 merged.** The fold deletes every `changelog.d/*.md` it folds into `CHANGELOG.md`; those deletions land in the release commit's delta; `grade-release-commit.sh`'s `GRC_DELTA_PATHS` never learned about them. The inheritance premise refused with 7 paths "OUTSIDE the release-commit set" and the cut aborted before tagging.

Measured instance: v0.19.0, [run 30885717462](https://github.com/5dive-ai/5dive/actions/runs/30885717462). Every cut — patch or minor — would have failed identically, and the pipeline could not drain itself because the fold is what removes the fragments.

**The guard was right to refuse.** Its premise is that the parent's CI describes this tree, and an unlisted path breaks that. What was stale was the list, and the comment asserting release-cut.yml's block "is the only writer".

## Two fixes, because the second is why nobody caught the first

1. `GRC_DELTA_PATHS` gains `changelog.d/*`, and the matcher's RHS is unquoted so entries work as globs at all. A glob entry could not have matched while the RHS was quoted, and the fragment names cannot be enumerated ahead of time.

2. **The section-11 drift census — which exists precisely to red at PR time when the workflow grows a writer the list does not name — matched the literal `git add -f`.** DIVE-2582's line is `git add -A -f changelog.d` behind `if [ -d changelog.d ]`: a flag inserted mid-command, and a directory test instead of a file test. Neither is unusual; both fell outside the pattern. The census counted **4 of 5 writers** and printed "0 unlisted", so the arm was **green on the exact commit whose cut refused**. It now matches any `git add` and strips flags in any order.

## Grading

| | |
|---|---|
| harness | **58 passed / 0 failed** (was 55/0; census now sees 5 staged, was 4) |
| mutant: drop the `changelog.d` entry | 4 fail |
| mutant: re-quote the matcher RHS | 4 fail |
| pre-fix silent green, reproduced on the real tree at edda7aa | 55/0 with "4 staged, 0 unlisted: none" |
| `shellcheck -S error` | clean |

The new `FOLD-DELTA` arms build the parent/release pair by hand — `mk_repo` only adds paths, and the shape under test is a path present in the parent and absent from the release commit.

DIVE-2700. Found by main while executing lodar's tier-2 tap to cut v0.19.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)