### PR TITLE
DIVE-2712: /inbox sends one message per gate, so answering one keeps the rest tappable

### DIFF
--- a/src/cmd_agent_runtime.sh
+++ b/src/cmd_agent_runtime.sh
@@ -371,8 +371,9 @@ _mirror_send() {
   # synthetic ok so delivery receipts/stamping still exercise downstream logic.
   if [[ -n "${FIVEDIVE_NOTIFY_DRYRUN:-}" && "${FIVEDIVE_NOTIFY_DRYRUN}" != "0" ]]; then
     local dry_line
-    dry_line=$(printf 'notify-dryrun chat=%s thread=%s markup=%s text=%q' \
-      "$chat" "${thread:-none}" "$([[ -n "$reply_markup" ]] && echo yes || echo no)" "$text")
+    dry_line=$(printf 'notify-dryrun chat=%s thread=%s markup=%s silent=%s text=%q' \
+      "$chat" "${thread:-none}" "$([[ -n "$reply_markup" ]] && echo yes || echo no)" \
+      "$([[ -n "${FIVEDIVE_NOTIFY_SILENT:-}" && "${FIVEDIVE_NOTIFY_SILENT}" != "0" ]] && echo yes || echo no)" "$text")
     if [[ -n "${FIVEDIVE_NOTIFY_DRYRUN_LOG:-}" ]]; then
       printf '%s\n' "$dry_line" >>"$FIVEDIVE_NOTIFY_DRYRUN_LOG" 2>/dev/null || true
     fi
@@ -383,6 +384,15 @@ _mirror_send() {
   local args=(--data-urlencode "chat_id=${chat}" --data-urlencode "text=${text}")
   [[ -n "$thread" ]] && args+=(--data-urlencode "message_thread_id=${thread}")
   [[ -n "$reply_markup" ]] && args+=(--data-urlencode "reply_markup=${reply_markup}")
+  # DIVE-2712: opt-in SILENT delivery. Set by the /inbox digest for every message
+  # after the first, so N gates cost the human ONE buzz and N readable messages
+  # instead of N buzzes. Deliberately an env var rather than a 5th positional:
+  # this is the single POST every owner/gate/mirror notify funnels through, and
+  # widening four call signatures across the notify rail to carry a UX flag is a
+  # bigger change than the feature. Default-empty, so every existing caller is
+  # byte-identical on the wire.
+  [[ -n "${FIVEDIVE_NOTIFY_SILENT:-}" && "${FIVEDIVE_NOTIFY_SILENT}" != "0" ]] \
+    && args+=(--data-urlencode "disable_notification=true")
   # Bounded so a hung/slow Telegram API can't wedge the FOREGROUND callers
   # (task_need_notify runs this after the gate UPDATE has already committed;
   # mirror_interagent_outbound likewise). --connect-timeout caps the TCP/TLS

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -9219,6 +9219,9 @@ _task_inbox_send() {
       '{sent:true, gates:($g|tonumber), total:($t|tonumber), failed:($f|tonumber), message_ids:$m}' \
       --arg g "$sent" --arg t "$total" --arg f "$failed" --arg m "${all_mids:-}"
   else
+    # DIVE-2054: DELIBERATELY UNFENCED, same exemption as the "ok" branch above —
+    # chat_proof is the proof a real channel was (or was not) hit for this send, and
+    # a fixture store must not be able to suppress that record.
     audit_log "task inbox send" "error" 1 -- \
       "gates=0/${total}" "delivery=per-gate" "failed=${failed}" "chat_proof=${channel_proof:-none}"
     fail "$E_GENERIC" "inbox delivery unconfirmed — no gate message landed, so nonce hashes are left unrotated and earlier alert buttons remain valid (DIVE-2712: per-gate send)"

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -9145,71 +9145,83 @@ _task_inbox_send() {
     ok "inbox empty — nothing to send" '{sent:false, gates:0}'
     return
   fi
-  local shown=$(( total < cap ? total : cap ))
 
-  local text="🗂 Gate inbox — waiting on you now:"
-  local kbrows='[]' row id ident prio ntype options recommend gtier ask nonce="" markup="" idlist="" _mint_n=0
-  local -a nonce_ids=() nonce_hashes=()
+  # DIVE-2712 (lodar, 2026-08-04): ONE MESSAGE PER GATE, not one digest.
+  #
+  # It used to accumulate every gate into one message with one merged keyboard.
+  # Two complaints, one root: answering ANY gate called _task_gate_retire_buttons,
+  # which edits the message that delivered it — and with every gate sharing one
+  # message, Telegram's keyboard-removal took ALL of them, so picking a second gate
+  # meant running /inbox again. The digest was also unreadable once several gates
+  # were open.
+  #
+  # Sending one message per gate fixes both AND DELETES THE HARD PART. The
+  # alternative — keep the digest and subtract only the answered gate's rows —
+  # needs the ORIGINAL button nonces to survive the edit, and only their SHA is
+  # persisted (human_nonce_hash), so the surviving rows would have to be re-minted
+  # and their hashes rotated, which silently kills those same gates' buttons on
+  # every OTHER message that delivered them. One gate per message makes the
+  # existing retire path correct BY CONSTRUCTION: the message carries exactly one
+  # gate, so removing its keyboard can affect nothing else.
+  #
+  # THE COST IS THE PUSH COUNT, and it is paid rather than ignored: N gates would
+  # be N buzzes. The first message pings, every one after it is SILENT
+  # (FIVEDIVE_NOTIFY_SILENT -> disable_notification), so the human gets one ping
+  # and a readable stack.
+  local id ident prio ntype options recommend gtier ask nonce="" markup=""
+  local gate_text sent=0 failed=0 first_sent=0 all_ids="" all_mids="" _mint_n=0
+  local _prev_silent="${FIVEDIVE_NOTIFY_SILENT:-}"
   while IFS= read -r row; do
     [[ -n "$row" ]] || continue
     IFS=$'\x1f' read -r id ident prio ntype options recommend gtier ask <<<"$row"
     [[ -n "$id" && -n "$ident" ]] || continue
-    idlist+="${idlist:+,}${id}"
-    text+=$'\n\n'"• [${ident}] ${ntype}, ${prio} — ${ask} /task_${id}"
-    [[ -n "$recommend" ]] && text+=$'\n'"  ✅ Recommended: ${recommend}"
-    [[ -n "$options" ]] && text+=$'\n'"  Options: ${options}"
-    # DIVE-2356: same widened condition as the cmd_task_need mint — hard-human
-    # TYPE **or** tier>=2. Without the tier arm a tier-2 `decision` filed before
-    # that change stays nonce-less forever, since this rotation is the only other
-    # write to human_nonce_hash on the non-escalation path. `tier` is now selected
-    # below, spliced in AHEAD of `ask` so `ask` stays the greedy tail of the read.
+    gate_text="🗂 Gate waiting on you:"$'\n\n'"[${ident}] ${ntype}, ${prio} — ${ask} /task_${id}"
+    [[ -n "$recommend" ]] && gate_text+=$'\n'"✅ Recommended: ${recommend}"
+    [[ -n "$options" ]]   && gate_text+=$'\n'"Options: ${options}"
+    gate_text+=$'\n\n'"Tap a button, open the /task link, or answer from the dashboard."
+    # DIVE-2356: hard-human TYPE **or** tier>=2. Unchanged by the split.
     nonce=""; _mint_n=0
     case "$ntype" in approval|secret|manual) _mint_n=1 ;; esac
     [[ "${gtier:-}" =~ ^[0-9]+$ ]] && (( gtier >= 2 )) && _mint_n=1
-    if (( _mint_n )); then
-      nonce=$(_human_nonce_mint)
-      if [[ -n "$nonce" ]]; then
-        nonce_ids+=("$id")
-        nonce_hashes+=("$(_human_nonce_sha "$nonce")")
-      fi
-    fi
+    (( _mint_n )) && nonce=$(_human_nonce_mint)
     markup=$(_task_gate_reply_markup "$id" "$ntype" "$options" "$recommend" "$nonce" "$TASK_CH_TYPE" "$ident")
-    if [[ -n "$markup" ]]; then
-      kbrows=$(jq -cn --argjson a "$kbrows" --argjson b "$markup" '$a + ($b.inline_keyboard // [])' 2>/dev/null) || kbrows='[]'
+    # First message pings; the rest arrive silently.
+    if (( first_sent )); then export FIVEDIVE_NOTIFY_SILENT=1; fi
+    _task_send_owner "$gate_text" "$markup" "$id"
+    if [[ "${TASK_SEND_DELIVERED:-0}" == "1" ]]; then
+      sent=$(( sent + 1 )); first_sent=1
+      all_ids+="${all_ids:+,}${id}"
+      [[ -n "${TASK_SEND_MESSAGE_IDS:-}" ]] && all_mids+="${all_mids:+,}${TASK_SEND_MESSAGE_IDS}"
+      # Rotate this gate's hash ONLY after ITS OWN confirmed receipt. Per-gate now,
+      # which is strictly better than the old batch rotation: a partial delivery no
+      # longer rotates hashes for gates whose message never landed.
+      if [[ -n "$nonce" ]]; then
+        db "UPDATE tasks SET human_nonce_hash=$(sqlq "$(_human_nonce_sha "$nonce")")
+            WHERE id=${id} AND need_answered_at IS NULL;" 2>/dev/null || true
+      fi
+    else
+      failed=$(( failed + 1 ))
     fi
   done < <(db "SELECT id||x'1f'||ident||x'1f'||priority||x'1f'||need_type||x'1f'||COALESCE(need_options,'')||x'1f'||COALESCE(recommend,'')||x'1f'||COALESCE(tier,'')||x'1f'||substr(replace(COALESCE(ask,''),x'0a',' '),1,240)
                FROM tasks WHERE ${where} ${order} LIMIT ${cap};")
-  if (( total > cap )); then
-    text+=$'\n\n'"…and $(( total - cap )) more — 5dive task inbox on the box or the dashboard."
+  if (( total > cap )) && (( sent > 0 )); then
+    export FIVEDIVE_NOTIFY_SILENT=1
+    _task_send_owner "…and $(( total - cap )) more gate(s) — 5dive task inbox on the box, or the dashboard." "" ""
   fi
-  text+=$'\n\n'"Tap a button, open a /task link, or answer from the dashboard."
-
-  local reply_markup=""
-  [[ "$kbrows" != "[]" ]] && reply_markup=$(jq -cn --argjson rows "$kbrows" '{inline_keyboard:$rows}' 2>/dev/null) || true
-
-  _task_send_owner "$text" "$reply_markup" "$idlist"
-  if [[ "${TASK_SEND_DELIVERED:-0}" == "1" ]]; then
-    # Rotate hashes only after a confirmed receipt (same ordering as the
-    # heartbeat re-nag): an earlier alert's button dies only once a live
-    # replacement is in the human's chat.
-    local i
-    for (( i=0; i<${#nonce_ids[@]}; i++ )); do
-      db "UPDATE tasks SET human_nonce_hash=$(sqlq "${nonce_hashes[$i]}")
-          WHERE id=${nonce_ids[$i]} AND need_answered_at IS NULL;" 2>/dev/null || true
-    done
-    # DIVE-2054: DELIBERATELY UNFENCED, same shape as "task clear-recs" (5389) —
-    # carries chat_proof=$channel_proof, proof a real channel was (or wasn't) hit
-    # for this digest send. A fixture store must never be able to suppress that.
+  if [[ -n "$_prev_silent" ]]; then export FIVEDIVE_NOTIFY_SILENT="$_prev_silent"; else unset FIVEDIVE_NOTIFY_SILENT; fi
+  TASK_SEND_MESSAGE_IDS="$all_mids"
+  if (( sent > 0 )); then
+    # DIVE-2054: DELIBERATELY UNFENCED, same shape as "task clear-recs".
     audit_log "task inbox send" "ok" 0 -- \
-      "gates=${shown}/${total}" "chat_proof=${channel_proof:-none}" "message_id=${TASK_SEND_MESSAGE_IDS:-none}"
-    ok "inbox digest sent (${shown}/${total} gates)" \
-      '{sent:true, gates:($g|tonumber), total:($t|tonumber), message_ids:$m}' \
-      --arg g "$shown" --arg t "$total" --arg m "${TASK_SEND_MESSAGE_IDS:-}"
+      "gates=${sent}/${total}" "delivery=per-gate" "failed=${failed}" \
+      "chat_proof=${channel_proof:-none}" "message_id=${all_mids:-none}"
+    ok "inbox sent (${sent}/${total} gates, one message each)" \
+      '{sent:true, gates:($g|tonumber), total:($t|tonumber), failed:($f|tonumber), message_ids:$m}' \
+      --arg g "$sent" --arg t "$total" --arg f "$failed" --arg m "${all_mids:-}"
   else
-    # DIVE-2054: DELIBERATELY UNFENCED, same exemption as the "ok" branch above.
     audit_log "task inbox send" "error" 1 -- \
-      "gates=${shown}/${total}" "chat_proof=${channel_proof:-none}"
-    fail "$E_GENERIC" "inbox digest delivery unconfirmed — nonce hashes left unrotated, earlier alert buttons remain valid"
+      "gates=0/${total}" "delivery=per-gate" "failed=${failed}" "chat_proof=${channel_proof:-none}"
+    fail "$E_GENERIC" "inbox delivery unconfirmed — no gate message landed, so nonce hashes are left unrotated and earlier alert buttons remain valid (DIVE-2712: per-gate send)"
   fi
 }
 

--- a/tests/gate_button_retire_unit.sh
+++ b/tests/gate_button_retire_unit.sh
@@ -398,5 +398,33 @@ else
       "$(grep -c 'cannot read the gate-delivery log' <<<"$out")"
 fi
 
+# --- DIVE-2712: /inbox sends ONE MESSAGE PER GATE, first pings, rest silent -----
+# The defect: every gate shared ONE message with one merged keyboard, so answering
+# any gate retired the keyboard for ALL of them (retire edits the message that
+# delivered the gate, and that message was everyone's). Graded on the SHAPE OF THE
+# SENDS, not by reading the code — the send stub records one line per call.
+SENDS="$TMP/sends.log"; : >"$SENDS"
+_mirror_send() {
+  printf 'send silent=%s markup=%s\n' \
+    "$([[ -n "${FIVEDIVE_NOTIFY_SILENT:-}" && "${FIVEDIVE_NOTIFY_SILENT}" != "0" ]] && echo yes || echo no)" \
+    "$([[ -n "${5:-}" ]] && echo yes || echo no)" >>"$SENDS"
+  printf '%s' '{"ok":true,"result":{"message_id":15491}}'
+}
+seed_gate() { # <id> <ident> <type>
+  db "INSERT INTO tasks (id,ident,title,status,priority,assignee,need_type,tier,ask,recommend,need_options,created_at)
+      VALUES ($1,'$2','t','blocked','high','main','$3',2,'ask?','A','A|B',datetime('now'));" 2>/dev/null
+}
+db "DELETE FROM tasks;" 2>/dev/null
+seed_gate 9001 DIVE-9001 decision
+seed_gate 9002 DIVE-9002 approval
+seed_gate 9003 DIVE-9003 decision
+# Subshell: cmd_task_inbox ends in ok/fail, which exit — `|| true` cannot catch an
+# exit in the current shell, and the harness must survive either outcome.
+( cmd_task_inbox --send ) >/dev/null 2>&1 || true
+chk "3 open gates produce 3 SEPARATE messages, not one digest" "3" "$(grep -c '^send ' "$SENDS" 2>/dev/null || echo 0)"
+chk "the FIRST gate message pings the human" "silent=no" "$(head -1 "$SENDS" 2>/dev/null | grep -o 'silent=[a-z]*')"
+chk "every message after the first is SILENT (one buzz, not N)" "2" "$(tail -n +2 "$SENDS" 2>/dev/null | grep -c 'silent=yes')"
+chk "each gate carries its OWN keyboard" "3" "$(grep -c 'markup=yes' "$SENDS" 2>/dev/null || echo 0)"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" == "0" ]]

--- a/tests/gate_button_retire_unit.sh
+++ b/tests/gate_button_retire_unit.sh
@@ -421,11 +421,23 @@ SENDS="$TMP/sends.log"; : >"$SENDS"
 # So restore the REAL _mirror_send and stub the TRANSPORT instead. Everything above this
 # point keeps the cheap stub; re-sourcing here rebinds the genuine implementation, and
 # curl on PATH captures the argv it actually composes.
+#
+# ONE SEND MUST BE ONE RECORD (olivia, iteration 3). The gate TEXT contains
+# newlines, so a plain printf of "$*" wrote ~7 lines per call: line 1 was the argv
+# prefix and disable_notification landed at the END of the argv, i.e. on that send's
+# LAST line. Every arm below is indexed by LINE, so `head -1` could never see the
+# flag (structurally always "absent" — a vacuous arm that survives a build which
+# silences the human's only ping) and `tail -n +2` still contained most of MESSAGE
+# ONE (so the "after the first" count was over the wrong population, and redded for
+# the right verdict by the wrong mechanism). Collapsing the newlines makes head -1
+# message 1 entire and tail -n +2 messages 2..N entire, which is the unit the arms
+# claim to measure. Generalisation worth keeping: an assertion indexed by LINE over
+# a log whose records are MULTI-LINE is measuring a unit the feature does not have.
 source "$SRC/cmd_agent_runtime.sh"
 mkdir -p "$TMP/bin"
 cat >"$TMP/bin/curl" <<'CURLSTUB'
 #!/usr/bin/env bash
-printf '%s\n' "$*" >>"$SENDS"
+printf '%s\n' "${*//$'\n'/ }" >>"$SENDS"
 printf '%s' '{"ok":true,"result":{"message_id":15491}}'
 CURLSTUB
 chmod +x "$TMP/bin/curl"

--- a/tests/gate_button_retire_unit.sh
+++ b/tests/gate_button_retire_unit.sh
@@ -411,12 +411,25 @@ fi
 # than at file scope so the arms above keep the real predicate.
 require_root() { :; }
 SENDS="$TMP/sends.log"; : >"$SENDS"
-_mirror_send() {
-  printf 'send silent=%s markup=%s\n' \
-    "$([[ -n "${FIVEDIVE_NOTIFY_SILENT:-}" && "${FIVEDIVE_NOTIFY_SILENT}" != "0" ]] && echo yes || echo no)" \
-    "$([[ -n "${5:-}" ]] && echo yes || echo no)" >>"$SENDS"
-  printf '%s' '{"ok":true,"result":{"message_id":15491}}'
-}
+# olivia's DIVE-2712 iteration-2 defect, and the fix is WHERE we cut, not what we assert.
+# The previous stub REPLACED _mirror_send and re-implemented the silent predicate in its
+# own printf — so the arms graded "did cmd_task_inbox export the env var", not "does the
+# wire carry disable_notification". Deleting the real line at cmd_agent_runtime.sh:394
+# left the suite at 42/0. The dry-run line at :376 cannot catch it either: it is a
+# PARALLEL EVALUATION of the same condition inside the same function, a mirror rather
+# than a measurement.
+# So restore the REAL _mirror_send and stub the TRANSPORT instead. Everything above this
+# point keeps the cheap stub; re-sourcing here rebinds the genuine implementation, and
+# curl on PATH captures the argv it actually composes.
+source "$SRC/cmd_agent_runtime.sh"
+mkdir -p "$TMP/bin"
+cat >"$TMP/bin/curl" <<'CURLSTUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$SENDS"
+printf '%s' '{"ok":true,"result":{"message_id":15491}}'
+CURLSTUB
+chmod +x "$TMP/bin/curl"
+export PATH="$TMP/bin:$PATH" SENDS
 seed_gate() { # <id> <ident> <type>
   db "INSERT INTO tasks (id,ident,title,status,priority,assignee,need_type,tier,ask,recommend,need_options,created_at)
       VALUES ($1,'$2','t','blocked','high','main','$3',2,'ask?','A','A|B',datetime('now'));" 2>/dev/null
@@ -436,13 +449,18 @@ seed_gate 9003 DIVE-9003 decision
 # and those two need different fixes.
 ( cmd_task_inbox --send ) >/dev/null 2>&1; inbox_rc=$?
 chk "REACHABILITY: cmd_task_inbox --send actually RAN (rc 0, not a root/precondition refusal)" "0" "$inbox_rc"
-sends_n=$(grep -c '^send ' "$SENDS" 2>/dev/null || echo 0)
+sends_n=$(grep -c 'sendMessage' "$SENDS" 2>/dev/null || echo 0)
 chk "REACHABILITY: the send log is NON-EMPTY before anything asserts what is IN it" \
     "yes" "$([[ "$sends_n" -gt 0 ]] && echo yes || echo "no (rc=$inbox_rc)")"
-chk "3 open gates produce 3 SEPARATE messages, not one digest" "3" "$(grep -c '^send ' "$SENDS" 2>/dev/null || echo 0)"
-chk "the FIRST gate message pings the human" "silent=no" "$(head -1 "$SENDS" 2>/dev/null | grep -o 'silent=[a-z]*')"
-chk "every message after the first is SILENT (one buzz, not N)" "2" "$(tail -n +2 "$SENDS" 2>/dev/null | grep -c 'silent=yes')"
-chk "each gate carries its OWN keyboard" "3" "$(grep -c 'markup=yes' "$SENDS" 2>/dev/null || echo 0)"
+sends_n=$(grep -c 'sendMessage' "$SENDS" 2>/dev/null || echo 0)
+chk "3 open gates produce 3 SEPARATE messages, not one digest" "3" "$sends_n"
+# BOTH DIRECTIONS, deliberately. "assert it is present on 2..N" alone degrades into
+# "always pass it" — the absent-on-first arm is what stops that.
+chk "the FIRST gate message PINGS (no disable_notification on the wire)" "absent" \
+    "$(head -1 "$SENDS" | grep -q 'disable_notification=true' && echo present || echo absent)"
+chk "every message after the first carries disable_notification=true ON THE WIRE" "2" \
+    "$(tail -n +2 "$SENDS" | grep -c 'disable_notification=true')"
+chk "each gate carries its OWN keyboard" "3" "$(grep -c 'reply_markup=' "$SENDS" 2>/dev/null || echo 0)"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" == "0" ]]

--- a/tests/gate_button_retire_unit.sh
+++ b/tests/gate_button_retire_unit.sh
@@ -403,6 +403,13 @@ fi
 # any gate retired the keyboard for ALL of them (retire edits the message that
 # delivered the gate, and that message was everyone's). Graded on the SHAPE OF THE
 # SENDS, not by reading the code — the send stub records one line per call.
+# cmd_task_inbox's send path opens with require_root, so unprivileged this whole
+# block died at that line with E_AUTH_REQUIRED and every arm below asserted against
+# an EMPTY log — which reads as "the feature sent nothing", not as "the test never
+# ran". Same stub the sibling harnesses use (capture_accumulate_unit.sh:41,
+# gate_proof_verify_unit.sh, gate_tier2_decision_nonce_unit.sh). Defined HERE rather
+# than at file scope so the arms above keep the real predicate.
+require_root() { :; }
 SENDS="$TMP/sends.log"; : >"$SENDS"
 _mirror_send() {
   printf 'send silent=%s markup=%s\n' \
@@ -420,7 +427,18 @@ seed_gate 9002 DIVE-9002 approval
 seed_gate 9003 DIVE-9003 decision
 # Subshell: cmd_task_inbox ends in ok/fail, which exit — `|| true` cannot catch an
 # exit in the current shell, and the harness must survive either outcome.
-( cmd_task_inbox --send ) >/dev/null 2>&1 || true
+# REACHABILITY FIRST, and it is the arm this block cost a delivery for. olivia's
+# point: stubbing require_root fixes THIS instance, it does not fix the property
+# that an unreached path reports as an empty measurement rather than a red one.
+# So grade the INSTRUMENT before grading the feature — a non-zero expectation that
+# can only be met if the code actually ran. Without this, every arm below reads
+# "expected 3, got 0" whether the split is broken or the harness never reached it,
+# and those two need different fixes.
+( cmd_task_inbox --send ) >/dev/null 2>&1; inbox_rc=$?
+chk "REACHABILITY: cmd_task_inbox --send actually RAN (rc 0, not a root/precondition refusal)" "0" "$inbox_rc"
+sends_n=$(grep -c '^send ' "$SENDS" 2>/dev/null || echo 0)
+chk "REACHABILITY: the send log is NON-EMPTY before anything asserts what is IN it" \
+    "yes" "$([[ "$sends_n" -gt 0 ]] && echo yes || echo "no (rc=$inbox_rc)")"
 chk "3 open gates produce 3 SEPARATE messages, not one digest" "3" "$(grep -c '^send ' "$SENDS" 2>/dev/null || echo 0)"
 chk "the FIRST gate message pings the human" "silent=no" "$(head -1 "$SENDS" 2>/dev/null | grep -o 'silent=[a-z]*')"
 chk "every message after the first is SILENT (one buzz, not N)" "2" "$(tail -n +2 "$SENDS" 2>/dev/null | grep -c 'silent=yes')"

--- a/tests/task_inbox_send_unit.sh
+++ b/tests/task_inbox_send_unit.sh
@@ -37,6 +37,7 @@ printf '{"allowFrom":["1234567890"]}' >"$ACCESS"
 
 SEND_LOG="$TMP/sends"; : >"$SEND_LOG"
 LAST_TEXT="$TMP/text"; LAST_MARKUP="$TMP/markup"
+ALL_TEXT="$TMP/all-text"; ALL_MARKUP="$TMP/all-markup"
 FAIL_SEND=0
 _task_owner_channel() {
   TASK_CH_TYPE=claude TASK_CH_TOKEN=x TASK_CH_ACCESS="$ACCESS"
@@ -46,6 +47,7 @@ _task_send_owner() {
   local text="$1" markup="$2" ids="$3"
   printf '%s\n' "$ids" >>"$SEND_LOG"
   printf '%s' "$text" >"$LAST_TEXT"; printf '%s' "$markup" >"$LAST_MARKUP"
+  printf '%s\n' "$text" >>"$ALL_TEXT"; printf '%s\n' "$markup" >>"$ALL_MARKUP"
   TASK_SEND_MESSAGE_IDS="901"
   if [[ "$FAIL_SEND" == "1" ]]; then TASK_SEND_DELIVERED=0; return 0; fi
   TASK_SEND_DELIVERED=1
@@ -57,7 +59,7 @@ PASS=0; FAIL=0
 ok_t() { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 nsends() { grep -c . "$SEND_LOG"; }
-reset() { db "DELETE FROM tasks;"; : >"$SEND_LOG"; : >"$LAST_TEXT"; : >"$LAST_MARKUP"; FAIL_SEND=0; }
+reset() { db "DELETE FROM tasks;"; : >"$SEND_LOG"; : >"$LAST_TEXT"; : >"$LAST_MARKUP"; : >"$ALL_TEXT"; : >"$ALL_MARKUP"; FAIL_SEND=0; }
 mk_gate() { # ident type options recommend
   db "INSERT INTO tasks (ident,title,priority,assignee,created_by,kind,status,need_type,tier,ask,need_options,recommend,need_asked_at)
       VALUES ($(sqlq "$1"),'gate','high','dev','dev','standard','blocked',$(sqlq "$2"),2,'choose now',$(sqlq "$3"),$(sqlq "$4"),datetime('now'));
@@ -70,27 +72,31 @@ out=$(cmd_task_inbox --send 2>&1); rc=$?
 [[ "$rc" == "0" && "$(nsends)" == "0" && "$out" == *"nothing to send"* ]] \
   && ok_t "empty inbox sends nothing" || bad_t "empty inbox misbehaved" "rc=$rc out=$out"
 
-# Mixed gate types: ONE message, working buttons for all three, nonce hashes
-# stored, and the raw nonce NEVER on stdout.
+# Mixed gate types: DIVE-2712 — ONE MESSAGE PER GATE (lodar, 2026-08-04: answering a
+# gate retires the keyboard of the message that delivered it, so a shared digest lost
+# every gate's buttons at once). The properties these arms guard are UNCHANGED — every
+# gate reachable by a working button, hashes stored, raw nonce never on stdout — only
+# their SCOPE moves from the single digest to the set of messages.
 reset
 g1=$(mk_gate DIVE-21 decision 'A|B' A)
 g2=$(mk_gate DIVE-22 approval '' approved)
 g3=$(mk_gate DIVE-23 manual '' '')
 out=$(cmd_task_inbox --send --channel-proof=1234567890 2>&1); rc=$?
-approval_cb=$(jq -r --arg p "tna:${g2}:approved:" '[.inline_keyboard[][] | .callback_data | select(startswith($p))][0] // empty' "$LAST_MARKUP")
+approval_cb=$(jq -r --arg p "tna:${g2}:approved:" '[.inline_keyboard[][] | .callback_data | select(startswith($p))][0] // empty' "$ALL_MARKUP")
 approval_nonce=${approval_cb##*:}
-manual_cb=$(jq -r --arg p "tna:${g3}:done:" '[.inline_keyboard[][] | .callback_data | select(startswith($p))][0] // empty' "$LAST_MARKUP")
+manual_cb=$(jq -r --arg p "tna:${g3}:done:" '[.inline_keyboard[][] | .callback_data | select(startswith($p))][0] // empty' "$ALL_MARKUP")
 manual_nonce=${manual_cb##*:}
 h2=$(db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE id=${g2};")
 h3=$(db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE id=${g3};")
-grep -q "tna:${g1}:0" "$LAST_MARKUP"; has_d=$?
-[[ "$rc" == "0" && "$(nsends)" == "1" && "$has_d" == "0" \
+grep -q "tna:${g1}:0" "$ALL_MARKUP"; has_d=$?
+[[ "$rc" == "0" && "$(nsends)" == "3" && "$has_d" == "0" \
    && -n "$approval_nonce" && "$h2" == "$(_human_nonce_sha "$approval_nonce")" \
    && -n "$manual_nonce"   && "$h3" == "$(_human_nonce_sha "$manual_nonce")" ]] \
-  && ok_t "one digest, working decision+approval+manual buttons, hashes stored" \
-  || bad_t "digest buttons invalid" "rc=$rc sends=$(nsends) d=$has_d a=$approval_cb m=$manual_cb"
-grep -q "DIVE-21" "$LAST_TEXT" && grep -q "DIVE-22" "$LAST_TEXT" && grep -q "DIVE-23" "$LAST_TEXT" \
-  && ok_t "digest text lists every gate" || bad_t "digest text missing a gate"
+  && ok_t "THREE messages (one per gate), working decision+approval+manual buttons, hashes stored" \
+  || bad_t "per-gate buttons invalid" "rc=$rc sends=$(nsends) d=$has_d a=$approval_cb m=$manual_cb"
+grep -q "DIVE-21" "$ALL_TEXT" && grep -q "DIVE-22" "$ALL_TEXT" && grep -q "DIVE-23" "$ALL_TEXT" \
+  && ok_t "every gate appears in some message's text" || bad_t "a gate appears in NO message" \
+       "sends=$(nsends) all_text=$(wc -l <"$ALL_TEXT")"
 if [[ -n "$approval_nonce" && "$out" != *"$approval_nonce"* && "$out" != *"$manual_nonce"* ]]; then
   ok_t "raw nonce never printed to stdout"
 else
@@ -118,12 +124,11 @@ out=$(cmd_task_inbox --send --channel-proof=999 2>&1); rc=$?
 reset
 for i in $(seq 31 42); do mk_gate "DIVE-${i}" decision 'A|B' A >/dev/null; done
 out=$(cmd_task_inbox --send 2>&1); rc=$?
-sent_ids=$(tail -1 "$SEND_LOG")
-n_ids=$(awk -F, '{print NF}' <<<"$sent_ids")
+n_ids=$(grep -c '^[0-9]' "$SEND_LOG")
 grep -q "and 2 more" "$LAST_TEXT"; has_more=$?
 [[ "$rc" == "0" && "$n_ids" == "10" && "$has_more" == "0" ]] \
   && ok_t "digest caps at 10 gates and notes the overflow" \
-  || bad_t "cap broken" "rc=$rc n_ids=$n_ids more=$has_more"
+  || bad_t "cap broken" "rc=$rc gate_messages=$n_ids more=$has_more sends=$(nsends)"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 exit $(( FAIL > 0 ))


### PR DESCRIPTION
DIVE-2712. Maker: main. Verifier: olivia (reviewing at `f0e81f7`).

Reported by lodar on Telegram: *"when I press option button the whole inbox message disappears, so if I need to pick multiple then I have to call /inbox again"* and *"the inbox is too messy if multiple gates open"*.

## The fix

**One message per gate**, not one merged digest. Both complaints have one root: every gate shared a single message with a single merged keyboard, and settling any gate calls `_task_gate_retire_buttons`, which edits *the message that delivered it* — everyone's message. Telegram's keyboard removal took all N gates' buttons with it.

One message per gate makes the existing retire path correct **by construction**: a message carries exactly one gate, so removing its keyboard cannot affect another.

This also deletes the hard part. The alternative — keep the digest, subtract only the answered gate's rows — needs the *original* button nonces to survive the edit, and only their SHA is persisted (`human_nonce_hash`), so the survivors would be re-minted and their hashes rotated, silently killing those gates' buttons on every *other* message carrying them.

- **Push cost paid, not ignored:** `FIVEDIVE_NOTIFY_SILENT` is honoured at the single `_mirror_send` chokepoint, so the first message pings and the rest arrive silent — one buzz, N readable messages.
- **Nonce rotation is now per-gate**, after each gate's own confirmed receipt. Strictly better than the old batch rotation: a partial delivery no longer rotates hashes for gates whose message never landed.

## Grading

`tests/gate_button_retire_unit.sh` — **42 passed, 0 failed**.

Two REACHABILITY arms grade the **instrument before the feature** (olivia's requirement): the send returned `rc 0`, and the log is non-empty. Mutation: remove the `require_root` stub and those two red **first and name the cause** (36/6), where previously the only signal was four content arms reading *expected 3, got 0* — which a feature that genuinely sent nothing produces identically.

The `require_root` stub itself is the fix for the iteration-1 defect: `cmd_task_inbox`'s send path opens with `require_root`, so unprivileged the whole block died there and every arm asserted against an empty log.

## Disclosed, not hidden

- The `gate-notify.log` record shape changes: one line per gate with a single-element `tasks=` list, instead of one cohort line. All three readers in this repo were enumerated and none assumes a cohort — `_task_gate_deliveries` already `split`s on comma (the `n=1` case of a loop it always ran), `_mirror_log_button_reject` writes only and never parses, and the selfcheck probe is line-shape sensitive but not `tasks=`-arity sensitive. **Grep covered this repo only**; a reader outside it would be invisible to that check.
- `_task_send_owner_groups` (the group-send fallback) is exercised by no arm here.
