### PR TITLE
feat(task): every merge-gate accept says merged is not deployed (DIVE-2641)

### DIFF
--- a/changelog.d/DIVE-2641.md
+++ b/changelog.d/DIVE-2641.md
@@ -1,0 +1,24 @@
+## Unreleased — feat(task): every merge-gate accept now says merged is not deployed (DIVE-2641)
+
+The close gate prints `done=merged-to-main satisfied` — which is true — at the exact moment
+the reader assumes the stronger claim nobody checked: that the change is **running**. Four
+agents made that substitution independently on 2026-08-03 while the artifact their readers
+execute was an older bundle. The gate is the cheapest place to interrupt it, because the
+system is what tells the reader they are done.
+
+Every accepting arm now appends, in the same breath, what it did **not** establish, and
+rows whose deliverable is a deployed artifact get a second sentence naming the check that
+can actually answer for that artifact — `5dive doctor --category=host` for the bundled CLI
+at `/usr/local/bin/5dive`, `--category=plugins` for the marketplace clone each agent runs
+out of its own `$HOME`. The prompt is keyed off the repo the **accepting evidence** was
+found in, never off the task's own prose.
+
+The ticket named two accepting arms and a `grep -c` correction said three. There are
+**four**: the declared-`delivery_ref` path accepted while emitting no line at all, so no
+enumeration keyed on the accept string could return it — and it is the most-travelled close
+route in the product. It is now audible. Patching only the three that already spoke would
+have removed every visible symptom while leaving the defect intact for every row that binds
+a PR.
+
+Nothing about acceptance changes: text is appended to warns on paths that already passed,
+and no refusal is touched.

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -1997,6 +1997,43 @@ _gate_slug_from_url() {
     | head -1 | sed -E 's#^(https://github\.com/|git@github\.com:)##; s#\.git$##' || true
 }
 
+# _gate_merged_not_deployed <accepting-repo-slug> — DIVE-2641 (split from DIVE-2621,
+# item b+c). The sentence EVERY accepting arm of the merge gate appends to its own
+# receipt.
+#
+# WHY HERE. Each accepting arm prints `done=merged-to-main satisfied`, which is TRUE,
+# at the exact moment the reader assumes the STRONGER claim nobody checked: that the
+# change is RUNNING. Four agents made that substitution independently on 2026-08-03
+# (olivia DIVE-2587, dev DIVE-2571, dev3 on marketplace clones, main across the
+# v0.18.3-v0.18.6 cuts). They were not careless — the system told them they were done.
+# So the close gate is the cheapest place to interrupt it: same breath as the grade.
+#
+# THIS CHANGES NO ACCEPTANCE. It appends text to warns that already fire on paths that
+# already passed; no arm refuses, no new failure mode exists, and every refusal is
+# untouched. Merged-to-main is necessary and correctly verified — this only stops the
+# SENTENCE AFTER the grade travelling further than the evidence.
+# community/wiki/merged-to-main-is-a-claim-about-the-authors-artifact-not-the-readers.md
+#
+# ONE SHORT SENTENCE, deliberately. A paragraph gets skipped, and the entire value is
+# that it is read at the instant of the inference.
+#
+# The DEPLOYED-ARTIFACT prompt (item c) is keyed off the repo the ACCEPTING EVIDENCE
+# was found in — never off the task text, which is the maker's prose and describes what
+# they meant rather than where it landed. Only repos whose artifact a reader EXECUTES
+# get a prompt, and each names the surface that actually measures THAT artifact: the
+# host CLI check cannot see a marketplace clone and vice versa, so naming one for the
+# other would be a check that cannot answer the question it was cited for.
+_gate_merged_not_deployed() {
+  local _slug="${1:-}"
+  printf '%s' ' NOT ESTABLISHED by this: that the change is DEPLOYED — merged is a property of the repo, not of the artifact anyone is RUNNING, so check the installed side (`5dive doctor --category=host`) before you report this live (DIVE-2621/2641).'
+  case "${_slug##*/}" in
+    5dive|5dive-cli)
+      printf ' DEPLOYED-ARTIFACT ROW: %s ships /usr/local/bin/5dive, which cron and every agent execute — a host still on the previous release runs the OLD code whatever main says; `5dive doctor --category=host` reports installed vs published (DIVE-2640).' "$_slug" ;;
+    5dive-plugins)
+      printf ' DEPLOYED-ARTIFACT ROW: %s ships the marketplace clone each agent runs out of its OWN $HOME, so freshness is per-agent and one refresh does not fix the fleet — `5dive doctor --category=plugins` reports it per clone (DIVE-2642).' "$_slug" ;;
+  esac
+}
+
 # _gate_task_repo_slug <delivery_ref> <body> — the repo THIS TASK DECLARED, or empty.
 # Precedence: the delivery_ref URL (a delivered PR carries its own repo, which is why
 # ask 1 says prefer it) > an explicit `Repo: owner/repo` body line, the sibling of the
@@ -2908,6 +2945,15 @@ _task_status_cmd() {
           '') warn "$ident: could not verify the check status of $_dref (no gh token / network / gh) — merged-state confirmed, checks UNVERIFIED."
               _mg_unverified="${_mg_unverified:+$_mg_unverified; }checks of $_dref unresolved (merged-state confirmed)" ;;
         esac
+        # DIVE-2641: THE FOURTH ACCEPTING PATH, and until now the SILENT one. The row
+        # bound a delivery_ref, the PR is MERGED (every refusal above returned), and
+        # this path printed nothing at all — so the most common close route in the
+        # product was the one arm that could not carry the deployed-vs-merged note, and
+        # patching only the three arms that already spoke would have re-created the
+        # defect for exactly the rows that bind a PR. Same reasoning DIVE-2217 applied
+        # to the merged-PR arm below: an accept that says nothing is indistinguishable
+        # from every other accept in the durable operator record.
+        warn "$ident: delivery PR $_dref is MERGED (at $_merged) — GitHub's merged-PR record on the DECLARED delivery is the accepting evidence. done=merged-to-main satisfied.$(_gate_merged_not_deployed "$(_gate_slug_from_url "$_dref")")"
       else
         # DIVE-1955: a `Branch:` line names no repo, so this used to look for the
         # merged PR in the CLI repo ONLY — an api/frontend branch could never satisfy
@@ -3013,7 +3059,7 @@ _task_status_cmd() {
           if [[ -z "$_task_slug" ]]; then
             _attr_scope=" SCOPE: this task declares no repo, so the gate searched $_searched and stopped at the first hit — repos outside that set were NOT looked at. If the delivery landed somewhere else, this accept is about a DIFFERENT repo's commit; declare it with a \`Repo: <owner>/<repo>\` line or bind the delivery_ref, and re-check."
           fi
-          warn "$ident: a commit on ${FIVE_GATE_MAIN_BRANCH:-main} in $_attr_slug names $ident in its SUBJECT — the work is on main (attribution, DIVE-2120). This does NOT establish HOW it landed: a delegated push and a squash-merged PR are indistinguishable to a subject scan, because a squash rewrites the sha. done=merged-to-main satisfied.$_attr_scope"
+          warn "$ident: a commit on ${FIVE_GATE_MAIN_BRANCH:-main} in $_attr_slug names $ident in its SUBJECT — the work is on main (attribution, DIVE-2120). This does NOT establish HOW it landed: a delegated push and a squash-merged PR are indistinguishable to a subject scan, because a squash rewrites the sha. done=merged-to-main satisfied.$_attr_scope$(_gate_merged_not_deployed "$_attr_slug")"
         elif [[ -n "$_attr_bound" && -z "$_bmerged" ]]; then
           # DIVE-2120: the scan stopped AT THE BOUND without finding the ident. That is NOT
           # a miss and must not read as one — a bounded search whose negative looks like an
@@ -3068,7 +3114,7 @@ _task_status_cmd() {
           # named for the evidence that assigned it, just as _attr_slug is owned by
           # _gate_branch_ident_on_main above. A silent success here made a merged-PR
           # close indistinguishable from attribution in the durable operator record.
-          warn "$ident: branch '$_branch' is the head of a MERGED PR in $_merged_slug (merged at $_bmerged) — GitHub's merged-PR record is the accepting evidence. done=merged-to-main satisfied."
+          warn "$ident: branch '$_branch' is the head of a MERGED PR in $_merged_slug (merged at $_bmerged) — GitHub's merged-PR record is the accepting evidence. done=merged-to-main satisfied.$(_gate_merged_not_deployed "$_merged_slug")"
         fi
       fi
     fi
@@ -3292,7 +3338,7 @@ $_body"
           done < <(if [[ -n "$_task_slug" ]]; then printf '%s\n' "$_task_slug"; else _gate_repo_slugs; fi)
         done < <(printf '%s\n' "$_br_cands")
         if [[ -n "$_bl_hit" ]]; then
-          warn "$ident: branch '$_bl_hit', named in the result/body, is on ${FIVE_GATE_MAIN_BRANCH:-main} in $_bl_hit_slug via $_bl_hit_how. done=merged-to-main satisfied (DIVE-2577)."
+          warn "$ident: branch '$_bl_hit', named in the result/body, is on ${FIVE_GATE_MAIN_BRANCH:-main} in $_bl_hit_slug via $_bl_hit_how. done=merged-to-main satisfied (DIVE-2577).$(_gate_merged_not_deployed "$_bl_hit_slug")"
         elif [[ $_bl_any_unreach -eq 1 ]]; then
           warn "$ident: result/body names branch(es) ${_br_cands//$'\n'/, } but the merge-gate could not fully scan ${_bl_searched2//,/, } for them (API/timeout on at least one repo) — this close is UNVERIFIED for the branch, not verified-clean (DIVE-2318 pattern)."
           _mg_unverified="${_mg_unverified:+$_mg_unverified; }branch named in result/body (${_br_cands//$'\n'/, }) could not be fully scanned"

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -2023,9 +2023,18 @@ _gate_slug_from_url() {
 # get a prompt, and each names the surface that actually measures THAT artifact: the
 # host CLI check cannot see a marketplace clone and vice versa, so naming one for the
 # other would be a check that cannot answer the question it was cited for.
+#
+# WHICH IS WHY THE GENERIC HALF NAMES BARE `5dive doctor` AND NO CATEGORY. It said
+# `--category=host` in the first cut, and that is only right for the host binary: on a
+# marketplace row the FIRST surface the reader was handed was the one that reads
+# /usr/local/bin/5dive and can say nothing about a clone in an agent's own $HOME. Bare
+# `5dive doctor` runs every category (cmd_doctor.sh: an empty filter sets run_host=1 AND
+# run_plugins=1), so it is true for every repo and the keyed half below narrows it.
+# Caught by RENDERING the three shapes and reading them, not by any assertion — the two
+# arms that now grade it (D5/D6) were written after the fact, which is the honest ordering.
 _gate_merged_not_deployed() {
   local _slug="${1:-}"
-  printf '%s' ' NOT ESTABLISHED by this: that the change is DEPLOYED — merged is a property of the repo, not of the artifact anyone is RUNNING, so check the installed side (`5dive doctor --category=host`) before you report this live (DIVE-2621/2641).'
+  printf '%s' ' NOT ESTABLISHED by this: that the change is DEPLOYED — merged is a property of the repo, not of the artifact anyone is RUNNING, so check the installed side (`5dive doctor`) before you report this live (DIVE-2621/2641).'
   case "${_slug##*/}" in
     5dive|5dive-cli)
       printf ' DEPLOYED-ARTIFACT ROW: %s ships /usr/local/bin/5dive, which cron and every agent execute — a host still on the previous release runs the OLD code whatever main says; `5dive doctor --category=host` reports installed vs published (DIVE-2640).' "$_slug" ;;

--- a/tests/task_merge_gate_deploy_note_unit.sh
+++ b/tests/task_merge_gate_deploy_note_unit.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# TIER: nightly — the core PR tier measured 270s of a 300s cap (DIVE-2525), so a new
+# harness goes to the nightly sweep rather than eating the remaining headroom.
+#
+# DIVE-2641 isolated unit harness — EVERY accepting arm of the merge gate must say
+# what it did NOT establish.
+#
+# THE DEFECT (DIVE-2621, four independent instances on 2026-08-03): each accepting arm
+# prints `done=merged-to-main satisfied`, which is TRUE, at the exact moment the reader
+# assumes the STRONGER claim nobody checked — that the change is RUNNING. olivia
+# (DIVE-2587), dev (DIVE-2571), dev3 (marketplace clones) and main (the v0.18.3-v0.18.6
+# cuts) each made that substitution without knowing about the others. The system told
+# them they were done. See
+# community/wiki/merged-to-main-is-a-claim-about-the-authors-artifact-not-the-readers.md
+#
+# WHAT IS PINNED. The ticket says VERIFY BY MUTATION, not by reading the diff: drive an
+# ACTUAL close down EACH accepting path and confirm the sentence appears on each. A
+# green on one path is not evidence for the other, so there is one case per path:
+#   D1  declared delivery_ref, PR MERGED           (the arm that was SILENT before this)
+#   D2  `Branch:` binding, ATTRIBUTION on main     (DIVE-2120)
+#   D3  `Branch:` binding, MERGED PR for the head  (DIVE-2217)
+#   D4  branch named in the RESULT/BODY            (DIVE-2577)
+# and the two arms that make the DEPLOYED-ARTIFACT prompt a measurement rather than a
+# decoration:
+#   D5  the SAME accepting path in a repo that ships no installed artifact -> generic
+#       note, NO prompt. Without this arm a prompt that fires unconditionally scores
+#       green on D1-D4 and proves nothing about the keying.
+#   D6  the marketplace repo gets the PER-CLONE surface, never the host-CLI one.
+# plus:
+#   D7  a REFUSAL carries neither (this text is a property of ACCEPTANCE; a refused
+#       close that printed an accept receipt would be a worse defect than the one
+#       being fixed).
+#   D8  SOURCE SHAPE: every `done=merged-to-main satisfied` in cmd_task.sh calls the
+#       helper on its own line. Behaviour arms cannot see an accepting arm added LATER
+#       and written the old way, and an unpatched accepting path is this whole defect
+#       re-created (cf. DIVE-2210's "the ticket named 2 sites; there were 3").
+#   D9  ZERO ACCEPTANCE CHANGE: the gate still refuses what it refused. The constraint
+#       on the ticket is that this must not weaken the merge gate or add failure modes.
+#
+# MUTATION GRADE (run by hand against src/cmd_task.sh; each must go red):
+#   * `_gate_merged_not_deployed() { :; }`            -> D1-D6 FAIL (all four paths).
+#   * drop the `case` from the helper (always print the generic half only)
+#                                                     -> D1-D4, D6 FAIL.
+#   * make the helper print the prompt unconditionally (delete the `case`, print the
+#     CLI arm always)                                 -> D5 FAILS (and only D5 — that
+#     is the arm that exists for it).
+#   * revert ANY ONE call site                        -> that path's case FAILS and the
+#     other three still pass, which is the point of one case per path.
+#   * revert any one call site                        -> D8 FAILS structurally too.
+# Isolation matches the sibling gate harnesses: source src/ into a throwaway STATE_DIR
+# (the live tasks.db is NEVER touched); gh is STUBBED on PATH.
+# Run: bash tests/task_merge_gate_deploy_note_unit.sh  (no root, no network).
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/gate-deploy-note-unit.XXXXXX)"
+
+# --- stub gh. Four surfaces matter here:
+#   `auth token`                              -> GH_STUB_AUTH_TOKEN
+#   `pr view <url> --json ... -q <expr>`      -> keyed on the EXPRESSION the caller
+#      asked for, because the declared-delivery path asks three different questions of
+#      the same PR: `.state`, `.mergedAt`, and _gate_pr_state's joined rollup triple.
+#   `pr list --repo <slug> --head <b> --state merged` -> GH_STUB_PRLIST_merged_<REPO>
+#   `api repos/<slug>/commits?sha=main`       -> GH_STUB_COMMITS_<REPO>_main
+mkdir -p "$TMP/bin"
+cat >"$TMP/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf 'ARGS=%s\n' "$*" >>"$GH_ARGS_LOG"
+if [[ "$1" == "auth" && "$2" == "token" ]]; then printf '%s\n' "${GH_STUB_AUTH_TOKEN:-}"; [[ -n "${GH_STUB_AUTH_TOKEN:-}" ]] || exit 1; exit 0; fi
+a=("$@"); expr='.'; repo=""; i=0; slice='.'
+while [[ $i -lt ${#a[@]} ]]; do
+  case "${a[$i]}" in
+    -q|--jq) expr="${a[$((i+1))]}"; i=$((i+2)) ;;
+    -q*)     expr="${a[$i]#-q}";    i=$((i+1)) ;;
+    --repo)  repo="${a[$((i+1))]}"; i=$((i+2)) ;;
+    *)       i=$((i+1)) ;;
+  esac
+done
+key() { printf '%s' "${1//[^A-Za-z0-9]/_}"; }
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  # The rollup call joins three fields; the two single-field calls ask for one each.
+  case "$expr" in
+    *join*)     printf '%s\n' "${GH_STUB_PRVIEW_ROLLUP:-}" ;;
+    .state)     printf '%s\n' "${GH_STUB_PRVIEW_STATE:-}" ;;
+    .mergedAt)  printf '%s\n' "${GH_STUB_PRVIEW_MERGEDAT:-}" ;;
+    *)          : ;;
+  esac
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  st="open"; for x in "${a[@]}"; do [[ "$x" == "merged" ]] && st="merged"; done
+  lx="GH_STUB_PRLIST_${st}_$(key "${repo##*/}")"
+  printf '%s' "${!lx:-[]}" | jq -r "$expr" 2>/dev/null; exit 0
+fi
+if [[ "$1" == "api" ]]; then
+  path="$2"
+  slug=$(printf '%s' "$path" | cut -d/ -f2,3)
+  case "$path" in
+    */commits\?*)
+      br="${path##*sha=}"; br="${br%%&*}"
+      fx="GH_STUB_COMMITS_$(key "${slug##*/}")_$(key "$br")"
+      pp=30; case "$path" in *per_page=*) pp="${path##*per_page=}"; pp="${pp%%&*}" ;; esac
+      [[ "$pp" =~ ^[0-9]+$ ]] || pp=30
+      (( pp > 100 )) && pp=100
+      pg=1; case "$path" in *"&page="*) pg="${path##*&page=}"; pg="${pg%%&*}" ;; esac
+      [[ "$pg" =~ ^[0-9]+$ && "$pg" -gt 0 ]] || pg=1
+      slice=".[$(( (pg-1)*pp )):$(( pg*pp ))]" ;;
+    *) exit 1 ;;
+  esac
+  json="${!fx:-}"
+  [[ -n "$json" ]] || exit 1
+  printf '%s' "$json" | jq -c "$slice" 2>/dev/null | jq -r "$expr" 2>/dev/null; exit 0
+fi
+exit 0
+STUB
+chmod +x "$TMP/bin/gh"
+cat >"$TMP/bin/sudo" <<'SUDOSTUB'
+#!/usr/bin/env bash
+exit 1
+SUDOSTUB
+chmod +x "$TMP/bin/sudo"
+export PATH="$TMP/bin:$PATH"
+export GH_ARGS_LOG="$TMP/gh.args"; : >"$GH_ARGS_LOG"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_push.sh cmd_task.sh; do
+  source "$SRC/$f"
+done
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=0
+mkdir -p "$TASKS_DIR"; set +e
+tasks_db_init
+# `tasks_db_init` creates the BASE schema only; the columns added since (delivery_ref
+# among them) come from _tasks_db_migrate, which a fresh fixture store has never run.
+# Measured, not assumed: PRAGMA table_info(tasks) counts 0 delivery_ref after init and 1
+# after this line. Without it D1's binding lands nowhere, the DIVE-1830 gate sees no
+# declared delivery, and the case reports a clean close having exercised NOTHING — a
+# green that means the opposite of what it reads as.
+_tasks_db_migrate >/dev/null 2>&1
+task_need_notify() { :; }
+_task_close_notify() { :; }
+AUDIT_CALLS="$TMP/audit.calls"; : >"$AUDIT_CALLS"
+audit_log() { printf '%s\n' "$*" >>"$AUDIT_CALLS"; }
+export GH_STUB_AUTH_TOKEN="tok"
+export FIVE_GATE_REPOS="5dive-ai/5dive"
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+seed()     { db "DELETE FROM tasks WHERE ident='$1';
+                 INSERT INTO tasks (ident, title, body, status, created_by, assignee)
+                   VALUES ('$1','t',$(sqlq "${2:-}"),'in_progress','main','main');"; }
+# Bind the delivery_ref by UPDATE, the same shape the sibling harnesses use
+# (task_merge_gate_diagnostic_unit.sh:147).
+seed_dref() { seed "$1"; db "UPDATE tasks SET delivery_ref='$2', delivered_at=datetime('now') WHERE ident='$1';"; }
+statusof() { db "SELECT status FROM tasks WHERE ident='$1';"; }
+refusals() { db "SELECT COUNT(*) FROM policy_refusals WHERE ident='$1';"; }
+run_done() { OUT=$(cmd_task_done "$@" 2>&1); RC=$?; }
+clear_fx() { unset "${!GH_STUB_PRLIST_@}" "${!GH_STUB_COMMITS_@}" "${!GH_STUB_PRVIEW_@}" 2>/dev/null; }
+commits() { printf '[{"commit":{"message":"%s"}},{"commit":{"message":"chore: unrelated"}}]' "$1"; }
+NO_MATCH_COMMITS='[{"commit":{"message":"chore(deps): bump something"}}]'
+MERGED_PR='[{"number":41,"mergedAt":"2026-07-26T09:00:00Z","headRefName":"x"}]'
+
+# The two halves, asserted as ANCHORED CLAUSES rather than loose substrings: a bare
+# grep for "DEPLOYED" would pass on any sentence containing the word, including the
+# generic half, so the arms could not tell each other apart (DIVE-2324's lesson).
+NOTE='NOT ESTABLISHED by this: that the change is DEPLOYED'
+PROMPT='DEPLOYED-ARTIFACT ROW'
+CLI_SURFACE='5dive doctor --category=host'
+CLONE_SURFACE='5dive doctor --category=plugins'
+
+# --- D1. DECLARED delivery_ref, PR MERGED -------------------------------------
+# The arm that printed NOTHING before this change, and the most common close route
+# in the product. Patching only the three arms that already spoke would have left the
+# defect fully intact for every row that binds a PR.
+clear_fx
+export GH_STUB_PRVIEW_STATE="MERGED"
+export GH_STUB_PRVIEW_MERGEDAT="2026-08-01T10:00:00Z"
+export GH_STUB_PRVIEW_ROLLUP="MERGED|2026-08-01T10:00:00Z|SUCCESS"
+seed_dref DEP-1 'https://github.com/5dive-ai/5dive/pull/457'
+run_done DEP-1 --result='landed'
+[[ $RC -eq 0 && "$(statusof DEP-1)" == "done" && "$(refusals DEP-1)" == "0" ]] \
+  && ok_t 'D1: a merged delivery_ref still closes (acceptance unchanged)' \
+  || bad_t 'D1 must close' "rc=$RC status=$(statusof DEP-1) refusals=$(refusals DEP-1) out=$OUT"
+[[ "$OUT" == *"done=merged-to-main satisfied"* ]] \
+  && ok_t 'D1: the declared-delivery accept is now AUDIBLE (it printed nothing before)' \
+  || bad_t 'D1 accept must emit a receipt' "out=$OUT"
+[[ "$OUT" == *"$NOTE"* ]] \
+  && ok_t 'D1: and it says what it did NOT establish' \
+  || bad_t 'D1 must carry the not-deployed note' "out=$OUT"
+[[ "$OUT" == *"$PROMPT"* && "$OUT" == *"$CLI_SURFACE"* ]] \
+  && ok_t 'D1: a CLI-repo delivery is prompted for the installed-side check' \
+  || bad_t 'D1 must prompt for the host check' "out=$OUT"
+
+# --- D2. `Branch:` binding, ATTRIBUTION on main -------------------------------
+clear_fx
+export GH_STUB_COMMITS_5dive_main="$(commits 'fix: the thing (DEP-2)')"
+seed DEP-2 'Branch: dep-2-attribution'
+run_done DEP-2 --result='landed by delegated push'
+[[ $RC -eq 0 && "$(statusof DEP-2)" == "done" && "$(refusals DEP-2)" == "0" ]] \
+  && ok_t 'D2: the attribution arm still closes (acceptance unchanged)' \
+  || bad_t 'D2 must close' "rc=$RC status=$(statusof DEP-2) refusals=$(refusals DEP-2) out=$OUT"
+[[ "$OUT" == *"names DEP-2 in its SUBJECT"* && "$OUT" == *"$NOTE"* && "$OUT" == *"$CLI_SURFACE"* ]] \
+  && ok_t 'D2: the ATTRIBUTION receipt carries the note and the surface' \
+  || bad_t 'D2 attribution arm must carry the note' "out=$OUT"
+
+# --- D3. `Branch:` binding, MERGED PR for the head ----------------------------
+clear_fx
+export GH_STUB_COMMITS_5dive_main="$NO_MATCH_COMMITS"
+export GH_STUB_PRLIST_merged_5dive="$MERGED_PR"
+seed DEP-3 'Branch: dep-3-squashed'
+run_done DEP-3 --result='squash-merged'
+[[ $RC -eq 0 && "$(statusof DEP-3)" == "done" && "$(refusals DEP-3)" == "0" ]] \
+  && ok_t 'D3: the merged-PR arm still closes (acceptance unchanged)' \
+  || bad_t 'D3 must close' "rc=$RC status=$(statusof DEP-3) refusals=$(refusals DEP-3) out=$OUT"
+[[ "$OUT" == *"is the head of a MERGED PR"* && "$OUT" == *"$NOTE"* && "$OUT" == *"$CLI_SURFACE"* ]] \
+  && ok_t 'D3: the MERGED-PR receipt carries the note and the surface' \
+  || bad_t 'D3 merged-PR arm must carry the note' "out=$OUT"
+
+# --- D4. branch named in the RESULT/BODY (DIVE-2577) --------------------------
+clear_fx
+export GH_STUB_COMMITS_5dive_main="$(commits 'fix: the thing (DEP-4)')"
+seed DEP-4
+run_done DEP-4 --result='landed via delegated push on branch dep-4-maker-credit'
+[[ $RC -eq 0 && "$(statusof DEP-4)" == "done" && "$(refusals DEP-4)" == "0" ]] \
+  && ok_t 'D4: the result/body branch arm still closes (acceptance unchanged)' \
+  || bad_t 'D4 must close' "rc=$RC status=$(statusof DEP-4) refusals=$(refusals DEP-4) out=$OUT"
+[[ "$OUT" == *"named in the result/body"* && "$OUT" == *"$NOTE"* && "$OUT" == *"$CLI_SURFACE"* ]] \
+  && ok_t 'D4: the result/body receipt carries the note and the surface' \
+  || bad_t 'D4 result/body arm must carry the note' "out=$OUT"
+
+# --- D5. THE DIFFERENTIAL: a repo that ships no installed artifact ------------
+# Same accepting path as D2, only the repo differs. The generic note is universal;
+# the PROMPT is a claim about the deliverable and must not fire where no reader
+# executes the artifact. Without this arm, a helper that always prints the prompt is
+# green on every case above.
+clear_fx
+export GH_STUB_COMMITS_5dive_api_main="$(commits 'fix: the api thing (DEP-5)')"
+seed DEP-5 'Branch: dep-5-api-side'
+FIVE_GATE_REPOS='lodar/5dive-api' run_done DEP-5 --result='landed in the api'
+[[ $RC -eq 0 && "$(statusof DEP-5)" == "done" ]] \
+  && ok_t 'D5: an api-repo close still closes' \
+  || bad_t 'D5 must close' "rc=$RC status=$(statusof DEP-5) out=$OUT"
+[[ "$OUT" == *"$NOTE"* ]] \
+  && ok_t 'D5: the merged-is-not-deployed note is UNIVERSAL — every accept carries it' \
+  || bad_t 'D5 must still carry the generic note' "out=$OUT"
+[[ "$OUT" != *"$PROMPT"* && "$OUT" != *"/usr/local/bin/5dive"* ]] \
+  && ok_t 'D5: but the DEPLOYED-ARTIFACT prompt does NOT fire for lodar/5dive-api (keyed, not unconditional)' \
+  || bad_t 'D5 prompt must be keyed to the accepting repo' "out=$OUT"
+
+# --- D6. the marketplace repo gets the PER-CLONE surface ----------------------
+# Naming the host-CLI check here would cite a surface that cannot answer the question:
+# `--category=host` reads /usr/local/bin/5dive and can say nothing about a clone in an
+# agent's $HOME (DIVE-2642 built the one that can).
+clear_fx
+export GH_STUB_COMMITS_5dive_plugins_main="$(commits 'feat: the plugin thing (DEP-6)')"
+seed DEP-6 'Branch: dep-6-plugin-side'
+FIVE_GATE_REPOS='5dive-ai/5dive-plugins' run_done DEP-6 --result='landed in plugins'
+[[ $RC -eq 0 && "$(statusof DEP-6)" == "done" ]] \
+  && ok_t 'D6: a plugins-repo close still closes' \
+  || bad_t 'D6 must close' "rc=$RC status=$(statusof DEP-6) out=$OUT"
+[[ "$OUT" == *"$PROMPT"* && "$OUT" == *"$CLONE_SURFACE"* && "$OUT" != *"/usr/local/bin/5dive"* ]] \
+  && ok_t 'D6: the marketplace repo is prompted for PER-CLONE freshness, not the host binary' \
+  || bad_t 'D6 must name the clone surface and not the host one' "out=$OUT"
+
+# --- D7. a REFUSAL carries neither -------------------------------------------
+clear_fx
+export GH_STUB_COMMITS_5dive_main="$NO_MATCH_COMMITS"
+seed DEP-7 'Branch: dep-7-never-landed'
+run_done DEP-7 --result='trust me'
+[[ $RC -ne 0 && "$(statusof DEP-7)" == "in_progress" && "$(refusals DEP-7)" == "1" ]] \
+  && ok_t 'D7: genuinely unlanded work is still REFUSED — the gate is not weakened' \
+  || bad_t 'D7 must refuse' "rc=$RC status=$(statusof DEP-7) refusals=$(refusals DEP-7) out=$OUT"
+[[ "$OUT" != *"$NOTE"* && "$OUT" != *"$PROMPT"* ]] \
+  && ok_t 'D7: and it prints no accept receipt (this text is a property of ACCEPTANCE)' \
+  || bad_t 'a refusal must not carry an accept receipt' "out=$OUT"
+
+# --- D8. SOURCE SHAPE: no accepting arm can be added without the note ---------
+# The behaviour arms above grade the four arms that exist TODAY. They are structurally
+# blind to a FIFTH written next year in the old style, and an unpatched accepting path
+# is this entire defect re-created — which is exactly how DIVE-2641 came to be filed
+# naming two sites when there were three. Grade the shape as well as the behaviour.
+_bad_lines=$(grep -n 'done=merged-to-main satisfied' "$SRC/cmd_task.sh" \
+             | grep -v '^[0-9]*:[[:space:]]*#' \
+             | grep -v '_gate_merged_not_deployed' || true)
+[[ -z "$_bad_lines" ]] \
+  && ok_t 'D8: EVERY accepting arm in cmd_task.sh calls _gate_merged_not_deployed on its own line' \
+  || bad_t 'an accepting arm prints the grade without the note' "$_bad_lines"
+# ...and the assertion above is not vacuous: there ARE accepting arms to find.
+_n_accepts=$(grep -c 'done=merged-to-main satisfied.*_gate_merged_not_deployed' "$SRC/cmd_task.sh")
+[[ "$_n_accepts" -ge 4 ]] \
+  && ok_t "D8: non-vacuity — $_n_accepts accepting arms matched, so D8 is grading a real population" \
+  || bad_t 'D8 is vacuous: fewer than 4 accepting arms found' "n=$_n_accepts"
+
+# --- D9. ZERO ACCEPTANCE CHANGE: an unbound, code-free close is untouched -----
+clear_fx
+seed DEP-9
+run_done DEP-9 --result='decision recorded, no code involved'
+[[ $RC -eq 0 && "$(statusof DEP-9)" == "done" && "$(refusals DEP-9)" == "0" ]] \
+  && ok_t 'D9: a close with no binding at all is unaffected (zero regression)' \
+  || bad_t 'no-binding close must be untouched' "rc=$RC status=$(statusof DEP-9) out=$OUT"
+[[ "$OUT" != *"$NOTE"* ]] \
+  && ok_t 'D9: and it carries no note — nothing claimed merged-to-main, so nothing to disclaim' \
+  || bad_t 'an ungated close must not carry the note' "out=$OUT"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/task_merge_gate_deploy_note_unit.sh
+++ b/tests/task_merge_gate_deploy_note_unit.sh
@@ -54,6 +54,11 @@
 #   M5  revert ONLY the D2 call site              -> 16/5: D2, and D5/D6 with it since
 #                                                   they accept through the same
 #                                                   attribution arm, plus both D8 arms.
+#   M6  ANCHOR: put `--category=host` back into the GENERIC half (its first shape)
+#                                                 -> 19/2: D5 and D6, the two arms added
+#                                                   for it. A fix nobody can red is a fix
+#                                                   nobody is grading.
+#
 # WHAT THE FIRST RUN CORRECTED, recorded because the prediction was wrong in a way that
 # would have shipped: M2 was predicted to red D1-D4 and, run against the FIRST version of
 # this file, it red only D1 and D6 (19/2). D2/D3/D4 asserted the SURFACE string, which the
@@ -268,8 +273,8 @@ FIVE_GATE_REPOS='lodar/5dive-api' run_done DEP-5 --result='landed in the api'
 [[ "$OUT" == *"$NOTE"* ]] \
   && ok_t 'D5: the merged-is-not-deployed note is UNIVERSAL — every accept carries it' \
   || bad_t 'D5 must still carry the generic note' "out=$OUT"
-[[ "$OUT" != *"$PROMPT"* && "$OUT" != *"/usr/local/bin/5dive"* ]] \
-  && ok_t 'D5: but the DEPLOYED-ARTIFACT prompt does NOT fire for lodar/5dive-api (keyed, not unconditional)' \
+[[ "$OUT" != *"$PROMPT"* && "$OUT" != *"/usr/local/bin/5dive"* && "$OUT" != *"$CLI_SURFACE"* ]] \
+  && ok_t 'D5: no prompt and no host-binary check for lodar/5dive-api (keyed, not unconditional)' \
   || bad_t 'D5 prompt must be keyed to the accepting repo' "out=$OUT"
 
 # --- D6. the marketplace repo gets the PER-CLONE surface ----------------------
@@ -283,8 +288,14 @@ FIVE_GATE_REPOS='5dive-ai/5dive-plugins' run_done DEP-6 --result='landed in plug
 [[ $RC -eq 0 && "$(statusof DEP-6)" == "done" ]] \
   && ok_t 'D6: a plugins-repo close still closes' \
   || bad_t 'D6 must close' "rc=$RC status=$(statusof DEP-6) out=$OUT"
-[[ "$OUT" == *"$PROMPT"* && "$OUT" == *"$CLONE_SURFACE"* && "$OUT" != *"/usr/local/bin/5dive"* ]] \
-  && ok_t 'D6: the marketplace repo is prompted for PER-CLONE freshness, not the host binary' \
+# `!= $CLI_SURFACE` is the arm that matters here and it is not decoration: the first cut
+# of the generic half named `--category=host` unconditionally, so a marketplace close
+# handed the reader a check that reads /usr/local/bin/5dive and is silent about clones.
+# The `/usr/local/bin/5dive` arm alone did NOT catch it — the generic half never carried
+# that path — so the assertion has to name the CATEGORY, which is the thing that was wrong.
+[[ "$OUT" == *"$PROMPT"* && "$OUT" == *"$CLONE_SURFACE"* \
+   && "$OUT" != *"/usr/local/bin/5dive"* && "$OUT" != *"$CLI_SURFACE"* ]] \
+  && ok_t 'D6: the marketplace repo is prompted for PER-CLONE freshness and never handed the host check' \
   || bad_t 'D6 must name the clone surface and not the host one' "out=$OUT"
 
 # --- D7. a REFUSAL carries neither -------------------------------------------

--- a/tests/task_merge_gate_deploy_note_unit.sh
+++ b/tests/task_merge_gate_deploy_note_unit.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# TIER: nightly — the core PR tier measured 270s of a 300s cap (DIVE-2525), so a new
-# harness goes to the nightly sweep rather than eating the remaining headroom.
+# TIER: nightly — 5.0s measured on the 5dive dev host (slowest of three consecutive
+# local runs of this file; 4.3/4.7/5.0). Demotion is argued, not defaulted: the core PR
+# tier last read 270s against its 300s cap (DIVE-2525), so 30s of headroom is all that
+# is left for every future harness, and this file needs no PR-time signal that the
+# nightly sweep cannot give a day later.
 #
 # DIVE-2641 isolated unit harness — EVERY accepting arm of the merge gate must say
 # what it did NOT establish.
@@ -37,16 +40,28 @@
 #   D9  ZERO ACCEPTANCE CHANGE: the gate still refuses what it refused. The constraint
 #       on the ticket is that this must not weaken the merge gate or add failure modes.
 #
-# MUTATION GRADE (run by hand against src/cmd_task.sh; each must go red):
-#   * `_gate_merged_not_deployed() { :; }`            -> D1-D6 FAIL (all four paths).
-#   * drop the `case` from the helper (always print the generic half only)
-#                                                     -> D1-D4, D6 FAIL.
-#   * make the helper print the prompt unconditionally (delete the `case`, print the
-#     CLI arm always)                                 -> D5 FAILS (and only D5 — that
-#     is the arm that exists for it).
-#   * revert ANY ONE call site                        -> that path's case FAILS and the
-#     other three still pass, which is the point of one case per path.
-#   * revert any one call site                        -> D8 FAILS structurally too.
+# MUTATION GRADE — RUN, not predicted. Baseline 21/0; each mutant applied to the
+# committed tree, `git checkout --` between, tree clean before and after:
+#   M1  `_gate_merged_not_deployed() { :; }`      -> 14/7: every note arm on all four
+#                                                   paths, plus D5 and D6.
+#   M2  helper keeps the generic half, `case` cut -> 16/5: D1-D4 and D6, i.e. the
+#                                                   prompt is graded on every path.
+#   M3  helper prints the CLI prompt UNCONDITIONALLY (the keying cut)
+#                                                 -> 19/2: D5 (the arm that exists for
+#                                                   it) and D6 (wrong surface cited).
+#   M4  revert ONLY the D1 call site              -> 17/4: D1's two note arms and BOTH
+#                                                   D8 arms (shape + non-vacuity).
+#   M5  revert ONLY the D2 call site              -> 16/5: D2, and D5/D6 with it since
+#                                                   they accept through the same
+#                                                   attribution arm, plus both D8 arms.
+# WHAT THE FIRST RUN CORRECTED, recorded because the prediction was wrong in a way that
+# would have shipped: M2 was predicted to red D1-D4 and, run against the FIRST version of
+# this file, it red only D1 and D6 (19/2). D2/D3/D4 asserted the SURFACE string, which the
+# generic half also contains, so deleting the prompt entirely could not move them. They
+# now assert $PROMPT as well and M2 was RE-RUN against the tightened arms for the 16/5
+# above — a mutant graded before the test changed is a reading of a file that no longer
+# exists. The mutation is what found the hole, which is the argument for grading a suite
+# by mutation rather than by reading its assertions.
 # Isolation matches the sibling gate harnesses: source src/ into a throwaway STATE_DIR
 # (the live tasks.db is NEVER touched); gh is STUBBED on PATH.
 # Run: bash tests/task_merge_gate_deploy_note_unit.sh  (no root, no network).
@@ -206,8 +221,9 @@ run_done DEP-2 --result='landed by delegated push'
 [[ $RC -eq 0 && "$(statusof DEP-2)" == "done" && "$(refusals DEP-2)" == "0" ]] \
   && ok_t 'D2: the attribution arm still closes (acceptance unchanged)' \
   || bad_t 'D2 must close' "rc=$RC status=$(statusof DEP-2) refusals=$(refusals DEP-2) out=$OUT"
-[[ "$OUT" == *"names DEP-2 in its SUBJECT"* && "$OUT" == *"$NOTE"* && "$OUT" == *"$CLI_SURFACE"* ]] \
-  && ok_t 'D2: the ATTRIBUTION receipt carries the note and the surface' \
+[[ "$OUT" == *"names DEP-2 in its SUBJECT"* && "$OUT" == *"$NOTE"* \
+   && "$OUT" == *"$PROMPT"* && "$OUT" == *"$CLI_SURFACE"* ]] \
+  && ok_t 'D2: the ATTRIBUTION receipt carries the note, the prompt and the surface' \
   || bad_t 'D2 attribution arm must carry the note' "out=$OUT"
 
 # --- D3. `Branch:` binding, MERGED PR for the head ----------------------------
@@ -219,8 +235,9 @@ run_done DEP-3 --result='squash-merged'
 [[ $RC -eq 0 && "$(statusof DEP-3)" == "done" && "$(refusals DEP-3)" == "0" ]] \
   && ok_t 'D3: the merged-PR arm still closes (acceptance unchanged)' \
   || bad_t 'D3 must close' "rc=$RC status=$(statusof DEP-3) refusals=$(refusals DEP-3) out=$OUT"
-[[ "$OUT" == *"is the head of a MERGED PR"* && "$OUT" == *"$NOTE"* && "$OUT" == *"$CLI_SURFACE"* ]] \
-  && ok_t 'D3: the MERGED-PR receipt carries the note and the surface' \
+[[ "$OUT" == *"is the head of a MERGED PR"* && "$OUT" == *"$NOTE"* \
+   && "$OUT" == *"$PROMPT"* && "$OUT" == *"$CLI_SURFACE"* ]] \
+  && ok_t 'D3: the MERGED-PR receipt carries the note, the prompt and the surface' \
   || bad_t 'D3 merged-PR arm must carry the note' "out=$OUT"
 
 # --- D4. branch named in the RESULT/BODY (DIVE-2577) --------------------------
@@ -231,8 +248,9 @@ run_done DEP-4 --result='landed via delegated push on branch dep-4-maker-credit'
 [[ $RC -eq 0 && "$(statusof DEP-4)" == "done" && "$(refusals DEP-4)" == "0" ]] \
   && ok_t 'D4: the result/body branch arm still closes (acceptance unchanged)' \
   || bad_t 'D4 must close' "rc=$RC status=$(statusof DEP-4) refusals=$(refusals DEP-4) out=$OUT"
-[[ "$OUT" == *"named in the result/body"* && "$OUT" == *"$NOTE"* && "$OUT" == *"$CLI_SURFACE"* ]] \
-  && ok_t 'D4: the result/body receipt carries the note and the surface' \
+[[ "$OUT" == *"named in the result/body"* && "$OUT" == *"$NOTE"* \
+   && "$OUT" == *"$PROMPT"* && "$OUT" == *"$CLI_SURFACE"* ]] \
+  && ok_t 'D4: the result/body receipt carries the note, the prompt and the surface' \
   || bad_t 'D4 result/body arm must carry the note' "out=$OUT"
 
 # --- D5. THE DIFFERENTIAL: a repo that ships no installed artifact ------------

--- a/tests/task_merge_gate_deploy_note_unit.sh
+++ b/tests/task_merge_gate_deploy_note_unit.sh
@@ -40,6 +40,14 @@
 #   D9  ZERO ACCEPTANCE CHANGE: the gate still refuses what it refused. The constraint
 #       on the ticket is that this must not weaken the merge gate or add failure modes.
 #
+# HOW "NO ACCEPTANCE CHANGE" IS PROVEN RATHER THAN ASSERTED. Under M1 — the helper
+# neutered to `:` — SEVEN arms go red and every one of them is a MESSAGE assertion. Not
+# one status arm and not one refusal-count arm moves: D1-D6 still close, D7 still refuses
+# with its one policy_refusals row, D9 is untouched. A function whose total removal cannot
+# move any verdict is not in the acceptance decision, and that is a stronger statement than
+# reading the diff and observing that only strings were appended. M7 supplies the missing
+# half — that the verdict arms can move at all.
+#
 # MUTATION GRADE — RUN, not predicted. Baseline 21/0; each mutant applied to the
 # committed tree, `git checkout --` between, tree clean before and after:
 #   M1  `_gate_merged_not_deployed() { :; }`      -> 14/7: every note arm on all four
@@ -54,6 +62,14 @@
 #   M5  revert ONLY the D2 call site              -> 16/5: D2, and D5/D6 with it since
 #                                                   they accept through the same
 #                                                   attribution arm, plus both D8 arms.
+#   M7  neuter `policy_refuse ... done-before-branch-merged` on the branch path
+#                                                 -> 20/1: D7 alone. This is what makes
+#                                                   "no acceptance change" a MEASUREMENT
+#                                                   rather than a claim, from the other
+#                                                   direction: D7 demonstrably reds when a
+#                                                   refusal stops happening, so its green
+#                                                   under this change means the refusal
+#                                                   still happens.
 #   M6  ANCHOR: put `--category=host` back into the GENERIC half (its first shape)
 #                                                 -> 19/2: D5 and D6, the two arms added
 #                                                   for it. A fix nobody can red is a fix


### PR DESCRIPTION
Split from DIVE-2621 (items b and c). Read the parent page first:
`community/wiki/merged-to-main-is-a-claim-about-the-authors-artifact-not-the-readers.md`

## The defect

The close gate prints `done=merged-to-main satisfied`, which is TRUE, at the exact moment
the reader assumes the stronger claim nobody checked: that the change is **running**. Four
agents made that substitution independently on 2026-08-03 (olivia DIVE-2587, dev DIVE-2571,
dev3 on marketplace clones, main across the v0.18.3-v0.18.6 cuts). They were not being
careless. The system told them they were done, which is why the gate is the cheapest place
to interrupt it.

## What changed

**b.** Every accepting arm appends one short sentence saying what it did NOT establish, and
names where to go instead.

**c.** Rows whose deliverable is a DEPLOYED artifact get a second sentence naming the check
that can actually answer for THAT artifact:

| accepting repo | reader's artifact | surface named |
|---|---|---|
| `5dive-ai/5dive` | `/usr/local/bin/5dive`, driven by cron on every host | `5dive doctor --category=host` (DIVE-2640) |
| `5dive-ai/5dive-plugins` | the marketplace clone in each agent's own `$HOME` | `5dive doctor --category=plugins` (DIVE-2642) |
| anything else | no installed artifact | generic note only |

The prompt is keyed off the repo the **accepting evidence** was found in, never off the
task's own prose, which says what the maker meant rather than where it landed.

## The finding: there were FOUR accepting paths, not three

The ticket named two sites; a `grep -c` correction appended at filing time said three.
There are **four**. The declared `delivery_ref` path accepted while emitting **no line at
all**, so no enumeration keyed on the accept string could ever return it, and it is the
most-travelled close route in the product. It is now audible.

Patching only the three that already spoke would have removed every symptom the sweep could
see while leaving the defect fully intact for every row that binds a PR. Compiled to
`community/wiki/an-accepting-path-that-prints-nothing-is-invisible-to-a-message-keyed-sweep.md`.

## No acceptance change, measured rather than asserted

Text is appended to warns on paths that already passed; no refusal is touched. Proven from
both directions:

- **M1** (helper neutered to `:`) reds SEVEN arms and every one is a message assertion. Not
  one status arm and not one refusal-count arm moves. A function whose total removal cannot
  move any verdict is not in the acceptance decision.
- **M7** (neuter `policy_refuse ... done-before-branch-merged`) reds D7 alone, which is the
  half that makes D7's green mean something.

## Evidence

New harness `tests/task_merge_gate_deploy_note_unit.sh`, **21/21**, one case per accepting
path, tier `nightly` with the argument in the header.

Mutation-graded, run rather than predicted, each red at the arm that owns it:

| mutant | result |
|---|---|
| M1 helper neutered | 14/7 — every note arm on all four paths, plus D5/D6 |
| M2 prompt deleted, generic half kept | 16/5 — D1-D4 and D6 |
| M3 prompt fires unconditionally (keying cut) | 19/2 — D5 (the arm that exists for it) and D6 |
| M4 revert ONLY the delivery_ref call site | 17/4 — D1's arms and BOTH source-shape arms |
| M5 revert ONLY the attribution call site | 16/5 — D2, D5/D6 (same arm), both shape arms |
| M6 restore the old `--category=host` generic wording | 19/2 — D5 and D6, the arms added for it |
| M7 neuter the branch-path refusal | 20/1 — D7 alone |

M2's first run was **19/2, not 16/5**: D2/D3/D4 asserted the surface string, which the
generic half also contains, so deleting the prompt entirely could not move them. They now
assert the prompt clause and every mutant was re-run against the tightened arms. A mutant
graded before the test changed is a reading of a file that no longer exists.

D8 grades SOURCE SHAPE as well as behaviour: every `done=merged-to-main satisfied` in
`cmd_task.sh` must sit on a line calling the helper, with a non-vacuity arm proving the
population it scanned is not empty. Behaviour arms are blind to a fifth accepting arm
written next year in the old style, and an unpatched accepting path is this whole defect
re-created.

### Regression

Sibling merge-gate harnesses green: ancestry 36/0, branch_in_result 13/0, repo_scope 25/0,
diagnostic 18/0, autodetect 14/0, gh_resolve 7/0, policy_refusals 18/0.

`task_merge_gate_multirepo_unit.sh` is 35/1 — the same assertion (`partial scan honesty`)
fails identically on a detached control worktree at `65f8ff1`, so that red is **pre-existing
on main**, not from this branch.

Core tier locally: **234 of 234 harnesses passed**, `exit 4` on BUDGET (410s vs the 300s cap,
confirmed by the runner's own re-timing). Not from this branch — this harness resolves as
`nightly` and appears zero times in that run.

`changelog.d/DIVE-2641.md` folds cleanly: `scripts/fold-changelog-fragments.sh` on a scratch
tree returns rc=0, folds 3 fragments and prints nothing to stderr, so it is not being skipped
non-fatally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
