### PR TITLE
fix(push): name the mint failure instead of leaking curl's rc=22 (DIVE-2566)

### DIFF
--- a/changelog.d/DIVE-2566.md
+++ b/changelog.d/DIVE-2566.md
@@ -27,3 +27,16 @@ lines — extracting the adoption block and the failure block and running them u
 real 404 body — rather than grepping that a string is present. Presence-of-string is not reachability,
 which is this row's own lesson: DIVE-2566 exists because a fallback that was *present* in the source was
 *unreachable* at runtime while the suite stayed green.
+
+**Caught by the row's own guard, and worth recording.** CI red on `unguarded_probe_substitution_unit`:
+the new arms' anchor lookups were themselves unguarded `$( )` probe substitutions — this row's exact
+defect class, committed inside its own fix. Now guarded (`|| _a_start=""` etc.), which also makes each
+arm's loud "could not locate its subject" path *reachable* instead of dying before it.
+
+The scan surfaced **six** sites, not three. `push_unit.sh` has no top-level `set -e`, so the scanner had
+always skipped the whole file; ARM A's `bash -c '` body carries `set -euo pipefail` **at column 0 inside a
+quoted string**, and the detector is line-anchored, so the file became eligible for scanning and three
+pre-existing unguarded probes (620, 823, 824) surfaced with mine. All six are fixed rather than worked
+around. Note for whoever owns that scanner: a file can be pulled into scope by a *string* that looks like
+a `set -e` declaration — harmless here (it found real defects) but the detector cannot tell a top-level
+`set -e` from one inside quotes.

--- a/changelog.d/DIVE-2566.md
+++ b/changelog.d/DIVE-2566.md
@@ -1,0 +1,29 @@
+## Unreleased — fix(push): a mint failure says which of four things went wrong (DIVE-2566)
+
+A delegated push to any `lodar/*` repo used to die with a bare **rc=22** — curl's exit for HTTP>=400,
+leaking through `set -euo pipefail`. That is not a 5dive code at all (`error_codes.sh` tops out at
+`E_PERMISSION=10`), so the operator got a number from another namespace with no message, sitting under
+an error string that named four possible causes at once. It read as a missing sudo grant and cost a
+builder an hour; the real cause was a GitHub App with no installation on the target account.
+
+The `set -e` half shipped separately (the lookup guard, PR #395). This is the legibility half:
+
+- **The mint fails `E_AUTH_REQUIRED`, not the `E_GENERIC` catch-all**, and a 404 gets its own sentence:
+  *the GitHub App has no installation covering `<owner>/<repo>` … retrying will not help.* That is the
+  one cause an operator cannot fix by trying again, so it says so and points at DIVE-2033 (a human-only
+  account-level step). No new code was added to the ladder on purpose — `error_codes.sh` says to keep
+  `err_class_for()` in sync, so a new code has a reader outside this file, and this genuinely is an
+  authentication class rather than a class of its own.
+- **`_push_fetch_why`'s four-way string is split.** *Could not read Username* / *terminal prompts
+  disabled* means git wanted to prompt and nothing was ever presented; *Authentication failed* means a
+  credential **was** presented and rejected. Opposite diagnoses with different fixes, previously one
+  sentence. A cause list is not a cause.
+
+**Two arms that could not fail are now behavioural.** olivia mutation-graded the DIVE-2563 arms and found
+two survive a mutation restoring the exact defect they name: replacing `inst="$_inst_for_repo"` with `:`
+(the installation is looked up, announced, never adopted) and stripping `${_why}` from the mint's `fail()`
+(the body is parsed, then discarded). Both left the suite 94/0. They now **execute** the source's own
+lines — extracting the adoption block and the failure block and running them under a real shell with a
+real 404 body — rather than grepping that a string is present. Presence-of-string is not reachability,
+which is this row's own lesson: DIVE-2566 exists because a fallback that was *present* in the source was
+*unreachable* at runtime while the suite stayed green.

--- a/changelog.d/DIVE-2566.md
+++ b/changelog.d/DIVE-2566.md
@@ -33,10 +33,18 @@ the new arms' anchor lookups were themselves unguarded `$( )` probe substitution
 defect class, committed inside its own fix. Now guarded (`|| _a_start=""` etc.), which also makes each
 arm's loud "could not locate its subject" path *reachable* instead of dying before it.
 
-The scan surfaced **six** sites, not three. `push_unit.sh` has no top-level `set -e`, so the scanner had
-always skipped the whole file; ARM A's `bash -c '` body carries `set -euo pipefail` **at column 0 inside a
-quoted string**, and the detector is line-anchored, so the file became eligible for scanning and three
-pre-existing unguarded probes (620, 823, 824) surfaced with mine. All six are fixed rather than worked
-around. Note for whoever owns that scanner: a file can be pulled into scope by a *string* that looks like
-a `set -e` declaration — harmless here (it found real defects) but the detector cannot tell a top-level
-`set -e` from one inside quotes.
+The scan surfaced **six** sites, not three — and the reason is a coverage gap in the scanner, corrected
+here by olivia's measurement rather than by my first reading of it.
+
+`push_unit.sh` has **always** carried a real `bash -c 'set -euo pipefail` region (the DIVE-2566 `_probe`
+helper), so its probe substitutions were genuinely at risk the whole time. They were invisible, not
+exempt: eligibility is a **file-level, line-anchored `^set -e`** test, and that region writes its mode
+line on the same line as `bash -c '`, so nothing matched. ARM A happens to write `set -euo pipefail` at
+**column 0 inside a quoted string**, which the regex reads as a top-level mode line — so the file became
+*visible*, by accident, and three pre-existing unguarded probes (620, 823, 824) appeared alongside my
+three. Write ARM A the normal indented way and the whole file goes dark again.
+
+So the scanner was right about this file for a wrong reason. All six sites are fixed rather than worked
+around. The standing gap — eligibility decided per FILE while the property is per BLOCK, which makes
+guard membership turn on the indentation of a string literal — is filed as DIVE-2733, with olivia's
+measurement (22 of 312 `tests/*.sh` eligible, 290 skipped).

--- a/src/cmd_push.sh
+++ b/src/cmd_push.sh
@@ -118,8 +118,20 @@ _push_repo_from_worktree() {
 _push_fetch_why() {
   local err="$1"
   case "$err" in
-    *"could not read Username"*|*"Authentication failed"*|*"terminal prompts disabled"*)
-      printf 'no git credential is available to this user for that repo' ;;
+    # DIVE-2566: these three used to share ONE string — 'no git credential is
+    # available to this user for that repo'. They are different faults and the
+    # collapsed wording sent a builder after the wrong one: on DIVE-1560 it read
+    # as a missing sudo grant for an hour, when the real cause was a GitHub App
+    # with no installation on the target account. A cause list is not a cause.
+    #
+    # ASKED-AND-COULD-NOT-ASK: git wanted to PROMPT, and prompting is disabled.
+    # Nothing was presented, so nothing was rejected.
+    *"could not read Username"*|*"terminal prompts disabled"*)
+      printf 'this user has no git credential helper for that repo, so git fell back to prompting and prompts are disabled here' ;;
+    # PRESENTED-AND-REJECTED: a credential existed and the remote turned it down.
+    # The opposite diagnosis from the arm above, and the fix is different too.
+    *"Authentication failed"*)
+      printf 'a git credential WAS presented and the remote REJECTED it — this is a wrong/expired credential, not a missing one' ;;
     *FETCH_HEAD*|*"Permission denied"*|*"unable to create"*|*"Unable to create"*|*"cannot open"*)
       printf "this user cannot write .git/ in that work tree — a root-owned FETCH_HEAD left by an earlier root-run fetch is the known cause; 'sudo chgrp -R claude <repo>/.git && sudo chmod -R g+w <repo>/.git' clears it" ;;
     *"Could not resolve host"*|*"Connection timed out"*|*"unable to access"*)
@@ -772,7 +784,34 @@ cmd_push_do() {
   if [[ -z "$tok" ]]; then
     local _why; _why=$(printf '%s' "$_tokresp" | jq -r '.message // empty' 2>/dev/null)
     [[ -n "$_why" ]] || _why="$(printf '%s' "$_tokresp" | head -c 300)"
-    fail "$E_GENERIC" "installation token exchange failed for ${slug} against installation ${inst}: ${_why:-no response body} — if that names an inaccessible repository, the App is not installed on '$(printf '%s' "$slug" | cut -d/ -f1)'."
+    local _owner; _owner="${slug%%/*}"
+    # DIVE-2566: NOT $E_GENERIC, and not a number from someone else's namespace.
+    # The original symptom of this whole row was an operator seeing rc=22 — curl's
+    # exit for HTTP>=400 — which is not a 5dive code at all (error_codes.sh tops out
+    # at E_PERMISSION=10), so the number carried no meaning and the message named
+    # four possible causes at once. E_AUTH_REQUIRED is the honest class: the App
+    # cannot authenticate FOR THIS REPO. It is deliberately distinct from
+    # E_PERMISSION (which means "must run as root" here) and from the git-credential
+    # faults _push_fetch_why now separates.
+    #
+    # No NEW code was added to the ladder on purpose: error_codes.sh says "keep
+    # err_class_for() in sync if you add a code", so a new code has a reader outside
+    # this file, and this failure genuinely IS an authentication class rather than a
+    # class of its own. Widening a shared ladder for one call site is a bigger blast
+    # radius than the fix needs.
+    #
+    # The no-installation case gets its own SENTENCE because it is the one an
+    # operator cannot act on by retrying, and it is the case that actually happens:
+    # the App is installed on the 5dive-ai org, while lodar/5dive-api and
+    # lodar/5dive-frontend live on a personal account. Installing it there is
+    # DIVE-2033, a human-only step. Until then this refusal is CORRECT behaviour and
+    # only has to say why.
+    case "$_why" in
+      *"not installed"*|*"Not Found"*|*"not accessible"*|*"does not exist"*)
+        fail "$E_AUTH_REQUIRED" "the GitHub App has no installation covering ${slug} — it cannot mint a token for a repo it was never installed on, so this push CANNOT succeed and retrying will not help. GitHub said: ${_why}. Install the App on '${_owner}' (DIVE-2033, a human-only account-level step), or relay this push to someone holding credentials for ${slug}. This is NOT a missing sudo grant and NOT a git-credential problem." ;;
+      *)
+        fail "$E_AUTH_REQUIRED" "installation token exchange failed for ${slug} against installation ${inst}. GitHub said: ${_why:-no response body}. If that names an inaccessible repository, the App is not installed on '${_owner}'." ;;
+    esac
   fi
 
   # Push ONLY the named branch, token via extraheader so it never lands in argv

--- a/tests/push_unit.sh
+++ b/tests/push_unit.sh
@@ -617,7 +617,7 @@ grep -Eq "cached refs/remotes/origin/main|could not fetch" <<<"$out" \
 # ...and a cached bound still CATCHES a genuinely mis-authored commit — exactly
 # one, the branch's own, not the pre-policy history behind it.
 out=$(scan3 feature-dirty "$UNFETCHABLE" authoritative); rc=$?
-n=$(grep -cE "^  [0-9a-f]{40} " <<<"$out")
+n=$(grep -cE "^  [0-9a-f]{40} " <<<"$out") || n=0
 { [[ $rc -ne 0 ]] && grep -q "author check FAILED" <<<"$out" && [[ "$n" -eq 1 ]] \
     && grep -q "MAY BE STALE" <<<"$out"; } \
   && ok_t "2161: cached bound catches a real bad author — exactly 1 offender, flagged stale" \
@@ -820,8 +820,8 @@ grep -q 'repos/\${slug}/installation' "$SRC/cmd_push.sh" \
 # of this fix referenced \$slug 40 lines above its assignment, which expands to
 # empty and silently queries /repos//installation — a lookup that cannot fail
 # loudly. Pin the ordering, not just the presence.
-_slug_ln=$(grep -n '^  slug=\$(_push_repo_slug "\$repourl")' "$SRC/cmd_push.sh" | head -1 | cut -d: -f1)
-_inst_ln=$(grep -n 'repos/\${slug}/installation' "$SRC/cmd_push.sh" | head -1 | cut -d: -f1)
+_slug_ln=$(grep -n '^  slug=\$(_push_repo_slug "\$repourl")' "$SRC/cmd_push.sh" | head -1 | cut -d: -f1) || _slug_ln=""
+_inst_ln=$(grep -n 'repos/\${slug}/installation' "$SRC/cmd_push.sh" | head -1 | cut -d: -f1) || _inst_ln=""
 [[ -n "$_slug_ln" && -n "$_inst_ln" && "$_slug_ln" -lt "$_inst_ln" ]] \
   && ok_t "installation: slug is assigned BEFORE the installation lookup reads it" \
   || bad_t "installation: slug assigned before use" "slug at line ${_slug_ln:-none}, lookup at ${_inst_ln:-none}"
@@ -855,9 +855,9 @@ grep -q "message // empty" "$SRC/cmd_push.sh" \
 # ASSERT THE ANCHORS FIRST. If the extraction misses, the arm must FAIL LOUDLY
 # rather than silently grade an empty string — an arm that cannot find its subject
 # is exactly the vacuous pass this whole ticket is about.
-_a_start=$(grep -n 'if \[\[ -n "\$_inst_for_repo" && "\$_inst_for_repo" != "\$inst" \]\]' "$SRC/cmd_push.sh" | head -1 | cut -d: -f1)
+_a_start=$(grep -n 'if \[\[ -n "\$_inst_for_repo" && "\$_inst_for_repo" != "\$inst" \]\]' "$SRC/cmd_push.sh" | head -1 | cut -d: -f1) || _a_start=""
 _a_end=$(awk -v s="${_a_start:-0}" 'NR>s && /^  fi$/ {print NR; exit}' "$SRC/cmd_push.sh")
-_a_url=$(grep -c 'app/installations/\${inst}/access_tokens' "$SRC/cmd_push.sh")
+_a_url=$(grep -c 'app/installations/\${inst}/access_tokens' "$SRC/cmd_push.sh") || _a_url=0
 if [[ -z "$_a_start" || -z "$_a_end" || "$_a_url" -eq 0 ]]; then
   bad_t "installation: ARM A could not locate its subject (DIVE-2566)" \
         "adoption block ${_a_start:-none}..${_a_end:-none}, mint-URL hits ${_a_url} — the arm graded nothing"
@@ -882,7 +882,7 @@ fi
 # Extracts the mint's failure block and runs it with a real GitHub 404 body, with
 # `fail` stubbed to capture what the operator would actually see. Greping that the
 # body is PARSED cannot tell that apart from a fail() that drops it on the floor.
-_b_start=$(grep -n 'if \[\[ -z "\$tok" \]\]; then' "$SRC/cmd_push.sh" | head -1 | cut -d: -f1)
+_b_start=$(grep -n 'if \[\[ -z "\$tok" \]\]; then' "$SRC/cmd_push.sh" | head -1 | cut -d: -f1) || _b_start=""
 _b_end=$(awk -v s="${_b_start:-0}" 'NR>s && /^  fi$/ {print NR; exit}' "$SRC/cmd_push.sh")
 if [[ -z "$_b_start" || -z "$_b_end" ]]; then
   bad_t "installation: ARM B could not locate its subject (DIVE-2566)" \

--- a/tests/push_unit.sh
+++ b/tests/push_unit.sh
@@ -834,6 +834,95 @@ grep -q "message // empty" "$SRC/cmd_push.sh" \
   && ok_t "installation: a failed mint surfaces GitHub's own message" \
   || bad_t "installation: mint failure names the cause" "the API error body is discarded"
 
+# === DIVE-2566: BEHAVIOURAL REPLACEMENTS FOR THE TWO PRESENCE GREPS ABOVE =====
+#
+# olivia mutation-graded the three DIVE-2563 arms at c728b00 and found two of them
+# survive a mutation that RESTORES the exact defect they name:
+#   MUT A  replace `inst="$_inst_for_repo"` with `:` — the installation is looked up,
+#          announced on stderr, and never ADOPTED, so the mint still POSTs to the
+#          pinned id and every lodar/* repo 422s exactly as before DIVE-2563.
+#          push_unit stayed 94/0, because the arm only greps that the LOOKUP EXISTS.
+#   MUT B  strip `${_why}` from the mint's fail(), leaving the `message // empty`
+#          extraction intact but discarding it before the operator sees it.
+#          push_unit stayed 94/0, because the arm greps that the body is PARSED.
+#
+# Both are this row's own lesson one layer up: DIVE-2566 exists because a fallback
+# that was PRESENT in the source was UNREACHABLE at runtime while the suite stayed
+# green. Presence-of-string is not reachability, and that fix was applied only to the
+# guard. These two arms EXECUTE the source's own lines instead of reading them.
+
+# --- ARM A: the mint URL must carry the RESOLVED id, not the pinned one -------
+# ASSERT THE ANCHORS FIRST. If the extraction misses, the arm must FAIL LOUDLY
+# rather than silently grade an empty string — an arm that cannot find its subject
+# is exactly the vacuous pass this whole ticket is about.
+_a_start=$(grep -n 'if \[\[ -n "\$_inst_for_repo" && "\$_inst_for_repo" != "\$inst" \]\]' "$SRC/cmd_push.sh" | head -1 | cut -d: -f1)
+_a_end=$(awk -v s="${_a_start:-0}" 'NR>s && /^  fi$/ {print NR; exit}' "$SRC/cmd_push.sh")
+_a_url=$(grep -c 'app/installations/\${inst}/access_tokens' "$SRC/cmd_push.sh")
+if [[ -z "$_a_start" || -z "$_a_end" || "$_a_url" -eq 0 ]]; then
+  bad_t "installation: ARM A could not locate its subject (DIVE-2566)" \
+        "adoption block ${_a_start:-none}..${_a_end:-none}, mint-URL hits ${_a_url} — the arm graded nothing"
+else
+  # Run the SOURCE's own adoption block with a resolved id that differs from the
+  # pinned one, then build the mint URL the way the source builds it.
+  _a_out=$(bash -c '
+set -euo pipefail
+inst=147419836; _inst_for_repo=999000111; slug=lodar/5dive-api
+'"$(sed -n "${_a_start},${_a_end}p" "$SRC/cmd_push.sh")"'
+printf "%s\n" "https://api.github.com/app/installations/${inst}/access_tokens"
+' 2>/dev/null)
+  if [[ "$_a_out" == *"/app/installations/999000111/access_tokens"* ]]; then
+    ok_t "installation: the mint URL carries the RESOLVED installation, not the pinned id (DIVE-2566, kills MUT A)"
+  else
+    bad_t "installation: resolved id reaches the mint (DIVE-2566)" \
+          "mint URL came out as '${_a_out:-<block died>}' — the lookup's answer is announced but never adopted, so every repo outside the pinned installation still 4xxs"
+  fi
+fi
+
+# --- ARM B: a 404 body's own message must REACH the operator ------------------
+# Extracts the mint's failure block and runs it with a real GitHub 404 body, with
+# `fail` stubbed to capture what the operator would actually see. Greping that the
+# body is PARSED cannot tell that apart from a fail() that drops it on the floor.
+_b_start=$(grep -n 'if \[\[ -z "\$tok" \]\]; then' "$SRC/cmd_push.sh" | head -1 | cut -d: -f1)
+_b_end=$(awk -v s="${_b_start:-0}" 'NR>s && /^  fi$/ {print NR; exit}' "$SRC/cmd_push.sh")
+if [[ -z "$_b_start" || -z "$_b_end" ]]; then
+  bad_t "installation: ARM B could not locate its subject (DIVE-2566)" \
+        "failure block ${_b_start:-none}..${_b_end:-none} — the arm graded nothing"
+else
+  _b_msg='Not Found'
+  _b_out=$(bash -c '
+set -uo pipefail
+E_AUTH_REQUIRED=6; E_GENERIC=1
+fail() { printf "FAILCODE:%s\nFAILMSG:%s\n" "$1" "$2"; exit 0; }
+tok=""; slug=lodar/5dive-api; inst=147419836
+_tokresp='"'"'{"message":"Not Found","documentation_url":"https://docs.github.com/rest"}'"'"'
+'"$(sed -n "${_b_start},${_b_end}p" "$SRC/cmd_push.sh")"'
+' 2>/dev/null)
+  if [[ "$_b_out" == *"FAILMSG:"* && "$_b_out" == *"$_b_msg"* ]]; then
+    ok_t "installation: GitHub's own 404 message REACHES the operator's failure text (DIVE-2566, kills MUT B)"
+  else
+    bad_t "installation: mint failure carries the remote's message (DIVE-2566)" \
+          "operator would have seen '${_b_out:-<block died>}' — the body is parsed but discarded before it is shown, which is the state that cost a builder an hour on DIVE-1560"
+  fi
+  # ...and the code must be OURS, not curl's rc=22 and not the E_GENERIC catch-all.
+  # This is the row's originating symptom: a number from another namespace.
+  if [[ "$_b_out" == *"no installation covering"* ]]; then
+    ok_t "installation: a 404 mint names the NO-INSTALLATION cause specifically, not a generic failure (DIVE-2566)"
+  else
+    bad_t "installation: 404 names the no-installation cause (DIVE-2566)" \
+          "got '${_b_out:-<block died>}' — the one cause an operator cannot fix by retrying must say so"
+  fi
+  # THE ROW'S ORIGINATING SYMPTOM was an exit code from someone else's namespace:
+  # curl's rc=22 leaking through set -euo pipefail, which is not a 5dive code at all.
+  # E_GENERIC would technically be "ours" and still tells the operator nothing, so
+  # the arm pins the CLASS and not merely the fact that we called fail().
+  if [[ "$_b_out" == *"FAILCODE:${E_AUTH_REQUIRED}"* ]]; then
+    ok_t "installation: the mint failure exits E_AUTH_REQUIRED, not the E_GENERIC catch-all (DIVE-2566)"
+  else
+    bad_t "installation: mint failure carries a meaningful E_ code (DIVE-2566)" \
+          "got '${_b_out:-<block died>}' — expected FAILCODE:${E_AUTH_REQUIRED}; rc=22 from curl and a generic 1 are equally unactionable"
+  fi
+fi
+
 
 # DIVE-2566: the installation lookup is a probe that is ALLOWED to fail — a repo
 # outside every installation 404s it, which is precisely the case the pinned-id


### PR DESCRIPTION
## Unreleased — fix(push): a mint failure says which of four things went wrong (DIVE-2566)

A delegated push to any `lodar/*` repo used to die with a bare **rc=22** — curl's exit for HTTP>=400,
leaking through `set -euo pipefail`. That is not a 5dive code at all (`error_codes.sh` tops out at
`E_PERMISSION=10`), so the operator got a number from another namespace with no message, sitting under
an error string that named four possible causes at once. It read as a missing sudo grant and cost a
builder an hour; the real cause was a GitHub App with no installation on the target account.

The `set -e` half shipped separately (the lookup guard, PR #395). This is the legibility half:

- **The mint fails `E_AUTH_REQUIRED`, not the `E_GENERIC` catch-all**, and a 404 gets its own sentence:
  *the GitHub App has no installation covering `<owner>/<repo>` … retrying will not help.* That is the
  one cause an operator cannot fix by trying again, so it says so and points at DIVE-2033 (a human-only
  account-level step). No new code was added to the ladder on purpose — `error_codes.sh` says to keep
  `err_class_for()` in sync, so a new code has a reader outside this file, and this genuinely is an
  authentication class rather than a class of its own.
- **`_push_fetch_why`'s four-way string is split.** *Could not read Username* / *terminal prompts
  disabled* means git wanted to prompt and nothing was ever presented; *Authentication failed* means a
  credential **was** presented and rejected. Opposite diagnoses with different fixes, previously one
  sentence. A cause list is not a cause.

**Two arms that could not fail are now behavioural.** olivia mutation-graded the DIVE-2563 arms and found
two survive a mutation restoring the exact defect they name: replacing `inst="$_inst_for_repo"` with `:`
(the installation is looked up, announced, never adopted) and stripping `${_why}` from the mint's `fail()`
(the body is parsed, then discarded). Both left the suite 94/0. They now **execute** the source's own
lines — extracting the adoption block and the failure block and running them under a real shell with a
real 404 body — rather than grepping that a string is present. Presence-of-string is not reachability,
which is this row's own lesson: DIVE-2566 exists because a fallback that was *present* in the source was
*unreachable* at runtime while the suite stayed green.

## How it was checked

`tests/push_unit.sh` **94 → 98, 0 failed.**

**Three mutants, three DISJOINT kills** — so each half is independently graded and none covers for another. The first two are olivia's own, reproduced verbatim; both left the suite **94/0** before this change:

| mutant | before | now reds |
|---|---|---|
| `inst="$_inst_for_repo"` → `:` (looked up, announced, never adopted) | 94/0 ✅ | *the mint URL carries the RESOLVED installation* — only |
| strip `${_why}` from the mint's `fail()` (parsed, then discarded) | 94/0 ✅ | *GitHub's own 404 message REACHES the operator* — only |
| `E_AUTH_REQUIRED` → `E_GENERIC` | n/a | *exits E_AUTH_REQUIRED, not the catch-all* — only |

Restored after each; back to 98/0.

The new arms **extract the source's own blocks** (the adoption block, and the `if [[ -z "$tok" ]]` failure block) and run them under a real shell with a real GitHub 404 body `{"message":"Not Found"}` and a stubbed `fail` that captures what the operator would actually see. Both arms **assert their anchors first** and fail loudly if the extraction misses — an arm that cannot find its subject is exactly the vacuous pass this row is about.

## Rollout note, now stale — resolved

The row warned the guard was on main but not on this box. **It is rolled:** installed `/usr/local/bin/5dive` 0.19.1 (built 2026-08-04 22:37) greps 2 hits for the guarded shape and **0** for the unguarded one, measured at runtime rather than from the repo. The rc=22 death is gone from the live binary.

## Scope

Item 2 of the row is unchanged and still **not ours**: the GitHub App has no installation on lodar's personal account, so delegated push to `lodar/5dive-api` and `lodar/5dive-frontend` still cannot mint and still *should* fail. This makes that failure legible; it does not make those repos pushable. That is DIVE-2033, a human-only step.
