### PR TITLE
fix(task): key the result guard on the column, not on closed-ness (DIVE-2483)

### DIFF
--- a/changelog.d/DIVE-2483.md
+++ b/changelog.d/DIVE-2483.md
@@ -1,0 +1,36 @@
+## Unreleased — fix(task): the result guard keys on the COLUMN, not on whether the row is closed (DIVE-2483)
+
+The guard standing between a `--result=` write and an existing record only ran when the row was
+already `done` or `cancelled`. That is the rare cell. The cell the maker→verifier rail
+**manufactures on every loop** is the other one: a delivered row is OPEN and already carries the
+maker's record, so the routine case was unprotected.
+
+Three verbs reached it and each was found separately, months apart — `task done` (DIVE-2483, a
+killed heredoc expanded to nothing and replaced a 2.6KB note with a zero-length string, exit 0),
+`task verify --cmd=` (DIVE-2624, a maker's delivery record replaced by a verify verdict), and
+`task deliver` (DIVE-2476). So did the *remedy*: `--append-result` was parsed, accepted and
+**silently inert** on an open row, because it was implemented inside the refusal's branch
+(DIVE-2717/DIVE-2712). A flag that no-ops in the situation its help text describes is worse than an
+absent one — an operator reaches for it precisely when they perceive the risk, and a clean `OK` is
+affirmative evidence that the protection ran.
+
+Now: both reads happen unconditionally and the gate is *"bytes are about to be lost"*.
+
+- **Open row carrying someone's result → AUTO-APPEND.** Prior text verbatim on top, yours under a
+  marker. Preservation is the default rather than a flag, which removes the class instead of
+  patching it; `--append-result` still works and is simply a no-op here.
+- **Closed row → unchanged.** The DIVE-2464 refusal, `--append-result` and the audited
+  `--force-result` all behave exactly as before.
+- **An EMPTY `--result=` over a non-empty column → refused at every status and under every flag,
+  `--force-result` included.** There is no legitimate reason to blank a result, and the value
+  arrives from ordinary shell accidents rather than decisions. It is also the least visible loss
+  available: a zero-length result renders as a blank field, indistinguishable from one nobody ever
+  wrote, so unlike a replacement with real text it leaves nothing for a reader to notice.
+- **`task verify` is guarded on the not-done path**, where DIVE-2067's preservation never reached.
+
+**Why auto-append and not a uniform refusal**, which was the other candidate: `task reject` writes
+the *verifier's* feedback into `result`, so after any rejection the row is open and carries someone
+else's text — and the maker's next `task done --result=` at iteration 2 is exactly this cell. A
+uniform refusal would have turned the second iteration of every graded task on the fleet into a
+refusal, training people to reach for `--force-result`. `tests/task_result_loss_open_row_unit.sh`
+arm R is the regression arm for that rail and is not optional.

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -2480,9 +2480,36 @@ _task_guard_result_over_closed() {
   _TASK_GUARDED_RESULT="$result"
   local _cl_st _cl_prev
   _cl_st=$(db "SELECT COALESCE(status,'') FROM tasks WHERE id=${id};")
+  _cl_prev=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=${id};")
+  # DIVE-2483: THE KEY IS THE COLUMN, NOT THE ROW STATE. Both reads now happen
+  # unconditionally, and the gate below is "bytes are about to be lost" — the
+  # thing this guard is actually for. Keyed on closed-ness it missed the cell the
+  # maker→verifier rail MANUFACTURES on every loop: a delivered row is OPEN and
+  # already carries the maker's record, so the guard protected the rare cell and
+  # skipped the routine one. Three verbs hit that cell (done, deliver, verify) and
+  # each was found separately, which is what a status key buys you.
+  #
+  # Nothing recorded, or nothing changing -> no bytes at risk, and in particular a
+  # bare repeat close (no --result at all) never reaches here because the callers
+  # only consult the guard when a result was actually passed.
+  if [[ -z "$_cl_prev" || "$_cl_prev" == "$result" ]]; then
+    _TASK_GUARDED_RESULT="$result"; return 0
+  fi
+
+  # DIVE-2483, and this one is unconditional on purpose: an EMPTY --result= over a
+  # non-empty column is refused at EVERY status and under EVERY flag, --force-result
+  # included. There is no legitimate reason to blank a result, and the value arrives
+  # from ordinary shell accidents rather than from a decision — an unset variable, a
+  # killed heredoc, a truncated arg. It is also the least visible loss available: a
+  # zero-length result renders as a blank field, indistinguishable from "nobody ever
+  # wrote one", so unlike a replacement with real text it leaves nothing for a reader
+  # to notice. That is why it does not get the escape hatch the lossy path gets.
+  if [[ -z "$result" ]]; then
+    policy_refuse "$E_CONFLICT" result-blanked DIVE-2483 "$ident" \
+      "$ident carries a result and '5dive task ${verb} --result=' was given an EMPTY value — that would blank the record, and the ledger keeps only a sha256 of it, so it could not be restored (DIVE-2483). This is refused at every status and under every flag (including --force-result): a zero-length result is indistinguishable from one that was never written, so nobody would ever notice the loss. Almost always this is a shell accident rather than an intent — an unset variable, a killed heredoc, a truncated argument. Check the value you passed. If you genuinely mean to REPLACE the text, pass the replacement; if you mean to ADD to it, that is the default on an open row and '--append-result' on a closed one."
+  fi
+
   if [[ "$_cl_st" == "done" || "$_cl_st" == "cancelled" ]]; then
-    _cl_prev=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=${id};")
-    if [[ -n "$_cl_prev" && "$_cl_prev" != "$result" ]]; then
       if (( append_result )); then
         # Prior text FIRST and untouched: the existing record is the one that
         # must survive verbatim, and the addition is what is new.
@@ -2503,6 +2530,36 @@ _task_guard_result_over_closed() {
         policy_refuse "$E_CONFLICT" "$policy" DIVE-2464 "$ident" \
           "$ident is ALREADY ${_cl_st} (closed ${_cl_at}; assignee '${_cl_asg}'${_cl_vf:+, verifier '${_cl_vf}'}${_cl_mk:+, maker '${_cl_mk}'}) and carries a result — a bare '5dive task ${verb} --result=' here would REPLACE that record with no warning, and the ledger keeps only a sha256 of it, so it could not be restored (DIVE-2464). Run '5dive trace $ident' to see who wrote it. If you are ADDING your half of the work, say so: '5dive task ${verb} $ident --append-result --result=<your text>' (keeps theirs verbatim, adds yours under it). Only if the recorded text is genuinely WRONG: '--force-result' (replaces it, audited with the overwritten text)."
       fi
+  else
+    # DIVE-2483: OPEN row already carrying someone's result. AUTO-APPEND — the
+    # decision on the row (olivia, 2026-08-04), and it is not the same answer as
+    # the closed cell above on purpose.
+    #
+    # Refusing here instead would have been the "uniform" choice and it WEDGES the
+    # rail: `task reject` writes the VERIFIER'S feedback into `result` (see the
+    # UPDATE in _task_reject_cmd), so after any rejection the row is open and
+    # carries someone else's non-empty text — and the maker's next
+    # `task done --result=` at iteration 2 is exactly this cell. Uniform refusal
+    # would turn the second iteration of every graded task into a refusal, which
+    # trains people to reach for --force-result. Appending cannot wedge anything.
+    #
+    # It also removes the DIVE-2717 class rather than patching it: --append-result
+    # was PARSED, accepted and silently INERT here, because the remedy lived inside
+    # the closed-row branch. A flag that no-ops in the situation its help text
+    # describes is worse than an absent one — an operator reaches for it precisely
+    # when they perceive the risk, and a clean OK is affirmative evidence that the
+    # protection ran. Making preservation the DEFAULT means the protection no
+    # longer depends on remembering a flag whose habit only forms where it works.
+    # (--append-result is therefore a no-op here, not an error: it asks for what
+    # already happens.)
+    if (( force_result )); then
+      # Same lossy escape as the closed cell, same audit obligation: the
+      # overwritten TEXT, not just its hash.
+      _task_store_audit_log "task.force-result-over-open" ok 0 -- \
+        "$ident" "open_status=$_cl_st" "overwritten_result=$_cl_prev"
+      warn "$ident: --force-result REPLACED a result this OPEN row already carried. The overwritten text is in the audit log (task.force-result-over-open); the board copy is gone (DIVE-2483)."
+    else
+      result="${_cl_prev}"$'\n\n'"--- appended by a later write (DIVE-2483); the text above was already on the row ---"$'\n'"${result}"
     fi
   fi
   _TASK_GUARDED_RESULT="$result"
@@ -4703,6 +4760,35 @@ cmd_task_verify() {
   else
     verdict="fail"
     result_txt="❌ verify FAIL (exit ${rc}): ${cmd}"$'\n'"--- output tail ---"$'\n'"${tail_out}"
+  fi
+
+  # DIVE-2483: `task verify` is the THIRD writer of this column and the only one
+  # that reached the OPEN cell completely unguarded. DIVE-2067 added preservation
+  # here, but inside `if [[ "$_v_st" == 'done' ]]` — so every not-done write below
+  # (the pending-gate refusal, the auth-failure exit, the done-flip, and the FAIL
+  # branch) put result_txt straight over whatever was there.
+  #
+  # A DELIVERED row is not done, which is what makes this live rather than
+  # theoretical: it is the cell a maker→verifier loop is in for its whole life.
+  # Measured on DIVE-2624 — dev's maker-delivery record was replaced by
+  # "✅ verify PASS (exit 0): bash /tmp/.../prove_2624.sh" and was gone from the
+  # board. That path is not an accident either: the DIVE-2318 merge-gate refuses a
+  # `task done` with no gh credential and suggests handing the close to an agent
+  # that holds one, DIVE-477 forbids that, and the refusal at :2707 then NAMES
+  # `task verify --cmd=` among its exits — so a no-gh verifier is ROUTED here by
+  # construction. The verb that a whole class of agents is funnelled into is the
+  # last one that should be the unguarded one.
+  #
+  # Deliberately scoped to the NOT-done cell: the closed cell already has
+  # DIVE-2067's own refusal and its "superseded result (DIVE-2067, preserved)"
+  # append below, and running both would append twice. This is keyed on status at
+  # the CALL SITE — which is fine and is not the defect this ticket is about — to
+  # avoid two preservation mechanisms overlapping on one write.
+  local _v_guard_st
+  _v_guard_st=$(db "SELECT COALESCE(status,'') FROM tasks WHERE id=${id};")
+  if [[ "$_v_guard_st" != "done" && "$_v_guard_st" != "cancelled" ]]; then
+    _task_guard_result_over_closed "$id" "$ident" verify "$result_txt" 0 0 verify-result-over-open
+    result_txt="$_TASK_GUARDED_RESULT"
   fi
 
   local flipped=0 self_verified_close=0

--- a/tests/task_done_over_closed_result_unit.sh
+++ b/tests/task_done_over_closed_result_unit.sh
@@ -137,10 +137,19 @@ out=$( cmd_task_done "$id" --result="$MINE" 2>&1 ); rc=$?
 res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
 [ "$rc" -eq 0 ] && [ "$res" = "$MINE" ] && ok "D3 a done row with an EMPTY result accepts one (nothing to destroy)" || no "D3 empty prior result" "rc=$rc res=$res $out"
 
+# D4 CHANGED BY DIVE-2483, and the old assertion is worth recording because it is
+# the defect written down as expected behaviour: it seeded an open row ALREADY
+# CARRYING "notes so far", closed it with a different --result, and asserted the
+# column now equals the new text EXACTLY — i.e. it pinned the silent wipe. An open
+# row carrying someone's result is the cell the maker→verifier rail manufactures on
+# every loop, so this arm was green throughout the defect's entire life. It still
+# must not REFUSE (that would wedge the rail); it must PRESERVE.
 id=$(seed in_progress "notes so far")
 out=$( cmd_task_done "$id" --result="$MINE" 2>&1 ); rc=$?
 res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
-[ "$rc" -eq 0 ] && [ "$res" = "$MINE" ] && ok "D4 a FIRST close of an open row is untouched by the guard" || no "D4 first close of open row" "rc=$rc res=$res $out"
+[ "$rc" -eq 0 ] && [ "${res#notes so far}" != "$res" ] && [ "${res%"$MINE"}" != "$res" ] \
+  && ok "D4 an open row carrying a result AUTO-APPENDS: prior text kept, new text under it (DIVE-2483)" \
+  || no "D4 open row auto-append" "rc=$rc res=$res $out"
 
 # --- E. cancel writes the same column, so it is guarded the same --------------
 id=$(seed done "$THEIRS")

--- a/tests/task_result_loss_open_row_unit.sh
+++ b/tests/task_result_loss_open_row_unit.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# TIER: nightly — sibling of task_done_over_closed_result_unit.sh (46.2s measured there); does not fit the 300s PR core.
+# DIVE-2211 / DIVE-2286: name the tree this harness grades. Sourced BEFORE any cd so
+# ${BASH_SOURCE[0]} still resolves relative to tests/.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+# DIVE-2483 isolated unit harness for the result guard on an OPEN row.
+#
+# WHY THIS FILE EXISTS SEPARATELY FROM ITS CLOSED-ROW SIBLING, which is the whole
+# point and not a filing preference: the DIVE-2464 guard keyed on the ROW STATE it
+# protects ("already closed") rather than on the COLUMN it protects ("the result").
+# Every arm anyone wrote for it therefore graded the CLOSED cell — and the cell the
+# maker→verifier rail MANUFACTURES on every single loop is the other one. A
+# delivered row is OPEN and already carries the maker's record. So the guard
+# protected the rare cell and skipped the routine one, and a harness exercising only
+# the closed cell passed green throughout the entire life of the defect. The sibling
+# harness even had an arm (D4) asserting the wipe as correct behaviour.
+#
+# Three verbs reached the open cell and each was found separately, months apart:
+#   task done    — DIVE-2483, the row that owns this (empty overwrite, killed heredoc)
+#   task verify  — DIVE-2624, dev's maker-delivery record replaced by a verify verdict
+#   task deliver — DIVE-2476, the same column through the door next door
+# ...plus the remedy itself: --append-result was parsed, accepted and SILENTLY INERT
+# here (DIVE-2717/DIVE-2712), because the remedy lived inside the refusal's branch.
+#
+# THE DECISION THIS GRADES (olivia, 2026-08-04, gate on DIVE-2483): on an OPEN row
+# carrying another agent's result, a write AUTO-APPENDS rather than refusing.
+# Refusing would have been the "uniform" choice and it WEDGES the rail — `task
+# reject` writes the VERIFIER'S feedback into `result`, so after any rejection the
+# row is open and carries someone else's text, and the maker's next
+# `task done --result=` at iteration 2 is exactly this cell. Arm R below is the
+# regression arm for that and it is not optional.
+#
+# Same isolation contract as the sibling task harnesses: sources src/ libs directly
+# with STATE_DIR on a throwaway temp dir, so it NEVER touches the live shared tasks.db.
+# Run: bash tests/task_result_loss_open_row_unit.sh
+set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/task-result-loss-open-unit.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh \
+         lib/registry.sh lib/disk.sh lib/tasks_db.sh lib/actor.sh cmd_task.sh \
+         cmd_push.sh cmd_org.sh cmd_project.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"
+TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"
+set +e
+
+P=0; F=0
+ok(){ P=$((P+1)); echo "ok   - $1"; }
+no(){ F=$((F+1)); echo "FAIL - $1"; [ -n "${2:-}" ] && echo "   ${2:0:300}"; }
+
+seedv() { # $1=status $2=result $3=assignee $4=verifier -> row id
+  tasks_db_init >/dev/null 2>&1
+  db "INSERT INTO tasks (title,status,assignee,verifier,result,kind,priority,created_by,done_at)
+      VALUES ('t','$1','$3',$(sqlq "$4"),$(sqlq "$2"),'standard','medium','main',
+              CASE WHEN '$1' IN ('done','cancelled') THEN '2026-07-30 21:08:59' ELSE NULL END);" >/dev/null 2>&1
+  db "SELECT id FROM tasks ORDER BY id DESC LIMIT 1;"
+}
+seed() { seedv "$1" "$2" olivia ""; }
+
+THEIRS="dev: maker delivery — implemented the include guard, 7/7 unit, four mutation arms confirmed red."
+MINE="main: grade — accepted, evidence checked against the branch."
+
+echo "== A. the acceptance sentence, verbatim: OPEN row + another agent's result =="
+# "on an OPEN row carrying agent A's result, agent B running
+#  'task done --result=X --append-result' yields A's text VERBATIM followed by X"
+id=$(seed in_progress "$THEIRS")
+out=$( cmd_task_done "$id" --append-result --result="$MINE" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -eq 0 ] && ok "A1 --append-result on an OPEN row is ACCEPTED (rc=0)" || no "A1 accepted" "rc=$rc $out"
+grep -qF "$THEIRS" <<<"$res" && ok "A2 the prior agent's text survives VERBATIM" || no "A2 prior verbatim" "$res"
+grep -qF "$MINE"   <<<"$res" && ok "A3 the new text is present too" || no "A3 new text present" "$res"
+# ORDER is load-bearing: the existing record is the one that must survive on top.
+[ "${res#"$THEIRS"}" != "$res" ] && ok "A4 the prior text comes FIRST" || no "A4 prior text first" "$res"
+
+echo "== B. the flag was the REMEDY, not the mechanism: a BARE write preserves too =="
+# DIVE-2717's finding is that an operator reaches for --append-result exactly when
+# they perceive the risk and it silently no-opped. Making preservation the DEFAULT
+# is what removes the class; if this arm reds, the fix is still a flag.
+id=$(seed in_progress "$THEIRS")
+out=$( cmd_task_done "$id" --result="$MINE" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -eq 0 ] && ok "B1 a BARE --result= on an open row is accepted (not refused — refusing wedges the rail)" || no "B1 bare accepted" "rc=$rc $out"
+grep -qF "$THEIRS" <<<"$res" && ok "B2 and it preserves the prior text with NO flag passed" || no "B2 bare preserves" "$res"
+grep -qF "$MINE"   <<<"$res" && ok "B3 and the new text landed" || no "B3 bare new text" "$res"
+
+echo "== C. EMPTY --result= over a non-empty column: refused at EVERY status and flag =="
+# The row's headline case: a killed heredoc expanded to nothing and the verb replaced
+# a 2.6KB note with a zero-length string, exit 0. This is the least visible loss
+# available — a blank field is indistinguishable from one nobody wrote — which is why
+# it gets no escape hatch, not even --force-result.
+id=$(seed in_progress "$THEIRS")
+out=$( cmd_task_done "$id" --result="" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -ne 0 ] && ok "C1 an EMPTY --result= over a non-empty column is REFUSED on an OPEN row (rc=$rc)" || no "C1 empty refused open" "rc=$rc $out"
+[ "$res" = "$THEIRS" ] && ok "C2 and the prior text is INTACT after the refusal" || no "C2 intact after refusal" "$res"
+grep -q 'DIVE-2483' <<<"$out" && ok "C3 the refusal cites DIVE-2483" || no "C3 cites DIVE-2483" "$out"
+
+id=$(seed done "$THEIRS")
+out=$( cmd_task_done "$id" --result="" 2>&1 ); rc=$?
+[ "$rc" -ne 0 ] && ok "C4 ...refused on a CLOSED row too (status is not the key)" || no "C4 empty refused closed" "rc=$rc $out"
+
+id=$(seed in_progress "$THEIRS")
+out=$( cmd_task_done "$id" --force-result --result="" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -ne 0 ] && ok "C5 ...and --force-result does NOT buy a blanking (the one path with no escape)" || no "C5 force cannot blank" "rc=$rc $out"
+[ "$res" = "$THEIRS" ] && ok "C6 the text survived the --force-result attempt" || no "C6 survived force blank" "$res"
+
+echo "== D. --force-result still REPLACES on an open row, and says so =="
+# The lossy escape must remain reachable when the recorded text is genuinely wrong,
+# and it must remain the only path that announces itself.
+id=$(seed in_progress "$THEIRS")
+out=$( cmd_task_done "$id" --force-result --result="$MINE" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -eq 0 ] && ok "D1 --force-result on an open row is accepted" || no "D1 force accepted" "rc=$rc $out"
+! grep -qF "$THEIRS" <<<"$res" && ok "D2 --force-result REPLACES (that is its job)" || no "D2 force replaces" "$res"
+grep -q 'force-result' <<<"$out" && ok "D3 the replace is ANNOUNCED on stderr, not silent" || no "D3 force announced" "$out"
+
+echo "== E. task verify: the THIRD writer, unguarded on the not-done path =="
+# DIVE-2624: a delivered row is NOT done, so DIVE-2067's preservation (which sits
+# inside `if [[ $_v_st == done ]]`) never ran, and the verify verdict replaced the
+# maker's delivery record outright.
+id=$(seedv in_progress "$THEIRS" olivia "")
+out=$( cmd_task_verify "$id" --cmd="true" --no-done 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+grep -qF "$THEIRS" <<<"$res" && ok "E1 'task verify --cmd' on an OPEN row PRESERVES the prior result (DIVE-2624)" || no "E1 verify preserves" "rc=$rc res=$res"
+grep -q 'verify PASS' <<<"$res" && ok "E2 and the verify verdict is recorded too" || no "E2 verdict recorded" "$res"
+
+echo "== R. REGRESSION: the reject -> re-deliver rail is NOT wedged =="
+# This is why the decision was auto-append and not refuse. `task reject` writes the
+# VERIFIER'S feedback into result, so iteration 2 is a maker writing over someone
+# else's text on an open row — the exact cell above. If this reds, every graded task
+# on the fleet stops at its second iteration.
+id=$(seedv in_progress "olivia: REJECT — the error path is untested, add an arm." dev main)
+out=$( cmd_task_done "$id" --result="dev: iteration 2, arm added." 2>&1 ); rc=$?
+st=$(db  "SELECT status FROM tasks WHERE id=$id;")
+asg=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=$id;")
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -eq 0 ] && ok "R1 a re-delivery over the verifier's feedback is NOT refused (rc=0)" || no "R1 re-delivery not refused" "rc=$rc $out"
+[ "$asg" = "main" ] && ok "R2 and it still ROUTES to the verifier (DIVE-477 rail intact)" || no "R2 still routes" "assignee=$asg st=$st"
+grep -qF "REJECT — the error path is untested" <<<"$res" && ok "R3 and the verifier's feedback was PRESERVED, not overwritten" || no "R3 feedback preserved" "$res"
+
+echo "== N. NON-VACUITY: prove these arms can go red =="
+# Every arm above asserts a PRESENCE in a column. A guard that appended unconditionally
+# — or one that never wrote at all — could satisfy several of them by accident. These
+# two anchors pin the cells where nothing should change, so the arms above are
+# measuring the guard and not the fixture.
+id=$(seed in_progress "")
+out=$( cmd_task_done "$id" --result="$MINE" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$rc" -eq 0 ] && [ "$res" = "$MINE" ] && ok "N1 an EMPTY prior column takes the new text CLEANLY (no marker, nothing to preserve)" || no "N1 empty prior clean" "rc=$rc res=$res"
+! grep -q 'DIVE-2483' <<<"$res" && ok "N2 and no append marker is added when there was nothing to append to" || no "N2 no spurious marker" "$res"
+
+id=$(seed in_progress "$THEIRS")
+out=$( cmd_task_done "$id" --result="$THEIRS" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+[ "$res" = "$THEIRS" ] && ok "N3 an IDENTICAL --result= is a no-op, not a self-append (no duplication)" || no "N3 identical no-op" "$res"
+
+echo
+echo "DIVE-2483 result-loss-on-open-row guard: passed: $P  failed: $F"
+[ "$F" -eq 0 ]


### PR DESCRIPTION
## Unreleased — fix(task): the result guard keys on the COLUMN, not on whether the row is closed (DIVE-2483)

The guard standing between a `--result=` write and an existing record only ran when the row was
already `done` or `cancelled`. That is the rare cell. The cell the maker→verifier rail
**manufactures on every loop** is the other one: a delivered row is OPEN and already carries the
maker's record, so the routine case was unprotected.

Three verbs reached it and each was found separately, months apart — `task done` (DIVE-2483, a
killed heredoc expanded to nothing and replaced a 2.6KB note with a zero-length string, exit 0),
`task verify --cmd=` (DIVE-2624, a maker's delivery record replaced by a verify verdict), and
`task deliver` (DIVE-2476). So did the *remedy*: `--append-result` was parsed, accepted and
**silently inert** on an open row, because it was implemented inside the refusal's branch
(DIVE-2717/DIVE-2712). A flag that no-ops in the situation its help text describes is worse than an
absent one — an operator reaches for it precisely when they perceive the risk, and a clean `OK` is
affirmative evidence that the protection ran.

Now: both reads happen unconditionally and the gate is *"bytes are about to be lost"*.

- **Open row carrying someone's result → AUTO-APPEND.** Prior text verbatim on top, yours under a
  marker. Preservation is the default rather than a flag, which removes the class instead of
  patching it; `--append-result` still works and is simply a no-op here.
- **Closed row → unchanged.** The DIVE-2464 refusal, `--append-result` and the audited
  `--force-result` all behave exactly as before.
- **An EMPTY `--result=` over a non-empty column → refused at every status and under every flag,
  `--force-result` included.** There is no legitimate reason to blank a result, and the value
  arrives from ordinary shell accidents rather than decisions. It is also the least visible loss
  available: a zero-length result renders as a blank field, indistinguishable from one nobody ever
  wrote, so unlike a replacement with real text it leaves nothing for a reader to notice.
- **`task verify` is guarded on the not-done path**, where DIVE-2067's preservation never reached.

**Why auto-append and not a uniform refusal**, which was the other candidate: `task reject` writes
the *verifier's* feedback into `result`, so after any rejection the row is open and carries someone
else's text — and the maker's next `task done --result=` at iteration 2 is exactly this cell. A
uniform refusal would have turned the second iteration of every graded task on the fleet into a
refusal, training people to reach for `--force-result`. `tests/task_result_loss_open_row_unit.sh`
arm R is the regression arm for that rail and is not optional.

## How it was checked

New harness `tests/task_result_loss_open_row_unit.sh` — **24 arms, 0 failed** — grading the OPEN-row cell specifically, because nothing did before. Arms: the acceptance sentence verbatim (A), preservation with **no flag** passed (B), the empty-result refusal at open/closed/`--force-result` (C), `--force-result` still replacing and announcing (D), `task verify` preserving on the not-done path (E), the reject→re-deliver rail not wedged (R), and non-vacuity anchors for the cells where nothing should change (N).

**Two mutation arms, each reding a DISJOINT set** — so each half of the fix is independently graded rather than one mutation covering for the other:

| mutation | reds | leaves green |
|---|---|---|
| open-row auto-append removed | A2, A4, B2, **E1**, **R3** (5) | all C arms |
| empty-result refusal removed | C1, C2, C3, C5, C6 (5) | all preservation arms |

Restored after each; tree diff empty, both back to 24/24.

Neighbours, all green: `task_done_over_closed_result_unit` 29/0, `task_deliver_over_closed_result_unit` 23/0, `task_verify_over_closed_unit` 7/0, `task_close_preserves_done_at_unit` 16/0, `task_core_unit` 47/0.

**Verified on the MERGED tree, not only the branch.** This branch was cut before `5d04f6d` (DIVE-2719) landed and both changes touch `cmd_task.sh`; merged clean and all of the above re-run green after the merge.

### One arm of the sibling harness was changed, and it is worth reading

`task_done_over_closed_result_unit.sh` arm **D4** seeded an open row already carrying text, closed it with a different `--result`, and asserted the column now equals the new text **exactly** — i.e. it pinned the silent wipe as correct behaviour. It was green for the defect's entire life. It now asserts preservation. Flagging it rather than burying it in the diff: the old assertion is the clearest evidence that grading only the closed cell is what kept this alive.

### Honest gap

`C4` (empty `--result=` refused on a *closed* row) is satisfied by the pre-existing DIVE-2464 refusal as well as by the new one, so it is a regression arm rather than an exclusive grade of this change. Stated because it does not red under mutation arm 2.
