### PR TITLE
feat(doctor): report per-host CLI freshness — installed vs published vs the bundle at the tag (DIVE-2640)

### DIFF
--- a/changelog.d/DIVE-2640.md
+++ b/changelog.d/DIVE-2640.md
@@ -1,0 +1,40 @@
+## Unreleased — feat(doctor): per-host CLI freshness, so a verifier can tell INSTALLED from MERGED (DIVE-2640)
+
+Nothing on the board distinguished **merged** from **installed**. On 2026-08-03 four agents
+who did not know about each other closed rows against `origin/main` while the artifact their
+readers actually execute — `/usr/local/bin/5dive`, driven by cron every five minutes — was an
+older bundle.
+
+`5dive doctor --category=host` now answers *is what is RUNNING what we merged?* in three rows,
+because they are three different facts and collapsing them is how the strong claim gets read
+off the weak one:
+
+- **`cli-installed`** — what the binary *is*: path, the `FIVE_VERSION` it declares, mtime, sha256.
+- **`cli-freshness`** — is it *behind*: declared version vs the newest tag the installer would
+  actually resolve. `STALE` is an error, `AHEAD` a warn (a box above the newest release is
+  refused every upgrade by the monotonicity guard, so it never self-corrects).
+- **`cli-provenance`** — is that version *true*: sha256 of the installed bytes against the
+  bundle published at that tag.
+
+Provenance is its own row because a version string is a claim a bundle makes about itself —
+`0.18.0+dive2563` satisfied a "runtime reads 0.18.x" criterion while hand-built, carrying
+unmerged code, and missing two published releases. Only the bytes make the version a
+consequence of provenance instead of an assertion about it. On a hand-stamped bundle
+`cli-freshness` legitimately reads `ok` while `cli-provenance` reads `error`; one row would
+have to pick, and the cheap check is the one that answers.
+
+**Ancestry is a positive-only oracle and the row inherits that rather than fighting it.** Under
+squash merges a sha comparison answers FALSE for reasons unrelated to whether the work landed.
+So a non-match is rendered as **UNPROVEN**, with the reason, at `warn` — never as "not merged".
+A row printing the strong negative would manufacture alarms about healthy boxes, which is this
+row's own defect class pointed backwards. Bytes escalate to `error` in exactly one case: the
+declared version *equals* the newest published one, which is the hand stamp and nothing else.
+
+**No green the check did not earn.** An absent binary, an unreadable one, a bundle with no
+`FIVE_VERSION`, an unresolvable tag and an indeterminate probe each read `UNKNOWN` at `warn`.
+The reference is resolved from the remote through the installer's own `_published_cli_probe`
+rather than a second resolver that would drift from it; that probe now emits the published
+bundle's sha256 as a fourth line, empty unless the answer is `consistent`.
+
+Found a real one on its first live run: a control-plane box on `0.18.6`, bundle dated
+2026-08-03 14:21:10, against a published `0.19.0` — reproduced on a second box the next day.

--- a/src/cmd_doctor.sh
+++ b/src/cmd_doctor.sh
@@ -90,6 +90,173 @@ doctor_check_audit_drop_dir() {
     "$dir is a directory with mode 2770 and group $expected_group; lost audit rows can leave a drop marker"
 }
 
+# doctor_check_cli_freshness [installed-bin] [probe-output]
+#
+# DIVE-2640 (split of DIVE-2621 item a) — NOTHING ON THIS BOARD DISTINGUISHED
+# MERGED FROM INSTALLED. On 2026-08-03 four agents who did not know about each
+# other closed rows against `origin/main` while the artifact their readers
+# actually execute — `/usr/local/bin/5dive`, driven by cron every five minutes —
+# was a different, older bundle. See
+# community/wiki/merged-to-main-is-a-claim-about-the-authors-artifact-not-the-readers.md.
+# This is the per-host surface that answers, in one command, the question that
+# board had no way to ask: IS WHAT IS RUNNING WHAT WE MERGED?
+#
+# Three rows, because they are three different facts and collapsing them is how
+# the strong one gets read off the weak one:
+#
+#   cli-installed    what the binary IS   — path, the version it declares, mtime
+#   cli-freshness    is it BEHIND         — declared version vs the newest tag
+#                                           the installer would actually resolve
+#   cli-provenance   is that version TRUE — sha256 of the installed bytes vs the
+#                                           bundle published at that tag
+#
+# WHY PROVENANCE IS ITS OWN ROW AND NOT A DETAIL ON THE FRESHNESS ONE. A version
+# string is a claim a bundle makes about itself. `0.18.0+dive2563` satisfied a
+# "runtime reads 0.18.x" criterion while being hand-built, carrying unmerged
+# code, and missing two published releases — and `sort -V` ranks that suffix
+# ABOVE the plain tag, so it also disabled the self-update that would have
+# corrected it (see
+# community/wiki/a-hand-stamped-build-suffix-satisfies-a-version-criterion.md).
+# Byte identity against the bundle committed at the tag is what makes the version
+# a CONSEQUENCE of provenance instead of an assertion about it.
+#
+# TWO CONSTRAINTS FROM THE INCIDENT, both load-bearing:
+#
+#  1. NO SYMBOL GREPPING. It is tempting to answer "is the fix deployed" with
+#     `grep -c <function> /usr/local/bin/5dive`. A function present in a bundle
+#     is not a function that executed, and the identity check below is strictly
+#     stronger anyway: it grades ALL the bytes against a known published object
+#     rather than one string against an expectation. Where the evidence really is
+#     only presence, it gets labelled presence.
+#
+#  2. NO GREEN THE CHECK DID NOT EARN. Every way this can fail to run — no
+#     binary, an unreadable one, a bundle with no version line, no network, a
+#     tag that will not resolve — defaults to the empty, reassuring answer. Each
+#     one is filed as UNKNOWN at `warn`, never `ok`. A freshness check inherits
+#     its denominator from its own visibility
+#     (community/wiki/a-freshness-check-inherits-its-denominator-from-its-own-visibility.md),
+#     so the accepting evidence for this function is the STALE arm going red and
+#     each cannot-run arm reading UNKNOWN — a pass on a host that happens to be
+#     current is a non-vacuity control and never the result.
+#
+# Both parameters exist so the arms above can be MUTATED offline: $1 points the
+# check at a deliberately stale or unreadable bundle, $2 substitutes the probe's
+# four-line answer so no arm needs the network to be graded.
+doctor_check_cli_freshness() {
+  local bin="${1:-/usr/local/bin/5dive}"
+  local probe="${2-}"
+  local installed_ver="" mtime="" sha=""
+
+  # --- row 1: what IS installed -------------------------------------------
+  # `-e` then `-r`: absent and denied are different answers and only one of them
+  # is about this box being unprovisioned. Neither is "fine".
+  if [[ ! -e "$bin" ]]; then
+    doctor_add host cli-installed warn \
+      "UNKNOWN — no installed CLI at $bin; this host runs 5dive from somewhere else (or not at all), so nothing here can say what is running"
+    doctor_add host cli-freshness warn "UNKNOWN — no installed CLI at $bin to compare against the published release"
+    doctor_add host cli-provenance warn "UNKNOWN — no installed CLI at $bin to identify"
+    return 0
+  fi
+  if [[ ! -r "$bin" ]]; then
+    doctor_add host cli-installed warn \
+      "UNKNOWN — $bin exists but is not readable by $(id -un); an unreadable binary is a permission answer, not a freshness one"
+    doctor_add host cli-freshness warn "UNKNOWN — $bin is unreadable, so its version cannot be compared to the published release"
+    doctor_add host cli-provenance warn "UNKNOWN — $bin is unreadable, so its bytes cannot be identified"
+    return 0
+  fi
+
+  mtime=$(stat -c '%y' "$bin" 2>/dev/null | cut -d. -f1) || mtime=""
+  [[ -n "$mtime" ]] || mtime="unknown"
+  # The bundle's own declaration, read the same way _published_cli_probe reads
+  # the published one. This is a CLAIM until cli-provenance confirms it.
+  installed_ver=$(grep -m1 -oP '(?<=^readonly FIVE_VERSION=")[^"]+' "$bin" 2>/dev/null) || installed_ver=""
+  sha=$(sha256sum "$bin" 2>/dev/null | awk '{print $1}') || sha=""
+
+  if [[ -z "$installed_ver" ]]; then
+    doctor_add host cli-installed warn \
+      "UNKNOWN — $bin declares no FIVE_VERSION (mtime $mtime); a bundle that will not say what it is cannot be graded fresh"
+    doctor_add host cli-freshness warn "UNKNOWN — $bin declares no version to compare against the published release"
+    doctor_add host cli-provenance warn "UNKNOWN — $bin declares no version, so there is no claim to check its bytes against"
+    return 0
+  fi
+
+  doctor_add host cli-installed ok \
+    "$bin declares $installed_ver, mtime $mtime${sha:+, sha256 ${sha:0:12}} — this is the artifact cron and every agent on this host actually execute"
+
+  # --- the reference, resolved from the REMOTE ----------------------------
+  # Never from a local checkout: a reference that shares a failure mode with the
+  # population makes staleness self-cancelling, and the check is then most
+  # confidently green exactly when the box is most stale. _published_cli_probe
+  # mirrors install.sh's own tag resolution and fails CLOSED, which is why it is
+  # reused here instead of a second resolver that would drift from it.
+  [[ -n "$probe" ]] || probe=$(_published_cli_probe)
+  local -a p=()
+  mapfile -t p <<<"$probe"
+  local state="${p[0]:-unavailable}" latest="${p[1]:-}" detail="${p[2]:-no detail}" pubsha="${p[3]:-}"
+
+  if [[ "$state" != "consistent" || -z "$latest" ]]; then
+    doctor_add host cli-freshness warn \
+      "UNKNOWN — installed $installed_ver, but the newest published release could not be resolved ($state: $detail); this is not a statement that $installed_ver is current"
+    doctor_add host cli-provenance warn \
+      "UNKNOWN — no published bundle to identify $bin against ($state: $detail)"
+    return 0
+  fi
+
+  # --- row 2: is it BEHIND ------------------------------------------------
+  local age=""
+  [[ "$mtime" != "unknown" ]] && age=", installed bundle dated $mtime"
+  if version_lt "$installed_ver" "$latest"; then
+    doctor_add host cli-freshness error \
+      "STALE — this host runs $installed_ver but $latest is published$age; anything merged after $installed_ver is NOT running here, whatever the board says. Fix: sudo 5dive update"
+  elif version_lt "$latest" "$installed_ver"; then
+    # DIVE-2287: above the newest release is its own state, and it is the state
+    # DIVE-2243's monotonicity guard REFUSES every subsequent upgrade from — so
+    # this box will never self-correct back onto the release line.
+    doctor_add host cli-freshness warn \
+      "AHEAD — this host runs $installed_ver, above the newest published $latest$age; self-update refuses to move a box that is ahead, so it will not return to the release line on its own"
+  else
+    doctor_add host cli-freshness ok \
+      "installed $installed_ver matches the newest published release $latest (from $detail)$age"
+  fi
+
+  # --- row 3: is that version TRUE ----------------------------------------
+  #
+  # ANCESTRY IS A POSITIVE-ONLY ORACLE AND THIS ROW IS BUILT TO INHERIT THAT
+  # RATHER THAN FIGHT IT. Under squash merges a `git merge-base --is-ancestor`
+  # answers FALSE for reasons that have nothing to do with whether the work
+  # landed, because the squash rewrote the sha
+  # (community/wiki/ancestry-is-a-positive-only-oracle-under-squash-merges.md).
+  # Byte identity has the same asymmetry by construction: a MATCH proves the
+  # installed bundle is the published release, and a NON-MATCH proves nothing
+  # whatsoever. So the negative side is never rendered as "not merged" — it is
+  # rendered as UNPROVEN, with the reason. A doctor row that printed the strong
+  # negative would manufacture alarms about healthy boxes, which is the same
+  # class of false report this row exists to end, pointed the other way.
+  if [[ -z "$sha" || -z "$pubsha" ]]; then
+    doctor_add host cli-provenance warn \
+      "UNKNOWN — could not checksum both sides (installed ${sha:-unreadable}, published ${pubsha:-unavailable}), so $installed_ver stays an unverified claim"
+  elif [[ "$sha" == "$pubsha" ]]; then
+    # Two of the three legs of the identity, and the third is named rather than
+    # assumed. A release tag is cut from main, so byte-equality with the bundle
+    # committed at that tag is a positive answer to "does this correspond to a
+    # commit that is an ancestor of main" — for THIS tag only.
+    doctor_add host cli-provenance ok \
+      "$bin is byte-identical to the bundle published at $detail (sha256 ${sha:0:12}) — the release tag is cut from main, so what is running here IS what we merged as of $latest"
+  elif [[ "$installed_ver" == "$latest" ]]; then
+    # The hand-stamp shape, and the only case where differing bytes are a defect
+    # rather than an ordinary lag: the bundle CLAIMS the published version and is
+    # not the published object.
+    doctor_add host cli-provenance error \
+      "$bin declares $installed_ver — the newest published version — but its bytes differ from the bundle published at $detail (installed ${sha:0:12}, published ${pubsha:0:12}). This is a hand-built or locally-staged bundle wearing a release number; its version string corresponds to no published commit and reading it as 'we are on $latest' is exactly the substitution DIVE-2621 is about"
+  else
+    # Stale or ahead: differing bytes are EXPECTED, and the only published object
+    # we hold is the newest tag's. Say plainly that we cannot tell, rather than
+    # inferring ancestry from a version string.
+    doctor_add host cli-provenance warn \
+      "CANNOT TELL — $bin declares $installed_ver, which is not the newest published $latest, so its bytes have nothing to be compared against here. This identity is a POSITIVE-ONLY oracle: a match proves the installed build is what we merged, a non-match proves NOTHING, because a squash merge rewrites the sha and this check holds only the newest tag's bundle anyway. Read this as UNPROVEN, never as 'not merged' — a row that printed 'not merged' here would manufacture alarms about healthy boxes"
+  fi
+}
+
 # doctor_marketplace_reference_sha [remote-url] [branch]
 #
 # The PUBLISHED head of the plugin marketplace, read from the remote rather than
@@ -759,6 +926,11 @@ cmd_doctor() {
     # shape itself; testing a marker path for writability cannot distinguish a
     # missing parent (partial/hand-built provision) from an actual disk fault.
     doctor_check_audit_drop_dir
+
+    # DIVE-2640: is what is RUNNING on this host what we merged? Nothing else on
+    # the board distinguishes merged from installed, and a category that is
+    # dispatched nowhere is a check that never runs.
+    doctor_check_cli_freshness
 
     # --- disk headroom (DIVE-1966/1967) ---
     #

--- a/src/cmd_selfupdate.sh
+++ b/src/cmd_selfupdate.sh
@@ -241,14 +241,22 @@ _cli_freeze_observe() {
 # version is not installable. Unresolvable tags => `unavailable`, which is honest
 # and is also what the installer does (it fails CLOSED on the same condition).
 #
-# Prints exactly three lines (never fails the caller):
+# Prints exactly four lines (never fails the caller):
 #   1  state    consistent | indeterminate | unavailable
 #   2  version  the published FIVE_VERSION — empty unless state is consistent
 #   3  detail   the ref the answer came from (consistent), else the reason.
 #               Never empty, so line 3 always exists.
+#   4  sha256   the sha256 of the published bundle — empty unless state is
+#               consistent. DIVE-2640: a version STRING is a claim the bundle
+#               makes about itself and nothing more — the hand-stamped
+#               `0.18.0+dive2563` bundle satisfied a `0.18.x` criterion while
+#               running neither the release nor main. The bytes are what turn
+#               that claim into provenance, so the one resolver that already
+#               fetched and checksum-verified the published bundle hands its
+#               digest out rather than making a second fetch drift from this one.
 _published_cli_probe() {
   local state version detail
-  _pcp_out() { printf '%s\n%s\n%s\n' "$1" "$2" "$3"; }
+  _pcp_out() { printf '%s\n%s\n%s\n%s\n' "$1" "$2" "$3" "${4:-}"; }
 
   command -v curl >/dev/null 2>&1 \
     || { _pcp_out unavailable "" "curl is not installed"; return 0; }
@@ -316,7 +324,7 @@ _published_cli_probe() {
     _pcp_out indeterminate "" "the published bundle carries no FIVE_VERSION"
     return 0
   fi
-  _pcp_out consistent "$version" "$ref"
+  _pcp_out consistent "$version" "$ref" "$served"
 }
 # <<< DIVE-2042 published-version probe
 

--- a/tests/doctor_cli_freshness_unit.sh
+++ b/tests/doctor_cli_freshness_unit.sh
@@ -3,7 +3,19 @@
 # answer "is what is RUNNING on this host what we merged?", and must NEVER
 # answer it green when it could not run.
 #
-# TIER: nightly — 0.6s measured on the control-plane box (agent-dev uid, offline, no root, `time bash tests/doctor_cli_freshness_unit.sh` = 0.57s over 5 runs). It is not the runtime that demotes it: core is ALREADY over its own 300s cap at 397s, so a new guard there is charged to every contributor on every push against a budget that is red before it arrives. `changed-harnesses` runs and verdict-probes this file at introduction regardless of tier, so the demotion moves the recurring cost without giving up the grade that matters.
+# TIER: core (the default — no marker needed, recorded here because the first cut of
+# this file demoted it and the demotion was argued from a FALSE premise). I carried
+# "core is already over its 300s cap at 397s" as settled. The number that governs is
+# the one CI measures, because CI is where the budget is enforced: run 30892536614
+# on this branch reported `harness-budget[core/pristine]: 233 harnesses, 270s
+# wall-clock, budget 300s (90% of budget)`, and 255s on the installed-host job. The
+# 397s figure was a control-plane reading, a contended box that is not the gate. At
+# 0.6s measured (`time bash tests/doctor_cli_freshness_unit.sh` = 0.57s over 5 runs,
+# agent-dev uid, offline, no root) against ~30s of headroom, the demotion argument
+# does not survive its premise being corrected, so this stays where the default puts
+# it. The runner's own warning that "the next few guards will not be" inside the cap
+# is real and is a reason to merge or retire a guard — not a reason to launder a new
+# one into the nightly on a number nobody re-measured.
 #
 # THE ACCEPTING EVIDENCE IS THE STALE ARM GOING RED. A freshness check that
 # passes on a host which happens to be current proves nothing — that arm is a

--- a/tests/doctor_cli_freshness_unit.sh
+++ b/tests/doctor_cli_freshness_unit.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# DIVE-2640 (split of DIVE-2621 item a) — `5dive doctor --category=host` must
+# answer "is what is RUNNING on this host what we merged?", and must NEVER
+# answer it green when it could not run.
+#
+# TIER: nightly — 0.6s measured on the control-plane box (agent-dev uid, offline, no root, `time bash tests/doctor_cli_freshness_unit.sh` = 0.57s over 5 runs). It is not the runtime that demotes it: core is ALREADY over its own 300s cap at 397s, so a new guard there is charged to every contributor on every push against a budget that is red before it arrives. `changed-harnesses` runs and verdict-probes this file at introduction regardless of tier, so the demotion moves the recurring cost without giving up the grade that matters.
+#
+# THE ACCEPTING EVIDENCE IS THE STALE ARM GOING RED. A freshness check that
+# passes on a host which happens to be current proves nothing — that arm is a
+# non-vacuity control and never the result. So every arm here is a MUTANT: the
+# check is pointed at a deliberately stale bundle, an unreadable one, a bundle
+# with no version line, a bundle wearing a release number it did not earn, and a
+# probe that could not resolve anything. Each must land on its own verdict.
+#
+# Run: bash tests/doctor_cli_freshness_unit.sh   (no root, no network)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.." || exit 1
+
+TMP="$(mktemp -d /tmp/doctor-cli-freshness.XXXXXX)"
+
+# shellcheck disable=SC1091
+source src/header.sh
+# shellcheck disable=SC1091
+source src/lib/error_codes.sh
+# shellcheck disable=SC1091
+source src/lib/output.sh
+# shellcheck disable=SC1091
+source src/cmd_doctor.sh
+# version_lt and _published_cli_probe live here; the check reuses the ONE
+# resolver rather than growing a second one that drifts from install.sh.
+# shellcheck disable=SC1091
+source src/cmd_selfupdate.sh
+set +e
+
+PASS=0; FAIL=0; SKIP=0
+ok_t()   { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t()  { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+skip_t() { SKIP=$((SKIP+1)); printf 'SKIP - %s\n   %s\n' "$1" "${2:-}"; }
+
+# ------------------------------------------------------------- fixtures --
+# Real bundles a release apart. `readonly FIVE_VERSION=` is the same line the
+# published-probe reads, so both sides of every comparison are read the one way.
+mkbundle() { printf '#!/usr/bin/env bash\nreadonly FIVE_VERSION="%s"\n# %s\n' "$1" "${2:-}" > "$3"; }
+mkbundle 0.18.4 ''          "$TMP/bundle-old"
+mkbundle 0.18.6 'published' "$TMP/bundle-new"
+mkbundle 0.18.6 'HAND-BUILT — same version string, different bytes' "$TMP/bundle-stamped"
+printf '#!/usr/bin/env bash\n# a bundle that declares no version\n'   > "$TMP/bundle-nover"
+SHA_NEW="$(sha256sum "$TMP/bundle-new" | awk '{print $1}')"
+
+# The probe's four-line contract, substituted so no arm needs the network.
+probe_ok()    { printf 'consistent\n0.18.6\nv0.18.6\n%s\n' "$SHA_NEW"; }
+probe_unavail(){ printf 'unavailable\n\nno release tag resolves — the installer could not upgrade this box either\n\n'; }
+probe_indet() { printf 'indeterminate\n\nthe bundle published at v0.18.6 does not match its own checksum\n\n'; }
+
+# run_check <bin> <probe> -> the three rows as one compact JSON array
+run_check() {
+  DOCTOR_CHECKS='[]'
+  doctor_check_cli_freshness "$1" "$2" >/dev/null 2>&1
+  jq -c '[.[] | {name, severity, message}]' <<<"$DOCTOR_CHECKS"
+}
+
+# assert_row <label> <rows-json> <name> <severity> <message-regex>
+assert_row() {
+  local label="$1" rows="$2" name="$3" sev="$4" rx="$5"
+  if jq -e --arg n "$name" --arg s "$sev" --arg rx "$rx" \
+      'map(select(.name == $n)) | length == 1 and (.[0].severity == $s) and (.[0].message | test($rx))' \
+      <<<"$rows" >/dev/null 2>&1; then
+    ok_t "$label"
+  else
+    bad_t "$label" "$(jq -c --arg n "$name" 'map(select(.name == $n))' <<<"$rows")"
+  fi
+}
+
+# =========================================================================
+# 1. THE ACCEPTING ARM. Installed 0.18.4, published 0.18.6 -> STALE, error.
+#    An `ok` or a `warn` here is the whole defect: the board says merged, the
+#    host runs something older, and nothing complains.
+rows="$(run_check "$TMP/bundle-old" "$(probe_ok)")"
+assert_row "stale install is an ERROR, and names both versions" \
+  "$rows" cli-freshness error 'STALE.*0\.18\.4.*0\.18\.6'
+# and it must not be reported as identified-against-main just because it is old
+assert_row "a stale bundle's provenance is CANNOT TELL, never ok" \
+  "$rows" cli-provenance warn 'CANNOT TELL'
+# THE ARM THAT CARRIES THE ROW'S VALUE. Ancestry under squash merges is a
+# POSITIVE-ONLY oracle — a match proves the build landed, a non-match proves
+# nothing, because the squash rewrote the sha. A row that rendered the negative
+# as "not merged" would manufacture alarms about healthy boxes, which is the
+# class of false report this row exists to end, pointed the other way. So the
+# unproven verdict must SAY it is unproven and must carry the reason.
+assert_row "CANNOT TELL names the positive-only oracle and says UNPROVEN" \
+  "$rows" cli-provenance warn 'POSITIVE-ONLY oracle.*a non-match proves NOTHING.*Read this as UNPROVEN'
+# DIFFERENTIAL, not a substring ban: a `test("not merged")` arm would red on this
+# check's own DISCLAIMER, which contains that phrase in order to forbid it. The
+# property that actually matters is that UNPROVEN and DEFECTIVE land on different
+# severities — so grade them against each other, on the same function, in one
+# comparison. Stale bytes differ innocently (warn); hand-stamped bytes differ
+# while CLAIMING the published version (error). If provenance ever collapsed
+# those two, this arm reds and no wording change can quiet it.
+sev_unproven="$(jq -r 'map(select(.name=="cli-provenance"))|.[0].severity' <<<"$rows")"
+sev_defect="$(jq -r 'map(select(.name=="cli-provenance"))|.[0].severity' <<<"$(run_check "$TMP/bundle-stamped" "$(probe_ok)")")"
+if [[ "$sev_unproven" == "warn" && "$sev_defect" == "error" ]]; then
+  ok_t "unproven (warn) and defective (error) are different severities on the same check"
+else
+  bad_t "unproven (warn) and defective (error) are different severities on the same check" \
+    "stale-bytes=$sev_unproven hand-stamped=$sev_defect — a non-match that cannot prove anything must not escalate like one that can"
+fi
+assert_row "a stale bundle still reports what it is" \
+  "$rows" cli-installed ok '0\.18\.4.*mtime'
+
+# 2. NON-VACUITY CONTROL (never the result): a genuinely current, byte-identical
+#    install is the only shape allowed to read ok on all three rows.
+rows="$(run_check "$TMP/bundle-new" "$(probe_ok)")"
+assert_row "current install is ok" "$rows" cli-freshness ok 'matches the newest published release 0\.18\.6 \(from v0\.18\.6\)'
+assert_row "byte-identical install is identified against the published tag" \
+  "$rows" cli-provenance ok 'byte-identical to the bundle published at v0\.18\.6'
+assert_row "current install reports version and mtime" "$rows" cli-installed ok '0\.18\.6.*mtime.*sha256'
+
+# 3. THE HAND-STAMP. Same version string as the newest release, different bytes:
+#    `0.18.0+dive2563` satisfied a 0.18.x criterion while running neither the
+#    release nor main. Version equal + sha differing is a DEFECT, not a lag.
+rows="$(run_check "$TMP/bundle-stamped" "$(probe_ok)")"
+assert_row "a bundle wearing a release number it did not earn is an ERROR" \
+  "$rows" cli-provenance error 'bytes differ from the bundle published at v0\.18\.6'
+assert_row "...and freshness alone cannot see it — version comparison says current" \
+  "$rows" cli-freshness ok 'matches the newest published release'
+
+# 4. AHEAD is its own state (DIVE-2287), not "up to date": the monotonicity
+#    guard refuses every upgrade from here, so it never self-corrects.
+mkbundle 0.19.0 '' "$TMP/bundle-ahead"
+rows="$(run_check "$TMP/bundle-ahead" "$(probe_ok)")"
+assert_row "a box above the newest release reads AHEAD, not ok" \
+  "$rows" cli-freshness warn 'AHEAD.*0\.19\.0.*above the newest published 0\.18\.6'
+
+# =========================== the cannot-run arms =========================
+# Each of these defaults to the empty, reassuring answer if written naively.
+# None of them is staleness and none of them may be green.
+
+# 5. No installed binary at all.
+rows="$(run_check "$TMP/does-not-exist" "$(probe_ok)")"
+for n in cli-installed cli-freshness cli-provenance; do
+  assert_row "absent binary: $n is UNKNOWN, not ok" "$rows" "$n" warn 'UNKNOWN'
+done
+
+# 6. Present but unreadable — a permission answer, not a freshness one.
+cp "$TMP/bundle-new" "$TMP/bundle-denied"; chmod 000 "$TMP/bundle-denied"
+if [[ -r "$TMP/bundle-denied" ]]; then
+  # chmod is inert against root; a root run cannot reach this arm, and a pass it
+  # cannot reach is worse than a skip that says so.
+  skip_t "unreadable binary is UNKNOWN" "running as uid $(id -u): chmod 000 is inert, the arm is UNREACHABLE here (re-run as non-root)"
+else
+  rows="$(run_check "$TMP/bundle-denied" "$(probe_ok)")"
+  assert_row "unreadable binary is UNKNOWN and names the uid" \
+    "$rows" cli-installed warn "UNKNOWN.*not readable by $(id -un)"
+  assert_row "unreadable binary: freshness is UNKNOWN, not ok" "$rows" cli-freshness warn 'UNKNOWN'
+fi
+
+# 7. A bundle that will not say what it is.
+rows="$(run_check "$TMP/bundle-nover" "$(probe_ok)")"
+assert_row "a bundle with no FIVE_VERSION is UNKNOWN" \
+  "$rows" cli-installed warn 'UNKNOWN.*declares no FIVE_VERSION'
+assert_row "no version: freshness is UNKNOWN, not ok" "$rows" cli-freshness warn 'UNKNOWN'
+
+# 8. The REFERENCE could not be resolved. This is the one that matters most for
+#    a NAT'd fleet sharing a rate limit: no tag, no network, no answer — and
+#    "no answer" must not read as "you are current".
+for pf in probe_unavail probe_indet; do
+  rows="$(run_check "$TMP/bundle-new" "$($pf)")"
+  assert_row "$pf: freshness is UNKNOWN and disclaims currency" \
+    "$rows" cli-freshness warn 'UNKNOWN.*not a statement that 0\.18\.6 is current'
+  assert_row "$pf: provenance is UNKNOWN, no published bundle to identify against" \
+    "$rows" cli-provenance warn 'UNKNOWN'
+  assert_row "$pf: what IS installed is still reported" "$rows" cli-installed ok '0\.18\.6'
+done
+
+# 9. A consistent probe with an EMPTY sha (an older probe, or a caller that
+#    dropped the field) must not silently pass provenance.
+rows="$(run_check "$TMP/bundle-new" "$(printf 'consistent\n0.18.6\nv0.18.6\n\n')")"
+assert_row "a probe with no published sha leaves provenance UNKNOWN" \
+  "$rows" cli-provenance warn 'UNKNOWN.*unverified claim'
+
+# ======================= the wiring, not the logic =======================
+# 10. A check nobody dispatches is a check that never runs (DIVE-2327 shape).
+# Captured into a variable, NOT piped into `grep -q`: under `pipefail` a -q grep
+# closes the pipe on its first match and the upstream awk dies of SIGPIPE, so the
+# pipeline reports failure on exactly the runs where the assertion PASSED
+# fastest. That arm flaked green-then-red on two consecutive runs of this file.
+host_block="$(awk '/if \(\( run_host \)\); then/,/^  fi$/' src/cmd_doctor.sh)"
+if grep -q 'doctor_check_cli_freshness' <<<"$host_block"; then
+  ok_t "the check is dispatched inside the run_host block"
+else
+  bad_t "the check is dispatched inside the run_host block" "not called under run_host — --category=host would never run it"
+fi
+# and `host` must be reachable through the --category allow-list. Read the list
+# OUT of the usage string rather than asserting the whole string: that list grows
+# (`plugins` arrived with DIVE-2642) and a literal match would red on someone
+# else's addition while saying nothing about `host`.
+catlist="$(grep -m1 -oP '(?<=unknown --category \()[^)]+' src/cmd_doctor.sh)"
+if [[ -n "$catlist" ]] && grep -qE '(^|\|)host(\||$)' <<<"$catlist"; then
+  ok_t "host is in the --category allow-list the usage error advertises"
+else
+  bad_t "host is in the --category allow-list the usage error advertises" "list read as '${catlist:-<unreadable>}'"
+fi
+# non-vacuity for the line above: the extraction really did find a list, and it
+# really can say no — an always-true probe would pass this arm on an empty file.
+if [[ -n "$catlist" ]] && ! grep -qE '(^|\|)notacategory(\||$)' <<<"$catlist"; then
+  ok_t "the allow-list probe can also return false"
+else
+  bad_t "the allow-list probe can also return false" "list read as '${catlist:-<unreadable>}'"
+fi
+
+# 11. THE PROBE'S FOURTH LINE, run rather than grepped. The provenance row is
+#     only as real as the published sha it compares against, so the resolver has
+#     to actually emit it — with stubs, offline, from the shipped source.
+block="$(sed -n '/^# >>> DIVE-2042 published-version probe/,/^# <<< DIVE-2042 published-version probe/p' src/cmd_selfupdate.sh)"
+if [[ -z "$block" ]] || ! grep -q '_published_cli_probe()' <<<"$block"; then
+  bad_t "probe block is extractable" "markers not found in src/cmd_selfupdate.sh"
+else
+  STUBS="$TMP/stubs"; mkdir -p "$STUBS"
+  TOOLS="$(dirname "$(command -v sha256sum)")"
+  cat >"$STUBS/git" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\trefs/tags/v0.18.6\n' 0000000000000000000000000000000000000000
+EOF
+  # Serve the real bundle and its real checksum, the way an intact tag does.
+  cp "$TMP/bundle-new" "$STUBS/served"
+  printf '%s  5dive\n' "$SHA_NEW" > "$STUBS/served.sha256"
+  cat >"$STUBS/curl" <<EOF
+#!/usr/bin/env bash
+out=""; prev=""
+for a in "\$@"; do [[ "\$prev" == "-o" ]] && out="\$a"; prev="\$a"; done
+case "\${!#}" in
+  */5dive.sha256) cp "$STUBS/served.sha256" "\$out" ;;
+  */5dive)        cp "$STUBS/served" "\$out" ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$STUBS/git" "$STUBS/curl"
+  out="$(env -i PATH="$STUBS:$TOOLS" HOME="$STUBS" bash -c "set -uo pipefail
+gh_org() { printf 'testorg\n'; }
+$block
+_published_cli_probe" 2>/dev/null)"
+  got4="$(sed -n '4p' <<<"$out")"
+  if [[ "$(sed -n '1p' <<<"$out")" == "consistent" && "$got4" == "$SHA_NEW" ]]; then
+    ok_t "the published probe emits the bundle's sha256 as line 4"
+  else
+    bad_t "the published probe emits the bundle's sha256 as line 4" "want '$SHA_NEW', got line4='$got4' (line1='$(sed -n '1p' <<<"$out")')"
+  fi
+  # Line 4 is EMPTY unless the answer is consistent — an unavailable probe must
+  # not hand out a digest that would let provenance read green off nothing.
+  cat >"$STUBS/git" <<'EOF'
+#!/usr/bin/env bash
+exit 128
+EOF
+  cat >"$STUBS/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$STUBS/git" "$STUBS/curl"
+  out="$(env -i PATH="$STUBS:$TOOLS" HOME="$STUBS" bash -c "set -uo pipefail
+gh_org() { printf 'testorg\n'; }
+$block
+_published_cli_probe" 2>/dev/null)"
+  if [[ "$(sed -n '1p' <<<"$out")" == "unavailable" && -z "$(sed -n '4p' <<<"$out")" ]]; then
+    ok_t "an unavailable probe emits an EMPTY sha, not a stale one"
+  else
+    bad_t "an unavailable probe emits an EMPTY sha, not a stale one" "$(tr '\n' '|' <<<"$out")"
+  fi
+fi
+
+echo
+printf '%d passed, %d failed, %d skipped\n' "$PASS" "$FAIL" "$SKIP"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
Split of DIVE-2621 item a. **Nothing on the board distinguished MERGED from INSTALLED.** On 2026-08-03 four agents who did not know about each other closed rows against `origin/main` while the artifact their readers execute — `/usr/local/bin/5dive`, driven by cron every five minutes — was an older bundle.

`5dive doctor --category=host` now emits three rows, because they are three different facts and collapsing them is how the strong one gets read off the weak:

| row | question | blind to |
|---|---|---|
| `cli-installed` | what the binary **is** — path, declared version, mtime, sha256 | — |
| `cli-freshness` | is it **behind** — declared version vs the newest tag the installer would resolve | a bundle that *declares* the newest version and is not it |
| `cli-provenance` | is that version **true** — installed bytes vs the bundle published at that tag | everything that is not the newest tag |

The separation is load-bearing, not tidy: on a hand-stamped bundle `cli-freshness` legitimately reads **ok** (`0.18.6 == 0.18.6`) while `cli-provenance` reads **error**. One row would have to pick, and the cheap check is the one that answers.

### Ancestry is a positive-only oracle, and this row inherits that rather than fighting it

Under squash merges `--is-ancestor` answers FALSE for reasons unrelated to whether the work landed. Byte identity has the same asymmetry **by construction**: a MATCH proves the installed bundle is the published release; a NON-MATCH proves nothing. So the negative is never rendered as *not merged* — it is rendered as **UNPROVEN**, with the reason, at `warn`:

> CANNOT TELL — /usr/local/bin/5dive declares 0.18.6, which is not the newest published 0.19.0 … This identity is a POSITIVE-ONLY oracle: a match proves the installed build is what we merged, a non-match proves NOTHING, because a squash merge rewrites the sha … Read this as UNPROVEN, never as 'not merged' — a row that printed 'not merged' here would manufacture alarms about healthy boxes.

Differing bytes escalate to `error` in exactly one case: the declared version **equals** the newest published one. That pair — version says yes, bytes say no — is the hand stamp (`0.18.0+dive2563`) and nothing else.

### Both constraints from the incident

1. **No symbol grepping.** A function present in a bundle is not a function that executed. The identity check grades *all* the bytes against a known published object rather than one string against an expectation.
2. **No green the check did not earn.** Absent binary, unreadable binary, a bundle with no `FIVE_VERSION`, an unresolvable tag, and an indeterminate probe each file as **UNKNOWN at warn** — never `ok`.

### The reference comes from the remote, through the one resolver

`_published_cli_probe` mirrors `install.sh`'s tag resolution and fails closed; a second resolver would drift from it. It now emits the published bundle's sha256 as a **fourth line, empty unless the state is `consistent`** — that emptiness is what stops provenance reading green off a digest that came from nowhere.

**Verified against `origin/main`, not a local tree:** two invocation sites in `src/` (`cmd_selfupdate.sh:339`, `cmd_supervisor.sh:307`), both `mapfile -t p` reading `p[0..2]` only, plus one harness reading lines 1–3 via `sed -n`. Nothing asserts a three-line count, so line 4 is additive.

### How it was checked

`tests/doctor_cli_freshness_unit.sh` — **30/30**, offline, no root, no network, **core tier**.

The first cut demoted it to `nightly` on the premise that *core is already over its 300s cap at 397s*. I carried that as settled and never re-measured it. **CI on this branch says otherwise** (run 30892536614): `harness-budget[core/pristine]: 233 harnesses, 270s wall-clock, budget 300s (90% of budget)`, and 255s on the installed-host job. The 397s was a control-plane reading — a contended box that is not the gate. At 0.6s against ~30s of headroom the demotion does not survive its premise being corrected, so it went back to the default in a second commit (339eebc).

Graded by mutation in a throwaway clone **proven green first**, real tree confirmed untouched after. **Nine mutants, each red at the arm that owns it:**

| mutant | arms red |
|---|---|
| stale reads `ok` | 1 |
| the cannot-run path reads `ok` | 2 |
| hand stamp reads `ok` | 1 |
| provenance UNKNOWN downgraded to `ok` | 4 |
| dispatch line deleted | 1 |
| probe drops its sha | 1 |
| CANNOT TELL upgraded to a positive identity | 3 |
| unproven escalated to `error` | 3 |
| positive-only disclaimer deleted | **1, and only that one** |

The unproven-vs-defective arm is **differential, not a substring ban** — a `test("not merged")` assertion would red on this check's own disclaimer, which contains that phrase in order to forbid it.

### It found a real one on the first live run

```
[ok]    cli-installed   /usr/local/bin/5dive declares 0.18.6, mtime 2026-08-03 14:21:10, sha256 927f821748bb
[error] cli-freshness   STALE — this host runs 0.18.6 but 0.19.0 is published … Fix: sudo 5dive update
[warn]  cli-provenance  CANNOT TELL — … POSITIVE-ONLY oracle … Read this as UNPROVEN
```

The control-plane box, a day after the incident, with nothing else on the board reporting it.

### Not included

No `CHANGELOG.md` entry — the version heading is decided by merge order at release-cut, not by this branch.

Compiled to the wiki: `byte-identity-answers-ancestry-for-one-tag-only.md` and `a-q-grep-under-pipefail-reds-the-run-where-it-matched-fastest.md`, both indexed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
