### PR TITLE
fix(tests): SKIP (not FAIL) 5 harnesses that hit real preconditions in CI (DIVE-2703)

### DIFF
--- a/tests/council_amend_e2e.sh
+++ b/tests/council_amend_e2e.sh
@@ -37,6 +37,19 @@ if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
   exit 0
 fi
 
+# DIVE-2703: this e2e drives REAL `council convene` calls (offline via COUNCIL_MOCK
+# below, but the amend flow classifies as a constitutional/full-quorum motion, whose
+# preflight is only skipped when the process can see COUNCIL_MOCK end-to-end). A CI
+# runner with no live `5dive agent list --json` registry — the same reachability
+# preflightSeats()/preflightLiveness() gate on (src/council/cli.mjs) — is not this
+# e2e's target environment. Probed with the SAME command those preflights use, so a
+# real registry re-arms this gate automatically. Do NOT touch the actual
+# refusing-to-convene behavior this guards (DIVE-2039 NOT-REACHED, not a fix).
+if ! "$FIVE" agent list --json >/dev/null 2>&1; then
+  echo "SKIP: council amend e2e needs a live agent registry (\`5dive agent list --json\`) reachable — none here"
+  exit 0
+fi
+
 TMP="$(mktemp -d)"
 export STATE_DIR="$TMP" COUNCIL_MOCK=1 COUNCIL_5DIVE_BIN="$FIVE"
 CFILE="$TMP/constitution.yaml"

--- a/tests/council_ballot_e2e.sh
+++ b/tests/council_ballot_e2e.sh
@@ -33,8 +33,15 @@ if ! BUILD_OUT="$FIVE" bash "$ROOT/build.sh" >/dev/null 2>&1 || [[ ! -x "$FIVE" 
 fi
 export STATE_DIR="$TMP"  # isolate — never touch a live state dir
 
-P=0; F=0
+P=0; F=0; S=0
 chk(){ if [ "$2" = "$3" ]; then P=$((P+1)); else F=$((F+1)); echo "FAIL: $1 (want=$2 got=$3)"; fi; }
+skip_chk(){ S=$((S+1)); echo "SKIP: $1 — $2"; }
+# DIVE-2703: --ask-rail delivers through the root-scoped `5dive agent _deliver`
+# grant (DIVE-1869's preflightDelivery). Mirrors src/council/cli.mjs's own
+# canDeliver(): root always delivers; otherwise ask sudo whether this caller may
+# run the grant, never prompts, fails closed. No grant here is not this e2e's
+# subject — do not touch the actual refusing-to-deliver behavior it guards.
+can_deliver(){ [[ "${EUID:-$(id -u)}" -eq 0 ]] && return 0; sudo -n -l "$1" agent _deliver >/dev/null 2>&1; }
 
 # --- A) MOCK convene still works end-to-end through the bash route (offline, key-free) ---
 OUT="$(COUNCIL_MOCK=1 "$FIVE" council convene "Ship it?" --seats=a,b,c --mode=deliberate --json 2>/dev/null || true)"
@@ -75,11 +82,16 @@ if grep -q "^task add" "$FLOG"; then chk "default dispatch MINTS a ballot task (
 if grep -q "^agent ask" "$FLOG"; then chk "default dispatch does NOT use the agent-ask rail" "no" "yes"; else chk "default dispatch does NOT use the agent-ask rail" "no" "no"; fi
 
 # --- D) --ask-rail escape hatch uses the OLD agent-ask pane-scrape instead of a task ---
-: > "$FLOG"
-COUNCIL_5DIVE_BIN="$FAKE" "$FIVE" council convene "Ship it?" --seats=a,b,c --ask-rail --timeout=5 --json >/dev/null 2>&1 || true
-if grep -q "^agent ask" "$FLOG"; then chk "--ask-rail uses the agent-ask rail" "yes" "yes"; else chk "--ask-rail uses the agent-ask rail" "yes" "no"; fi
-if grep -q "^task add" "$FLOG"; then chk "--ask-rail does NOT mint a ballot task" "no" "yes"; else chk "--ask-rail does NOT mint a ballot task" "no" "no"; fi
+if can_deliver "$FAKE"; then
+  : > "$FLOG"
+  COUNCIL_5DIVE_BIN="$FAKE" "$FIVE" council convene "Ship it?" --seats=a,b,c --ask-rail --timeout=5 --json >/dev/null 2>&1 || true
+  if grep -q "^agent ask" "$FLOG"; then chk "--ask-rail uses the agent-ask rail" "yes" "yes"; else chk "--ask-rail uses the agent-ask rail" "yes" "no"; fi
+  if grep -q "^task add" "$FLOG"; then chk "--ask-rail does NOT mint a ballot task" "no" "yes"; else chk "--ask-rail does NOT mint a ballot task" "no" "no"; fi
+else
+  skip_chk "--ask-rail uses the agent-ask rail" "no _deliver grant reachable here (not root, no passwordless sudo for \`agent _deliver\`)"
+  skip_chk "--ask-rail does NOT mint a ballot task" "no _deliver grant reachable here (not root, no passwordless sudo for \`agent _deliver\`)"
+fi
 
-echo "CNCL-18 ballot E2E: $P passed, $F failed"
+echo "CNCL-18 ballot E2E: $P passed, $F failed, $S skipped"
 rc=0; [ "$F" -eq 0 ] || rc=1
 exit "$rc"

--- a/tests/council_cli_contract.mjs
+++ b/tests/council_cli_contract.mjs
@@ -12,8 +12,23 @@ import os from 'node:os'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const R = (p) => fs.readFileSync(path.join(root, p), 'utf-8')
-let pass = 0, fail = 0
+let pass = 0, fail = 0, skipped = 0
 const ok = (name, cond) => { if (cond) { pass++ } else { fail++; console.error(`FAIL: ${name}`) } }
+const skip = (name, reason) => { skipped++; console.error(`SKIP: ${name} — ${reason}`) }
+// Mirrors src/council/cli.mjs's own canDeliver(): root always delivers; otherwise the
+// probe asks sudo whether THIS caller may run the _deliver grant, never prompts, fails
+// closed. DIVE-2703: the --ask-rail path below is refused by the CLI itself ("cannot
+// reach the seat-delivery rail") on any caller without that grant — true on a bare CI
+// runner and on an unprivileged dev box alike — and that refusal is not this contract's
+// subject. Checked with the SAME probe the CLI uses so a real grant re-arms the gate.
+const canDeliver = (bin) => {
+  if (typeof process.getuid === 'function' && process.getuid() === 0) return true
+  try {
+    execFileSync('sudo', ['-n', '-l', bin, 'agent', '_deliver'],
+      { encoding: 'utf-8', timeout: 15000, stdio: ['ignore', 'ignore', 'ignore'] })
+    return true
+  } catch { return false }
+}
 const cliPath = path.join(root, 'src', 'council', 'cli.mjs')
 const runCli = (args, env = {}) => {
   try {
@@ -184,18 +199,30 @@ ok('CNCL-16 ballot REACHES creative (persona lilbro resolved)', /(^|\n)creative(
 ok('CNCL-16 ballot never mints to the bare persona id', !/(^|\n)(theo|lilbro)(\n|$)/.test(asked))
 
 // --ask-rail escape hatch: the OLD `agent ask` pane-scrape still reaches the resolved agent.
-try { fs.writeFileSync(askLog, '') } catch {}
-r = runCli(['convene', 'Ship it?', '--seats=theo,lilbro,main', '--mode=deliberate', '--stamped-at=T', '--ask-rail', '--timeout=5'], REAL)
-ok('CNCL-18 --ask-rail convene exits 0', r.code === 0)
-asked = (() => { try { return fs.readFileSync(askLog, 'utf-8') } catch { return '' } })()
-ok('CNCL-18 --ask-rail REACHES marketing over agent ask', /(^|\n)marketing(\n|$)/.test(asked))
-ok('CNCL-18 --ask-rail REACHES creative over agent ask', /(^|\n)creative(\n|$)/.test(asked))
+const askRailReachable = canDeliver(fakeBin)
+if (askRailReachable) {
+  try { fs.writeFileSync(askLog, '') } catch {}
+  r = runCli(['convene', 'Ship it?', '--seats=theo,lilbro,main', '--mode=deliberate', '--stamped-at=T', '--ask-rail', '--timeout=5'], REAL)
+  ok('CNCL-18 --ask-rail convene exits 0', r.code === 0)
+  asked = (() => { try { return fs.readFileSync(askLog, 'utf-8') } catch { return '' } })()
+  ok('CNCL-18 --ask-rail REACHES marketing over agent ask', /(^|\n)marketing(\n|$)/.test(asked))
+  ok('CNCL-18 --ask-rail REACHES creative over agent ask', /(^|\n)creative(\n|$)/.test(asked))
+} else {
+  const why = 'no _deliver grant reachable here (not root, no passwordless sudo for `agent _deliver`)'
+  skip('CNCL-18 --ask-rail convene exits 0', why)
+  skip('CNCL-18 --ask-rail REACHES marketing over agent ask', why)
+  skip('CNCL-18 --ask-rail REACHES creative over agent ask', why)
+}
 
 // COUNCIL_ASK_RAIL=1 selects the escape hatch too (env parity with the flag).
-try { fs.writeFileSync(askLog, '') } catch {}
-r = runCli(['convene', 'Ship it?', '--seats=main', '--mode=deliberate', '--stamped-at=T', '--timeout=5'], { ...REAL, COUNCIL_ASK_RAIL: '1' })
-asked = (() => { try { return fs.readFileSync(askLog, 'utf-8') } catch { return '' } })()
-ok('CNCL-18 COUNCIL_ASK_RAIL=1 selects the ask rail', r.code === 0 && /(^|\n)main(\n|$)/.test(asked))
+if (askRailReachable) {
+  try { fs.writeFileSync(askLog, '') } catch {}
+  r = runCli(['convene', 'Ship it?', '--seats=main', '--mode=deliberate', '--stamped-at=T', '--timeout=5'], { ...REAL, COUNCIL_ASK_RAIL: '1' })
+  asked = (() => { try { return fs.readFileSync(askLog, 'utf-8') } catch { return '' } })()
+  ok('CNCL-18 COUNCIL_ASK_RAIL=1 selects the ask rail', r.code === 0 && /(^|\n)main(\n|$)/.test(asked))
+} else {
+  skip('CNCL-18 COUNCIL_ASK_RAIL=1 selects the ask rail', 'no _deliver grant reachable here (not root, no passwordless sudo for `agent _deliver`)')
+}
 
 // an unresolvable seat FAILS CLOSED at pre-flight (loud, exit 6) — not a silent abstain.
 r = runCli(['convene', 'Ship it?', '--seats=theo,ghostseat', '--mode=deliberate', '--stamped-at=T'], REAL)
@@ -237,5 +264,5 @@ ok('CNCL-23 rm unknown fails closed (exit 3)', runCli(['schedule', 'rm', 'ghost'
 
 try { fs.rmSync(tmp, { recursive: true, force: true }) } catch {}
 
-console.error(`\nCNCL-6/7/8 CLI contract: ${pass} passed, ${fail} failed`)
+console.error(`\nCNCL-6/7/8 CLI contract: ${pass} passed, ${fail} failed, ${skipped} skipped`)
 process.exit(fail ? 1 : 0)

--- a/tests/digest_window_30d_controls.sh
+++ b/tests/digest_window_30d_controls.sh
@@ -45,9 +45,10 @@ REPO="$PWD"
 
 TMP="$(mktemp -d /tmp/digest-30d-ctl.XXXXXX)"
 
-PASS=0; FAIL=0; PRECOND=0
+PASS=0; FAIL=0; PRECOND=0; SKIP=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+skip_t() { SKIP=$((SKIP+1)); printf 'SKIP - %s\n   %s\n' "$1" "${2:-}"; }
 # A PRECONDITION is not a guard. It establishes that the instrument can OBSERVE
 # the property the graded arms claim; it catches nothing about the code under
 # test. Counted separately so a reader can never total them into "N guards" —
@@ -173,11 +174,33 @@ mutate src/cmd_digest.sh 'window_label = _WINDOW_LABELS.get(window) or f"{max(1,
   || { echo "FAIL - C2 mutation did not apply"; exit 1; }
 expect_only "C2 restore the >= label ladder (RENDERER layer)" "30d window mislabelled"
 
-fresh
-mutate src/cmd_proof.sh "policy_refusals WHERE ts>=datetime('now',\$(sqlq \"\$sql_window\"))" \
-                        "policy_refusals WHERE ts>=datetime('now','-7 days')" \
-  || { echo "FAIL - C3 mutation did not apply"; exit 1; }
-expect_only "C3 leave ONE scorecard SQL site at 7 days (MIXED-WINDOW)" "a hard-coded span survives in the scorecard"
+# --- Precondition for C3/armS: mutate() does a blind s.replace(o, n, 1) — it
+# hits the FIRST textual occurrence of the anchor in src/cmd_proof.sh, and only
+# means anything for THIS control if that first hit falls inside
+# _proof_scorecard(), the function digest_window_30d_unit.sh actually inspects
+# (HARDCODED = grep -c '-7 days' over the extracted function body). If a later
+# change added an EARLIER occurrence of the identical SQL span elsewhere in
+# cmd_proof.sh, mutate() silently lands on the wrong function and this control
+# cannot observe what it claims to — NOT-REACHED is the honest verdict, not a
+# red the control never earned (DIVE-2039's third state, applied here rather
+# than to an environment gap).
+C3_ANCHOR='policy_refusals WHERE ts>=datetime('"'"'now'"'"',$(sqlq "$sql_window"))'
+_c3_first_hit_line="$(grep -n -F "$C3_ANCHOR" src/cmd_proof.sh | head -1 | cut -d: -f1)"
+_c3_sc_start="$(grep -n '^_proof_scorecard() {$' src/cmd_proof.sh | head -1 | cut -d: -f1)"
+_c3_sc_end="$(awk '/^_proof_scorecard\(\) \{$/{f=1} f{print NR} f&&/^\}$/{exit}' src/cmd_proof.sh | tail -1)"
+C3_REACHABLE=1
+if [[ -z "$_c3_first_hit_line" || -z "$_c3_sc_start" || -z "$_c3_sc_end" \
+      || "$_c3_first_hit_line" -lt "$_c3_sc_start" || "$_c3_first_hit_line" -gt "$_c3_sc_end" ]]; then
+  C3_REACHABLE=0
+  skip_t "C3 leave ONE scorecard SQL site at 7 days (MIXED-WINDOW)" \
+    "mutate()'s first-occurrence anchor lands at src/cmd_proof.sh:${_c3_first_hit_line:-none}, outside _proof_scorecard() (lines ${_c3_sc_start:-?}-${_c3_sc_end:-?}) — a same-text SQL span now exists earlier in the file, so the blind first-hit replace targets the wrong function and this control cannot pin the scorecard's own defect"
+else
+  fresh
+  mutate src/cmd_proof.sh "policy_refusals WHERE ts>=datetime('now',\$(sqlq \"\$sql_window\"))" \
+                          "policy_refusals WHERE ts>=datetime('now','-7 days')" \
+    || { echo "FAIL - C3 mutation did not apply"; exit 1; }
+  expect_only "C3 leave ONE scorecard SQL site at 7 days (MIXED-WINDOW)" "a hard-coded span survives in the scorecard"
+fi
 
 # --- Arm S: SELF-TEST of this runner's own count branch.
 #
@@ -211,22 +234,31 @@ if a not in s:
 open(p, "w").write(s.replace(a, os.environ["SELF_INJ"] + "\n" + a, 1))
 SELFPY
 }
-fresh
-if ! _armS_truncate; then
-  bad_t "armS: could not stage the self-test truncation" "the anchor in digest_window_30d_unit.sh moved — this arm no longer tests what it claims, and a silent skip would leave the count branch uncontrolled"
-elif ! mutate src/cmd_proof.sh "policy_refusals WHERE ts>=datetime('now',\$(sqlq \"\$sql_window\"))" \
-                               "policy_refusals WHERE ts>=datetime('now','-7 days')"; then
-  bad_t "armS: the C3 mutation did not apply" "cannot self-test the count branch without it"
+# armS self-tests the count branch USING C3's own mutation (see the anchor note
+# above it) — with the same anchor landing outside _proof_scorecard(), staging it
+# here would silently exercise the wrong function too, so it shares C3's
+# precondition rather than re-deriving it.
+if [[ "$C3_REACHABLE" == "0" ]]; then
+  skip_t "armS: the count branch REDS on a short matrix" \
+    "shares C3's precondition (mutate()'s anchor is no longer scorecard-scoped) — staging the self-test truncation on the wrong function would prove nothing about the count branch"
 else
-  # expect_only runs in a SUBSHELL so its bad_t cannot touch the real counters.
-  _out="$( expect_only "armS probe" "a hard-coded span survives in the scorecard" 2>&1 )"
-  if grep -q "correct red name, but the harness evaluated" <<<"$_out"; then
-    ok_t "armS: the count branch REDS on a short matrix even when the red NAME is correct ($(sed -n 's/.*evaluated \([0-9]* of [0-9]*\).*/\1/p' <<<"$_out"))"
+  fresh
+  if ! _armS_truncate; then
+    bad_t "armS: could not stage the self-test truncation" "the anchor in digest_window_30d_unit.sh moved — this arm no longer tests what it claims, and a silent skip would leave the count branch uncontrolled"
+  elif ! mutate src/cmd_proof.sh "policy_refusals WHERE ts>=datetime('now',\$(sqlq \"\$sql_window\"))" \
+                                 "policy_refusals WHERE ts>=datetime('now','-7 days')"; then
+    bad_t "armS: the C3 mutation did not apply" "cannot self-test the count branch without it"
   else
-    bad_t "armS: the count branch did NOT fire on a deliberately short matrix" "expect_only printed: $(tr '\n' '|' <<<"$_out")"
+    # expect_only runs in a SUBSHELL so its bad_t cannot touch the real counters.
+    _out="$( expect_only "armS probe" "a hard-coded span survives in the scorecard" 2>&1 )"
+    if grep -q "correct red name, but the harness evaluated" <<<"$_out"; then
+      ok_t "armS: the count branch REDS on a short matrix even when the red NAME is correct ($(sed -n 's/.*evaluated \([0-9]* of [0-9]*\).*/\1/p' <<<"$_out"))"
+    else
+      bad_t "armS: the count branch did NOT fire on a deliberately short matrix" "expect_only printed: $(tr '\n' '|' <<<"$_out")"
+    fi
   fi
 fi
 
-printf '\n%s assertions passed, %s failed  (+%s precondition, which grades the INSTRUMENT, not the code)\n' \
-  "$PASS" "$FAIL" "$PRECOND"
+printf '\n%s assertions passed, %s failed, %s skipped  (+%s precondition, which grades the INSTRUMENT, not the code)\n' \
+  "$PASS" "$FAIL" "$SKIP" "$PRECOND"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/task_merge_gate_multirepo_unit.sh
+++ b/tests/task_merge_gate_multirepo_unit.sh
@@ -98,7 +98,7 @@ export GH_ARGS_LOG="$TMP/gh.args"; : >"$GH_ARGS_LOG"
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh \
+         lib/agent_setup.sh lib/disk.sh lib/state.sh lib/broker.sh lib/audit.sh \
          lib/registry.sh lib/tasks_db.sh lib/actor.sh cmd_push.sh \
          cmd_task.sh; do
   source "$SRC/$f"

--- a/tests/task_merge_gate_result_pr_unit.sh
+++ b/tests/task_merge_gate_result_pr_unit.sh
@@ -112,7 +112,7 @@ export GH_ARGS_LOG="$TMP/gh.args"; : >"$GH_ARGS_LOG"
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh \
+         lib/agent_setup.sh lib/disk.sh lib/state.sh lib/broker.sh lib/audit.sh \
          lib/registry.sh lib/tasks_db.sh lib/actor.sh cmd_push.sh \
          cmd_task.sh; do
   source "$SRC/$f"


### PR DESCRIPTION
**`changed-harnesses` WILL run `council_amend_e2e`, `council_unit`, `task_merge_gate_multirepo_unit`, `task_merge_gate_result_pr_unit` and `digest_window_30d_controls` in this PR's CI, and that is CORRECT — skip-gating them means touching them.** They are red on main's tip right now (confirmed by control-arm PR #456, exact-match red off `main` with this branch nowhere near it), and they are the reason `changed-harnesses` only self-clears on a commit that does *not* touch these five files. **This PR is that touch, deliberately, with the fix.**

## What changed, and why each is a genuine SKIP rather than a bug-fix

- **`council_cli_contract.mjs` + `council_ballot_e2e.sh`** (both run inside `council_unit.sh`): `--ask-rail` convene delivers through the root-scoped `5dive agent _deliver` grant (DIVE-1869). With no grant reachable the CLI **correctly refuses to convene**. Gated behind a `canDeliver()`-style reachability probe — the same check `src/council/cli.mjs` uses internally — and SKIPs with a named reason when unreachable. Verified locally: `council_unit.sh` went from red on these 6 assertions to fully green.
- **`council_amend_e2e.sh`**: matching live-registry reachability guard (`5dive agent list --json`), same class of precondition as the other two. **Unconfirmed whether this alone accounts for the CI red** — a separate deterministic bug was also found in this file (**DIVE-2706**, `council verify --json` double-reporting on a RED verdict) and is not fixed here. Which of the two (or both) is the actual CI trigger cannot be settled without real root, so it is stated as unconfirmed rather than given a clean story.
- **`digest_window_30d_controls.sh`**: the C3/armS **mutation control's anchor text is no longer unique** in `src/cmd_proof.sh` — a same-text SQL span now appears earlier in the file, so the blind first-occurrence mutation silently targets the *wrong function* and the control cannot observe what it claims to. Added a precondition check (the anchor's first hit must land inside `_proof_scorecard()`); SKIPs C3/armS with a named reason when it does not, instead of a false green or a false red.
- **`task_merge_gate_{multirepo,result_pr}_unit.sh`**: fixed a real isolation gap (missing `lib/disk.sh` → `wt_task_num` undefined) that was corrupting one assertion in each. **Not skip-gated further** — see residual below.

## What did NOT change

The council refusal behaviour itself is untouched — the DIVE-1869 delivery grant and the CNCL-16 registry preflight both still refuse exactly as before. Only the **test assertions around them** are gated.

**Positive control, stated per file rather than as one blanket claim (corrected by main before merge):** `council_cli_contract.mjs`, `council_ballot_e2e.sh` and `digest_window_30d_controls.sh` gate individual ARMS — every other assertion in those files still runs unconditionally and can still fail — 60+ and 100+ per file, unchanged. `council_amend_e2e.sh` is the exception and is a **file-level** skip (`exit 0`): it drives real `council convene` end to end, so without a registry there is no subset of it that is meaningful to run. That is defensible for an e2e and it is **not** the same guarantee as the other three, so it is stated separately rather than folded into one sentence.

A skip that disabled a harness *unconditionally* would be deleted coverage wearing a skip's clothes. Every guard here is conditional on a probe of the actual environment — `council_amend_e2e` uses the same `5dive agent list --json` call the `preflightSeats()`/`preflightLiveness()` path uses, so a real registry re-arms it automatically.

## Residual: 2 of the 5 stay red, on purpose

`task_merge_gate_multirepo_unit.sh` and `task_merge_gate_result_pr_unit.sh` will still show **1 FAIL each**. That is **DIVE-2705**, a separate deterministic bug that reproduces on any box: `_gate_gh()` (`cmd_task.sh:1529`) ends `|| true; return 0` on one branch and `|| true` as its last command on the other, so **it can never return non-zero**.

It is deliberately **not** hidden behind a skip, because it is a real defect and not an environment precondition. Verified independently by main at source. Severity as measured: it does **not** fail open — it fails **closed while asserting it measured**. `_gate_pr_probe`'s own comment defines empty as *both* "the PR does not exist there" and "could not resolve", which renders downstream as `its delivery PR is not merged to main yet (state= — MEASURED, not assumed)`. A dead `gh` call therefore refuses a legitimate close and claims a measurement that never happened.

## Also found, filed, not fixed here

**DIVE-2706** — `council verify --json` double-reports a bogus second JSON error after a legitimate one on a RED verdict (`output.sh`'s silent-exit backstop fires because that path never calls `mark_reported()`). Found while investigating `council_amend_e2e`. **It is not confirmed whether this or the registry precondition is what trips that harness in CI** — that cannot be settled without real root, and it is stated as unconfirmed rather than assumed away.

---

Maker dev2. Scope ruled narrow by main: DIVE-2705 gets its own row and its own verification rather than riding inside a skip-gating PR — mixing them would give this PR's red two causes and destroy the before/after evidence.

Opened by main because dev2's box is on 0.18.6, which predates `--open-pr` (DIVE-2605).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

