### PR TITLE
fix(task): treat a literal 'null' PR state as UNRESOLVED, not as not-merged (DIVE-2720)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -3252,6 +3252,19 @@ _task_status_cmd() {
         local _state _merged
         _state=$(_gate_gh "$_ghtok" 0 pr view "$_dref" --json state,mergedAt -q '.state' 2>/dev/null || echo "")
         _merged=$(_gate_gh "$_ghtok" 0 pr view "$_dref" --json state,mergedAt -q '.mergedAt' 2>/dev/null || echo "")
+        # DIVE-2720: NORMALISE the literal 'null' to empty, at CAPTURE, so every
+        # reader below inherits it. `gh -q .state` renders a MISSING .state as the
+        # four-character string 'null' — not empty — so a SUCCESSFUL query with an
+        # unusable payload slipped the `-z "$_state"` guard below and landed on the
+        # DIVE-1830 refusal, which printed "not merged to main yet (..., state=null
+        # — MEASURED, not assumed)". Same defect class as DIVE-2318/2705 by a third
+        # route: the earlier two reached it through a FAILED call, this one through a
+        # call that succeeded and answered nothing. jq's null and a query that never
+        # returned are the same epistemic state — unresolved — so they get the same
+        # representation here rather than a second parallel branch that can drift
+        # from the first. Line ~3265 already special-cased 'null' for _merged and
+        # nothing did for _state; that asymmetry was the hole.
+        if [[ "$_state" == "null" ]]; then _state=""; fi
         # DIVE-2318: an EMPTY state is "the question was not answered", not "the answer
         # was no". A token is present by here (guarded above), so an empty state means
         # the query itself failed — network, timeout, a PR/repo this token cannot see,

--- a/tests/task_merge_gate_diagnostic_unit.sh
+++ b/tests/task_merge_gate_diagnostic_unit.sh
@@ -103,6 +103,15 @@ if [[ "$1" == "pr" && "$2" == "list" ]]; then
   printf '%s' "${!lx:-[]}" | jq -r "$expr" 2>/dev/null; exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  # DIVE-2720: GH_STUB_NOSTATE models the OTHER unresolved route — the query
+  # SUCCEEDS (exit 0) but the payload carries no .state key at all, so `gh -q .state`
+  # emits the LITERAL four-character string 'null'. That is not empty, so it reaches
+  # the gate as a value rather than as an absence. Distinct from the empty case below,
+  # which models a query that never returned.
+  if [[ -n "${GH_STUB_NOSTATE:-}" ]]; then
+    printf '%s' "{\"mergedAt\":${GH_STUB_MERGED:-null},\"statusCheckRollup\":[]}" \
+      | jq -r "$expr" 2>/dev/null; exit 0
+  fi
   # An EMPTY GH_STUB_STATE models a query that returned nothing at all (the ref is
   # invisible to this token / deleted / gh failed), not a PR in state "".
   [[ -n "${GH_STUB_STATE:-}" ]] || exit 1
@@ -153,7 +162,7 @@ commits()   { local o="["; local s; for s in "$@"; do o="$o{\"commit\":{\"messag
 no_token()  { unset GH_TOKEN GITHUB_TOKEN; export SUDO_USER=""; export GH_STUB_AUTH_TOKEN=""; }
 a_token()   { unset GH_TOKEN GITHUB_TOKEN; export SUDO_USER=""; export GH_STUB_AUTH_TOKEN="tok-2318"; }
 clear_fx()  { local v; for v in $(compgen -v | grep -E '^GH_STUB_(COMMITS|CMP|PRLIST)_' || true); do unset "$v"; done
-              unset GH_STUB_STATE GH_STUB_MERGED; }
+              unset GH_STUB_STATE GH_STUB_MERGED GH_STUB_NOSTATE; }
 
 # ---------------------------------------------------------------------------
 # T1 — NO CREDENTIAL, declared delivery_ref. The refusal must name the missing
@@ -189,6 +198,26 @@ run_done D-2 --result='landed'
 [[ "$OUT" == *"COULD NOT READ"* && "$OUT" != *"is not merged to main yet"* ]] \
   && ok_t 'T2 says the question was never answered' \
   || bad_t 'T2 wording' "out=$OUT"
+
+# ---------------------------------------------------------------------------
+# T2b — DIVE-2720. Token present, and the PR query SUCCEEDS — but the payload has
+# no .state field, so `gh -q .state` hands back the LITERAL string 'null'. Four
+# characters, not empty, so it slipped T2's `-z "$_state"` guard and fell through
+# to the DIVE-1830 refusal, which printed "not merged to main yet (..., state=null
+# — MEASURED, not assumed)". Same defect as T1/T2 by a different route: a question
+# that was never ANSWERED rendered as a measured no, with MEASURED stamped on it.
+# The unresolved route here is a SUCCESSFUL call with an unusable payload, not a
+# failed one — which is exactly why the empty-string guard did not cover it.
+# ---------------------------------------------------------------------------
+clear_fx; a_token; export GH_STUB_NOSTATE=1
+seed D-20; bind_pr D-20 'https://github.com/5dive-ai/5dive/pull/2720'
+run_done D-20 --result='landed'
+[[ $RC -eq $E_CONFLICT && "$(slugof D-20)" == "done-pr-state-unresolved" ]] \
+  && ok_t 'T2b a payload with NO .state refuses as UNRESOLVED, not as not-merged (DIVE-2720)' \
+  || bad_t 'T2b unresolved slug' "rc=$RC slug=[$(slugof D-20)] out=$OUT"
+[[ "$OUT" != *"is not merged to main yet"* && "$OUT" != *"state=null"* ]] \
+  && ok_t 'T2b never asserts a merge verdict off the literal string null' \
+  || bad_t 'T2b must not assert a merge verdict' "out=$OUT"
 
 # ---------------------------------------------------------------------------
 # T3 — ANCHOR. A real negative must survive all of this: an OPEN PR is a MEASURED


### PR DESCRIPTION
DIVE-2720. `gh -q .state` renders a **missing** `.state` as the four-character string `null`, not as empty — so a query that *succeeded and answered nothing* slipped the `-z "$_state"` guard and fell through to the DIVE-1830 refusal, which then printed `not merged to main yet (..., state=null — MEASURED, not assumed)`.

That message is the harm: it asserts a merge verdict the gate never reached, in the one place whose whole job is to distinguish *unresolved* from *not merged*.

**The asymmetry that was the hole**, confirmed on `origin/main` before the fix: the very next branch already special-cased the literal for the sibling field —

```bash
if [[ -z "$_state" ]]; then                                      # <- no null check
if [[ "$_state" != "MERGED" || -z "$_merged" || "$_merged" == "null" ]]; then   # <- has one
```

`_merged` was guarded against `null`; `_state` was not. Third route into the DIVE-2318/2705 class — the earlier two arrived through a *failed* call, this one through a call that succeeded and said nothing. jq's null and a query that never returned are the same epistemic state, so the fix gives them one representation at capture rather than a second parallel branch that can drift from the first.

## Verification

Graded independently by main2 at `be16613` in a fresh clone, and **re-verified by me in a separate detached worktree before merging** rather than relayed:

| | result |
|---|---|
| `task_merge_gate_diagnostic_unit` with the fix | **20 passed, 0 failed** |
| same, with the single normalisation line mutated out | **18 passed, 2 failed** — exactly `T2b` |

The arm fails *first*, so it is evidence rather than decoration. 12 sibling merge-gate harnesses green.

Authored by olivia; pushed and merged by main because olivia holds no gh credential — the same credential split DIVE-2483 tracks. Routing the branch was the pass here, not a rebuild; main2's iteration-1 reject said so explicitly.
