### PR TITLE
fix(tests): close the HARNESS-RC gaps that landed mid-flight, and guard the corpus contract (DIVE-2692)

### DIFF
--- a/tests/account_set_active_provider_model_pin_unit.sh
+++ b/tests/account_set_active_provider_model_pin_unit.sh
@@ -22,6 +22,7 @@
 # written.md, DIVE-2666 addendum, for the full scope correction.
 
 set -uo pipefail
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits).
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \

--- a/tests/actionlint_scan_unit.sh
+++ b/tests/actionlint_scan_unit.sh
@@ -43,6 +43,7 @@ set -uo pipefail
 # so ${BASH_SOURCE[0]} still resolves relative to tests/.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 REPO="$PWD"
 SCAN="$REPO/scripts/actionlint-scan.sh"
@@ -55,7 +56,7 @@ no(){   FAIL=$((FAIL+1)); printf 'NOT OK - %s\n' "$1"; }
 # A skip is NOT a pass. An unavailable precondition must never inflate a green log.
 skip(){ SKIP=$((SKIP+1)); printf 'skip - %s\n' "$1"; }
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 
 [[ -x "$SCAN" ]] || { no "scripts/actionlint-scan.sh is missing or not executable"; printf '\n%s passed, %s failed, %s skipped\n' "$PASS" "$FAIL" "$SKIP"; exit 1; }
 

--- a/tests/actor_claim_corroboration_unit.sh
+++ b/tests/actor_claim_corroboration_unit.sh
@@ -51,6 +51,7 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 PASS=0; FAIL=0; SKIP=0
 ok(){   PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/agent_git_identity_unit.sh
+++ b/tests/agent_git_identity_unit.sh
@@ -24,10 +24,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/agent-git-identity.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 E_GENERIC=1
 warn() { echo "warn: $*" >&2; }

--- a/tests/agent_home_teardown_unit.sh
+++ b/tests/agent_home_teardown_unit.sh
@@ -31,11 +31,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; chmod -R u+rwX "${TMP:-}" 2>/dev/null; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/agent-home-teardown-unit.XXXXXX)"
-trap 'chmod -R u+rwX "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
 
 export AGENT_HOME_ROOT="$TMP/home"
 export REAPED_DIR="$AGENT_HOME_ROOT/.5dive-reaped"

--- a/tests/agent_isolation_unit.sh
+++ b/tests/agent_isolation_unit.sh
@@ -22,11 +22,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/agent-iso-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/agent_list_auth_health_unit.sh
+++ b/tests/agent_list_auth_health_unit.sh
@@ -26,10 +26,10 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; chmod -R u+rwX "${TMP:-}" 2>/dev/null; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/agent-list-auth-health-unit.XXXXXX)"
-trap 'chmod -R u+rwX "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/agent_list_sudo_unit.sh
+++ b/tests/agent_list_sudo_unit.sh
@@ -29,11 +29,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/agent-list-sudo-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/state.sh lib/audit.sh lib/registry.sh; do

--- a/tests/agent_prompt_wait_skip_unit.sh
+++ b/tests/agent_prompt_wait_skip_unit.sh
@@ -19,6 +19,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 SRC="${SRC:-$(cd "$(dirname "$0")/.." && pwd)}"
 pass=0; fail=0
 ok(){ printf '  ok   %s\n' "$1"; pass=$((pass+1)); }

--- a/tests/agent_rm_org_cascade_unit.sh
+++ b/tests/agent_rm_org_cascade_unit.sh
@@ -20,11 +20,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/agent-rm-cascade-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/agent_send_credential_guard_unit.sh
+++ b/tests/agent_send_credential_guard_unit.sh
@@ -48,6 +48,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # Counter shape matches the rest of tests/ on purpose: tests/meta/harness-verdict-probe.sh

--- a/tests/agent_send_wake_unit.sh
+++ b/tests/agent_send_wake_unit.sh
@@ -44,6 +44,7 @@ set -uo pipefail
 # stderr line IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 PASS=0; FAIL=0

--- a/tests/agent_start_cred_seed_unit.sh
+++ b/tests/agent_start_cred_seed_unit.sh
@@ -27,10 +27,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 START=5dive-agent-start
 TMP="$(mktemp -d /tmp/agent-start-seed-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 fail=0
 check() { if [[ "$2" == "$3" ]]; then echo "ok: $1"; else echo "FAIL: $1 (want=$3 got=$2)"; fail=1; fi; }

--- a/tests/agent_sudo_fallback_unit.sh
+++ b/tests/agent_sudo_fallback_unit.sh
@@ -38,11 +38,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/agent-sudo-fallback-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/state.sh lib/audit.sh lib/registry.sh; do

--- a/tests/agent_sudo_grant_unit.sh
+++ b/tests/agent_sudo_grant_unit.sh
@@ -26,11 +26,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/agent-sudo-grant-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/antigravity_auth_finalize_unit.sh
+++ b/tests/antigravity_auth_finalize_unit.sh
@@ -28,6 +28,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
@@ -44,7 +45,6 @@ bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 
 # Sandbox the profile store so we never touch /var/lib/5dive.
 TMP=$(mktemp -d -t agy-finalize.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
 AUTH_PROFILES_DIR="$TMP/auth-profiles"
 
 prof="qaagy"

--- a/tests/ask_capture_grok_inline_unit.sh
+++ b/tests/ask_capture_grok_inline_unit.sh
@@ -47,6 +47,7 @@ set -euo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${W:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # shellcheck disable=SC1091
@@ -67,7 +68,7 @@ ok_() { if (( dirty )); then dirty=0; return; fi; pass=$((pass+1)); echo "  ok: 
 fails=0
 bad() { echo "FAIL: $*" >&2; fails=$((fails+1)); dirty=1; }
 
-W="$(mktemp -d)"; trap 'rm -rf "$W"' EXIT
+W="$(mktemp -d)"
 base="$W/base"; msg="$W/msg"
 # The grok pane's own furniture. Nothing in the extractor may know these strings;
 # they exist so a leak is caught by equality AND by name.

--- a/tests/ask_capture_live_replay.sh
+++ b/tests/ask_capture_live_replay.sh
@@ -48,6 +48,7 @@ set -euo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${W:-}" "${W2:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # shellcheck disable=SC1091
@@ -61,7 +62,7 @@ pass=0
 ok_() { pass=$((pass+1)); echo "  ok: $1"; }
 die() { echo "FAIL: $*" >&2; exit 1; }
 
-W="$(mktemp -d)"; trap 'rm -rf "$W"' EXIT
+W="$(mktemp -d)"
 msg="$W/msg"; acc="$W/acc"; : > "$acc"
 { printf 'CONTEXT LINE 1: filler to push this ask past one screen height so any marker scrolls off an alt-screen pane. '
   printf 'Reply with exactly this token and nothing else: AFTER-AGY-LONG-R2K7 '
@@ -102,7 +103,7 @@ fi
 # replay earlier frames out of order to force the mis-alignment, and require the
 # reply back intact with its relative indentation.
 # ---------------------------------------------------------------------------
-W2="$(mktemp -d)"; trap 'rm -rf "$W" "$W2"' EXIT
+W2="$(mktemp -d)"
 M2=abc12345; acc2="$W2/a"; : > "$acc2"; base2="$W2/b"; msg2="$W2/m"
 printf 'vote please\n' > "$msg2"
 printf '  idle\n──────\n>\n──────\n? for shortcuts   Model X\n' > "$base2"

--- a/tests/ask_capture_unit.sh
+++ b/tests/ask_capture_unit.sh
@@ -52,6 +52,7 @@ set -euo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${WORK:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # shellcheck disable=SC1091
@@ -64,7 +65,6 @@ ok_() { pass=$((pass+1)); echo "  ok: $1"; }
 die() { echo "FAIL: $*" >&2; exit 1; }
 
 WORK="$(mktemp -d)"
-trap 'rm -rf "$WORK"' EXIT
 
 MID="ab12cd34"
 CHROME_NEEDLES=('weekly limit' 'bypass permissions' 'shift+tab' 'esc to interrupt')

--- a/tests/ask_cmd_wiring_unit.sh
+++ b/tests/ask_cmd_wiring_unit.sh
@@ -26,6 +26,7 @@ set -euo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${WORK:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # shellcheck disable=SC1091
@@ -49,7 +50,7 @@ die() { echo "FAIL: $*" >&2; exit 1; }
 # forever and every run times out. (Found in about ten seconds by pointing the
 # new FIVE_ASK_DEBUG_DIR at this very test: the dumped transcript showed the
 # mid-write frame and nothing after it. The instrument works.)
-WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+WORK="$(mktemp -d)"
 FRAME_F="$WORK/frame_n"; echo 0 > "$FRAME_F"
 
 JSON_MODE=0

--- a/tests/audit_nonroot_unit.sh
+++ b/tests/audit_nonroot_unit.sh
@@ -44,10 +44,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/audit-nonroot-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/audit.sh; do

--- a/tests/audit_task_store_classification_unit.sh
+++ b/tests/audit_task_store_classification_unit.sh
@@ -36,6 +36,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 

--- a/tests/audit_task_store_fence_unit.sh
+++ b/tests/audit_task_store_fence_unit.sh
@@ -35,10 +35,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/audit-task-store-fence.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/auth_session_reaper_unit.sh
+++ b/tests/auth_session_reaper_unit.sh
@@ -31,6 +31,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
@@ -47,7 +48,6 @@ bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 
 # Sandbox the session store so we never touch /var/lib/5dive.
 TMP=$(mktemp -d -t auth-reap.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
 AUTH_SESSIONS_DIR="$TMP/auth-sessions"
 mkdir -p "$AUTH_SESSIONS_DIR"
 

--- a/tests/baseline_pin_unit.sh
+++ b/tests/baseline_pin_unit.sh
@@ -70,6 +70,7 @@ set -uo pipefail
 # DIVE-2211: name the tree this harness grades.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 PASS=0; FAIL=0
@@ -77,7 +78,6 @@ ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; [[ -n "${2:-}" ]] && printf '       %s\n' "$2"; return 0; }
 
 TMP="$(mktemp -d /tmp/baseline-pin.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # DIVE-2525: the suite that anchors to pinned commits is no longer run by ONE
 # workflow. unit-tests.yml runs the CORE tier on every PR; full-sweep.yml runs the

--- a/tests/branch_hygiene_unit.sh
+++ b/tests/branch_hygiene_unit.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
 
 cat >"$TMP/gh" <<'MOCK'
 #!/usr/bin/env bash

--- a/tests/broker_surface_unit.sh
+++ b/tests/broker_surface_unit.sh
@@ -40,6 +40,7 @@ set -uo pipefail
   exit 1
 }
 
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PASS=0; FAIL=0
 want() { local n="$1"; shift; if eval "$@"; then echo "  ok   $n"; PASS=$((PASS+1)); else echo "  FAIL $n"; FAIL=$((FAIL+1)); fi; }
@@ -48,7 +49,7 @@ same() { # <name> <expected> <actual>
   else echo "  FAIL $1"; echo "    old: $2"; echo "    new: $3"; FAIL=$((FAIL+1)); fi
 }
 
-TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+TMP=$(mktemp -d)
 
 # ---------------------------------------------------------------- the baseline
 # The pre-INST-5 copies of these functions, renamed so both live in one shell.

--- a/tests/bug_report_pii_allowlist_unit.sh
+++ b/tests/bug_report_pii_allowlist_unit.sh
@@ -18,6 +18,7 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
 SRC=src
 export GH_ORG="5dive-ai"

--- a/tests/build_bundle_self_order_unit.sh
+++ b/tests/build_bundle_self_order_unit.sh
@@ -25,12 +25,12 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; rm -rf "${TMP:-}" "${MUT_BUILD:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 ROOT="$PWD"
 
 TMP="$(mktemp -d /tmp/bundle-order.XXXXXX)"
 MUT_BUILD="$ROOT/.dive2097-mutant-build.sh"
-trap 'rm -rf "$TMP" "$MUT_BUILD"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/builder_gh_rail_unit.sh
+++ b/tests/builder_gh_rail_unit.sh
@@ -37,10 +37,10 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/builder-gh-rail-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 mkdir -p "$TMP/bin"
 

--- a/tests/byo_model_create_unit.sh
+++ b/tests/byo_model_create_unit.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -f "${capture:-}" "${captured_settings:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # shellcheck disable=SC1091
@@ -26,7 +27,6 @@ source src/cmd_agent_create.sh
 
 capture=$(mktemp)
 captured_settings=$(mktemp)
-trap 'rm -f "$capture" "$captured_settings"' EXIT
 step() { :; }
 warn() { printf 'WARN %s\n' "$*" >>"$capture"; }
 profile_set_var() {

--- a/tests/capability_registry_unit.sh
+++ b/tests/capability_registry_unit.sh
@@ -19,8 +19,9 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; rm -rf "${work:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-work=$(mktemp -d); trap 'rm -rf "$work"' EXIT
+work=$(mktemp -d)
 STATE_DIR="$work/state"; mkdir -p "$STATE_DIR"
 export STATE_DIR
 export CAPABILITY_DB="$STATE_DIR/capabilities.json"

--- a/tests/capture_accumulate_unit.sh
+++ b/tests/capture_accumulate_unit.sh
@@ -36,6 +36,7 @@ set -euo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${WORK:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # shellcheck disable=SC1091
@@ -48,7 +49,6 @@ ok_() { pass=$((pass+1)); echo "  ok: $1"; }
 die() { echo "FAIL: $*" >&2; exit 1; }
 
 WORK="$(mktemp -d)"
-trap 'rm -rf "$WORK"' EXIT
 
 MID="a1b2c3d4"          # our marker — minted per-ask by gen_msg_id
 FOREIGN="99887766"      # a third agent's marker, arriving mid-wait

--- a/tests/codex_bin_resolution_unit.sh
+++ b/tests/codex_bin_resolution_unit.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 START="$ROOT/5dive-agent-start"
 
@@ -39,7 +40,6 @@ declare -F newest_node24_bin >/dev/null || fail "could not extract newest_node24
 declare -F resolve_codex     >/dev/null || fail "could not extract resolve_codex"
 
 TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
 
 # Repoint the hardcoded absolute paths at a sandbox so the test never depends on
 # (or is rescued by) the hand-made v24 symlink on the control-plane host.

--- a/tests/codex_install_node24_unit.sh
+++ b/tests/codex_install_node24_unit.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # shellcheck source=../src/header.sh
@@ -135,7 +136,6 @@ echo "PASS: codex locator targets the installing npm's prefix and asserts it res
 # provide, and an unnamed one cannot be told from a rig that is merely broken.
 
 TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
 
 # The PRE-FIX locator, verbatim from before DIVE-2596, so the red anchor grades
 # the shape that actually shipped rather than a paraphrase of it.

--- a/tests/codex_return_channel_unit.sh
+++ b/tests/codex_return_channel_unit.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${tmp:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # shellcheck disable=SC1091
@@ -43,7 +44,6 @@ check "doc interpolates any name"      '[[ "$doc2" == *"# worker7 — standing i
 
 # --- non-destructive + fresh-seed behavior, with primitives stubbed ----------
 tmp=$(mktemp -d)
-trap 'rm -rf "$tmp"' EXIT
 HOME_BASE="$tmp/home"
 # Stub the plumbing so preseed_codex_return_channel writes into $tmp, not /home.
 id() { return 0; }                                   # user "exists"

--- a/tests/company_unit.sh
+++ b/tests/company_unit.sh
@@ -21,11 +21,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/company-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/compose_skill_degraded_unit.sh
+++ b/tests/compose_skill_degraded_unit.sh
@@ -26,6 +26,7 @@
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 set +e
 
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
 SRC="$ROOT/src/cmd_compose.sh"

--- a/tests/constitution_gate_floor_unit.sh
+++ b/tests/constitution_gate_floor_unit.sh
@@ -12,6 +12,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
@@ -22,7 +23,6 @@ for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
 done
 
 TMP="$(mktemp -d /tmp/constitution-floor.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 STATE_DIR="$TMP"
 export FIVEDIVE_CONSTITUTION_FILE="$TMP/constitution.yaml"
 # DIVE-1752: hermetic council seal. cmd_council.sh (sourced above) sets

--- a/tests/constitution_set_e2e.sh
+++ b/tests/constitution_set_e2e.sh
@@ -24,6 +24,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${BASE:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 FIVE="$ROOT/5dive"
 
@@ -42,7 +43,7 @@ if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
   exit 0
 fi
 
-BASE="$(mktemp -d)"; trap 'rm -rf "$BASE"' EXIT
+BASE="$(mktemp -d)"
 pass=0; fail=0
 ok(){ echo "  ok:   $1"; pass=$((pass+1)); }
 no(){ echo "  FAIL: $1"; fail=$((fail+1)); }

--- a/tests/constitution_set_json_e2e.sh
+++ b/tests/constitution_set_json_e2e.sh
@@ -23,6 +23,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${BASE:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 FIVE="$ROOT/5dive"
 
@@ -41,7 +42,7 @@ if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
   exit 0
 fi
 
-BASE="$(mktemp -d)"; trap 'rm -rf "$BASE"' EXIT
+BASE="$(mktemp -d)"
 pass=0; fail=0
 ok(){ echo "  ok:   $1"; pass=$((pass+1)); }
 no(){ echo "  FAIL: $1"; fail=$((fail+1)); }

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -46,12 +46,12 @@ set -uo pipefail
 # `set -e` harness is not killed by a failed source.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TIER_LIB="tests/lib/tier.sh"
 RUNNER="scripts/run-harnesses.sh"
 TMP="$(mktemp -d /tmp/corpus-tier-budget.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 pass=0; fail=0
 ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }

--- a/tests/council_amend_e2e.sh
+++ b/tests/council_amend_e2e.sh
@@ -22,6 +22,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 FIVE="$ROOT/5dive"
 
@@ -36,7 +37,7 @@ if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
   exit 0
 fi
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 export STATE_DIR="$TMP" COUNCIL_MOCK=1 COUNCIL_5DIVE_BIN="$FIVE"
 CFILE="$TMP/constitution.yaml"
 LIN="$TMP/council/lineage.jsonl"

--- a/tests/council_capture_e2e.sh
+++ b/tests/council_capture_e2e.sh
@@ -26,6 +26,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 
 pass=0; fail=0
@@ -36,7 +37,6 @@ command -v node >/dev/null 2>&1 || { echo "SKIP: node not on PATH"; exit 0; }
 command -v jq   >/dev/null 2>&1 || { echo "SKIP: jq not on PATH"; exit 0; }
 
 TMP="$(mktemp -d -t 5dive-1869.XXXXXX)" || { echo "SKIP: mktemp failed"; exit 0; }
-trap 'rm -rf "$TMP"' EXIT
 
 BIN="$TMP/5dive"
 if ! BUILD_OUT="$BIN" ./build.sh >/dev/null 2>&1; then echo "SKIP: could not build a throwaway binary"; exit 0; fi

--- a/tests/council_gate_e2e.sh
+++ b/tests/council_gate_e2e.sh
@@ -24,6 +24,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 FIVE="$ROOT/5dive"
 
@@ -38,7 +39,7 @@ if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
   exit 0
 fi
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 export STATE_DIR="$TMP" TASKS_DB="$TMP/tasks.db" COUNCIL_MOCK=1 COUNCIL_5DIVE_BIN="$FIVE"
 DB="$TASKS_DB"
 pass=0; fail=0

--- a/tests/council_notify_e2e.sh
+++ b/tests/council_notify_e2e.sh
@@ -21,6 +21,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 FIVE="$ROOT/5dive"
 
@@ -35,7 +36,7 @@ if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
   exit 0
 fi
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 export STATE_DIR="$TMP" COUNCIL_MOCK=1
 SINK="$TMP/notify.sink"
 pass=0; fail=0

--- a/tests/council_principal_redaction_unit.sh
+++ b/tests/council_principal_redaction_unit.sh
@@ -18,6 +18,7 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC="$HERE/../src/council/cmd_council.template.sh"
 FAILED=0

--- a/tests/council_record_e2e.sh
+++ b/tests/council_record_e2e.sh
@@ -21,6 +21,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 FIVE="$ROOT/5dive"
 
@@ -35,7 +36,7 @@ if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
   exit 0
 fi
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 export STATE_DIR="$TMP" TASKS_DB="$TMP/tasks.db" FIVEDIVE_PROD_TASKS_DB="$TMP/tasks.db" COUNCIL_5DIVE_BIN="$FIVE"
 mkdir -p "$TMP/council/receipts"
 

--- a/tests/council_roster_lineage_e2e.sh
+++ b/tests/council_roster_lineage_e2e.sh
@@ -22,6 +22,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 FIVE="$ROOT/5dive"
 
@@ -36,7 +37,7 @@ if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
   exit 0
 fi
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 # COUNCIL_5DIVE_BIN pins the nested convene (a motion shells `council convene`) to the BINARY UNDER
 # TEST, not whatever `5dive` is (or isn't) on PATH — CI has no installed 5dive, so a bare `5dive`
 # call would fail the motion convene. Same pattern as council_gate_e2e.sh.

--- a/tests/council_unit.sh
+++ b/tests/council_unit.sh
@@ -16,6 +16,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 
 if ! command -v node >/dev/null 2>&1; then

--- a/tests/council_veto_e2e.sh
+++ b/tests/council_veto_e2e.sh
@@ -24,6 +24,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 FIVE="$ROOT/5dive"
 
@@ -38,7 +39,7 @@ if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
   exit 0
 fi
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 export STATE_DIR="$TMP" COUNCIL_MOCK=1
 SINK="$TMP/nonce.sink"
 pass=0; fail=0

--- a/tests/council_veto_window_unit.sh
+++ b/tests/council_veto_window_unit.sh
@@ -29,6 +29,7 @@ set -uo pipefail
 # swallows the helper's own stderr line, which IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 
 for b in jq sha256sum date sed; do
@@ -38,7 +39,7 @@ SRC="$ROOT/src/cmd_council.sh"
 [[ -r "$SRC" ]] || { echo "SKIP: $SRC not readable"; exit 0; }
 date -u -d "+900 seconds" +%s >/dev/null 2>&1 || { echo "SKIP: GNU date -d not available"; exit 0; }
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 pass=0; fail=0
 ok(){ echo "  ok:   $1"; pass=$((pass+1)); }
 no(){ echo "  FAIL: $1"; fail=$((fail+1)); }

--- a/tests/crashloop_run_loop_unit.sh
+++ b/tests/crashloop_run_loop_unit.sh
@@ -18,10 +18,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/crashloop-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # Source the helper without running its loop.
 _RUN_LOOP_SOURCED=1

--- a/tests/create_channel_list_guards_unit.sh
+++ b/tests/create_channel_list_guards_unit.sh
@@ -21,6 +21,7 @@ set -euo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # shellcheck disable=SC1091

--- a/tests/deploy_unit.sh
+++ b/tests/deploy_unit.sh
@@ -31,11 +31,11 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/deploy-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/digest_autonomy_unit.sh
+++ b/tests/digest_autonomy_unit.sh
@@ -17,10 +17,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/digest-autonomy.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # Extract the embedded python block (between the heredoc markers) verbatim.
 awk "/python3 - >.*<<'PY'/{f=1;next} f&&/^PY\$/{f=0} f" src/cmd_digest.sh > "$TMP/digest.py"

--- a/tests/digest_maker_credit_unit.sh
+++ b/tests/digest_maker_credit_unit.sh
@@ -33,11 +33,11 @@ set -uo pipefail
 # NOTE the absence of `2>/dev/null` — the helper's stderr line IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/digest-maker-credit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/digest_mttu_unit.sh
+++ b/tests/digest_mttu_unit.sh
@@ -19,10 +19,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/digest-mttu.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 awk "/python3 - >.*<<'PY'/{f=1;next} f&&/^PY\$/{f=0} f" src/cmd_digest.sh > "$TMP/digest.py"
 [[ -s "$TMP/digest.py" ]] || { echo "FAIL - could not extract digest python"; exit 1; }

--- a/tests/digest_window_30d_controls.sh
+++ b/tests/digest_window_30d_controls.sh
@@ -39,11 +39,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 REPO="$PWD"
 
 TMP="$(mktemp -d /tmp/digest-30d-ctl.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0; PRECOND=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/digest_window_30d_unit.sh
+++ b/tests/digest_window_30d_unit.sh
@@ -32,10 +32,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/digest-30d.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/dive1762_regression_unit.sh
+++ b/tests/dive1762_regression_unit.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # shellcheck disable=SC1091
@@ -97,7 +98,6 @@ done
 source src/cmd_account.sh
 
 TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
 AUTH_PROFILES_DIR="$TMP/profiles"
 # BYO has no .credentials.json sentinel; stub the auth-path lookup empty so the
 # claude) branch falls back to combined.env for the signedInAt mtime.

--- a/tests/dive1767_regression_unit.sh
+++ b/tests/dive1767_regression_unit.sh
@@ -29,6 +29,7 @@ set -euo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # shellcheck disable=SC1091

--- a/tests/doctor_audit_drop_dir_unit.sh
+++ b/tests/doctor_audit_drop_dir_unit.sh
@@ -8,10 +8,10 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/doctor-audit-drop-dir.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1091
 source src/header.sh

--- a/tests/doctor_marketplace_freshness_unit.sh
+++ b/tests/doctor_marketplace_freshness_unit.sh
@@ -15,10 +15,10 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; chmod -R u+rwX "${TMP:-}" 2>/dev/null; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/doctor-mp-freshness.XXXXXX)"
-trap 'chmod -R u+rwX "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1091
 source src/header.sh

--- a/tests/doctor_reaped_homes_unit.sh
+++ b/tests/doctor_reaped_homes_unit.sh
@@ -9,10 +9,10 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/doctor-reaped-homes.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1091
 source src/header.sh

--- a/tests/env_isolation_unit.sh
+++ b/tests/env_isolation_unit.sh
@@ -47,6 +47,7 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${tmp:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 LIB="tests/lib/env_isolation.sh"
 SEAM="tests/lib/grading_tree.sh"
@@ -118,7 +119,7 @@ out=$(FIVE_VERIFY_DEFAULT=0 bash tests/task_verifier_rail_unit.sh 2>/dev/null | 
 # --- T8: an unreachable helper is its own third state — it must SAY so and must
 #     not kill a `set -e` harness. Same discipline grading_tree.sh applies to
 #     itself; a fix that turns a knob leak into a dead suite is not a fix.
-tmp=$(mktemp -d /tmp/env-iso-unit.XXXXXX); trap 'rm -rf "$tmp"' EXIT
+tmp=$(mktemp -d /tmp/env-iso-unit.XXXXXX)
 mkdir -p "$tmp/lib"; cp "$SEAM" "$tmp/lib/"          # copy the seam WITHOUT the helper
 out=$(set -e; bash -c 'set -e; . '"$tmp"'/lib/grading_tree.sh || printf "fallback\n" >&2; printf STILLALIVE' 2>"$tmp/err"); rc=$?
 [[ $rc -eq 0 && "$out" == "STILLALIVE" ]] \

--- a/tests/env_overrides_report_unit.sh
+++ b/tests/env_overrides_report_unit.sh
@@ -65,6 +65,7 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; chmod -R u+rwX "${TMP:-}" 2>/dev/null; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
@@ -82,7 +83,7 @@ done
 # the missing summary is the only witness. Grade on the summary line, never the tail.
 set +e
 
-TMP="$(mktemp -d /tmp/env-ov-unit.XXXXXX)"; trap 'chmod -R u+rwX "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d /tmp/env-ov-unit.XXXXXX)"
 PASS=0; FAIL=0; SKIP=0
 ok_t()   { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t()  { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }

--- a/tests/env_overrides_unavailable_unit.sh
+++ b/tests/env_overrides_unavailable_unit.sh
@@ -60,6 +60,7 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 # shellcheck source=/dev/null
@@ -71,7 +72,7 @@ done
 # printing oks, no FAIL and NO SUMMARY. (Cost me a run on DIVE-2328.)
 set +e
 
-TMP="$(mktemp -d /tmp/env-ov-unavail.XXXXXX)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d /tmp/env-ov-unavail.XXXXXX)"
 PASS=0; FAIL=0; SKIP=0
 ok_t()   { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t()  { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }

--- a/tests/envelope_divergence_marker_unit.sh
+++ b/tests/envelope_divergence_marker_unit.sh
@@ -49,6 +49,7 @@ set -uo pipefail
 # which IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 PASS=0; FAIL=0

--- a/tests/envelope_sender_fallback_unit.sh
+++ b/tests/envelope_sender_fallback_unit.sh
@@ -31,6 +31,7 @@ set -uo pipefail
 # fifteen ok, no summary, rc=10. 132 sibling harnesses carry this; grade the summary.
 set +e
 
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
 SRC="$ROOT/src/cmd_agent_runtime.sh"

--- a/tests/envelope_tier_provenance_unit.sh
+++ b/tests/envelope_tier_provenance_unit.sh
@@ -48,6 +48,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 PASS=0; FAIL=0
@@ -67,7 +68,7 @@ for fn in registry_read registry_read_checked envelope_tier; do
     || { echo "FAIL: could not extract ${fn} from $SRC (function missing?)"; exit 1; }
 done
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 
 # ---------------------------------------------------------------------------
 # A. envelope_tier(): every path yields a non-empty, self-describing value.

--- a/tests/fold_changelog_fragments_unit.sh
+++ b/tests/fold_changelog_fragments_unit.sh
@@ -12,11 +12,11 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.." || exit 1
 SCRIPT="$(pwd)/scripts/fold-changelog-fragments.sh"
 
 TMP="$(mktemp -d /tmp/fold-changelog-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/gate_actor_path_forgery_unit.sh
+++ b/tests/gate_actor_path_forgery_unit.sh
@@ -38,6 +38,7 @@ set -uo pipefail
 # a naming-blindness defect was itself naming no tree.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${SHIM:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 PASS=0; FAIL=0; SKIP=0
 ok(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
@@ -88,7 +89,6 @@ SHIM=$(mktemp -d)
 # `id -u`, not `id -un`. Dispatching on the flag keeps arms 1-4 byte-identical.
 printf '#!/bin/sh\ncase "$1" in\n  -u) echo 4242 ;;\n  *)  echo agent-lodar ;;\nesac\n' > "$SHIM/id"; chmod +x "$SHIM/id"
 printf '#!/bin/sh\necho agent-lodar:x:0:0:::\n' > "$SHIM/getent"; chmod +x "$SHIM/getent"
-trap 'rm -rf "$SHIM"' EXIT
 
 got_clean=$(_gate_authenticated_actor)
 got_shim=$(PATH="$SHIM:$PATH" _gate_authenticated_actor)

--- a/tests/gate_answer_audit_unit.sh
+++ b/tests/gate_answer_audit_unit.sh
@@ -56,7 +56,7 @@ FAILURES=()
 # next occurrence had nothing to inspect and needed a repro. On failure, keep
 # the dir and dump every captured artifact instead of deleting the evidence.
 cleanup() {
-  local rc=$?
+  local rc="$1"
   if [[ "${FAIL:-0}" -gt 0 || "$rc" -ne 0 ]]; then
     printf '\n=== FAILURE: TMP preserved for inspection: %s ===\n' "$TMP" >&2
     if [[ ${#FAILURES[@]} -gt 0 ]]; then
@@ -72,7 +72,7 @@ cleanup() {
     rm -rf "$TMP"
   fi
 }
-trap cleanup EXIT
+trap 'rc=$?; cleanup "$rc"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: cleanup() used to read $? itself; now takes it as $1 so this wrapper's own `rc=$?` doesn't clobber it before cleanup runs.
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_approval_routing_unit.sh
+++ b/tests/gate_approval_routing_unit.sh
@@ -26,10 +26,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-approval-routing-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_button_retire_unit.sh
+++ b/tests/gate_button_retire_unit.sh
@@ -22,10 +22,10 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP=$(mktemp -d /tmp/gate-button-retire.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_channel_proof_unit.sh
+++ b/tests/gate_channel_proof_unit.sh
@@ -23,10 +23,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-cp-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_channel_session_t2_mutation.sh
+++ b/tests/gate_channel_session_t2_mutation.sh
@@ -35,9 +35,9 @@ set -uo pipefail
 # swallow the helper's own stderr line, which IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 TMP="$(mktemp -d /tmp/gate-cs-mut.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/gate_channel_session_t2_unit.sh
+++ b/tests/gate_channel_session_t2_unit.sh
@@ -28,9 +28,9 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 TMP="$(mktemp -d /tmp/gate-cs-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # The harness sources a COPY of src, and CS_SRC_DIR lets the mutation runner
 # point it at a staged defect without touching the tree. CS_MUTATED is named in

--- a/tests/gate_channelless_escalation_unit.sh
+++ b/tests/gate_channelless_escalation_unit.sh
@@ -26,13 +26,13 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: `--from` is a CLAIM that must corroborate the uid-derived actor,
 # so filing a gate AS dev3 now means DERIVING as dev3. tests/lib/actor_seam.sh.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-chanless.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_class_over_tier_unit.sh
+++ b/tests/gate_class_over_tier_unit.sh
@@ -31,11 +31,11 @@ set -uo pipefail
 # payload, and silently unnames all 210 harnesses at once.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/gate-class-over-tier.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_clear_leads_reader_unit.sh
+++ b/tests/gate_clear_leads_reader_unit.sh
@@ -19,10 +19,10 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-clear-leads-reader.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # STATE_DIR before cmd_council.sh: COUNCIL_DIR/COUNCIL_LINEAGE are source-time globals.
 STATE_DIR="$TMP"

--- a/tests/gate_delivery_actor_unit.sh
+++ b/tests/gate_delivery_actor_unit.sh
@@ -58,10 +58,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-actor-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_delivery_assertion_unit.sh
+++ b/tests/gate_delivery_assertion_unit.sh
@@ -19,10 +19,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP=$(mktemp -d /tmp/gate-delivery-assert.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_delivery_receipt_unit.sh
+++ b/tests/gate_delivery_receipt_unit.sh
@@ -12,10 +12,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP=$(mktemp -d /tmp/gate-delivery.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_enforce_env_bypass_unit.sh
+++ b/tests/gate_enforce_env_bypass_unit.sh
@@ -48,10 +48,10 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-enforce-bypass.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_filer_of_record_unit.sh
+++ b/tests/gate_filer_of_record_unit.sh
@@ -31,13 +31,13 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: `--from` is a CLAIM that must corroborate the uid-derived actor,
 # so filing a gate AS dev3 now means DERIVING as dev3. tests/lib/actor_seam.sh.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-filer-record.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_filer_own_channel_unit.sh
+++ b/tests/gate_filer_own_channel_unit.sh
@@ -30,10 +30,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-filer-own.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_filing_preserves_handoff_unit.sh
+++ b/tests/gate_filing_preserves_handoff_unit.sh
@@ -18,12 +18,12 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 as_agent() { local _w="$1"; shift; ( actor_seam_as "$_w"; "$@" ); }
 SRC=src
 TMP="$(mktemp -d /tmp/gate-handoff-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_floor_branch_name_unit.sh
+++ b/tests/gate_floor_branch_name_unit.sh
@@ -63,10 +63,10 @@ set -uo pipefail
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-floor-branch-name-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_floor_declared_discussion_unit.sh
+++ b/tests/gate_floor_declared_discussion_unit.sh
@@ -48,13 +48,13 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: `--from` is provenance; the TIER and ROUTING decisions read the uid
 # derivation, so an arm impersonating a filer must DERIVE as them.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-discusses-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_floor_provenance_unit.sh
+++ b/tests/gate_floor_provenance_unit.sh
@@ -74,11 +74,11 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 . "$(dirname "${BASH_SOURCE[0]}")/lib/env_isolation.sh" 2>/dev/null || true
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 declare -F _five_env_isolate >/dev/null && _five_env_isolate
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-floor-prov.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_floor_word_boundary_unit.sh
+++ b/tests/gate_floor_word_boundary_unit.sh
@@ -37,10 +37,10 @@ set -uo pipefail
 # helper's own stderr line, which IS the payload (see gate_tier2_floor_unit.sh).
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-floor-boundary-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_history_unit.sh
+++ b/tests/gate_history_unit.sh
@@ -48,10 +48,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-history.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_internal_ops_floor_unit.sh
+++ b/tests/gate_internal_ops_floor_unit.sh
@@ -25,13 +25,13 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: `--from` is provenance; TIER and ROUTING read the uid derivation, so an
 # arm impersonating a filer must DERIVE as them. tests/lib/actor_seam.sh.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-internalops-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_json_envelope_unit.sh
+++ b/tests/gate_json_envelope_unit.sh
@@ -30,10 +30,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-json-env.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_lead_clear_stamp_unit.sh
+++ b/tests/gate_lead_clear_stamp_unit.sh
@@ -44,13 +44,13 @@ set -uo pipefail
 # `set -e` harness is not killed by a failed source.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: `--from` no longer moves the actor — derive as the agent each arm
 # is impersonating. tests/lib/actor_seam.sh.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-lead-clear-stamp.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_lead_standing_unit.sh
+++ b/tests/gate_lead_standing_unit.sh
@@ -32,10 +32,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-lead-standing-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # STATE_DIR must be set BEFORE cmd_council.sh is sourced: its COUNCIL_DIR/COUNCIL_LINEAGE
 # are source-time globals derived from it (they are re-pinned below anyway, belt-and-braces).

--- a/tests/gate_needs_capability_unit.sh
+++ b/tests/gate_needs_capability_unit.sh
@@ -40,13 +40,13 @@
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: `--from` is provenance; TIER/ROUTING read the uid derivation, so an arm
 # impersonating a filer must DERIVE as them. tests/lib/actor_seam.sh.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-needs-capability-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_nonce_unit.sh
+++ b/tests/gate_nonce_unit.sh
@@ -28,10 +28,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-nonce-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_notify_log_observable_unit.sh
+++ b/tests/gate_notify_log_observable_unit.sh
@@ -27,10 +27,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-notify-log-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 source "$SRC/header.sh"

--- a/tests/gate_option_account_frame_unit.sh
+++ b/tests/gate_option_account_frame_unit.sh
@@ -13,10 +13,10 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-option-frame.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_parity_smoke.sh
+++ b/tests/gate_parity_smoke.sh
@@ -36,6 +36,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
@@ -43,7 +44,6 @@ SRC=src
 unset TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID TELEGRAM_TOKEN TELEGRAM_API_ID 2>/dev/null || true
 
 TMP="$(mktemp -d /tmp/gate-parity.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_precedent_unit.sh
+++ b/tests/gate_precedent_unit.sh
@@ -24,10 +24,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-precedent-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_proof_lazy_resolve_unit.sh
+++ b/tests/gate_proof_lazy_resolve_unit.sh
@@ -23,11 +23,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${OLD_STATE:-}" "${NEW_STATE:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 OLD_STATE="$(mktemp -d /tmp/gate-proof-lazy-old.XXXXXX)"
 NEW_STATE="$(mktemp -d /tmp/gate-proof-lazy-new.XXXXXX)"
-trap 'rm -rf "$OLD_STATE" "$NEW_STATE"' EXIT
 
 STATE_DIR="$OLD_STATE"   # the pre-isolation default, same as header.sh's own default at source time
 

--- a/tests/gate_proof_verify_unit.sh
+++ b/tests/gate_proof_verify_unit.sh
@@ -26,10 +26,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-proof-verify-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_route_delivery_unit.sh
+++ b/tests/gate_route_delivery_unit.sh
@@ -38,13 +38,13 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: `--from` is provenance; TIER and ROUTING read the uid derivation, so an
 # arm impersonating a filer must DERIVE as them. tests/lib/actor_seam.sh.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-route-delivery-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_seam_concatenation_unit.sh
+++ b/tests/gate_seam_concatenation_unit.sh
@@ -49,13 +49,13 @@ set -uo pipefail
 # the helper's own stderr line, which IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: `--from` is provenance; TIER/ROUTING read the uid derivation, so an arm
 # impersonating a filer must DERIVE as them. tests/lib/actor_seam.sh.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-seam-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \

--- a/tests/gate_ship_routing_unit.sh
+++ b/tests/gate_ship_routing_unit.sh
@@ -20,13 +20,13 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: identity comes from the uid now; `USER=agent-x` / `--from=x` no longer
 # move it. Impersonate through the sealed seam. tests/lib/actor_seam.sh.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-route-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_subject_state_unit.sh
+++ b/tests/gate_subject_state_unit.sh
@@ -26,11 +26,11 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/gate-subject.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_sudo_uid_forge_unit.sh
+++ b/tests/gate_sudo_uid_forge_unit.sh
@@ -38,10 +38,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-sudo-forge-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_t2_routed_escalate_unit.sh
+++ b/tests/gate_t2_routed_escalate_unit.sh
@@ -25,10 +25,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-t2-routed-escalate-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_telemetry_fence_unit.sh
+++ b/tests/gate_telemetry_fence_unit.sh
@@ -41,10 +41,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-fence-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_tier2_decision_nonce_unit.sh
+++ b/tests/gate_tier2_decision_nonce_unit.sh
@@ -48,7 +48,7 @@ TMP="$(mktemp -d /tmp/gate-t2-decision-nonce.XXXXXX)"
 # the refusal it is meant to name.
 exec 8>&2
 REACHED_END=0
-trap 'rc=$?; if (( ! REACHED_END )); then printf "ABORT - gate_tier2_decision_nonce_unit truncated at rc=%d after %d ok / %d FAIL: an unsubshelled cmd_task_* call exited instead of grading. NOT a pass.\n" "$rc" "${PASS:-0}" "${FAIL:-0}" >&8; fi; rm -rf "$TMP"' EXIT
+trap 'rc=$?; if (( ! REACHED_END )); then printf "ABORT - gate_tier2_decision_nonce_unit truncated at rc=%d after %d ok / %d FAIL: an unsubshelled cmd_task_* call exited instead of grading. NOT a pass.\n" "$rc" "${PASS:-0}" "${FAIL:-0}" >&8; fi; rm -rf "$TMP"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: appends the HARNESS-RC line to this harness's pre-existing abort-backstop trap; trap stays where it was (TMP/REACHED_END/fd8 are all already live by this point) rather than moving to the top.
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_tier2_explicit_pin_unit.sh
+++ b/tests/gate_tier2_explicit_pin_unit.sh
@@ -37,13 +37,13 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: `--from` is provenance; TIER/ROUTING read the uid derivation, so an arm
 # impersonating a filer must DERIVE as them. tests/lib/actor_seam.sh.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/gate-t2pin-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \

--- a/tests/gate_tier2_floor_unit.sh
+++ b/tests/gate_tier2_floor_unit.sh
@@ -24,10 +24,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-tier2-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_tier2_nonce_evidence_unit.sh
+++ b/tests/gate_tier2_nonce_evidence_unit.sh
@@ -22,10 +22,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-1448-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gate_verifier_route_unit.sh
+++ b/tests/gate_verifier_route_unit.sh
@@ -30,7 +30,7 @@ SUMMARY_PRINTED=0
 # kills the shell while that redirect is live, so a trap printing to fd 2 lands in
 # /dev/null and the truncation is silent again. Graded by tests/truncation_marker_guard_unit.sh.
 exec 8>&2
-trap 'rc=$?; rm -rf "$TMP"; [[ "$SUMMARY_PRINTED" == 1 ]] || printf "ABORTED - gate_verifier_route_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8' EXIT
+trap 'rc=$?; rm -rf "$TMP"; [[ "$SUMMARY_PRINTED" == 1 ]] || printf "ABORTED - gate_verifier_route_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: appends the HARNESS-RC line to this harness's pre-existing abort-backstop trap; trap stays where it was (TMP/SUMMARY_PRINTED/fd8 are all already live by this point) rather than moving to the top.
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \

--- a/tests/gate_withdraw_unit.sh
+++ b/tests/gate_withdraw_unit.sh
@@ -34,10 +34,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-withdraw-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gh_actor_routing_unit.sh
+++ b/tests/gh_actor_routing_unit.sh
@@ -22,11 +22,11 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/gh-actor-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/gitattributes_generated_merge_unit.sh
+++ b/tests/gitattributes_generated_merge_unit.sh
@@ -17,6 +17,7 @@
 set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 REPO_ROOT=$PWD
 pass=0; fail=0

--- a/tests/goal_add_unit.sh
+++ b/tests/goal_add_unit.sh
@@ -22,11 +22,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/goal-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/goal_async_unit.sh
+++ b/tests/goal_async_unit.sh
@@ -25,11 +25,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/goal-async-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/grade_release_commit_unit.sh
+++ b/tests/grade_release_commit_unit.sh
@@ -7,6 +7,7 @@
 # "never ran" reproduces that defect one layer down, so every arm below is about
 # keeping those two apart.
 set -uo pipefail
+trap 'rc=$?; rm -rf "${T:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GRADE="${GRADE:-$HERE/../scripts/grade-release-commit.sh}"
 
@@ -18,7 +19,7 @@ GRADE="${GRADE:-$HERE/../scripts/grade-release-commit.sh}"
 pass=0; fail=0
 ok(){ if eval "$2"; then echo "ok   - $1"; pass=$((pass+1)); else echo "FAIL - $1"; fail=$((fail+1)); fi; }
 
-T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
+T=$(mktemp -d)
 
 # A stand-in bundle whose behaviour each arm controls. The real bundle is 53k lines;
 # what is being graded here is the GRADER, so the artifact is stubbed deliberately.

--- a/tests/grading_tree_unit.sh
+++ b/tests/grading_tree_unit.sh
@@ -11,6 +11,7 @@
 # handle -- a clean repo, a dirty repo, a non-repo -- rather than stubbing git.
 # A stubbed observable would make these vacuously green.
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # shellcheck source=lib/grading_tree.sh
@@ -25,7 +26,6 @@ cd "$(dirname "$0")/.."
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
 TMP="$(mktemp -d /tmp/grading-tree.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok()   { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/grok_freeze_guard_unit.sh
+++ b/tests/grok_freeze_guard_unit.sh
@@ -17,6 +17,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.." || exit 1
 SRC="src/cmd_agent_create.sh"
 BIN="./5dive"

--- a/tests/handoff_ack_unit.sh
+++ b/tests/handoff_ack_unit.sh
@@ -14,6 +14,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: identity comes from the uid now — `USER=agent-x` no longer moves it.
 # Impersonate through the sealed seam instead. The subshell keeps each call's
@@ -22,7 +23,6 @@ cd "$(dirname "$0")/.."
 as_agent() { local _w="$1"; shift; ( actor_seam_as "$_w"; "$@" ); }
 SRC=src
 TMP="$(mktemp -d /tmp/handoff-ack-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/harness_rc_corpus_contract_unit.sh
+++ b/tests/harness_rc_corpus_contract_unit.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# DIVE-2692 corpus contract: every harness in tests/*.sh carries the
+# HARNESS-RC EXIT trap (DIVE-2573 landed the mechanism; DIVE-2692 extended it
+# from 13 to the full corpus).
+#
+# WHY THIS EXISTS AT ALL (olivia, reviewing DIVE-2692): the ticket's own body
+# is that DIVE-2573 shipped covering "the 12 graded harnesses" when that 12
+# was a SUBSET, not the corpus — and while DIVE-2692 was in flight, 4 more
+# harnesses landed on origin/main via unrelated PRs, uncovered, which is the
+# exact same shape recurring a third time. A follow-up ticket for the next
+# batch just ages into the next residue the moment one more harness lands.
+# This file converts that unbounded recurring chore into a one-time gate: the
+# next harness that lands without the trap fails THIS check, in CI, on its
+# own PR — not a future ticket someone has to notice is needed.
+#
+# It is a CONTRACT test rather than a run of the corpus (see
+# tests/names_the_tree_contract_unit.sh, the DIVE-2211 sibling this is
+# modeled on) because executing 300+ harnesses to observe one line each costs
+# minutes and would grade the corpus, not the property. The cost is the seam
+# above; the seam is named, not hidden. tests/lib/*.sh is out of scope by
+# construction (the tests/*.sh glob does not reach it) — DIVE-2692's own body
+# argues sourced libraries stay excluded, since a trap or shell option in a
+# sourced file leaks into every caller.
+#
+# Sources src/ nothing at all (no root, no network). Run:
+#   bash tests/harness_rc_corpus_contract_unit.sh
+set -uo pipefail
+trap 'rc=$?; rm -rf "${MUTTMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: this file is itself part of the corpus it enforces; folds in the mutation tempdir cleanup below so a second `trap ... EXIT` doesn't silently replace this one.
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+nok() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+# COULD-NOT-RUN IS ITS OWN BRANCH, and it REFUSES rather than reporting green —
+# a corpus enumeration that silently collapsed is the exact "green suite either
+# way" failure mode this file exists to close off.
+shopt -s nullglob
+CORPUS=(tests/*.sh)
+shopt -u nullglob
+if (( ${#CORPUS[@]} == 0 )); then
+  printf 'FAIL - could not run: tests/*.sh enumerated 0 harnesses; this file asserts nothing\n'
+  exit 1
+fi
+# Floor deliberately far below the real count (300+): a collapse detector, not
+# a pin that has to be bumped on every new harness.
+if (( ${#CORPUS[@]} < 50 )); then
+  printf 'FAIL - could not run: tests/*.sh enumerated only %d harnesses; expected the full corpus\n' "${#CORPUS[@]}"
+  exit 1
+fi
+ok "corpus enumerates ${#CORPUS[@]} harnesses"
+
+# What matters is "a trap that fires on every EXIT and echoes the marker",
+# not one exact spelling. Every author's cleanup differs (rm -rf a tempdir,
+# a named cleanup() with rc threaded through as $1, folding into a
+# pre-existing ABORT-marker trap, ${VAR:-} hardening for set -u, ...) — the
+# invariant is trap ... HARNESS-RC=$rc ... EXIT co-occurring on one line,
+# which is how bash traps are written throughout this corpus.
+RC_RE='trap.*HARNESS-RC=\$rc.*EXIT'
+
+MISSING=()
+for t in "${CORPUS[@]}"; do
+  grep -qE "$RC_RE" "$t" && continue
+  MISSING+=("$t")
+done
+
+if (( ${#MISSING[@]} == 0 )); then
+  ok "every harness in tests/*.sh carries the HARNESS-RC EXIT trap"
+else
+  nok "${#MISSING[@]} harness(es) do not carry the HARNESS-RC EXIT trap:"
+  for m in "${MISSING[@]}"; do printf '       %s\n' "$m"; done
+  printf '\n       FIX -- add, immediately after your set -[e]uo pipefail line (BEFORE any\n'
+  printf '       early SKIP/precondition exit, so that path is covered too):\n\n'
+  printf '           trap '"'"'rc=$?; <fold in any existing cleanup here>; echo "HARNESS-RC=$rc"'"'"' EXIT\n\n'
+  printf '       bash keeps only the LAST trap registered per signal, so an existing\n'
+  printf '       `trap ... EXIT` must be FOLDED into this one line, never left as a second\n'
+  printf '       trap alongside it -- the second registration silently replaces the first.\n'
+  printf '       See tests/names_the_tree_contract_unit.sh for the sibling corpus contract\n'
+  printf '       this file is modeled on, and DIVE-2692 for the full writeup.\n'
+fi
+
+# MUTATION, not just reading the regex: a check that cannot fail proves
+# nothing (this file's own sibling on DIVE-2211 exists partly to name that
+# risk). Stage a throwaway harness missing the trap and confirm THIS FILE's
+# own detector -- run against a corpus of exactly one -- calls it missing;
+# then stage one carrying it and confirm the same detector calls it present.
+# Never touches the real tests/ tree.
+MUTTMP="$(mktemp -d /tmp/harness-rc-contract-mut.XXXXXX)"
+
+printf '#!/usr/bin/env bash\nset -uo pipefail\necho hi\n' > "$MUTTMP/no_trap_unit.sh"
+if grep -qE "$RC_RE" "$MUTTMP/no_trap_unit.sh"; then
+  nok "mutation: a harness with NO trap at all is (wrongly) reported present"
+else
+  ok "mutation: a harness with no trap at all is correctly reported MISSING"
+fi
+
+printf '#!/usr/bin/env bash\nset -uo pipefail\ntrap '"'"'rc=$?; echo "HARNESS-RC=$rc"'"'"' EXIT\necho hi\n' > "$MUTTMP/has_trap_unit.sh"
+if grep -qE "$RC_RE" "$MUTTMP/has_trap_unit.sh"; then
+  ok "mutation: a harness carrying the trap is correctly reported PRESENT (the check can pass, not just fail)"
+else
+  nok "mutation: a harness carrying the trap is (wrongly) reported missing"
+fi
+
+# A trap missing the ECHO (cleanup only, no marker) must still be caught --
+# guards against a detector that fires on the bare word "trap ... EXIT".
+printf '#!/usr/bin/env bash\nset -uo pipefail\ntrap '"'"'rm -rf /tmp/whatever'"'"' EXIT\necho hi\n' > "$MUTTMP/cleanup_only_unit.sh"
+if grep -qE "$RC_RE" "$MUTTMP/cleanup_only_unit.sh"; then
+  nok "mutation: a trap with cleanup but no HARNESS-RC echo is (wrongly) reported present"
+else
+  ok "mutation: a trap with cleanup but no HARNESS-RC echo is correctly reported MISSING"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/harness_rc_corpus_contract_unit.sh
+++ b/tests/harness_rc_corpus_contract_unit.sh
@@ -60,7 +60,20 @@ ok "corpus enumerates ${#CORPUS[@]} harnesses"
 # pre-existing ABORT-marker trap, ${VAR:-} hardening for set -u, ...) — the
 # invariant is trap ... HARNESS-RC=$rc ... EXIT co-occurring on one line,
 # which is how bash traps are written throughout this corpus.
-RC_RE='trap.*HARNESS-RC=\$rc.*EXIT'
+#
+# olivia (reviewing this file at e6524ed): presence-and-reference alone is
+# not enough. `trap 'cleanup; rc=$?; echo "HARNESS-RC=$rc"' EXIT` matches a
+# looser regex here but is the EXACT hazard this ticket hand-fixed in 3 files
+# and threaded through cleanup's own $1 in gate_answer_audit_unit.sh: if
+# cleanup runs (or fails) before `rc=$?` captures the real exit code, $? has
+# already been overwritten by cleanup's own status by the time it's read.
+# Measured: `cleanup(){ :; }; trap 'cleanup; rc=$?; echo HARNESS-RC=$rc' EXIT;
+# exit 7` reports HARNESS-RC=0, not 7. The invariant this regex enforces is
+# therefore narrower than "references $rc somewhere" — it requires `rc=$?` to
+# be the FIRST thing the trap body does, before any cleanup can run and
+# disturb $?. Measured against the pushed tree: rejects 0 of 309 (every
+# current file already opens this way).
+RC_RE='trap .rc=\$\?;.*HARNESS-RC=\$rc.*EXIT'
 
 MISSING=()
 for t in "${CORPUS[@]}"; do
@@ -112,6 +125,26 @@ if grep -qE "$RC_RE" "$MUTTMP/cleanup_only_unit.sh"; then
   nok "mutation: a trap with cleanup but no HARNESS-RC echo is (wrongly) reported present"
 else
   ok "mutation: a trap with cleanup but no HARNESS-RC echo is correctly reported MISSING"
+fi
+
+# THE HAZARDOUS ORDERING (olivia's finding): cleanup BEFORE rc=$? captures the
+# real exit code, so by the time it's read $? has already been overwritten by
+# cleanup's own status. This is a static grep check, but its value is what it
+# discriminates at RUNTIME, so confirm both halves: the static detector must
+# reject the file, AND actually running the hazardous form on a real non-zero
+# exit must misreport 0 -- proving there is a live bug here for the detector
+# to be worth rejecting, not just a shape the regex happens to dislike.
+printf '#!/usr/bin/env bash\nset -uo pipefail\ncleanup() { :; }\ntrap '"'"'cleanup; rc=$?; echo "HARNESS-RC=$rc"'"'"' EXIT\nexit 7\n' > "$MUTTMP/hazardous_order_unit.sh"
+if grep -qE "$RC_RE" "$MUTTMP/hazardous_order_unit.sh"; then
+  nok "mutation: the hazardous cleanup-before-rc ordering is (wrongly) reported present"
+else
+  ok "mutation: the hazardous cleanup-before-rc ordering is correctly reported MISSING"
+fi
+HAZ_OUT="$(bash "$MUTTMP/hazardous_order_unit.sh" 2>&1)"
+if [[ "$HAZ_OUT" == *"HARNESS-RC=0"* ]]; then
+  ok "mutation: the hazardous form is a LIVE bug, not just a disliked shape -- exit 7 misreports as HARNESS-RC=0 at runtime"
+else
+  nok "mutation: expected the hazardous form to misreport rc at runtime (got: $HAZ_OUT) -- the arm above is not grading a real hazard"
 fi
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"

--- a/tests/harness_tree_guard_unit.sh
+++ b/tests/harness_tree_guard_unit.sh
@@ -32,7 +32,7 @@ RE_FILE="$ROOT/tests/lib/grading_tree_source_re.sh"
 
 TMP="$(mktemp -d /tmp/harness-tree-guard-unit.XXXXXX)"
 cleanup() { rm -rf "$TMP"; }
-trap cleanup EXIT
+trap 'rc=$?; cleanup; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path; cleanup() has no $? dependency of its own so wrapping it is safe.
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/harness_verdict_union_unit.sh
+++ b/tests/harness_verdict_union_unit.sh
@@ -26,12 +26,12 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
 UNION="$PWD/tests/meta/harness-verdict-union.sh"
 [[ -x "$UNION" || -r "$UNION" ]] || { printf 'FAIL: %s not found\n' "$UNION"; exit 1; }
 
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/hvu.XXXXXX") || exit 2
-trap 'rm -rf "$TMP"' EXIT
 PASS=0; FAIL=0
 
 ok()   { PASS=$((PASS+1)); printf 'ok   %s\n' "$1"; }

--- a/tests/heartbeat_active_defer_unit.sh
+++ b/tests/heartbeat_active_defer_unit.sh
@@ -23,6 +23,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMPD:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
@@ -44,7 +45,6 @@ REGISTRY_LOCK="$TMPD/registry.lock"
 printf '{"agents":{"dev":{"heartbeat":{"enabled":true}}}}' > "$REGISTRY"
 registry_write() { local tmp; tmp=$(mktemp "${REGISTRY}.XXXXXX"); cat > "$tmp"; mv "$tmp" "$REGISTRY"; }
 with_registry_lock() { local fn="$1"; shift; "$fn" "$@"; }  # no flock/ensure_state in the harness
-trap 'rm -rf "$TMPD"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/heartbeat_dispatcher_claim_unit.sh
+++ b/tests/heartbeat_dispatcher_claim_unit.sh
@@ -42,11 +42,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/hb-dispatch-claim-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/heartbeat_gate_escalate_unit.sh
+++ b/tests/heartbeat_gate_escalate_unit.sh
@@ -18,11 +18,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/hb-gate-esc.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/heartbeat_gate_renag_unit.sh
+++ b/tests/heartbeat_gate_renag_unit.sh
@@ -12,10 +12,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP=$(mktemp -d /tmp/gate-renag.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/heartbeat_gate_shipped_unit.sh
+++ b/tests/heartbeat_gate_shipped_unit.sh
@@ -18,11 +18,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/hb-gate-shipped.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/heartbeat_goal_loop_terminal_unit.sh
+++ b/tests/heartbeat_goal_loop_terminal_unit.sh
@@ -38,11 +38,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/hb-goal-loop.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/heartbeat_idle_marker_unit.sh
+++ b/tests/heartbeat_idle_marker_unit.sh
@@ -21,6 +21,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 

--- a/tests/heartbeat_materialize_recurring_unit.sh
+++ b/tests/heartbeat_materialize_recurring_unit.sh
@@ -23,11 +23,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/hb-materializer-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/heartbeat_pick_unit.sh
+++ b/tests/heartbeat_pick_unit.sh
@@ -20,11 +20,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/hb-pick-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/heartbeat_recall_compile_unit.sh
+++ b/tests/heartbeat_recall_compile_unit.sh
@@ -21,11 +21,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/hb-recall-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/heartbeat_reclaim_verifier_handoff_unit.sh
+++ b/tests/heartbeat_reclaim_verifier_handoff_unit.sh
@@ -33,11 +33,11 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/hb-reclaim-verifier-handoff.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/heartbeat_recurring_stall_unit.sh
+++ b/tests/heartbeat_recurring_stall_unit.sh
@@ -15,6 +15,7 @@
 # keep passing while doing so. Same reasoning as tests that derive a table from its
 # call sites instead of pinning a literal.
 set -euo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry
@@ -35,7 +36,7 @@ bad_t() { printf 'FAIL - %s\n' "$1"; [ -n "${2:-}" ] && printf '   %s\n' "$2"; F
 
 command -v sqlite3 >/dev/null 2>&1 || { echo "SKIP: sqlite3 not present"; exit 0; }
 
-TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+TMP=$(mktemp -d)
 DB="$TMP/t.db"
 
 # ---------------------------------------------------------------------------

--- a/tests/heartbeat_stall_sweep_unit.sh
+++ b/tests/heartbeat_stall_sweep_unit.sh
@@ -26,11 +26,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/hb-stall-sweep.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/heartbeat_tier_guard_unmeasured_unit.sh
+++ b/tests/heartbeat_tier_guard_unmeasured_unit.sh
@@ -67,6 +67,7 @@ set -uo pipefail
 # DIVE-2229: pinned-commit baselines, fail-closed. Same no-2>/dev/null rule.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/pinned_baseline.sh" \
   || printf 'pinned baseline helper: UNRESOLVED (tests/lib/pinned_baseline.sh not reachable)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 PASS=0; FAIL=0; SKIP=0
@@ -92,7 +93,7 @@ done
 eval "$(awk '/^_hb_tier_rank\(\) \{$/ { on=1 } on { print } on && $0 == "}" { exit }' src/cmd_heartbeat.sh)"
 declare -F _hb_tier_rank >/dev/null || { echo "FAIL: could not extract _hb_tier_rank"; exit 1; }
 
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 
 FIXTURE='{"agents":{
   "dev":{"isolation":"admin"},

--- a/tests/heartbeat_usage_heal_unit.sh
+++ b/tests/heartbeat_usage_heal_unit.sh
@@ -24,6 +24,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMPD:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
@@ -49,7 +50,6 @@ printf '%s' '{"agents":{
 }}' > "$REGISTRY"
 registry_write() { local tmp; tmp=$(mktemp "${REGISTRY}.XXXXXX"); cat > "$tmp"; mv "$tmp" "$REGISTRY"; }
 with_registry_lock() { local fn="$1"; shift; "$fn" "$@"; }  # no flock/ensure_state in the harness
-trap 'rm -rf "$TMPD"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/heartbeat_wake_dispatch_unit.sh
+++ b/tests/heartbeat_wake_dispatch_unit.sh
@@ -24,11 +24,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/hb-wakedispatch-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/heartbeat_wake_guard_unit.sh
+++ b/tests/heartbeat_wake_guard_unit.sh
@@ -23,11 +23,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/hb-wakeguard-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/heartbeat_wake_sleep_unit.sh
+++ b/tests/heartbeat_wake_sleep_unit.sh
@@ -24,11 +24,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/hb-wakesleep-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/heredoc_substitution_unit.sh
+++ b/tests/heredoc_substitution_unit.sh
@@ -29,10 +29,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/heredoc-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }

--- a/tests/hermes_openclaw_byo_model_unit.sh
+++ b/tests/hermes_openclaw_byo_model_unit.sh
@@ -15,6 +15,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh cmd_auth.sh cmd_agent_create.sh; do

--- a/tests/hermes_zai_baseurl_unit.sh
+++ b/tests/hermes_zai_baseurl_unit.sh
@@ -19,6 +19,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh cmd_auth.sh cmd_agent_create.sh; do

--- a/tests/hire_market_resolve_unit.sh
+++ b/tests/hire_market_resolve_unit.sh
@@ -22,11 +22,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/hire-market-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do

--- a/tests/hook_staleness_unit.sh
+++ b/tests/hook_staleness_unit.sh
@@ -17,9 +17,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 CHECK="$PWD/scripts/hook-staleness-check.sh"
-TMP="$(mktemp -d /tmp/hook-staleness-unit.XXXXXX)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d /tmp/hook-staleness-unit.XXXXXX)"
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/identity_stub_guard_unit.sh
+++ b/tests/identity_stub_guard_unit.sh
@@ -42,6 +42,7 @@ set -u
 # shellcheck source=/dev/null
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 PASS=0; FAIL=0
@@ -226,7 +227,6 @@ FIX='tests/gate_enforce_env_bypass_unit.sh:127-154 is the in-tree pattern to cop
 # ── A1 positive control: a violating fixture MUST be flagged ──────────────────
 # Without this the whole file could be a no-op that reports a clean corpus.
 TMP="$(mktemp -d /tmp/identity-stub-guard.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 cat > "$TMP/violator_unit.sh" <<'EOF'
 FAKE_CALLER="root"
 id() { if [[ "${1:-}" == -un ]]; then echo "$FAKE_CALLER"; else command id "$@"; fi; }

--- a/tests/inherit_memory_unit.sh
+++ b/tests/inherit_memory_unit.sh
@@ -25,11 +25,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/inherit-mem-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/init_isolation_picker_unit.sh
+++ b/tests/init_isolation_picker_unit.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=../src/cmd_init.sh
 source "$ROOT/src/cmd_init.sh"

--- a/tests/init_pi_unit.sh
+++ b/tests/init_pi_unit.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # cmd_init.sh only defines cmd_init; inspecting its definition lets this test

--- a/tests/init_pick_drain_unit.sh
+++ b/tests/init_pick_drain_unit.sh
@@ -4,6 +4,7 @@
 # submission. This exercises the real interactive (PTY) branch of _init_pick.
 set -euo pipefail
 
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Driver script run *inside* a PTY: source the wizard's helpers, pick via the

--- a/tests/init_run_unit.sh
+++ b/tests/init_run_unit.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 export NO_COLOR=1
 # shellcheck disable=SC1091

--- a/tests/init_ux_unit.sh
+++ b/tests/init_ux_unit.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # Structural coverage: every bounded choice uses the shared picker, all secret

--- a/tests/install_checksum_unit.sh
+++ b/tests/install_checksum_unit.sh
@@ -12,6 +12,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 PASS=0; FAIL=0
 ok_t(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/install_monotonicity_unit.sh
+++ b/tests/install_monotonicity_unit.sh
@@ -20,6 +20,7 @@ set -uo pipefail
 # stderr line, which IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TD:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 PASS=0; FAIL=0
 ok_t(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
@@ -41,7 +42,7 @@ else
   echo; echo "$PASS passed, $FAIL failed"; exit 1
 fi
 
-TD="$(mktemp -d)"; trap 'rm -rf "$TD"' EXIT
+TD="$(mktemp -d)"
 # A "5dive binary" here is only ever grepped for its FIVE_VERSION line, so a
 # one-line stand-in exercises the real read path. `--none--` writes a file that
 # carries no version at all (the unreadable case).

--- a/tests/install_pin_sha_unit.sh
+++ b/tests/install_pin_sha_unit.sh
@@ -28,6 +28,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
 PASS=0; FAIL=0
 ok_t(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/install_update_hint_unit.sh
+++ b/tests/install_update_hint_unit.sh
@@ -14,6 +14,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 1
 PASS=0; FAIL=0
 ok_t(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/ledger_unit.sh
+++ b/tests/ledger_unit.sh
@@ -42,12 +42,12 @@ set -uo pipefail
 # source's stderr also swallows the helper's own line, which IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 command -v sqlite3 >/dev/null 2>&1 || { echo "skip - sqlite3 not available"; exit 0; }
 
 TMP="$(mktemp -d /tmp/ledger-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/local_array_unbound_default_unit.sh
+++ b/tests/local_array_unbound_default_unit.sh
@@ -43,10 +43,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP=$(mktemp -d /tmp/local-array-unbound.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()   { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/loop_batch_unit.sh
+++ b/tests/loop_batch_unit.sh
@@ -21,10 +21,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; [[ -n "${SIMPID:-}" ]] && kill "${SIMPID:-}" 2>/dev/null; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/loop-batch-unit.XXXXXX)"
-trap 'rm -rf "$TMP"; [[ -n "${SIMPID:-}" ]] && kill "$SIMPID" 2>/dev/null' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/loop_ceiling_enforce_unit.sh
+++ b/tests/loop_ceiling_enforce_unit.sh
@@ -15,10 +15,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/loop-ceil-enforce.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \

--- a/tests/loop_control_unit.sh
+++ b/tests/loop_control_unit.sh
@@ -18,10 +18,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/loop-control-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/loop_grade_unit.sh
+++ b/tests/loop_grade_unit.sh
@@ -19,11 +19,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/loop-grade-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/loop_id_collision_unit.sh
+++ b/tests/loop_id_collision_unit.sh
@@ -33,11 +33,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/loop-id-collision.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/loop_panel_unit.sh
+++ b/tests/loop_panel_unit.sh
@@ -21,11 +21,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/loop-panel-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/loop_spawn_unit.sh
+++ b/tests/loop_spawn_unit.sh
@@ -20,12 +20,12 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 # temp state dir we own → mkdir works as a normal user, live db untouched.
 TMP="$(mktemp -d /tmp/loop-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # Source in build.sh order, minus main.sh (we call functions directly).
 # shellcheck disable=SC1090

--- a/tests/loop_spend_not_reached_unit.sh
+++ b/tests/loop_spend_not_reached_unit.sh
@@ -26,10 +26,10 @@ set -uo pipefail
 # NOTE the absence of `2>/dev/null` — the helper's stderr line IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/loop-spend-nr.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \

--- a/tests/loop_status_unit.sh
+++ b/tests/loop_status_unit.sh
@@ -16,10 +16,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/loop-status-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/loop_verify_unit.sh
+++ b/tests/loop_verify_unit.sh
@@ -18,10 +18,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/loop-verify-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/loop_wake_wait_unit.sh
+++ b/tests/loop_wake_wait_unit.sh
@@ -22,11 +22,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/loop-wake-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/managed_settings_reconcile_unit.sh
+++ b/tests/managed_settings_reconcile_unit.sh
@@ -19,6 +19,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 PASS=0; FAIL=0
@@ -26,7 +27,6 @@ ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 
 TMP="$(mktemp -d /tmp/msj-reconcile.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # ---- 1. template ships both 5dive fork channels -----------------------------
 TPL=$(sed -n '/cat > "\$msj" <<.\?MANAGED/,/^MANAGED/p' install.sh)

--- a/tests/managed_settings_selfheal_unit.sh
+++ b/tests/managed_settings_selfheal_unit.sh
@@ -23,6 +23,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 PASS=0; FAIL=0
@@ -32,7 +33,6 @@ bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 command -v jq >/dev/null 2>&1 || { echo "jq required"; exit 1; }
 
 TMP="$(mktemp -d /tmp/msj-selfheal.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # ---- source ONLY the reconcile helper (no other lib deps) --------------------
 HELPER="$(sed -n '/^reconcile_managed_settings() {/,/^}/p' src/lib/agent_setup.sh)"

--- a/tests/memory_doctor_unit.sh
+++ b/tests/memory_doctor_unit.sh
@@ -23,11 +23,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/mem-doctor-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do

--- a/tests/mirror_chunk_label_unit.sh
+++ b/tests/mirror_chunk_label_unit.sh
@@ -18,8 +18,9 @@ set -uo pipefail
 # swallow the helper's own stderr line, which IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+TMP="$(mktemp -d)"
 pass=0; fail=0
 ok()  { printf '  ok   - %s\n' "$1"; pass=$((pass+1)); }
 no()  { printf '  FAIL - %s\n' "$1"; [[ -n "${2:-}" ]] && printf '         %s\n' "$2"; fail=$((fail+1)); }

--- a/tests/model_aliases_unit.sh
+++ b/tests/model_aliases_unit.sh
@@ -19,6 +19,7 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 ROOT=$PWD
 pass=0; fail=0

--- a/tests/names_the_tree_contract_unit.sh
+++ b/tests/names_the_tree_contract_unit.sh
@@ -18,6 +18,7 @@
 # harness anyone adds, and its absence looks exactly like its presence -- a
 # green suite either way.  That is the same wrong-target shape one level up.
 set -uo pipefail
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # shellcheck source=lib/grading_tree.sh

--- a/tests/notify_dryrun_unit.sh
+++ b/tests/notify_dryrun_unit.sh
@@ -16,10 +16,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP=$(mktemp -d /tmp/notify-dryrun.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/objective_preflight_unit.sh
+++ b/tests/objective_preflight_unit.sh
@@ -26,11 +26,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/obj-preflight-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/objective_reconcile_unit.sh
+++ b/tests/objective_reconcile_unit.sh
@@ -23,11 +23,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/obj-reconcile-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/objective_replan_unit.sh
+++ b/tests/objective_replan_unit.sh
@@ -26,11 +26,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/obj-replan-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/objective_status_unit.sh
+++ b/tests/objective_status_unit.sh
@@ -28,11 +28,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/objective-status-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/objective_unit.sh
+++ b/tests/objective_unit.sh
@@ -22,11 +22,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/objective-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/openclaw_init_provider_unit.sh
+++ b/tests/openclaw_init_provider_unit.sh
@@ -15,6 +15,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 for f in src/header.sh src/lib/error_codes.sh src/lib/output.sh src/lib/validation.sh src/cmd_auth.sh; do

--- a/tests/openclaw_runtime_unit.sh
+++ b/tests/openclaw_runtime_unit.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${tmp:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 # shellcheck disable=SC1091
@@ -40,7 +41,6 @@ create_src=$(<src/cmd_agent_create.sh)
 # empty PATH. The launcher cannot resolve its shebang on its own, while the
 # product's explicit-node invocation shape succeeds under the same environment.
 tmp=$(mktemp -d)
-trap 'rm -rf "$tmp"' EXIT
 mkdir -p "$tmp/empty-path"
 printf '%s\n' '#!/usr/bin/env node' 'process.stdout.write("openclaw-ok")' > "$tmp/openclaw"
 chmod +x "$tmp/openclaw"

--- a/tests/openclaw_zai_baseurl_unit.sh
+++ b/tests/openclaw_zai_baseurl_unit.sh
@@ -21,6 +21,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh cmd_auth.sh cmd_agent_create.sh; do

--- a/tests/opencode_init_provider_unit.sh
+++ b/tests/opencode_init_provider_unit.sh
@@ -12,6 +12,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -f "${capture:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 for f in src/header.sh src/lib/error_codes.sh src/lib/output.sh src/lib/validation.sh src/cmd_auth.sh; do
@@ -37,7 +38,6 @@ out=$(opencode_provider_var anthropic 2>/dev/null); rc=$?
   || bad_t "unsupported provider rejection" "rc=$rc out='$out'"
 
 capture=$(mktemp)
-trap 'rm -f "$capture"' EXIT
 require_root() { :; }
 write_default_connector() {
   local file="$1" var="$2" key

--- a/tests/opencode_openrouter_unit.sh
+++ b/tests/opencode_openrouter_unit.sh
@@ -12,6 +12,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -f "${capture:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 for f in src/header.sh src/lib/error_codes.sh src/lib/output.sh src/lib/validation.sh src/cmd_auth.sh; do
@@ -37,7 +38,6 @@ out=$(opencode_provider_var deepseek 2>/dev/null); rc=$?
   || bad_t "unsupported provider rejection" "rc=$rc out='$out'"
 
 capture=$(mktemp)
-trap 'rm -f "$capture"' EXIT
 require_root() { :; }
 step() { :; }
 write_default_connector() {

--- a/tests/org_write_authz_unit.sh
+++ b/tests/org_write_authz_unit.sh
@@ -30,10 +30,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/org-authz-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/pack_agents_md_unit.sh
+++ b/tests/pack_agents_md_unit.sh
@@ -16,11 +16,11 @@ set -uo pipefail
 # redirecting the source's stderr also swallows the helper's own stderr payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/agents-md-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do

--- a/tests/pack_cross_harness_unit.sh
+++ b/tests/pack_cross_harness_unit.sh
@@ -29,11 +29,11 @@ set -uo pipefail
 # source's stderr also swallows the helper's own stderr payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/cross-harness-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do

--- a/tests/pack_disclosure_unit.sh
+++ b/tests/pack_disclosure_unit.sh
@@ -20,11 +20,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/pack-disc-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do

--- a/tests/pack_export_memory_dir_missing_unit.sh
+++ b/tests/pack_export_memory_dir_missing_unit.sh
@@ -27,6 +27,7 @@
 #
 # Run: bash tests/pack_export_memory_dir_missing_unit.sh
 set -uo pipefail
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits).
 
 # DIVE-2211: name the tree this harness grades.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \

--- a/tests/pack_import_model_alias_unit.sh
+++ b/tests/pack_import_model_alias_unit.sh
@@ -16,6 +16,7 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 ROOT=$PWD
 pass=0; fail=0

--- a/tests/pack_memory_leakscan_unit.sh
+++ b/tests/pack_memory_leakscan_unit.sh
@@ -16,11 +16,11 @@ set -uo pipefail
 # stderr line IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/pack-leak-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do
   # shellcheck source=/dev/null

--- a/tests/pack_secret_tripwire_precision_unit.sh
+++ b/tests/pack_secret_tripwire_precision_unit.sh
@@ -25,11 +25,11 @@ set -uo pipefail
 # DIVE-2211: name the tree this harness grades.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/tripwire-precision.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do

--- a/tests/pack_skill_source_roundtrip_unit.sh
+++ b/tests/pack_skill_source_roundtrip_unit.sh
@@ -21,11 +21,11 @@ set -uo pipefail
 # DIVE-2211: name the tree this harness grades.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/skill-source-roundtrip.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # Pin the org so gh_org never probes the network from a unit harness — and so the
 # "default repo" the assertions talk about is a value this file states, not one the

--- a/tests/persona_per_harness_path_unit.sh
+++ b/tests/persona_per_harness_path_unit.sh
@@ -35,6 +35,7 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HEADER="$ROOT/src/header.sh"
 SETUP="$ROOT/src/lib/agent_setup.sh"
@@ -72,7 +73,7 @@ install() {
   command install "${a[@]}"
 }
 
-TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+TMP=$(mktemp -d)
 export PERSONA_HOME_ROOT="$TMP/home"
 WARNLOG="$TMP/warn.log"; : >"$WARNLOG"
 

--- a/tests/pi_auth_provider_unit.sh
+++ b/tests/pi_auth_provider_unit.sh
@@ -24,6 +24,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 

--- a/tests/pi_channel_wiring_unit.sh
+++ b/tests/pi_channel_wiring_unit.sh
@@ -27,6 +27,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 

--- a/tests/pi_install_node24_unit.sh
+++ b/tests/pi_install_node24_unit.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # shellcheck source=../src/header.sh

--- a/tests/pi_signin_badge_unit.sh
+++ b/tests/pi_signin_badge_unit.sh
@@ -17,10 +17,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP=$(mktemp -d /tmp/pi-badge.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh cmd_auth.sh cmd_account.sh; do

--- a/tests/pii_scan_range_unit.sh
+++ b/tests/pii_scan_range_unit.sh
@@ -40,7 +40,7 @@ PII_SCAN_SH="$ROOT/scripts/pii-scan.sh"
 
 TMP="$(mktemp -d /tmp/pii-scan-range-unit.XXXXXX)"
 cleanup() { rm -rf "$TMP"; }
-trap cleanup EXIT
+trap 'rc=$?; cleanup; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path; cleanup() has no $? dependency of its own so wrapping it is safe.
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/policy_refusals_unit.sh
+++ b/tests/policy_refusals_unit.sh
@@ -32,10 +32,10 @@ set -uo pipefail
 # DIVE-2229: pinned-commit baselines, fail-closed. Same no-2>/dev/null rule.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/pinned_baseline.sh" \
   || printf 'pinned baseline helper: UNRESOLVED (tests/lib/pinned_baseline.sh not reachable)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/policy-refusals.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/poller_liveness_unit.sh
+++ b/tests/poller_liveness_unit.sh
@@ -22,6 +22,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 

--- a/tests/profile_seed_perms_unit.sh
+++ b/tests/profile_seed_perms_unit.sh
@@ -17,10 +17,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/profile-seed-perms-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/project_show_graph_unit.sh
+++ b/tests/project_show_graph_unit.sh
@@ -25,11 +25,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/projshow-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/proof_cron_user_unit.sh
+++ b/tests/proof_cron_user_unit.sh
@@ -22,10 +22,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/proof-cron-user.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # --- stub the deps cmd_proof.sh reaches for, then source it ------------------
 E_USAGE=2

--- a/tests/proof_identity_guard_unit.sh
+++ b/tests/proof_identity_guard_unit.sh
@@ -27,10 +27,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/proof-identity.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # --- stub the deps cmd_proof.sh reaches for, then source it ------------------
 E_USAGE=2; E_VALIDATION=3; E_GENERIC=1

--- a/tests/proof_ledger_unit.sh
+++ b/tests/proof_ledger_unit.sh
@@ -30,13 +30,13 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 command -v sqlite3 >/dev/null 2>&1 || { echo "SKIP - sqlite3 absent"; exit 0; }
 command -v jq >/dev/null 2>&1 || { echo "SKIP - jq absent"; exit 0; }
 
 TMP="$(mktemp -d /tmp/proof-ledger.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # --- stub the deps _proof_ledger reaches for, then source cmd_proof.sh -------
 STATE_DIR="$TMP/state"; mkdir -p "$STATE_DIR"

--- a/tests/proof_publish_gate_unit.sh
+++ b/tests/proof_publish_gate_unit.sh
@@ -23,12 +23,12 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 command -v jq >/dev/null 2>&1 || { echo "SKIP - jq absent"; exit 0; }
 
 TMP="$(mktemp -d /tmp/proof-gate.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 STATE_DIR="$TMP/state"; mkdir -p "$STATE_DIR"
 JSON_MODE=0; E_USAGE=2; E_GENERIC=1

--- a/tests/proof_publish_unit.sh
+++ b/tests/proof_publish_unit.sh
@@ -20,10 +20,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/proof-publish.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # Extract the embedded python builder (between the PROOFPY heredoc markers).
 awk "/python3 <<'PROOFPY'/{f=1;next} f&&/^PROOFPY\$/{f=0} f" src/cmd_proof.sh > "$TMP/proof.py"

--- a/tests/proof_scorecard_unit.sh
+++ b/tests/proof_scorecard_unit.sh
@@ -23,10 +23,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/proof-scorecard.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 awk "/python3 <<'SCOREPY'/{f=1;next} f&&/^SCOREPY\$/{f=0} f" src/cmd_proof.sh > "$TMP/score.py"
 [[ -s "$TMP/score.py" ]] || { echo "FAIL - could not extract scorecard python"; exit 1; }

--- a/tests/proof_state_persist_unit.sh
+++ b/tests/proof_state_persist_unit.sh
@@ -35,10 +35,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; chmod -R u+rwX "${TMP:-}" 2>/dev/null; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/proof-state.XXXXXX)"
-trap 'chmod -R u+rwX "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0; SKIP=0
 ok_t()   { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/proof_tick_log_unit.sh
+++ b/tests/proof_tick_log_unit.sh
@@ -30,10 +30,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/proof-tick-log.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 E_USAGE=2
 E_GENERIC=1

--- a/tests/prose_file_flags_unit.sh
+++ b/tests/prose_file_flags_unit.sh
@@ -44,7 +44,7 @@ set -uo pipefail
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/prose-file-flags-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/push_unit.sh
+++ b/tests/push_unit.sh
@@ -30,11 +30,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/push-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/release_cut_assign_unit.sh
+++ b/tests/release_cut_assign_unit.sh
@@ -22,6 +22,7 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WF="$ROOT/.github/workflows/release-cut.yml"
 PASS=0; FAIL=0

--- a/tests/release_cut_bundle_unit.sh
+++ b/tests/release_cut_bundle_unit.sh
@@ -25,6 +25,7 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WF="$ROOT/.github/workflows/release-cut.yml"
 PASS=0; FAIL=0

--- a/tests/release_cut_guards_unit.sh
+++ b/tests/release_cut_guards_unit.sh
@@ -27,6 +27,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${POLLDIR:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 WF=.github/workflows/release-cut.yml
@@ -167,7 +168,6 @@ echo "== DIVE-2466: the guard POLLS instead of refusing on the first look =="
 # function outside the fence: with no stub these would hit the network, and a deleted
 # stub fails loudly rather than quietly grading one look.
 POLLDIR=$(mktemp -d /tmp/relcut-poll.XXXXXX)
-trap 'rm -rf "$POLLDIR"' EXIT
 
 poll_run(){ # $1.. = one check-runs fixture per look ; echoes "<verdict> looks=<n>"
   local i=0 f out rc

--- a/tests/release_notes_unit.sh
+++ b/tests/release_notes_unit.sh
@@ -20,11 +20,11 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.." || exit 1
 SCRIPTS="$(pwd)/scripts"
 
 TMP="$(mktemp -d /tmp/release-notes-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/rollback_rate_unit.sh
+++ b/tests/rollback_rate_unit.sh
@@ -34,10 +34,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/rollback-rate.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/schema_sync_unit.sh
+++ b/tests/schema_sync_unit.sh
@@ -19,6 +19,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 command -v python3 >/dev/null 2>&1 || { echo "skip - python3 not available"; exit 0; }

--- a/tests/secret_drop_unit.sh
+++ b/tests/secret_drop_unit.sh
@@ -21,10 +21,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/secret-drop-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/secret_gate_delivery_path_mutation.sh
+++ b/tests/secret_gate_delivery_path_mutation.sh
@@ -32,9 +32,9 @@ set -uo pipefail
 # swallow the helper's own stderr line, which IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 TMP="$(mktemp -d /tmp/sgdp-mut.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/secret_gate_delivery_path_unit.sh
+++ b/tests/secret_gate_delivery_path_unit.sh
@@ -61,10 +61,10 @@ set -uo pipefail
 # source's stderr also swallows the helper's own line, which IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC="${SGDP_SRC_DIR:-src}"
 TMP="$(mktemp -d /tmp/sgdp-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/self_bundle_evidence_unit.sh
+++ b/tests/self_bundle_evidence_unit.sh
@@ -32,11 +32,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 ROOT="$PWD"
 
 TMP="$(mktemp -d /tmp/self-bundle.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/selfcheck_cred_reached_unit.sh
+++ b/tests/selfcheck_cred_reached_unit.sh
@@ -32,11 +32,11 @@ set -uo pipefail
 # which IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/selfcheck-cred-reached.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/state.sh lib/audit.sh lib/registry.sh; do

--- a/tests/selfcheck_mutation_e2e.sh
+++ b/tests/selfcheck_mutation_e2e.sh
@@ -29,13 +29,13 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
 REPO="$PWD"
 
 command -v sqlite3 >/dev/null 2>&1 || { printf 'skip - sqlite3 absent\n'; exit 0; }
 
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/sc-mut.XXXXXX") || exit 2
-trap 'rm -rf "$TMP"' EXIT
 PASS=0; FAIL=0
 ok_t()   { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 fail_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }

--- a/tests/selfcheck_union_unit.sh
+++ b/tests/selfcheck_union_unit.sh
@@ -21,12 +21,12 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
 UNION="$PWD/tests/meta/selfcheck-union.sh"
 [[ -r "$UNION" ]] || { printf 'FAIL: %s not found\n' "$UNION"; exit 1; }
 
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/scu.XXXXXX") || exit 2
-trap 'rm -rf "$TMP"' EXIT
 PASS=0; FAIL=0
 ok_t()   { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 fail_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }

--- a/tests/selfcheck_unit.sh
+++ b/tests/selfcheck_unit.sh
@@ -26,6 +26,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
 SRC=src
 # shellcheck disable=SC1090
@@ -40,7 +41,6 @@ fail_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
 chk()    { if [[ "$2" == "$3" ]]; then ok_t "$1"; else fail_t "$1 (expected '$2', got '$3')"; fi }
 
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/selfcheck-unit.XXXXXX") || exit 2
-trap 'rm -rf "$TMP"' EXIT
 
 # The fixture table one run answers with. Keyed by probe id.
 declare -A FIX=()

--- a/tests/silent_nonzero_exit_backstop_unit.sh
+++ b/tests/silent_nonzero_exit_backstop_unit.sh
@@ -119,12 +119,12 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 . "$(dirname "${BASH_SOURCE[0]}")/lib/env_isolation.sh" 2>/dev/null || true
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 declare -F _five_env_isolate >/dev/null && _five_env_isolate
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/silent-nonzero-backstop.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/skill_id_traversal_unit.sh
+++ b/tests/skill_id_traversal_unit.sh
@@ -29,6 +29,7 @@
 # re-enables errexit and the first non-zero command substitution kills the file.
 set +e
 
+trap 'rc=$?; rm -rf "$(dirname "${BASE:-}")"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
 SRC="$ROOT/src/cmd_skill.sh"
@@ -53,7 +54,6 @@ FN_IN="$(awk '/^skill_target_within\(\) \{/,/^\}/' "$VSRC")"
 eval "$FN_ID"; eval "$FN_IN"
 
 BASE="$(mktemp -d)/skills"; mkdir -p "$BASE"
-trap 'rm -rf "$(dirname "$BASE")"' EXIT
 
 # --- T1 the NAME check refuses the traversal tokens --------------------------
 for tok in ".." "."; do

--- a/tests/skill_manifest_unit.sh
+++ b/tests/skill_manifest_unit.sh
@@ -45,7 +45,7 @@ SRC="$ROOT/src/cmd_skill.sh"
 
 TMP="$(mktemp -d /tmp/skill-manifest-unit.XXXXXX)"
 cleanup() { rm -rf "$TMP"; }
-trap cleanup EXIT
+trap 'rc=$?; cleanup; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path; cleanup() has no $? dependency of its own so wrapping it is safe.
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/supervisor_classify_unit.sh
+++ b/tests/supervisor_classify_unit.sh
@@ -19,6 +19,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 

--- a/tests/supervisor_unit.sh
+++ b/tests/supervisor_unit.sh
@@ -19,11 +19,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/supervisor-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_answer_cancelled_loop_bounce_mutation.sh
+++ b/tests/task_answer_cancelled_loop_bounce_mutation.sh
@@ -9,9 +9,9 @@ set -uo pipefail
 # shellcheck source=tests/lib/grading_tree.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.." || exit
 TMP="$(mktemp -d /tmp/task-answer-cancelled-loop-bounce-mut.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 mkdir -p "$TMP/tree"
 cp -r src "$TMP/tree/src"
 

--- a/tests/task_answer_cancelled_loop_bounce_unit.sh
+++ b/tests/task_answer_cancelled_loop_bounce_unit.sh
@@ -15,13 +15,13 @@ set -uo pipefail
 # shellcheck source=tests/lib/grading_tree.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.." || exit
 # shellcheck source=tests/lib/actor_seam.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 
 SRC="${DIVE2261_SRC_DIR:-src}"
 TMP="$(mktemp -d /tmp/task-answer-cancelled-loop-bounce.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh \

--- a/tests/task_answer_closed_row_unit.sh
+++ b/tests/task_answer_closed_row_unit.sh
@@ -35,6 +35,7 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
 # the actor — that env path WAS the forgery this ticket closed, and these arms
@@ -53,7 +54,6 @@ fi
 
 SRC=src
 TMP="$(mktemp -d /tmp/task-answer-closed-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh \

--- a/tests/task_block_anchor_unit.sh
+++ b/tests/task_block_anchor_unit.sh
@@ -21,11 +21,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/task-block-anchor.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_cascade_unblock_unit.sh
+++ b/tests/task_cascade_unblock_unit.sh
@@ -22,11 +22,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/task-cascade-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_close_preserves_done_at_unit.sh
+++ b/tests/task_close_preserves_done_at_unit.sh
@@ -33,6 +33,7 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
 # the actor — that env path WAS the forgery this ticket closed, and these arms
@@ -41,7 +42,6 @@ cd "$(dirname "$0")/.."
 
 SRC=src
 TMP="$(mktemp -d /tmp/task-doneat-preserve-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \

--- a/tests/task_core_unit.sh
+++ b/tests/task_core_unit.sh
@@ -20,10 +20,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/task-core-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_deliver_merge_gate_unit.sh
+++ b/tests/task_deliver_merge_gate_unit.sh
@@ -20,10 +20,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/deliver-gate-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # --- stub gh: emits state/mergedAt from env, keyed off the -q '.field' arg. -----
 # DIVE-1935: stub sudo fail-closed. The token resolver's last resort is

--- a/tests/task_deliver_over_closed_result_unit.sh
+++ b/tests/task_deliver_over_closed_result_unit.sh
@@ -35,11 +35,11 @@
 # tasks.db.
 # Run: bash tests/task_deliver_over_closed_result_unit.sh
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/task-deliver-over-closed-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_done_ack_before_merge_gate_unit.sh
+++ b/tests/task_done_ack_before_merge_gate_unit.sh
@@ -23,10 +23,10 @@ set -uo pipefail
 # harnesses for why silencing it would swallow the payload, not just the noise.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/done-ack-before-gate-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # --- stub gh + sudo, same convention as tests/task_deliver_merge_gate_unit.sh ---
 # (fail-closed sudo so the token resolver never reaches a real host credential;

--- a/tests/task_done_delivered_guard_unit.sh
+++ b/tests/task_done_delivered_guard_unit.sh
@@ -24,6 +24,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
 # the actor — that env path WAS the forgery this ticket closed, and these arms
@@ -32,7 +33,6 @@ cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/task-done-delivered-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_done_over_closed_result_unit.sh
+++ b/tests/task_done_over_closed_result_unit.sh
@@ -34,11 +34,11 @@
 # tasks.db.
 # Run: bash tests/task_done_over_closed_result_unit.sh
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/task-done-over-closed-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_fixture_send_guard_unit.sh
+++ b/tests/task_fixture_send_guard_unit.sh
@@ -16,10 +16,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP=$(mktemp -d /tmp/fixture-guard.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_inbox_send_unit.sh
+++ b/tests/task_inbox_send_unit.sh
@@ -13,10 +13,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP=$(mktemp -d /tmp/inbox-send.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_merge_gate_ancestry_unit.sh
+++ b/tests/task_merge_gate_ancestry_unit.sh
@@ -64,10 +64,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-ancestry-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # --- stub gh. Three surfaces matter here:
 #   `api repos/<slug>/compare/<base>...<head>` -> GH_STUB_CMP_<REPO>_<HEAD> (JSON).

--- a/tests/task_merge_gate_autodetect_unit.sh
+++ b/tests/task_merge_gate_autodetect_unit.sh
@@ -21,10 +21,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-autodetect-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # --- stub gh: answers `pr list` from env-driven fixtures, records argv. --------
 # DIVE-1935: stub sudo fail-closed. The token resolver's last resort is

--- a/tests/task_merge_gate_branch_in_result_unit.sh
+++ b/tests/task_merge_gate_branch_in_result_unit.sh
@@ -30,10 +30,10 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-branch-in-result-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 mkdir -p "$TMP/bin"
 cat >"$TMP/bin/gh" <<'STUB'

--- a/tests/task_merge_gate_delivered_vs_cited_unit.sh
+++ b/tests/task_merge_gate_delivered_vs_cited_unit.sh
@@ -44,10 +44,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-delivered-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # Repo-aware gh stub, identical in shape to the DIVE-1955 harness: a PR number
 # exists in a specific repo, never in the abstract.

--- a/tests/task_merge_gate_diagnostic_unit.sh
+++ b/tests/task_merge_gate_diagnostic_unit.sh
@@ -45,10 +45,10 @@ set -uo pipefail
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-diagnostic-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 mkdir -p "$TMP/bin"
 
 # --- stub sudo (DIVE-1935 resolution order): the token resolver's last resort is

--- a/tests/task_merge_gate_gh_resolve_unit.sh
+++ b/tests/task_merge_gate_gh_resolve_unit.sh
@@ -22,10 +22,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-gh-resolve-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # --- stub sudo (DIVE-1935): the resolver's last resort is
 # `sudo -n -u claude gh auth token`, and real sudo resets PATH to secure_path — so

--- a/tests/task_merge_gate_inferred_repo_unit.sh
+++ b/tests/task_merge_gate_inferred_repo_unit.sh
@@ -42,10 +42,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-inferred-repo-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # Repo-aware gh stub, same contract as tests/task_merge_gate_multirepo_unit.sh: a PR
 # number exists in a SPECIFIC repo, never in the abstract, so a stub that ignores

--- a/tests/task_merge_gate_multirepo_unit.sh
+++ b/tests/task_merge_gate_multirepo_unit.sh
@@ -39,10 +39,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-multirepo-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # --- stub gh. REPO-AWARE, which is the whole point: a PR number exists in a
 # specific repo, never in the abstract. `GH_STUB_PR_<REPO>_<n>` is the fixture for

--- a/tests/task_merge_gate_repo_scope_unit.sh
+++ b/tests/task_merge_gate_repo_scope_unit.sh
@@ -13,6 +13,7 @@
 #      the drift in property 1, so a change that widens the list while dropping the
 #      disclosure has not kept this file green.
 set -uo pipefail
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC="${SRC:-$HERE/../src}"
 

--- a/tests/task_merge_gate_result_pr_unit.sh
+++ b/tests/task_merge_gate_result_pr_unit.sh
@@ -27,10 +27,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-resultpr-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # --- stub gh: `pr view` answers per-PR fixtures from GH_STUB_PR_<n>, `pr list`
 # answers the repo-wide scan, `auth token` answers token resolution. A PR with no

--- a/tests/task_need_t0_auto_unit.sh
+++ b/tests/task_need_t0_auto_unit.sh
@@ -24,10 +24,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/task-need-t0-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_park_gate_guard_unit.sh
+++ b/tests/task_park_gate_guard_unit.sh
@@ -21,10 +21,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/park-gate-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_reject_actor_and_closed_unit.sh
+++ b/tests/task_reject_actor_and_closed_unit.sh
@@ -26,6 +26,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
 # the actor — that env path WAS the forgery this ticket closed, and these arms
@@ -34,7 +35,6 @@ cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/task-reject-actor-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_set_body_unit.sh
+++ b/tests/task_set_body_unit.sh
@@ -16,10 +16,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/task-set-body-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_set_branch_unit.sh
+++ b/tests/task_set_branch_unit.sh
@@ -17,10 +17,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/task-set-branch-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_start_closed_unit.sh
+++ b/tests/task_start_closed_unit.sh
@@ -30,9 +30,9 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 SRC="${SRC:-src}"
 TMP="$(mktemp -d /tmp/task-start-closed.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_start_delivered_guard_unit.sh
+++ b/tests/task_start_delivered_guard_unit.sh
@@ -52,6 +52,7 @@ set -uo pipefail
 # which IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
 # the actor — that env path WAS the forgery this ticket closed, and these arms
@@ -59,7 +60,6 @@ cd "$(dirname "$0")/.."
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/task-start-delivered-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_start_recurring_guard_unit.sh
+++ b/tests/task_start_recurring_guard_unit.sh
@@ -22,10 +22,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/start-recurring-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_verifier_rail_unit.sh
+++ b/tests/task_verifier_rail_unit.sh
@@ -29,6 +29,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
 # the actor — that env path WAS the forgery this ticket closed, and these arms
@@ -36,7 +37,6 @@ cd "$(dirname "$0")/.."
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
 TMP="$(mktemp -d /tmp/task-verifier-rail-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_verify_over_closed_unit.sh
+++ b/tests/task_verify_over_closed_unit.sh
@@ -29,6 +29,7 @@
 # tasks.db. Actor is forced per-case via FIVE_SENDER/USER rather than sudo.
 # Run: bash tests/task_verify_over_closed_unit.sh
 set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: `USER=agent-x` no longer moves the actor; derive as them instead.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
@@ -36,7 +37,6 @@ as_agent() { local _w="$1"; shift; ( actor_seam_as "$_w"; "$@" ); }
 SRC=src
 
 TMP="$(mktemp -d /tmp/task-verify-closed-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/task_verify_self_close_visibility_unit.sh
+++ b/tests/task_verify_self_close_visibility_unit.sh
@@ -17,10 +17,10 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/task-verify-self-close-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/tasks_db_restore_guard_unit.sh
+++ b/tests/tasks_db_restore_guard_unit.sh
@@ -24,6 +24,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; for t in "${TREES[@]}"; do rm -rf "${t:-}"; done; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
@@ -49,7 +50,6 @@ fresh_tree() {
   TREES+=("$TMP")
 }
 TREES=()
-trap 'for t in "${TREES[@]}"; do rm -rf "$t"; done' EXIT
 
 # Emulate 5dive-tasks-backup.sh: snapshot the (non-empty) live db into tasks-backups.
 snapshot() {

--- a/tests/tasks_store_fence_unit.sh
+++ b/tests/tasks_store_fence_unit.sh
@@ -30,7 +30,7 @@ SUMMARY_PRINTED=0
 # kills the shell while that redirect is live, so a trap printing to fd 2 lands in
 # /dev/null and the truncation is silent again. Graded by tests/truncation_marker_guard_unit.sh.
 exec 8>&2
-trap 'rc=$?; rm -rf "$TMP" "$PWD/tests/.dive2249-mutant.sh"; [[ "$SUMMARY_PRINTED" == 1 ]] || printf "ABORTED - tasks_store_fence_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8' EXIT
+trap 'rc=$?; rm -rf "$TMP" "$PWD/tests/.dive2249-mutant.sh"; [[ "$SUMMARY_PRINTED" == 1 ]] || printf "ABORTED - tasks_store_fence_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: appends the HARNESS-RC line to this harness's pre-existing abort-backstop trap; trap stays where it was (TMP/SUMMARY_PRINTED/fd8 are all already live by this point) rather than moving to the top.
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/truncation_marker_guard_unit.sh
+++ b/tests/truncation_marker_guard_unit.sh
@@ -25,9 +25,9 @@ set -uo pipefail
 # swallow the helper's own stderr line, which IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 TMP="$(mktemp -d /tmp/truncation-marker-guard.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/type_install_gate_dimension_unit.sh
+++ b/tests/type_install_gate_dimension_unit.sh
@@ -34,6 +34,7 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=../src/header.sh
 source "$ROOT/src/header.sh"

--- a/tests/type_map_registration_contract_unit.sh
+++ b/tests/type_map_registration_contract_unit.sh
@@ -25,6 +25,7 @@ set -uo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HEADER="$ROOT/src/header.sh"
 

--- a/tests/unguarded_probe_substitution_unit.sh
+++ b/tests/unguarded_probe_substitution_unit.sh
@@ -28,11 +28,11 @@ set -uo pipefail
 # DIVE-2211: name the tree this harness grades.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.." || exit 2
 ROOT="$PWD"
 SCAN="$ROOT/scripts/unguarded-probe-scan.sh"
 TMP="$(mktemp -d /tmp/unguarded-probe.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/update_check_propagation_unit.sh
+++ b/tests/update_check_propagation_unit.sh
@@ -27,6 +27,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${FIX:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 1
 PASS=0; FAIL=0
 ok_t(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
@@ -49,7 +50,7 @@ fi
 # ---------------------------------------------------------------- fixtures --
 # Two real bundles a release apart, and the REAL sha256 of each. Serving
 # bundle-old beside sum-new is the exact split the CDN produced on 2026-07-26.
-FIX="$(mktemp -d)"; trap 'rm -rf "$FIX"' EXIT
+FIX="$(mktemp -d)"
 printf '#!/usr/bin/env bash\nreadonly FIVE_VERSION="0.15.34"\n' > "$FIX/bundle-old"
 printf '#!/usr/bin/env bash\nreadonly FIVE_VERSION="0.15.35"\n' > "$FIX/bundle-new"
 printf '#!/usr/bin/env bash\n# a bundle with no version line\n'  > "$FIX/bundle-nover"

--- a/tests/usage_coverage_unit.sh
+++ b/tests/usage_coverage_unit.sh
@@ -29,10 +29,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; chmod -R u+rwX "${TMP:-}" 2>/dev/null; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 TMP="$(mktemp -d /tmp/usage-coverage.XXXXXX)"
-trap 'chmod -R u+rwX "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
 
 # Drive the collector's python directly, same seam the scorecard unit uses.
 awk "/python3 - <<'PY'/{f=1;next} f&&/^PY\$/{f=0} f" src/cmd_usage.sh > "$TMP/collect.py"

--- a/tests/usage_dispatch_flag_unit.sh
+++ b/tests/usage_dispatch_flag_unit.sh
@@ -74,7 +74,7 @@ HOMEDIR="$USAGE_HOME_ROOT/agent-$AGENT"
 PROJDIR="$HOMEDIR/.claude/projects/dive2058-unittest-$$"
 mkdir -p "$PROJDIR"
 cleanup() { rm -rf "$TMP"; }
-trap cleanup EXIT
+trap 'rc=$?; cleanup; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path; cleanup() has no $? dependency of its own so wrapping it is safe.
 
 STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
 REGISTRY="$TMP/registry.json"

--- a/tests/usage_presenter_coverage_unit.sh
+++ b/tests/usage_presenter_coverage_unit.sh
@@ -39,11 +39,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 
 SRC_DIR="${USAGE_SRC_DIR:-src}"
 TMP="$(mktemp -d /tmp/usage-presenter.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/verifier_gate_ack_unit.sh
+++ b/tests/verifier_gate_ack_unit.sh
@@ -37,6 +37,7 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: impersonate through the SEALED seam. `USER=agent-x` no longer moves
 # the actor — that env path WAS the forgery this ticket closed, and these arms
@@ -45,7 +46,6 @@ cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/verifier-gate-ack.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/verify_tripwire_unit.sh
+++ b/tests/verify_tripwire_unit.sh
@@ -20,11 +20,11 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 
 TMP="$(mktemp -d /tmp/verify-tripwire-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \

--- a/tests/version_bump_guard_unit.sh
+++ b/tests/version_bump_guard_unit.sh
@@ -34,7 +34,7 @@ UNIQ_SCAN="$ROOT/scripts/version-uniqueness-scan.sh"
 
 TMP="$(mktemp -d /tmp/version-bump-guard-unit.XXXXXX)"
 cleanup() { rm -rf "$TMP"; }
-trap cleanup EXIT
+trap 'rc=$?; cleanup; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path; cleanup() has no $? dependency of its own so wrapping it is safe.
 
 PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/version_freeze_observer_unit.sh
+++ b/tests/version_freeze_observer_unit.sh
@@ -20,6 +20,7 @@ set -uo pipefail
 # stderr line IS the payload, and silencing it silenced 210 harnesses at once.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${WORK:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 1
 PASS=0; FAIL=0
 ok_t(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
@@ -34,7 +35,7 @@ else
   echo; echo "$PASS passed, $FAIL failed"; exit 1
 fi
 
-WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+WORK="$(mktemp -d)"
 DAY=86400
 NOW=1753800000   # fixed epoch; never `date +%s` — a wall-clock test is not a test
 

--- a/tests/welcome_403_nudge_unit.sh
+++ b/tests/welcome_403_nudge_unit.sh
@@ -16,10 +16,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP=$(mktemp -d /tmp/welcome-403.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh cmd_agent_pairing.sh; do

--- a/tests/welcome_isolation_unit.sh
+++ b/tests/welcome_isolation_unit.sh
@@ -15,10 +15,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP=$(mktemp -d /tmp/welcome-iso.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh cmd_agent_pairing.sh; do

--- a/tests/whoami_for_chain_unit.sh
+++ b/tests/whoami_for_chain_unit.sh
@@ -39,7 +39,7 @@ cd "$(dirname "$0")/.."
 
 SRC=src
 TMP="$(mktemp -d /tmp/whoami-for-chain-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \

--- a/tests/whoami_sealed_actor_unit.sh
+++ b/tests/whoami_sealed_actor_unit.sh
@@ -38,6 +38,7 @@ set -uo pipefail
 # IS the payload.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 PASS=0; FAIL=0; SKIP=0
 ok(){   PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }

--- a/tests/worktree_reclaim_unit.sh
+++ b/tests/worktree_reclaim_unit.sh
@@ -19,10 +19,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/wt-reclaim-unit.XXXXXX)"
-trap 'rm -rf "$TMP"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \


### PR DESCRIPTION
DIVE-2573 landed the HARNESS-RC mechanism on 12 of 301 harnesses. This extends it to the rest and adds the guard that stops the gap reopening.

## What is in it

- The four HARNESS-RC gaps that landed **mid-flight** while DIVE-2573 was in review — including `tests/pack_export_memory_dir_missing_unit.sh`, which merged as part of DIVE-2680 (#452) an hour ago and arrived without the trap.
- A **corpus-contract guard**, so a new harness cannot land without the trap again. This is the part that matters: the gap did not come from carelessness, it came from harnesses being written in parallel with the mechanism, and only a contract check catches that class.
- The trap-ordering tightening: `rc=$?` must be **first** in the trap body. Anything before it clobbers `$?` and the harness reports `HARNESS-RC=0` while exiting non-zero — the exact silent-success shape the mechanism exists to prevent.

## Verification

Graded firsthand by **olivia**, not taken from the maker's report:

| | |
|---|---|
| corpus coverage | **309/309** |
| corpus-contract guard | **7/7** |
| the load-bearing arm | runs the hazardous trap ordering on **exit 7** and proves it misreports `HARNESS-RC=0` |
| branch position | **0 commits behind main** — clean fast-forward |

That last arm is why the guard is not vacuous: it demonstrates the failure it forbids, rather than only asserting the correct form.

Maker dev2. Verified by olivia. Opened by main because dev2's installed CLI (0.18.6) predates `--open-pr` (DIVE-2605) — the same constraint as DIVE-2680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)