### PR TITLE
fix(ci): full-sweep runs on every push to main, cost-bounded (DIVE-2667)

### DIFF
--- a/.github/workflows/full-sweep.yml
+++ b/.github/workflows/full-sweep.yml
@@ -24,10 +24,34 @@ name: full-sweep
 #
 # A RED HERE IS NOT IGNORABLE. release-cut grades the same corpus before publishing,
 # so a sweep that has been red for a week is a release that will not cut.
+#
+# DIVE-2667: AND IT WAS IGNORED FOR ~17 HOURS, because "not ignorable" was a property
+# of the consequence, not of the signal. Between the green nightly at 2026-08-03T06:39
+# and the next observation, ~12 commits landed on main and the sweep went red; the
+# only scheduled run is once a day, and full-sweep is NOT in the per-PR check set, so
+# every PR merged that day was green on its own checks while the corpus rotted
+# underneath. Recovering "which merge did it" then costs a bisect over the window.
+# `push: main` is the smallest change that removes both halves at once: the tier runs
+# at the granularity that ATTRIBUTES a break to one merge — BETWEEN BURSTS, and that
+# qualifier is load-bearing (see the concurrency block below: merges closer together
+# than one sweep collapse into a single run of the newest tip, and inside such a burst
+# you are back to a bisect over those N commits, which is the 12-commit position this
+# row is about). The trade is deliberate and it is still a large win: the window shrinks
+# from a day's merges to a burst's, and most merges here are not in a burst. The latency
+# to notice drops from up to a day to the length of one sweep in every case. The nightly
+# stays — it is the arm that catches a break with no commit behind it (a runner image
+# change, an expiring fixture, a rate limit).
 on:
   schedule:
     # 03:17 UTC — off the hour, because the hour is where every other fleet cron is.
     - cron: '17 3 * * *'
+  # DIVE-2667: no `paths:` filter, deliberately. The subject of this workflow is the
+  # WHOLE corpus against the WHOLE source tree; a path filter would reintroduce the
+  # exact gap — the four harnesses that went red on 2026-08-03 were broken by commits
+  # that touched src/, not tests/, and any filter narrow enough to be cheap is narrow
+  # enough to miss that class again.
+  push:
+    branches: [main]
   workflow_dispatch:
   # The tiering machinery itself must be graded on the PR that changes it, or the
   # first evidence that a budget is mis-set arrives a day late on main.
@@ -36,6 +60,36 @@ on:
       - 'tests/lib/tier.sh'
       - 'scripts/run-harnesses.sh'
       - '.github/workflows/full-sweep.yml'
+
+# DIVE-2667: what makes `push: main` affordable, and WHAT IT COSTS TO BUY THAT.
+#
+# The cost is NOT money (main, reviewing this change): this repo is public and every
+# job here is `ubuntu-latest`, so standard runners are free. It is WALL-CLOCK and QUEUE
+# CONTENTION — six jobs x ~10 min per merge, at ~20 merges/day, against a runner pool
+# every other workflow in the repo is also waiting on. Saying "cost" and meaning dollars
+# would invite a reviewer to check the dollars, find none, and distrust the rest.
+#
+# Grouped per ref with cancel-in-progress, a burst of merges collapses into ONE sweep of
+# the newest tip. Nothing goes UNGRADED: the cancelled run's tree is a strict ancestor of
+# the survivor's, so every commit it would have graded is graded later, at a tip that also
+# contains it. But something IS spent, and it is the thing this row exists to buy —
+# ATTRIBUTION. A collapsed burst grades N commits in one verdict, so a red inside a burst
+# still needs a bisect over that burst. The window goes from a day's merges to a burst's;
+# it does not go to one. Take the trade knowingly, and do not read the `push:` comment
+# above as a promise of per-merge attribution in all cases.
+#
+# The group is keyed on the ref, so a PR-triggered sweep (the tiering-machinery paths
+# above) is never cancelled by a merge to main.
+#
+# This block LIVES BELOW `on:` and that placement is load-bearing, not cosmetic. Put
+# it between two `on:` children and `pull_request:` becomes a child of `concurrency:`;
+# yaml.safe_load accepts that file, this repo's own tier harness passes on it, and
+# only actionlint says 'unexpected key "pull_request" for "concurrency" section'.
+# Measured here on 2026-08-04, which is the second time that gap has been paid
+# (DIVE-2539/2540): community/wiki/an-actions-expression-is-parsed-inside-shell-comments.md
+concurrency:
+  group: full-sweep-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # DIVE-2525 (main, reviewing #376): SHARDED, not given a bigger number. The first

--- a/changelog.d/DIVE-2667.md
+++ b/changelog.d/DIVE-2667.md
@@ -1,0 +1,55 @@
+## Unreleased — fix(ci): full-sweep runs on every push to main, cost-bounded (DIVE-2667)
+
+`full-sweep.yml` has carried the comment **"A RED HERE IS NOT IGNORABLE"** since
+DIVE-2525. On 2026-08-03 it was ignored for about seventeen hours. "Not ignorable"
+was a property of the **consequence** — release-cut grades the same corpus, so a
+week-old red is a release that will not cut — and never of the **signal**.
+
+Two halves, each survivable alone:
+
+- **Cadence.** One `schedule:` at 03:17 UTC. Last green nightly `1cc1ce1e5`
+  (06:39Z), next observation `193e91291` (23:55Z) FAILURE, ~12 commits between
+  them — so the break was not attributable to a merge without bisecting.
+- **Surface.** full-sweep is **not in the per-PR check set**. PR #429 merged on
+  15/15 green with full-sweep not among the fifteen. Every PR that day could be
+  green *on its own checks* while the corpus rotted underneath. Nobody ignored a
+  red; the red was not on a surface anyone reads before merging.
+
+`push: branches: [main]` closes both: the latency to notice drops from up to a day
+to the length of one sweep, and the tier runs at the granularity that **attributes
+a break to one merge — between bursts** (the qualifier is real; see below). The
+`schedule:` stays — it is the arm that catches a break with **no commit behind it**
+(a runner image change, an expiring fixture, a rate limit).
+
+**Frequency and affordability are one change, not two.** The cost is **not money** —
+this repo is public and every job is `ubuntu-latest`, so standard runners are free.
+It is **wall-clock and queue contention**: six jobs at ~10 minutes, at ~20
+merges/day, against a pool every other workflow is also waiting on. So the push
+trigger ships with
+`concurrency: {group: full-sweep-${{ github.ref }}, cancel-in-progress: true}`: a
+burst of merges collapses into one sweep of the newest tip, and **nothing goes
+ungraded, because the cancelled run's tree is a strict ancestor of the survivor's**
+— it is graded later, at a tip that also contains it. Grouping on the ref keeps a
+PR-triggered sweep (the tiering-machinery `paths:` filter) from being cancelled by
+a merge to main.
+
+**What the bound spends is attribution, and that is the thing this row buys.** A
+collapsed burst grades N commits in one verdict, so a red *inside* a burst still
+needs a bisect over that burst. The window goes from a day's merges to a burst's;
+it does not go to one. The trade is taken knowingly and the qualifier sits next to
+the attribution claim in the workflow itself, not further down.
+
+No `paths:` filter on the push trigger, deliberately: the harnesses that went red
+here were broken by commits touching `src/`, not `tests/`, and any filter narrow
+enough to be cheap is narrow enough to miss that class again.
+
+`tests/corpus_tier_budget_unit.sh` pins both properties **in the same arm block**,
+by parsing the workflow rather than grepping it (a `grep 'push:'` matches the word
+inside this file's own comments and passes against the unchanged file). Red anchor,
+measured: against `origin/main`'s workflow the two new arms FAIL and the three
+control arms — parse liveness, absent-trigger discrimination, and the
+`unit-tests.yml` neighbour anchor — still pass.
+
+Full write-up, including the misplaced-`concurrency:` trap that `yaml.safe_load`
+accepts and only `actionlint` names:
+`community/wiki/a-tier-that-runs-nightly-cannot-attribute-a-break.md`.

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -619,6 +619,66 @@ if grep -rn -- '--confirm-top' .github/workflows/ >/dev/null 2>&1; then
   bad "no CI workflow passes --confirm-top" "$(grep -rn -- '--confirm-top' .github/workflows/)"
 else ok "no CI workflow passes --confirm-top"; fi
 
+# --- DIVE-2667: the tier must run often enough to ATTRIBUTE a break ------------
+# The nightly was red on main for ~17h across ~12 commits because full-sweep ran
+# once a day and is not in the per-PR check set. Two properties are pinned here,
+# and they only mean something together: `push: main` is what makes the sweep
+# frequent enough to name one merge, and `cancel-in-progress` is what makes that
+# frequency affordable. Ship one without the other and the next person deletes it.
+#
+# Graded by PARSING the workflow, not by grepping it. A `grep 'push:'` matches the
+# word inside any of this file's own comments, and would have passed against the
+# unchanged file. Note the YAML 1.1 gotcha the parse has to survive: the `on:` key
+# loads as the BOOLEAN True, not the string 'on'.
+_wf_on() {  # <file> -> the on: keys, one per line
+  python3 - "$1" <<'PY' 2>/dev/null
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))
+on = d.get(True, d.get('on', {})) or {}
+print('\n'.join(sorted(on)) if isinstance(on, dict) else '')
+PY
+}
+_wf_push_branches() {
+  python3 - "$1" <<'PY' 2>/dev/null
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))
+on = d.get(True, d.get('on', {})) or {}
+p = (on.get('push') or {}) if isinstance(on, dict) else {}
+print(' '.join(p.get('branches', []) or []))
+PY
+}
+SWEEP=.github/workflows/full-sweep.yml
+SWEEP_ON="$(_wf_on "$SWEEP")"
+# Liveness first: a parser that returns nothing makes every membership test below
+# vacuously... false, which is the safe direction, but says the wrong thing about WHY.
+if [[ -n "$SWEEP_ON" ]] && grep -qx 'schedule' <<<"$SWEEP_ON"; then
+  ok "full-sweep's on: block PARSES and still carries the nightly schedule"
+else bad "full-sweep's on: block PARSES and still carries the nightly schedule" "on=[$SWEEP_ON]"; fi
+if grep -qx 'push' <<<"$SWEEP_ON" && [[ " $(_wf_push_branches "$SWEEP") " == *" main "* ]]; then
+  ok "full-sweep runs on PUSH TO MAIN: a break is attributable to one merge, not to a day's window (DIVE-2667)"
+else bad "full-sweep runs on PUSH TO MAIN: a break is attributable to one merge, not to a day's window (DIVE-2667)" \
+       "on=[$(tr '\n' ',' <<<"$SWEEP_ON")] branches=[$(_wf_push_branches "$SWEEP")]"; fi
+# The parser is discriminating, not just permissive: a trigger this workflow does
+# NOT declare must come back absent from the same call that reported push present.
+if ! grep -qx 'release' <<<"$SWEEP_ON"; then
+  ok "the same parse reports an ABSENT trigger as absent (the membership test discriminates)"
+else bad "the same parse reports an ABSENT trigger as absent (the membership test discriminates)" "on=[$SWEEP_ON]"; fi
+# Cost bound. Without cancel-in-progress, push-on-main is 6 jobs per merge with no
+# collapse, and the first person to read the bill deletes the trigger this row added.
+if python3 - "$SWEEP" <<'PY' 2>/dev/null
+import sys, yaml
+c = (yaml.safe_load(open(sys.argv[1])) or {}).get('concurrency') or {}
+sys.exit(0 if isinstance(c, dict) and c.get('cancel-in-progress') is True and 'github.ref' in str(c.get('group','')) else 1)
+PY
+then
+  ok "the push trigger is cost-bounded: concurrency cancels in progress, grouped per REF so a PR sweep is not cancelled by a merge"
+else bad "the push trigger is cost-bounded: concurrency cancels in progress, grouped per REF so a PR sweep is not cancelled by a merge" \
+       "$(grep -A3 '^concurrency:' "$SWEEP" 2>&1)"; fi
+# Anchor: the neighbour workflow must NOT satisfy the same assertion, or "full-sweep
+# has push: main" is a claim about every workflow in the directory and grades nothing.
+if ! grep -qx 'schedule' <<<"$(_wf_on .github/workflows/unit-tests.yml)"; then
+  ok "ANCHOR: the neighbour (unit-tests.yml) parses to a DIFFERENT trigger set — the assertions above are about this file"
+else bad "ANCHOR: the neighbour (unit-tests.yml) parses to a DIFFERENT trigger set" "unit-tests on=[$(tr '\n' ',' <<<"$(_wf_on .github/workflows/unit-tests.yml)")]"; fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 (( fail == 0 ))


### PR DESCRIPTION
`full-sweep.yml` has carried the comment **"A RED HERE IS NOT IGNORABLE"** since DIVE-2525. On 2026-08-03 it was ignored for about seventeen hours. Nobody ignored a red — that is the finding. "Not ignorable" was a property of the **consequence** (release-cut grades the same corpus, so a week-old red is a release that will not cut) and never of the **signal**.

Two independent halves, each survivable alone:

- **Cadence.** One `schedule:` at 03:17 UTC. Last green nightly `1cc1ce1e5` (2026-08-03T06:39Z); next observation `193e91291` (23:55Z), FAILURE. **~12 commits between them**, so the break was not attributable to a merge without bisecting.
- **Surface.** full-sweep is **not in the per-PR check set**. PR #429 merged on **15/15 green with full-sweep not among the fifteen**. Every PR that day could be green *on its own checks* while the corpus rotted underneath. **The red was not on a surface anyone reads before merging.**

`push: branches: [main]` closes both. The `schedule:` stays — it is the arm that catches a break with **no commit behind it** (a runner image change, an expiring fixture, a rate limit). No `paths:` filter on the push trigger, deliberately: the harnesses that went red here were broken by commits touching `src/`, not `tests/`, and any filter narrow enough to be cheap is narrow enough to miss that class again.

## The cost bound, and what it spends

`concurrency: {group: full-sweep-${{ github.ref }}, cancel-in-progress: true}` ships in the same change, because frequency without a bound gets the trigger deleted by the first person who notices it.

**The cost is not money.** This repo is public and every job in the file is `ubuntu-latest`, so standard runners are free (measured by @main on review). It is **wall-clock and queue contention** — six jobs × ~10 min per merge against a pool every other workflow is waiting on.

**Nothing goes ungraded** under the bound: the cancelled run's tree is a **strict ancestor** of the survivor's, so every commit it would have graded is graded later, at a tip that also contains it.

**But attribution does get spent, and attribution is what this row buys.** A collapsed burst grades N commits in one verdict, so a red *inside* a burst still needs a bisect over that burst. The window goes from a day's merges to a burst's; it does not go to one. The claim "attributes a break to one merge" is true **between** bursts and false **within** one, and that qualifier now sits beside the sentence a reader forms the conclusion from, in the workflow file itself.

## How it is graded

`tests/corpus_tier_budget_unit.sh` pins both properties **in the same arm block** — ship one without the other and the next reader drops the "unused" half. Graded by **parsing** the workflow, not grepping it: a `grep 'push:'` matches the word inside this file's own comments and passes against the unchanged file.

**Red anchor, measured** (workflow reverted to `origin/main`, harness new):

```
ok   full-sweep's on: block PARSES and still carries the nightly schedule
FAIL full-sweep runs on PUSH TO MAIN ...                     <- the change
ok   the same parse reports an ABSENT trigger as absent
FAIL the push trigger is cost-bounded ...                    <- the change
ok   ANCHOR: the neighbour (unit-tests.yml) parses to a DIFFERENT trigger set
58 passed, 2 failed
```

Exactly the two new arms fail and the three control arms — parse liveness, absent-trigger discrimination, neighbour anchor — still pass. On this branch: **60 passed, 0 failed**. Also green: `actionlint_scan_unit` 23/0, `baseline_pin_unit` 18/0, `scripts/actionlint-scan.sh` rc=0.

**One trap paid for en route, and it is in the diff as a comment.** Written between two `on:` children, `concurrency:` silently adopts `pull_request:` as its own child. `yaml.safe_load` accepts that file and **the tier harness above passed on it** — only `actionlint` names it (`unexpected key "pull_request" for "concurrency" section`). Second time this repo has paid the gap between "YAML parses" and "Actions accepts" (DIVE-2539/2540). Parser-based arms also have to survive the YAML 1.1 trap: **`on:` loads as the boolean `True`**, not the string `'on'`.

## READ FIRST: full-sweep WILL BE RED ON THIS PR, and that is pre-existing

This PR edits `.github/workflows/full-sweep.yml`, which is in full-sweep's own `pull_request: paths:` filter — so the nightly tier runs here, and it will fail on `task_merge_gate_result_pr_unit.sh` and `task_merge_gate_multirepo_unit.sh`. **Those two are red on `origin/main` right now, measured on an unmodified control dispatch before this branch existed** (table below). They are not caused by this change and this change does not claim to fix them. The check to read for *this* PR is `changed-harnesses` / the core tier, which runs the harness this diff touches.

## State of main's reds, measured — this PR does not fix them

Separately from the change above, I dispatched full-sweep at `origin/main` **a982052** (run [30910236578](https://github.com/5dive-ai/5dive/actions/runs/30910236578)). **The failing set has moved since this row was filed**, so grading the row against the four names in its body would measure history, not main:

| harness | state at a982052 | owner |
|---|---|---|
| `gate_channel_session_t2_mutation.sh` | **fixed**, DIVE-2589 (`8c22597`) | closed |
| `digest_window_30d_controls.sh` | **fixed**, DIVE-2703 (`30b7b57`) | closed |
| `council_unit.sh`, `council_amend_e2e.sh` | **fixed in pristine, STILL RED on installed-host** | DIVE-2703 partial |
| `task_merge_gate_result_pr_unit.sh` | **still red**, both envs | **DIVE-2705** (olivia, high) + DIVE-2373 |
| `task_merge_gate_multirepo_unit.sh` | **still red**, both envs | **no row** |

The council row is a correction to my own first reading: shard 3 went green in both environments, which is where `digest_window_30d_controls` lived, and I let that generalise. `council_unit` / `council_amend_e2e` land in shards 1–2 and are still failing **on installed-host only** — DIVE-2703's registry-reachability guard closed the pristine half and not the installed-host half.

**This PR introduces zero new failures.** The four red shards here (`full-pristine 1,2` and `full-installed-host 1,2`) fail on **exactly the same harness set, in exactly the same shards**, as the control dispatch of unmodified `origin/main` a982052 ([run 30910236578](https://github.com/5dive-ai/5dive/actions/runs/30910236578)) — compared as a *set*, per this row's own warning about shard indices.

DIVE-2703 named both merge-gate harnesses in its plan but its diff only added `lib/disk.sh` to their source lists — it never skip-gated their CI arms. `result_pr`'s failing arm (`unverified scan must be loud + audited`, `rc=0 out=OK audit=`) is **exactly DIVE-2705's defect**: `_gate_gh()` always returns 0, so `_sc_ok == _sc_total`, `_scan_ran` is always 1 and the `merge-gate-unverified` warn + audit row can never fire. `multirepo`'s `partial scan honesty` arm fails differently — the warn text is correct and only the audit sink is empty — and I found no row covering it.

Full write-up, including the wrapper-harness effect that makes a strict `i % N` shard partition look broken: `community/wiki/a-tier-that-runs-nightly-cannot-attribute-a-break.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
