### PR TITLE
DIVE-2705: a dead GitHub query is not a completed scan

### DIFF
--- a/changelog.d/DIVE-2705.md
+++ b/changelog.d/DIVE-2705.md
@@ -1,0 +1,37 @@
+## Unreleased — fix(merge-gate): a dead GitHub query no longer counts as a completed scan (DIVE-2705)
+
+`_gate_gh` ended `|| true; return 0` on **both** rails and discarded stderr on both, so a call
+that DIED and a call that succeeded and found nothing were indistinguishable on every channel at
+once: same empty stdout, same empty stderr, same exit 0.
+
+Most call sites were unharmed because the contract is carried by OUTPUT — DIVE-2318 reads
+`-z "$_state"` / `-z "$_attr"` and refuses as UNRESOLVED, which is why those paths were already
+honest. The autodetect scan is the exception: it counts a repo as scanned on the **exit status**
+(`_hit=$(_gate_gh …) && _sc_ok=$((_sc_ok+1))`), so an unlistable repo incremented `_sc_ok`,
+`_sc_ok == _sc_total` set `_scan_ran=1`, and the whole partial-repo-scan block — warn, audit row,
+`merge-gate: UNVERIFIED` stamp — never fired. Partial coverage was announced as a clean scan:
+the exact defect DIVE-1955 exists to delete, surviving one level down inside its own remedy.
+
+**Blast radius is refusals only, never acceptances.** `_GATE_ROLLUP_JQ` maps an empty rollup to
+`NONE` and never to `OK`, so no dead call could ever manufacture a green. No bad `done` was
+admitted by this bug.
+
+Three changes:
+
+1. **Both rails return the real status**, and stderr is captured into `_GATE_GH_LAST_ERR` rather
+   than discarded. An unusable bot rail now returns non-zero too — "there was nothing to run it
+   with" is not "the query ran and found nothing". Stderr is captured rather than passed through
+   deliberately: a repo a token cannot see is an ordinary condition on a multi-repo close, and
+   printing gh's error text on every gate would be the alarm fatigue DIVE-2711 names.
+2. **`_scan_why` stops using the token as a proxy for reachability.** `no-gh-token` is now only
+   reported when no rail answered at all (`_sc_total == 0`), and partial coverage is judged on how
+   many repos ANSWERED rather than on which rail asked. This was the same token-as-proxy that
+   DIVE-2605 replaced with `_gate_gh_reachable` one level up, left behind here — with the bot rail
+   reporting real failures it made a partial bot-rail scan announce itself as `no-gh-token`, which
+   is wrong and is the more reassuring of the two errors.
+3. **An arm that drives the bot rail.** The fixture exports `GH_STUB_AUTH_TOKEN`, so every
+   pre-existing arm in `task_merge_gate_multirepo_unit.sh` took the token rail and none could see
+   the bot rail's copy of the defect — a token-rail-only fix would have turned the corpus green
+   with the bot rail still laundering partial coverage, and the green is what would have stopped
+   anyone looking. The sudo stub gained a `BOT_RAIL_ON` mode serving the same fixtures over
+   stdin-delivered args; default behaviour is unchanged, so no existing arm moved.

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -1530,17 +1530,57 @@ _gate_gh_reachable() {
 # Args reach `_gh_do` NUL-separated over STDIN (never argv), the same posture
 # `cmd_gh` uses: the jq filters below carry newlines and quotes, and the NOPASSWD
 # grant stays an exact command path with no argument wildcard.
+# DIVE-2705: the stderr of the most recent _gate_gh call, or empty. Read it to
+# tell a DEAD call apart from a successful empty one — see the contract below.
+_GATE_GH_LAST_ERR=""
+
+# DIVE-2705 — THE CONTRACT, and why it needed both halves.
+#
+# This used to end `|| true; return 0` on BOTH rails, and swallow stderr on both.
+# That left a failed call and a successful-but-empty one indistinguishable on
+# EVERY channel at once: same empty stdout, same empty stderr, same exit 0. Most
+# call sites are output-driven and were unharmed (DIVE-2318 reads `-z "$_state"`
+# / `-z "$_attr"` and refuses as UNRESOLVED, which is why those paths were already
+# honest). But the autodetect scan counts a repo as SCANNED on the exit status:
+#   _hit=$(_gate_gh ...) && _sc_ok=$((_sc_ok+1)) || _hit=""
+# so an unlistable repo incremented _sc_ok, _sc_ok==_sc_total set _scan_ran=1, and
+# the whole DIVE-1935/1955 partial-repo-scan block — warn, audit row, UNVERIFIED
+# stamp — never fired. Partial coverage was announced as a clean scan, which is
+# the exact defect DIVE-1955 exists to delete, surviving one level down inside its
+# own remedy.
+#
+# So: the status is now REAL, and stderr is CAPTURED rather than discarded. Empty
+# stdout keeps its documented meaning (COULD NOT RESOLVE, never "fine"); the
+# status says whether the call itself ran; _GATE_GH_LAST_ERR says why it did not.
+# Stderr is captured rather than passed through on purpose — a repo this token
+# cannot see is an ordinary, expected condition on a multi-repo close, and
+# spraying gh's error text on every gate would be noise that trains readers to
+# ignore it (the alarm-fatigue shape DIVE-2711 names).
 _gate_gh() {
   local tok="${1:-}" secs="${2:-0}"; shift 2
   local -a bound=()
+  local _rc=0 _errf
+  _GATE_GH_LAST_ERR=""
+  _errf="${TMPDIR:-/tmp}/.5dive-gate-gh-err.$$"
   if [[ -n "$tok" ]]; then
     [[ "$secs" != "0" ]] && bound=(timeout "${secs}s")
-    GH_TOKEN="$tok" "${bound[@]}" gh "$@" 2>/dev/null || true
-    return 0
+    GH_TOKEN="$tok" "${bound[@]}" gh "$@" 2>"$_errf" || _rc=$?
+  else
+    # No rail at all is NOT "the query ran and found nothing" — there was nothing
+    # to run it with. Returning 0 here made an unusable bot rail count as a
+    # completed scan, which is the same laundering as a failed listing.
+    if ! _gate_gh_bot_ok; then
+      _GATE_GH_LAST_ERR="no gh rail: no token, and the gate bot is not usable here"
+      rm -f "$_errf" 2>/dev/null || true
+      printf ''
+      return 1
+    fi
+    [[ "$secs" == "0" ]] && secs=10
+    printf '%s\0' "$@" | timeout "${secs}s" sudo -n "$_GATE_GH_DO" _gh_do 2>"$_errf" || _rc=$?
   fi
-  _gate_gh_bot_ok || { printf ''; return 0; }
-  [[ "$secs" == "0" ]] && secs=10
-  printf '%s\0' "$@" | timeout "${secs}s" sudo -n "$_GATE_GH_DO" _gh_do 2>/dev/null || true
+  [[ -s "$_errf" ]] && _GATE_GH_LAST_ERR="$(cat "$_errf" 2>/dev/null || printf '')"
+  rm -f "$_errf" 2>/dev/null || true
+  return "$_rc"
 }
 
 # DIVE-1935: extract every PR REFERENCE a piece of prose names, one number per
@@ -3331,10 +3371,20 @@ _task_status_cmd() {
     if [[ $_scan_ran -eq 0 ]]; then
       local _scan_why="query-failed"
       command -v gh >/dev/null 2>&1 || _scan_why="gh-absent"
-      [[ -n "$_ghtok2" ]] || _scan_why="no-gh-token"
+      # DIVE-2705: "no token" is a statement about ONE rail, and it is only the
+      # right label when NO rail answered — i.e. the loop was never entered, so
+      # _sc_total is still 0. Gating it on the token alone predates the bot rail
+      # and mislabels a bot-rail scan that ran and partly failed.
+      [[ $_sc_total -eq 0 && -z "$_ghtok2" ]] && _scan_why="no-gh-token"
       # DIVE-1955: "3 repos, 2 listed" is partial coverage, and partial coverage
       # announced as a clean scan is the defect this ticket is about, one level up.
-      [[ -n "$_ghtok2" && $_sc_total -gt 0 && $_sc_ok -lt $_sc_total ]] && _scan_why="partial-repo-scan-${_sc_ok}-of-${_sc_total}"
+      # DIVE-2705: partial coverage is a fact about how many repos ANSWERED, never
+      # about WHICH RAIL asked — the `-n "$_ghtok2"` that used to guard this was
+      # the same token-as-proxy-for-reachability that DIVE-2605 replaced with
+      # _gate_gh_reachable one level up, left behind here. With the bot rail now
+      # reporting real failures, that proxy made a partial bot-rail scan announce
+      # itself as "no-gh-token": wrong, and the more reassuring of the two.
+      [[ $_sc_total -gt 0 && $_sc_ok -lt $_sc_total ]] && _scan_why="partial-repo-scan-${_sc_ok}-of-${_sc_total}"
       warn "$ident: merge-gate could not query GitHub ($_scan_why) — this close is UNVERIFIED, not verified-clean (DIVE-1935)."
       _task_store_audit_log "task.merge-gate-unverified" ok 0 -- "$ident" "reason=$_scan_why"
       _mg_unverified="${_mg_unverified:+$_mg_unverified; }repo scan did not complete ($_scan_why)"

--- a/tests/task_merge_gate_multirepo_unit.sh
+++ b/tests/task_merge_gate_multirepo_unit.sh
@@ -88,9 +88,21 @@ chmod +x "$TMP/bin/gh"
 
 # sudo must be stubbed for the whole run or the token resolver reaches the HOST's
 # real gh login (real sudo resets PATH to secure_path, so the gh stub is bypassed).
+# DIVE-2705: the sudo stub now has TWO modes. Default is the historical one —
+# exit 1, so _gate_gh_bot_ok fails and every arm above this file's bot-rail
+# section keeps driving the TOKEN rail exactly as before. With BOT_RAIL_ON set it
+# emulates the bot rail instead: `-l` answers the capability probe, and the real
+# call reads its NUL-separated args off STDIN (never argv, which is the whole
+# posture of that rail) and serves them from the same gh stub, so both rails
+# answer from ONE fixture and an arm cannot pass on the wrong one by accident.
 cat >"$TMP/bin/sudo" <<SUDOSTUB
 #!/usr/bin/env bash
-exit 1
+[[ -n "\${BOT_RAIL_ON:-}" ]] || exit 1
+[[ "\$1" == "-n" ]] && shift
+[[ "\$1" == "-l" ]] && exit 0
+printf 'BOT_RAIL_CALL\n' >>"\$BOT_RAIL_LOG"
+mapfile -d '' -t _a < /dev/stdin
+exec "$TMP/bin/gh" "\${_a[@]}"
 SUDOSTUB
 chmod +x "$TMP/bin/sudo"
 export PATH="$TMP/bin:$PATH"
@@ -430,6 +442,65 @@ out=$(cmd_task_cancel CAN-1 --result='abandoning, api PR #6 stays open' 2>&1); r
 [[ $rc -eq 0 && "$(statusof CAN-1)" == "cancelled" ]] \
   && ok_t 'task cancel is never merge-gated, multi-repo included' \
   || bad_t 'cancel must not be gated' "rc=$rc status=$(statusof CAN-1) out=$out"
+
+# --- 13. THE BOT RAIL carries the same honesty as the token rail (DIVE-2705) ---
+# WHY THIS ARM EXISTS. Every arm above drives the TOKEN rail, because line ~119
+# exports GH_STUB_AUTH_TOKEN and _gate_gh takes the token branch whenever one
+# resolves. _gate_gh has a SECOND rail, and it carried the identical defect: it
+# ended `|| true`, so a listing that DIED on the bot rail returned 0 and counted
+# as SCANNED. Nothing in this file could see that, which is the actual hazard —
+# a token-rail-only fix turns the whole corpus green while the bot rail keeps
+# laundering partial coverage into a clean scan, and the green is what would stop
+# anyone looking. Two fail-opens on one path hide each other; the second is only
+# findable while you are already holding the first.
+#
+# _gate_gh_bot_ok is overridden rather than satisfied for real: it tests
+# `[[ -x /usr/local/bin/5dive ]]`, and _GATE_GH_DO is readonly and absolute, so
+# satisfying it honestly would make this arm pass or vanish depending on whether
+# the box happens to have 5dive INSTALLED — a test that needs the host is not a
+# test. The predicate is not what is under test here; the status propagation
+# below it is.
+clear_fx
+unset GH_STUB_AUTH_TOKEN                   # no token => _gate_gh takes the bot rail
+export BOT_RAIL_ON=1                       # ...and the sudo stub answers as that rail
+export BOT_RAIL_LOG="$TMP/botrail.log"; : >"$BOT_RAIL_LOG"
+_gate_gh_bot_ok() { return 0; }            # see the note above
+export GH_STUB_LIST_FAIL_5dive_api=1       # one repo's listing dies ON THE BOT RAIL
+: >"$AUDIT_CALLS"
+seed BOT-1
+run_done BOT-1 --result='shipped as PR #99'
+# Liveness first: if the call never went over the bot rail, everything below would
+# be grading the token rail a second time and would pass for the wrong reason.
+if [[ -s "$BOT_RAIL_LOG" ]]; then
+  ok_t 'the bot rail actually carried the scan (arm is not silently re-testing the token rail)'
+else
+  bad_t 'bot rail never invoked — this arm proves nothing' "log=[$(cat "$BOT_RAIL_LOG" 2>/dev/null)] out=$OUT"
+fi
+# Two SEPARATE assertions, because two separate parts of the fix are load-bearing
+# here and one combined arm would let either part hide behind the other.
+#
+#   (i)  the bot rail must REPORT the failure at all — without it the listing is
+#        counted as scanned, _scan_ran flips to 1, and nothing is emitted;
+#   (ii) and the failure must be LABELLED as partial coverage rather than as a
+#        missing token, which is a different edit (_scan_why) further down.
+#
+# (ii) is only observable when (i) works — a rail that swallows its failure emits
+# no label to get wrong — so a mutation of (i) necessarily reds both. That is
+# causal ordering, not missing coverage: the reverse is NOT true, and mutating
+# _scan_why alone reds (ii) and leaves (i) green, which is what makes them two.
+if [[ $RC -eq 0 && "$OUT" == *UNVERIFIED* ]] \
+   && grep -q 'merge-gate-unverified' "$AUDIT_CALLS" \
+   && [[ "$(db "SELECT COALESCE(result,'') FROM tasks WHERE ident='BOT-1';")" == *"merge-gate: UNVERIFIED"* ]]; then
+  ok_t 'a listing that DIED on the bot rail is not counted as scanned — stamped, audited, fail-open'
+else
+  bad_t 'bot rail failure counted as a completed scan' "rc=$RC out=$OUT audit=$(cat "$AUDIT_CALLS")"
+fi
+if [[ "$OUT" == *partial-repo-scan* ]] && ! grep -q 'reason=no-gh-token' "$AUDIT_CALLS"; then
+  ok_t 'a partial BOT-RAIL scan is labelled partial coverage, not "no-gh-token"'
+else
+  bad_t 'bot rail partial scan mislabelled as a token problem' "out=$OUT audit=$(cat "$AUDIT_CALLS")"
+fi
+unset BOT_RAIL_ON GH_STUB_LIST_FAIL_5dive_api
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## DIVE-2705 — a dead GitHub query is not a completed scan

`_gate_gh` ended `|| true; return 0` on **both** rails and discarded stderr on both. A call that **died** and a call that **succeeded and found nothing** were therefore identical on every channel at once: same empty stdout, same empty stderr, same exit 0.

Most call sites were unharmed, because the contract there is carried by **output** — DIVE-2318 reads `-z "$_state"` / `-z "$_attr"` and refuses as UNRESOLVED. The autodetect scan is the exception: it counts a repo as scanned on the **exit status**.

```sh
_hit=$(_gate_gh …) && _sc_ok=$((_sc_ok+1)) || _hit=""
```

So an unlistable repo incremented `_sc_ok`, `_sc_ok == _sc_total` set `_scan_ran=1`, and the entire partial-repo-scan block — warn, audit row, `merge-gate: UNVERIFIED` stamp — never fired. Partial coverage was announced as a clean scan: the exact defect DIVE-1955 exists to delete, surviving one level down **inside its own remedy**.

**Blast radius is refusals only, never acceptances.** `_GATE_ROLLUP_JQ` maps an empty rollup to `NONE` and never to `OK`, so no dead call could manufacture a green. No bad `done` was admitted by this bug.

### What changed

1. **Both rails return the real status**, with stderr captured into `_GATE_GH_LAST_ERR` instead of discarded. An unusable bot rail returns non-zero too — *"there was nothing to run it with"* is not *"the query ran and found nothing"*. Stderr is captured rather than passed through deliberately: a repo a credential cannot see is an ordinary condition on a multi-repo close, and printing gh's error text on every gate is the alarm fatigue DIVE-2711 is about.

2. **`_scan_why` stops using the credential as a proxy for reachability.** Both branches were gated on `-n "$_ghtok2"`, so a partial *bot-rail* scan reported itself as `no-gh-token`. That is the same proxy DIVE-2605 replaced with `_gate_gh_reachable` one level up, left behind here — and it is the more reassuring of the two errors. **I did not go looking for this; the new bot-rail arm found it.**

3. **An arm that drives the bot rail.** The fixture exports `GH_STUB_AUTH_TOKEN`, so every pre-existing arm took the token rail and none could see the bot rail's copy of the defect. A token-rail-only fix would have turned the corpus green with the bot rail still laundering partial coverage — and the green is what would have stopped anyone looking. The `sudo` stub gains a `BOT_RAIL_ON` mode serving the same fixtures over stdin-delivered args; default behaviour is unchanged, so no existing arm moved. The arm asserts **liveness** first, so it cannot silently re-test the token rail and pass for the wrong reason.

### Per-part mutation grading

Each part reverted **alone**, each mutation confirmed landed by grep before running, each restored by `git checkout` and re-verified clean.

| mutation | result | arms red |
|---|---|---|
| baseline | 39/0 | — |
| **A** token rail | 38/1 | `partial scan honesty` **only** |
| **B** bot rail | 37/2 | both bot-rail arms |
| **C** `_scan_why` | 38/1 | `bot rail partial scan mislabelled as a token problem` **only** |

**A** and **C** each red an arm no other mutation reds. **B** overlaps **C**, and that is stated rather than dressed up: **C is only observable when B works** — a rail that swallows its failure emits no label to get wrong — so mutating B necessarily reds both. The reverse is not true, which is what makes them two parts rather than one. The original single bot-rail assertion was split precisely so C could red alone.

### Not in this PR

`olivia`'s originally-specified edit (2) — *"the caller renders MEASURED over an empty state"* — was **already implemented by DIVE-2318** and is deliberately not rebuilt here. `cmd_task.sh:2999` guards `-z "$_state"` with `policy_refuse done-pr-state-unresolved`; `policy_refuse` ends in `fail`; `fail` ends in an unconditional `exit`. The `MEASURED` string is unreachable on an empty state, and `task_merge_gate_diagnostic_unit.sh` T2 already asserts exactly that property. Re-reading it at source is what stopped a redundant second guard shipping into a safety rail.

A narrower real hole found on the way — a payload with no `.state` yields the literal string `null`, which is non-empty and slips the `-z` guard — is filed as **DIVE-2720** and deliberately not folded in.

### Green

All 13 `task_merge_gate_*` / `task_deliver_*` harnesses, including `task_merge_gate_result_pr_unit.sh` (31/0, this row's originally-named red) and `task_merge_gate_diagnostic_unit.sh` (18/0, untouched). `pii-scan` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
