### PR TITLE
DIVE-2702: make the changelog.d fold idempotent across cuts

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -447,7 +447,17 @@ jobs:
           # so stamp-changelog.sh sees the folded headings same as a manually-typed
           # one. Not fatal for the same reason the stamp isn't: a cut must not die
           # because a fragment drifted from the expected format.
-          if _folded=$(bash scripts/fold-changelog-fragments.sh 2>&1); then
+          #
+          # DIVE-2702: PASS THE ALREADY-CONSUMED BASELINE. The fold deletes fragments
+          # in this detached tree only — main keeps them (DIVE-2247: no push to a
+          # protected branch) — so without this the NEXT cut re-folds every fragment
+          # ever written and each release's notes repeat all previous releases'.
+          # "${incumbent}^" is main's tip as of the last cut, and it is the SAME
+          # incumbent this job already derived and asserted above, so this is not a
+          # third copy of the tag-resolution rule. Empty incumbent (first cut ever) is
+          # passed through as set-but-empty on purpose: it means "nothing has shipped
+          # yet, fold everything", which is different from the unset auto-detect case.
+          if _folded=$(FOLD_RELEASED_BASELINE="${incumbent:+${incumbent}^}" bash scripts/fold-changelog-fragments.sh 2>&1); then
             echo "changelog.d fragments folded for ${tag}: ${_folded} (DIVE-2582)"
           else
             echo "::warning::changelog.d fragments could not be folded for ${tag} (${_folded}) — publishing anyway"

--- a/changelog.d/DIVE-2702.md
+++ b/changelog.d/DIVE-2702.md
@@ -1,0 +1,15 @@
+## Unreleased — fix(release): the changelog fold is idempotent across cuts (DIVE-2702)
+
+`scripts/fold-changelog-fragments.sh` deletes folded `changelog.d/` fragments in
+the detached release commit only — main keeps them, deliberately, because
+DIVE-2247 removed this job's ability to push a protected branch. The consequence
+was that the NEXT cut folded every surviving fragment again, so each release's
+notes repeated all previous releases' and it compounded, on a nightly auto-cut.
+
+The fold now skips a fragment that was already consumed by an earlier cut,
+reading that off history main can see: the previous release tag's parent is
+main's tip as of that cut, so a fragment present there and byte-identical to the
+one on disk has already shipped. Comparison is by BLOB, not by ident, so an
+edited fragment is new content and folds again. `release-cut.yml` passes the
+baseline as `${incumbent}^` — the incumbent it already derived — and an
+unresolvable baseline is reported rather than silently folding everything.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -31,3 +31,13 @@ commit, never main), folds every fragment here into `CHANGELOG.md`'s top
 tree only*. Fragments are not deleted from main by this step — same
 "Unreleased never clears off main" property `CHANGELOG.md` itself already has
 (see the header of `scripts/stamp-changelog.sh`); this is not a new limitation.
+
+**So how does the next cut not fold it twice?** It checks (DIVE-2702). A fragment
+still sitting on main that is *byte-identical* to the copy the previous release
+tag's parent carried has already shipped, so the fold skips it. Two consequences
+worth knowing when you write one:
+
+- Leaving your fragment on main after it ships is expected. Nothing to clean up.
+- **Editing** a fragment after it shipped makes it new content, so it folds again
+  and the entry appears in a second release's notes. If that is not what you want,
+  write a new fragment instead of editing the shipped one.

--- a/scripts/fold-changelog-fragments.sh
+++ b/scripts/fold-changelog-fragments.sh
@@ -36,6 +36,35 @@
 # clears on main" property CHANGELOG.md already has today (see stamp-changelog.sh's
 # header). Not a new limitation; matched to the existing one on purpose.
 #
+# WHY THAT NEEDED A SECOND HALF (DIVE-2702). A fragment surviving on main is
+# harmless once; it is not harmless twice. The deletion lives only in the tag, so
+# the NEXT cut sees the same fragment still sitting on main and folds it AGAIN,
+# on top of whatever is new — v0.19.1's notes would repeat all of v0.19.0's,
+# v0.19.2 both, and it COMPOUNDS. Measured 2026-08-04 straight after v0.19.0:
+# `git ls-tree origin/main changelog.d/` still listed all 8 fragments while
+# `git ls-tree v0.19.0 changelog.d/` listed 1. The cut is also a NIGHTLY AUTO-CUT
+# (lodar 2026-07-27, cadence option A), so the degraded artifact is public before
+# anyone chooses to look.
+#
+# THE FIX, and note which property it adds: IDEMPOTENCE, not a push to main. The
+# fold skips a fragment that was ALREADY CONSUMED BY AN EARLIER CUT, and it reads
+# that fact off history main can see — the previous release tag's PARENT is main's
+# tip as of that cut, so a fragment present in that tree, byte-identical to the one
+# here, was folded into that tag and has shipped. Everything else folds. This adds
+# no credential, no second workflow, and no push to a protected branch (DIVE-2247
+# removed that on purpose; restoring it via a post-tag PR was the rejected shape).
+#
+# Deliberately BYTE-IDENTICAL and not by ident: a fragment EDITED after its cut is
+# new content and folds again, which is what a re-filed fragment needs.
+#
+# BASELINE: $FOLD_RELEASED_BASELINE, a git ref whose tree is main as of the last
+# cut. release-cut.yml passes "${incumbent}^" — the incumbent it already derived
+# and asserted, so this is not a third copy of the tag rule. SET-BUT-EMPTY means
+# "no previous cut, fold everything" (the first cut ever). UNSET means auto-detect
+# with the same filter+sort release-cut.yml and install.sh use. Unresolvable is
+# NOT fatal — the cut must not die over a changelog — but it is reported, because
+# folding everything is exactly the defect above and must never pass silently.
+#
 # FRAGMENT FORMAT: a fragment's first non-blank line MUST be a
 # `## Unreleased — <headline>` (or bare `## Unreleased`) heading — the exact text
 # that would otherwise have been typed at the top of CHANGELOG.md, so authoring a
@@ -69,12 +98,46 @@ if [[ ${#frags[@]} -eq 0 ]]; then
   exit 0
 fi
 
+# DIVE-2702: resolve the ALREADY-CONSUMED baseline (see the header). Three states,
+# kept distinct on purpose — "nothing to skip against" and "I could not look" are
+# not the same answer, and only one of them deserves a warning.
+baseline="${FOLD_RELEASED_BASELINE-__auto__}"
+baseline_explicit=1
+if [[ "$baseline" == "__auto__" ]]; then
+  baseline_explicit=0
+  # Same filter and same sort as release-cut.yml's incumbent and install.sh's
+  # resolve_gh_tag(). At fold time the tag for THIS cut does not exist yet, so the
+  # newest tag is the previous release.
+  _prev_tag="$(git tag -l 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)"
+  baseline="${_prev_tag:+${_prev_tag}^}"
+fi
+if [[ -n "$baseline" ]] && ! git rev-parse --verify -q "${baseline}^{commit}" >/dev/null 2>&1; then
+  # Loud, and it names the consequence rather than the symptom: this is the exact
+  # state in which every already-shipped fragment folds a second time.
+  echo "fold-changelog-fragments: baseline '${baseline}' does not resolve to a commit ($([[ $baseline_explicit -eq 1 ]] && echo 'passed in FOLD_RELEASED_BASELINE' || echo 'auto-detected from the newest release tag')) — folding EVERY fragment, so entries that already shipped may repeat in these notes (DIVE-2702)" >&2
+  baseline=""
+fi
+# Fragment paths are matched against the baseline TREE, so they must be
+# repo-relative even when the script is run from a subdirectory.
+prefix="$(git rev-parse --show-prefix 2>/dev/null || true)"
+
 folded=0
+skipped_released=0
 tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
 
 for f in "${frags[@]}"; do
   path="${fragdir}/${f}"
+  # DIVE-2702: already consumed by an earlier cut? Compare BLOBS, not idents —
+  # an edited fragment is new content and must fold again.
+  if [[ -n "$baseline" ]]; then
+    released_blob="$(git rev-parse --verify -q "${baseline}:${prefix}${path}" 2>/dev/null || true)"
+    if [[ -n "$released_blob" && "$released_blob" == "$(git hash-object -- "$path" 2>/dev/null)" ]]; then
+      echo "fold-changelog-fragments: ${path} already shipped in a previous cut (unchanged since ${baseline}) — skipping (DIVE-2702)" >&2
+      skipped_released=$((skipped_released + 1))
+      continue
+    fi
+  fi
   # First non-blank line must anchor a well-formed heading, same pattern
   # stamp-changelog.sh anchors on — a fragment that drifted from the format is
   # reported and skipped, never silently folded as prose.
@@ -99,6 +162,10 @@ if [[ "$folded" -gt 0 ]]; then
     tail -n +2 "$changelog" | sed '/./,$!d'
   } > "${changelog}.new"
   mv "${changelog}.new" "$changelog"
+fi
+
+if [[ "$skipped_released" -gt 0 ]]; then
+  echo "fold-changelog-fragments: ${skipped_released} fragment(s) skipped as already shipped before ${baseline} (DIVE-2702)" >&2
 fi
 
 echo "$folded"

--- a/tests/fold_changelog_fragments_unit.sh
+++ b/tests/fold_changelog_fragments_unit.sh
@@ -7,6 +7,14 @@
 #   - a fragment that doesn't start with '## Unreleased' is reported and
 #     skipped: not folded into CHANGELOG.md, not deleted from changelog.d/
 #   - a bare '## Unreleased' (no em-dash headline) is accepted
+#
+# DIVE-2702 extends it with the arm that was missing — IDEMPOTENCE ACROSS CUTS,
+# graded the only way that means anything here: a real scratch git repo cut THREE
+# times, the fold run detached exactly as release-cut.yml runs it, asserting each
+# tag's CHANGELOG carries only its own entries. Two cuts would not have caught the
+# obvious wrong fix (checking only the immediately previous tag's notes), because
+# the compounding shows up on the THIRD. Extended in place rather than added as a
+# new harness — tests/lib/tier.sh's ledger argument, the corpus is at its cap.
 # Run: bash tests/fold_changelog_fragments_unit.sh   (no root, no network)
 set -uo pipefail
 
@@ -103,6 +111,135 @@ out4=$(cd "$R4" && bash "$SCRIPT" 2>"$TMP/err4"); rc4=$?
 [[ $rc4 -eq 0 && "$out4" == "1" ]] \
   && ok_t "bare '## Unreleased' heading (no em-dash) is accepted" \
   || bad_t "bare heading fold count" "rc=$rc4 out=$out4 err=$(cat "$TMP/err4")"
+
+# ===========================================================================
+# DIVE-2702: the fold is IDEMPOTENT ACROSS CUTS.
+#
+# The regression this arm exists for: the fold deletes fragments in the DETACHED
+# release commit only (DIVE-2247 removed this job's push to main), so main keeps
+# every fragment forever and the next cut folded them all again — each release's
+# notes repeating all previous releases', compounding, on a nightly auto-cut.
+#
+# Modelled on the real thing rather than on the script's arguments: a git repo
+# with a main branch, `git checkout --detach` before each fold, a commit and a
+# `v*` tag after it, and main left carrying its fragments the whole time.
+# ===========================================================================
+RG="$TMP/repo-cuts"
+mkdir -p "$RG/changelog.d"
+git -C "$RG" init -q -b main 2>/dev/null
+git -C "$RG" config user.email 'harness@example.com'
+git -C "$RG" config user.name  'harness'
+printf '# Changelog\n' > "$RG/CHANGELOG.md"
+
+# add a fragment on MAIN and commit it there
+frag_on_main() { # $1 = ident, $2 = body marker
+  printf '## Unreleased — feat(x): %s (%s)\n\nBody %s.\n' "$2" "$1" "$2" > "$RG/changelog.d/${1}.md"
+  git -C "$RG" add -A && git -C "$RG" commit -q -m "add ${1}"
+}
+
+# one release cut: detach at main, fold, commit, tag, return to main.
+# $1 = tag, $2 = "auto" (no env, script self-detects) | an explicit baseline ref
+cut_release() {
+  local tag="$1" mode="$2" out
+  git -C "$RG" checkout -q --detach main
+  if [[ "$mode" == "auto" ]]; then
+    out=$( cd "$RG" && bash "$SCRIPT" 2>>"$TMP/cuterr" )
+  else
+    out=$( cd "$RG" && FOLD_RELEASED_BASELINE="$mode" bash "$SCRIPT" 2>>"$TMP/cuterr" )
+  fi
+  git -C "$RG" add -A
+  git -C "$RG" commit -q -m "release ${tag}"
+  git -C "$RG" tag "$tag"
+  git -C "$RG" checkout -q main
+  printf '%s' "$out"
+}
+
+frag_on_main DIVE-9101 "entry one"
+frag_on_main DIVE-9102 "entry two"
+
+# CUT 1 — nothing has shipped yet, so everything folds. No tags exist, so this
+# also covers the auto-detect path's "no previous release" state.
+c1=$(cut_release v1.0.0 auto)
+c1_notes="$(git -C "$RG" show v1.0.0:CHANGELOG.md)"
+[[ "$c1" == "2" ]] \
+  && ok_t "cut 1 folds both pending fragments" \
+  || bad_t "cut 1 fold count" "out=$c1 err=$(cat "$TMP/cuterr" 2>/dev/null)"
+[[ "$c1_notes" == *"entry one"* && "$c1_notes" == *"entry two"* ]] \
+  && ok_t "cut 1 notes carry both entries" \
+  || bad_t "cut 1 notes" "$c1_notes"
+# The premise of the whole defect, asserted rather than assumed: the deletion
+# lives in the TAG and main still has the fragments.
+[[ -f "$RG/changelog.d/DIVE-9101.md" && -z "$(git -C "$RG" ls-tree --name-only v1.0.0 changelog.d/DIVE-9101.md)" ]] \
+  && ok_t "fragment consumed in the tag, still present on main (the immortality this arm is about)" \
+  || bad_t "fragment lifetime after cut 1" "main:$(ls "$RG/changelog.d") tag:$(git -C "$RG" ls-tree --name-only v1.0.0 changelog.d/)"
+
+# CUT 2 — one new fragment. Baseline passed EXPLICITLY, exactly as release-cut.yml
+# passes "${incumbent}^".
+frag_on_main DIVE-9103 "entry three"
+c2=$(cut_release v1.1.0 'v1.0.0^')
+c2_notes="$(git -C "$RG" show v1.1.0:CHANGELOG.md)"
+[[ "$c2" == "1" ]] \
+  && ok_t "cut 2 folds ONLY the new fragment (explicit baseline)" \
+  || bad_t "cut 2 fold count" "out=$c2 err=$(cat "$TMP/cuterr" 2>/dev/null)"
+[[ "$c2_notes" == *"entry three"* && "$c2_notes" != *"entry one"* && "$c2_notes" != *"entry two"* ]] \
+  && ok_t "cut 2 notes do NOT repeat cut 1's entries" \
+  || bad_t "cut 2 notes repeat an earlier release" "$c2_notes"
+
+# CUT 3 — the COMPOUNDING arm, and the reason two cuts are not enough. A fix that
+# only asked "is this entry in the previous TAG's CHANGELOG?" passes cut 2 and
+# fails here: v1.1.0's notes do not mention entry one/two either. Auto-detect
+# (no env) so the self-detection path is graded too.
+frag_on_main DIVE-9104 "entry four"
+c3=$(cut_release v1.2.0 auto)
+c3_notes="$(git -C "$RG" show v1.2.0:CHANGELOG.md)"
+[[ "$c3" == "1" ]] \
+  && ok_t "cut 3 folds ONLY the new fragment (auto-detected baseline)" \
+  || bad_t "cut 3 fold count" "out=$c3 err=$(cat "$TMP/cuterr" 2>/dev/null)"
+[[ "$c3_notes" == *"entry four"* \
+   && "$c3_notes" != *"entry one"* && "$c3_notes" != *"entry two"* && "$c3_notes" != *"entry three"* ]] \
+  && ok_t "cut 3 notes repeat NEITHER earlier release (the compounding arm)" \
+  || bad_t "cut 3 notes repeat an earlier release" "$c3_notes"
+
+# CUT 4 — an EDITED fragment is new content and MUST fold again. This is the
+# control whose expected value is non-zero: it fails if the skip is too greedy
+# (e.g. keyed on the ident/filename instead of the blob), which every other arm
+# above would happily pass.
+printf '## Unreleased — feat(x): entry one REWRITTEN (DIVE-9101)\n\nBody rewritten.\n' > "$RG/changelog.d/DIVE-9101.md"
+git -C "$RG" add -A && git -C "$RG" commit -q -m "edit DIVE-9101"
+c4=$(cut_release v1.3.0 auto)
+c4_notes="$(git -C "$RG" show v1.3.0:CHANGELOG.md)"
+[[ "$c4" == "1" && "$c4_notes" == *"entry one REWRITTEN"* ]] \
+  && ok_t "an EDITED fragment folds again (skip is by blob, not by ident)" \
+  || bad_t "edited fragment did not re-fold" "out=$c4 notes=$c4_notes"
+
+# --- baseline states that are not "a previous cut" -------------------------
+# Set-but-EMPTY means "nothing has shipped yet": fold everything, silently.
+RG2="$TMP/repo-empty-baseline"
+mkdir -p "$RG2/changelog.d"
+printf '# Changelog\n' > "$RG2/CHANGELOG.md"
+printf '## Unreleased — feat(x): first ever (DIVE-9105)\n\nBody.\n' > "$RG2/changelog.d/DIVE-9105.md"
+out5=$( cd "$RG2" && FOLD_RELEASED_BASELINE="" bash "$SCRIPT" 2>"$TMP/err5" ); rc5=$?
+[[ $rc5 -eq 0 && "$out5" == "1" ]] \
+  && ok_t "set-but-empty baseline (first cut ever): folds everything, rc=0" \
+  || bad_t "empty baseline fold" "rc=$rc5 out=$out5 err=$(cat "$TMP/err5")"
+grep -q 'DIVE-2702' "$TMP/err5" \
+  && bad_t "empty baseline warned" "an empty baseline is a normal first cut, not a broken one: $(cat "$TMP/err5")" \
+  || ok_t "set-but-empty baseline does not warn (it is not a failure to look)"
+
+# UNRESOLVABLE baseline: still folds (a cut must not die over a changelog) but is
+# REPORTED, because folding everything is precisely the defect and must never pass
+# silently. Graded on stderr, which release-cut.yml captures into its log line.
+RG3="$TMP/repo-bad-baseline"
+mkdir -p "$RG3/changelog.d"
+printf '# Changelog\n' > "$RG3/CHANGELOG.md"
+printf '## Unreleased — feat(x): pending (DIVE-9106)\n\nBody.\n' > "$RG3/changelog.d/DIVE-9106.md"
+out6=$( cd "$RG3" && FOLD_RELEASED_BASELINE="v9.9.9^" bash "$SCRIPT" 2>"$TMP/err6" ); rc6=$?
+[[ $rc6 -eq 0 && "$out6" == "1" ]] \
+  && ok_t "unresolvable baseline: non-fatal, still folds (rc=0)" \
+  || bad_t "unresolvable baseline fold" "rc=$rc6 out=$out6 err=$(cat "$TMP/err6")"
+grep -q 'does not resolve' "$TMP/err6" && grep -q 'may repeat' "$TMP/err6" \
+  && ok_t "unresolvable baseline is REPORTED, naming the repeat consequence" \
+  || bad_t "unresolvable baseline not reported" "$(cat "$TMP/err6")"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Maker: olivia. Graded PASS by main2 (independent re-derivation, not a relay of the maker's claims).

## What it fixes

The `changelog.d` fold is not idempotent across cuts. It deletes fragments in the detached cut
tree only — main keeps them (DIVE-2247: no push to a protected branch) — so the NEXT cut re-folds
every fragment ever written and each release's notes repeat all previous releases'. It compounds
every cut until this lands.

Fix passes the already-consumed baseline: `FOLD_RELEASED_BASELINE="${incumbent:+${incumbent}^}"`.
Empty incumbent (first cut ever) is passed through as set-but-empty deliberately — "nothing has
shipped yet, fold everything" — which is a different case from the unset auto-detect path.

## Evidence

main2's grade, re-derived rather than accepted: fold_changelog_fragments 20/0, release_cut
assign/bundle/guards 23/20/44, all HARNESS-RC=0, actionlint and shellcheck clean. It also
re-checked the two mutation claims — disabling the skip fails 5 arms including both do-not-repeat
arms, and keying on ident rather than blob fails exactly the edited-fragment control. DIVE-2700 is
the live case a by-ident skip would have suppressed forever; the blob rule saves it.

## Rebase note (DIVE-2656)

main2 graded `61fc21f`. main moved to `6c0543e` before this could be pushed, and branch protection
is strict, so this is `61fc21f` rebased to `ea1068f` — same tree, new sha. I re-ran the fold suite
at the rebased sha as a DELIVERY check (20/0, HARNESS-RC=0, shellcheck rc=0, actionlint rc=0).
That is not a re-grade and I am not the grader; it establishes the rebase carried the change
intact. The graded sha of record is `61fc21f`.

Pushed by main because neither olivia nor main2 holds a push credential.
