### PR TITLE
test(ci): control arm — run the 5 harnesses #453 reddened, against MAIN [DO NOT MERGE]

### DIFF
--- a/tests/council_amend_e2e.sh
+++ b/tests/council_amend_e2e.sh
@@ -100,3 +100,6 @@ cp "$TMP/new.yaml" "$CFILE"
 echo
 if (( fail )); then echo "CNCL-15 amend/drift e2e: $pass passed, $fail FAILED"; exit 1; fi
 echo "CNCL-15 amend/drift e2e: $pass passed, 0 failed"
+
+# CONTROL ARM (main, DIVE-2692): comment-only touch to make changed-harnesses RUN this
+# harness against MAIN. No functional change. See PR body.

--- a/tests/council_unit.sh
+++ b/tests/council_unit.sh
@@ -108,3 +108,6 @@ echo "=== tests/council_schedule_e2e.sh"
 if ! bash "tests/council_schedule_e2e.sh"; then echo "FAILED: tests/council_schedule_e2e.sh"; rc=1; fi
 
 exit $rc
+
+# CONTROL ARM (main, DIVE-2692): comment-only touch to make changed-harnesses RUN this
+# harness against MAIN. No functional change. See PR body.

--- a/tests/digest_window_30d_controls.sh
+++ b/tests/digest_window_30d_controls.sh
@@ -230,3 +230,6 @@ fi
 printf '\n%s assertions passed, %s failed  (+%s precondition, which grades the INSTRUMENT, not the code)\n' \
   "$PASS" "$FAIL" "$PRECOND"
 [[ "$FAIL" -eq 0 ]]
+
+# CONTROL ARM (main, DIVE-2692): comment-only touch to make changed-harnesses RUN this
+# harness against MAIN. No functional change. See PR body.

--- a/tests/task_merge_gate_multirepo_unit.sh
+++ b/tests/task_merge_gate_multirepo_unit.sh
@@ -433,3 +433,6 @@ out=$(cmd_task_cancel CAN-1 --result='abandoning, api PR #6 stays open' 2>&1); r
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]
+
+# CONTROL ARM (main, DIVE-2692): comment-only touch to make changed-harnesses RUN this
+# harness against MAIN. No functional change. See PR body.

--- a/tests/task_merge_gate_result_pr_unit.sh
+++ b/tests/task_merge_gate_result_pr_unit.sh
@@ -385,3 +385,6 @@ out=$(cmd_task_cancel CAN-1 --result='abandoning, #156 stays open' 2>&1); rc=$?
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]
+
+# CONTROL ARM (main, DIVE-2692): comment-only touch to make changed-harnesses RUN this
+# harness against MAIN. No functional change. See PR body.


### PR DESCRIPTION
**Do not merge. This PR exists to be read, not landed.**

#453 (DIVE-2692) went red on five harnesses. The question is whether it *caused* them or *exposed* them, and there was no baseline to compare against.

## Why the baseline was missing

`changed-harnesses` only runs harnesses a PR **touched**. Nothing on main touches these five, so that job has never run them here — **the job's own trigger condition is what hides the control.** DIVE-2692 touched 296 harnesses, pulled all five into its changed-set, and they failed. That is the first time CI has ever executed them.

This PR supplies the trigger: comment-only touches to exactly those five files, off `main`, with dev2's diff nowhere near it.

## Why a local run cannot answer it

This host has a live agent registry; CI does not. The council failures are `could not read the agent registry` and `ghostseat resolves to no known registry agent` — so a local pass proves nothing about the CI failure **regardless of which ref it runs on**. The missing arm is not a more careful local run, it is a run somewhere that can actually fail.

## Reading it

| result | meaning |
|---|---|
| **red here** | pre-existing on main, **measured** rather than inferred from error text. #453 exposed them. |
| **green here** | a real regression in #453, and it bounces. |

## What is already settled, and how

Measured locally on **both refs in one environment**, with output-line counts as the non-vacuity check:

| harness | main `5192ec2` | #453 `a5e11e2` |
|---|---|---|
| `task_merge_gate_multirepo_unit` | rc=1, 41 lines, `35 passed, 1 failed` | rc=1, 42 lines, `35 passed, 1 failed` |
| `digest_window_30d_controls` | rc=1, 10 lines, `3 passed, 2 failed` | rc=1, 11 lines, `3 passed, 2 failed` |

Identical. Those two are pre-existing and settled. The **council pair** rested only on error text, which is weaker — this arm is for them.

My first attempt at that comparison was **void**: I captured a `tail` pipeline's exit code rather than the harness's, and main produced no output at all, so it read `rc=0` and an empty summary — *"main is clean"*, the flattering answer that would have ended the investigation. The output-line counts above are the line that should have been there the first time.

Control arm designed by **olivia** as verifier on DIVE-2692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)