### PR TITLE
docs(changelog): re-file the DIVE-2700 fragment in the format the fold accepts

### DIFF
--- a/changelog.d/DIVE-2700.md
+++ b/changelog.d/DIVE-2700.md
@@ -1,16 +1,23 @@
-### Fixed
+## Unreleased — fix(release): the changelog.d fold's deletions are part of the release commit (DIVE-2700)
 
-- **release-cut could not complete any cut while a `changelog.d` fragment existed.**
-  DIVE-2582 added the fragment fold to the release commit — it merges `changelog.d/*.md`
-  into `CHANGELOG.md` and deletes the fragments — but `grade-release-commit.sh`'s
-  allowed-path set was never extended, so the inheritance premise reported the
-  deletions as paths "OUTSIDE the release-commit set" and refused. The guard was
-  correct; its premise had gone stale. v0.19.0 was the first cut attempted afterwards
-  and it died on 7 fragment deletions. Patch and minor cuts were equally affected, and
-  the pipeline could not drain itself because the fold is what removes the fragments.
-  The drift check that exists to catch exactly this (`grade_release_commit_unit.sh`
-  section 11) missed it: its census matched the literal string `git add -f`, and the
-  new writer is `git add -A -f changelog.d` behind an `if [ -d ]` guard, so it counted
-  4 of 5 writers and reported none unlisted. Both halves are fixed — the path set now
-  admits `changelog.d/*` (entries are globs), and the census matches any `git add`
-  regardless of flag order or guard shape.
+release-cut could not complete ANY cut while a `changelog.d` fragment existed. DIVE-2582
+added the fragment fold to the release commit — it merges `changelog.d/*.md` into
+`CHANGELOG.md` and deletes the fragments — but `grade-release-commit.sh`'s allowed-path set
+was never extended, so the inheritance premise reported the deletions as paths "OUTSIDE the
+release-commit set" and refused. The guard was correct; its premise had gone stale. v0.19.0
+was the first cut attempted afterwards and it died on 7 fragment deletions. Patch and minor
+cuts were equally affected, and the pipeline could not drain itself because the fold is what
+removes the fragments.
+
+The drift check that exists to catch exactly this (`grade_release_commit_unit.sh` section 11)
+missed it: its census matched the literal string `git add -f`, and the new writer is
+`git add -A -f changelog.d` behind an `if [ -d ]` guard, so it counted 4 of 5 writers and
+reported none unlisted. Both halves are fixed — the path set now admits `changelog.d/*`
+(entries are globs, split with `read -ra` so the pattern is not glob-expanded against the
+working directory before it can be used), and the census matches any `git add` regardless of
+flag order or guard shape.
+
+**This entry missed v0.19.0.** Its first version opened with `### Fixed` rather than the
+required `## Unreleased` heading, so the fold skipped it — correctly, and loudly enough to
+print, but non-fatally by design, because a cut must not die over a malformed fragment. The
+fix it describes did ship in v0.19.0; only the note is late.


### PR DESCRIPTION
My own fragment missed v0.19.0.

`changelog.d/DIVE-2700.md` opened with `### Fixed`. `changelog.d/README.md` requires the first non-blank line to be `## Unreleased[ — …]`, so the cut skipped it:

```
changelog.d fragments folded for v0.19.0: fold-changelog-fragments:
changelog.d/DIVE-2700.md does not start with '## Unreleased' — skipping
(not folded, not deleted)
```

The other 7 fragments folded and were deleted; only this one survived into the tagged tree. **So the fix that made v0.19.0 cuttable at all is absent from v0.19.0's own release notes.** The code shipped; only the note is late.

The skip is correct behaviour and deliberately non-fatal — a cut must not die because a fragment drifted from the expected format. That design is right, and it is exactly why the author has to read the format rather than rely on the cut to reject it. Not proposing to change it.

Not re-cutting v0.19.0 for a changelog line. This lands in the next release, and the fragment now says plainly that it missed its own.

DIVE-2700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)