### PR TITLE
DIVE-2711: a failed council verify is a verdict, not a silent crash

### DIFF
--- a/changelog.d/DIVE-2711.md
+++ b/changelog.d/DIVE-2711.md
@@ -1,0 +1,26 @@
+## Unreleased — fix(council): a failed `verify` is a verdict, not a silent crash (DIVE-2711)
+
+`council verify` returned `E_GENERIC` on a legitimate failure — a drifted `constitution.yaml`,
+which it is *supposed* to fail closed on — without calling `mark_reported`. The EXIT backstop in
+`lib/output.sh` then treated that deliberate non-zero exit as an unreported one and appended its
+generic *"exited 1 without reporting a reason … this is a bug in the CLI"* text.
+
+On the stderr rail that is only noise. Under `--json` it is a **correctness bug**: the backstop
+emits a SECOND JSON object on stdout, so the command stops returning one document. Every reader
+breaks the same way — `jq -r '.data.constitutionOk'` returns `"false\nnull"` instead of `"false"`,
+so a caller checking `== "false"` sees a drifted constitution as *not flagged*. The verdict was
+right and unreadable, which is worse than either alone.
+
+Fixed by marking the failure reported: both rails already print the reason (the JSON envelope
+carries `constitutionOk` and `constitution`, the prose rail prints the `council verify: FAILED`
+block), so the backstop has nothing to add.
+
+**Why it only ever showed up on the installed-host CI matrix.** The environment did not change the
+bug; it changed how far the harness got. `council_amend_e2e.sh` drives real `convene` calls whose
+preflight needs a reachable agent registry, so on a pristine runner it stops before the drift arm
+and the defect is never reached. On a box with 5dive installed the preflight passes, the arm runs,
+and the second JSON object appears. `council_unit.sh` reds only because it aggregates that file.
+
+Also: the arm's failure message now prints the rc, stdout and stderr it rejected. It previously
+said only "verify json did not flag the drift", which is the one thing the payload already made
+obvious while hiding the second envelope that was the actual cause.

--- a/src/cmd_council.sh
+++ b/src/cmd_council.sh
@@ -4709,6 +4709,16 @@ _council_verify() {
       [[ -n "$target" && "$rcpt_ok" != "1" ]] && echo "  receipt: $target not found or does not re-seal" >&2
     fi
   fi
+  # DIVE-2711: a FAILED verify has already printed its reason on both rails above
+  # (the JSON envelope with constitutionOk/constitution, or the "council verify:
+  # FAILED" block on stderr), so mark it reported. Without this, the EXIT backstop
+  # in lib/output.sh treats the non-zero return as a SILENT exit and appends its
+  # generic "exited N without reporting a reason … this is a bug in the CLI" text.
+  # On the stderr rail that is merely noise; under --json it emits a SECOND JSON
+  # object on STDOUT, so the output stops being one document and every reader
+  # breaks — `jq -r .data.constitutionOk` returns "false\nnull" rather than
+  # "false". A drift verdict is a correct, deliberate non-zero exit, not a crash.
+  (( all_ok )) || mark_reported
   (( all_ok )) && return 0 || return "$E_GENERIC"
 }
 

--- a/src/council/cmd_council.template.sh
+++ b/src/council/cmd_council.template.sh
@@ -1313,6 +1313,16 @@ _council_verify() {
       [[ -n "$target" && "$rcpt_ok" != "1" ]] && echo "  receipt: $target not found or does not re-seal" >&2
     fi
   fi
+  # DIVE-2711: a FAILED verify has already printed its reason on both rails above
+  # (the JSON envelope with constitutionOk/constitution, or the "council verify:
+  # FAILED" block on stderr), so mark it reported. Without this, the EXIT backstop
+  # in lib/output.sh treats the non-zero return as a SILENT exit and appends its
+  # generic "exited N without reporting a reason … this is a bug in the CLI" text.
+  # On the stderr rail that is merely noise; under --json it emits a SECOND JSON
+  # object on STDOUT, so the output stops being one document and every reader
+  # breaks — `jq -r .data.constitutionOk` returns "false\nnull" rather than
+  # "false". A drift verdict is a correct, deliberate non-zero exit, not a crash.
+  (( all_ok )) || mark_reported
   (( all_ok )) && return 0 || return "$E_GENERIC"
 }
 

--- a/tests/council_amend_e2e.sh
+++ b/tests/council_amend_e2e.sh
@@ -99,8 +99,8 @@ CHAIN_DIGEST="$(jq -r 'select((.record.constitutionDigest // "")!="") | .record.
 # --- (3) drift FAILS CLOSED: hand-edit -> verify RED + convene ESCALATE --------------------------
 printf '\n# sneaky unsanctioned edit\n' >> "$CFILE"
 if "$FIVE" council verify >/dev/null 2>&1; then no "verify GREEN on a drifted (hand-edited) constitution"; else ok "verify RED on a drifted constitution (fail-closed)"; fi
-V="$("$FIVE" council verify --json 2>/dev/null)"
-[[ "$(printf '%s' "$V" | jq -r '.data.constitutionOk')" == "false" ]] && ok "verify --json flags constitutionOk=false on drift" || no "verify json did not flag the drift"
+V="$("$FIVE" council verify --json 2>"$TMP/verify.err")"; V_RC=$?
+[[ "$(printf '%s' "$V" | jq -r '.data.constitutionOk')" == "false" ]] && ok "verify --json flags constitutionOk=false on drift" || no "verify json did not flag the drift (rc=$V_RC stdout=<$V> stderr=<$(cat "$TMP/verify.err")>)"
 # a primary-council convene under drift ESCALATES (does not enforce forged governance)
 C="$("$FIVE" council convene "Ship the thing?" --subject="DIVE-2257 drift leg" --json 2>/dev/null)"
 [[ "$(printf '%s' "$C" | jq -r '.data.driftEscalated')" == "true" ]] && ok "primary-council convene ESCALATES under drift" || no "convene did not drift-escalate ($C)"


### PR DESCRIPTION
## DIVE-2711 (council half) — a failed `council verify` is a verdict, not a silent crash

Two of the four harnesses red on `full-sweep` are **one defect**. `council_unit.sh` reds only because it aggregates `council_amend_e2e.sh`.

`_council_verify` returned `E_GENERIC` on a legitimate fail-closed verdict — a drifted `constitution.yaml`, which it is *supposed* to refuse on — without calling `mark_reported`. The EXIT backstop in `lib/output.sh` then treated that deliberate non-zero exit as an unreported one and appended its generic *"exited 1 without reporting a reason … this is a bug in the CLI"* text.

On the stderr rail that is only noise, which is why the prose arm directly above passed. Under `--json` it is a correctness bug: the backstop emits a **second JSON object on stdout**, so the command stops returning one document.

```
$ 5dive council verify --json     # on a drifted constitution
{"ok":false,"data":{ … "constitutionOk":false, "constitution":"constitution.yaml digest … does not match the sealed …"}}
{"ok":false,"error":{"code":1,"class":"generic","message":"5dive council exited 1 without reporting a reason …"}}
```

Every reader breaks the same way: `jq -r '.data.constitutionOk'` returns `"false\nnull"` instead of `"false"`, so a caller comparing against `"false"` reads a drifted constitution as **not flagged**. The verdict was correct and unreadable, which is worse than either alone.

Fixed by marking the failure reported. Both rails already print the reason — the JSON envelope carries `constitutionOk` and `constitution`, the prose rail prints the `council verify: FAILED` block — so the backstop has nothing to add. No verdict changes.

### Why it only ever showed on the installed-host matrix

**The environment did not change the bug; it changed how far the harness got.** `council_amend_e2e.sh` drives real `convene` calls whose preflight needs a reachable agent registry (DIVE-2703), so on a pristine runner it stops before the drift arm and the defect is never reached. On a box with 5dive installed the preflight passes, the arm runs, and the second object appears. That is exactly the isolation-leak the `full-sweep` job comment predicts — *"harnesses that leak out of their isolation red HERE"* — working as intended.

Practical consequence worth recording: this row was filed as needing CI iteration because *"all of these pass locally"*. They do not. The control-plane box **is** an installed host, and both files reproduce on it directly, which is how this was root-caused without round-tripping through Actions.

### Verification

Differential on this tree — reverting the one line and rebuilding:

| | result |
|---|---|
| fix present | `17 passed, 0 failed` |
| fix reverted | `16 passed, 1 FAILED` |

Green: all 17 `council_*` harnesses, plus `silent_nonzero_exit_backstop_unit.sh` (15/0), which is the only harness that asserts the backstop's own behaviour.

`src/cmd_council.sh` is **generated** by `src/council/gen_cmd.mjs` — the template is the edit site and the generated file is regenerated, so `bundle-drift` stays clean. Regenerated again after rebasing onto `6c0543e`, with no drift.

The failing arm's message now prints the `rc`, stdout and stderr it rejected. It previously said only *"verify json did not flag the drift"* — the one thing already obvious — while hiding the second envelope that was the actual cause.

### Scope

This is the **council half** of DIVE-2711 only. The other named red, `task_merge_gate_multirepo_unit.sh`, is not separate unowned work: it is DIVE-2705's `_gate_gh` defect, fixed in #467. Both must land before `full-sweep` is green and the release cut unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
