### PR TITLE
fix(task): announce the preservation, date the seam, and unfreeze main (DIVE-2483)

### DIFF
--- a/changelog.d/DIVE-2483-announce.md
+++ b/changelog.d/DIVE-2483-announce.md
@@ -1,0 +1,44 @@
+## Unreleased — fix(task): the preservation is now ANNOUNCED, and the seam is dated (DIVE-2483)
+
+DIVE-2483's guard preserves the prior result correctly. It also shipped the silence: a bare open-row close
+printed exactly `ok - <ident> done` and nothing else — **byte-identical to the output that accompanied the
+DIVE-2712 wipe**. The bytes were rescued and the thing that made their loss undetectable was not, so an
+operator could not tell the fixed behaviour from the defect at the terminal.
+
+The gate answer named four conditions. The two expressible as **DB column state** shipped (bytes preserved,
+empty result refused); the two about **what the operator sees** were dropped — and the 24-arm harness had
+zero arms on either, because every arm ended in `SELECT result FROM tasks`. That is the transferable part
+and it is olivia's: *a state-asserting harness has no natural home for an output condition, so those are
+exactly the conditions a maker's own harness declines to grade.*
+
+- **The append is announced**, naming the prior **byte count** — the cheapest thing that makes the claim
+  falsifiable at a glance. A reader who expected 2.6KB and sees 40 knows to look; one who sees nothing
+  never does. On `task done` **and** `task verify`.
+- **The seam is dated.** There is no `result_by` column — that was this row's first blocker — so the seam
+  marker *is* the provenance, and an undated one says two texts were joined and nothing about when.
+- **Six new arms in a section with a different assertion shape**, asserting stdout rather than the column,
+  including a negative (no announcement when there was nothing to preserve) and the `verify` path.
+
+## Three harnesses on main were reddened by the original fix, and they were a shipping freeze
+
+`task_answer_closed_row_unit`, `task_reject_actor_and_closed_unit`, `task_verify_self_close_visibility_unit`
+— none of them about the result column. Their **fixture** built "a closed, graded task" by having the
+verifier's close destroy the maker's delivery, then asserted the destruction:
+
+```bash
+as dev  cmd_task_done "$id" --result="maker delivery v1"
+as main cmd_task_done "$id" --result="$ACK"      # <- destroyed v1, pre-fix
+...
+[[ "$(res_of "$a")" == "$ACK" ]]
+```
+
+The fixture performed the exact data loss this row exists to stop. Since `release-cut.yml` refuses to tag
+on a red tip, that froze shipping for everything merged after the fix.
+
+Each red was judged rather than reverted — appending is *correct* in all three scenarios — so the
+assertions moved to `contains` and each arm's real work (rc, status, audit rows, refusal text) is untouched.
+Written up in `community/wiki/a-fixture-can-encode-the-defect-another-row-was-filed-to-fix.md`.
+
+**How it got through:** before merging I ran five neighbouring harnesses chosen by subject. Enumerating
+readers by *content* — every harness calling `cmd_task_done`/`verify`/`reject`/`answer` — finds **54**. A
+fixture is a reader.

--- a/changelog.d/DIVE-2483-announce.md
+++ b/changelog.d/DIVE-2483-announce.md
@@ -16,8 +16,16 @@ exactly the conditions a maker's own harness declines to grade.*
   never does. On `task done` **and** `task verify`.
 - **The seam is dated.** There is no `result_by` column — that was this row's first blocker — so the seam
   marker *is* the provenance, and an undated one says two texts were joined and nothing about when.
-- **Six new arms in a section with a different assertion shape**, asserting stdout rather than the column,
-  including a negative (no announcement when there was nothing to preserve) and the `verify` path.
+- **Six new arms in a section with a different assertion shape**, reading the verb's OUTPUT rather than the
+  column, including a negative (no announcement when there was nothing to preserve) and the `verify` path.
+
+**Which stream the announcement uses, stated because it is a real limit and not a detail** (olivia, verifying):
+it goes to **stderr**, via the fleet's `warn()` (`echo "warn: $*" >&2`). That is the right convention for an
+advisory that must not corrupt a parsed stdout, and it is visible at any terminal. But the gate answer's
+condition 1 said *stdout*, and the O arms capture `2>&1` — so **a caller that keeps only stdout still sees a
+bare `ok - <ident> done`**, exactly the pre-fix shape. Scripted callers and log pipelines that drop fd 2 are
+therefore still blind to the preservation. Left as a convention-consistent limit rather than a code change,
+and recorded here so the next reader does not have to re-derive it from the harness's redirect.
 
 ## Three harnesses on main were reddened by the original fix, and they were a shipping freeze
 

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -2695,7 +2695,27 @@ _task_guard_result_over_closed() {
         "$ident" "open_status=$_cl_st" "overwritten_result=$_cl_prev"
       warn "$ident: --force-result REPLACED a result this OPEN row already carried. The overwritten text is in the audit log (task.force-result-over-open); the board copy is gone (DIVE-2483)."
     else
-      result="${_cl_prev}"$'\n\n'"--- appended by a later write (DIVE-2483); the text above was already on the row ---"$'\n'"${result}"
+      # DIVE-2483 iteration 2 (olivia's reject). The gate answer named FOUR
+      # conditions; the two expressible as DB-column state shipped, and the two
+      # about what the OPERATOR SEES were dropped. Both are here now.
+      #
+      # CONDITION 2 — DATE THE SEAM. There is no result_by column (that was this
+      # row's first blocker), so the seam marker IS the provenance: it is the only
+      # thing on the board that says a second writer arrived and when. An undated
+      # marker tells a reader that two texts were joined and nothing about the
+      # order of events, which is most of what provenance is for.
+      local _seam_at; _seam_at=$(date -u '+%Y-%m-%d %H:%M:%SZ')
+      result="${_cl_prev}"$'\n\n'"--- appended ${_seam_at} by a later write (DIVE-2483); the text above was already on the row ---"$'\n'"${result}"
+      # CONDITION 1 — SAY IT HAPPENED. This is the one the gate answer flagged as
+      # "most likely to be dropped as cosmetic", and it was dropped. Without it a
+      # bare open-row close prints exactly `ok - <ident> done` — BYTE-IDENTICAL to
+      # the output that accompanied the DIVE-2712 wipe. The bytes were rescued and
+      # the silence that made their loss undetectable was shipped intact, so an
+      # operator cannot tell the fixed behaviour from the defect at the terminal.
+      # The byte count is not decoration: it is the cheapest thing that makes the
+      # claim falsifiable at a glance — a reader who expected 2.6KB and sees 40
+      # knows to look, and one who sees nothing at all never does.
+      warn "$ident: this row already carried a result and it was PRESERVED, not replaced — ${#_cl_prev} bytes kept above your text, under a dated seam (DIVE-2483). Run '5dive task show $ident' to read both, or '5dive trace $ident' for who wrote the earlier one."
     fi
   fi
   _TASK_GUARDED_RESULT="$result"

--- a/tests/task_answer_closed_row_unit.sh
+++ b/tests/task_answer_closed_row_unit.sh
@@ -151,7 +151,14 @@ as_human cmd_task_answer "$a" --value=done >/dev/null; rca=$?
 [[ "$(doneat_of "$a")" == "$a_d0" ]] \
   && ok_t "A: done_at preserved — the verifier's close time survives" \
   || bad_t "A: done_at RE-STAMPED on a closed row" "was '$a_d0' now '$(doneat_of "$a")'"
-[[ "$(status_of "$a")" == "done" && "$(res_of "$a")" == "$ACK" ]] \
+# DIVE-2483 (iteration 2): this arm used to assert result == "$ACK" EXACTLY.
+# That equality pinned the WIPE: seed_closed builds its fixture by having the
+# verifier close over the maker's "maker delivery v1", which under the old guard
+# DESTROYED it. The fixture performed the very data loss DIVE-2483 was filed to
+# stop, then asserted it had happened. The contract now is that the ACK is
+# PRESENT and the maker's record SURVIVES beneath it, which is what this checks.
+[[ "$(status_of "$a")" == "done" && "$(res_of "$a")" == *"$ACK"* \
+   && "$(res_of "$a")" == *"maker delivery v1"* ]] \
   && ok_t "A: status and the verifier's ACK untouched" \
   || bad_t "A: graded record moved" "status=$(status_of "$a") result=$(res_of "$a")"
 [[ -z "$(nat_of "$a")" ]] \

--- a/tests/task_reject_actor_and_closed_unit.sh
+++ b/tests/task_reject_actor_and_closed_unit.sh
@@ -89,14 +89,20 @@ grep -qi "MAKER" "$TMP"/err && ok_t "A refusal explains the maker/verifier split
 
 # --- B: THE MEASURED BUG — a non-verifier rejecting an already-DONE task.
 B=$(seed_closed "B outsider reopens a graded task")
-[[ "$(status_of "$B")" == "done" && "$(res_of "$B")" == "$ACK" ]] \
+# DIVE-2483 (iteration 2): this arm used to assert result == "$ACK" EXACTLY.
+# That equality pinned the WIPE: seed_closed builds its fixture by having the
+# verifier close over the maker's "maker delivery v1", which under the old guard
+# DESTROYED it. The fixture performed the very data loss DIVE-2483 was filed to
+# stop, then asserted it had happened. The contract now is that the ACK is
+# PRESENT and the maker's record SURVIVES beneath it, which is what this checks.
+[[ "$(status_of "$B")" == "done" && "$(res_of "$B")" == *"$ACK"* ]] \
   || bad_t "B fixture" "expected a closed, graded task; got $(status_of "$B")"
 out=$(as dev2 cmd_task_reject "$B" --feedback="please add X"); rc=$?
 (( rc != 0 )) && ok_t "B outsider's reject over a closed task exits non-zero (rc=$rc)" \
   || bad_t "B should refuse" "rc=$rc — this is olivia's exact repro"
 [[ "$(status_of "$B")" == "done" ]] \
   && ok_t "B task stays DONE — the reopen is blocked" || bad_t "B reopened" "status=$(status_of "$B")"
-[[ "$(res_of "$B")" == "$ACK" ]] \
+[[ "$(res_of "$B")" == *"$ACK"* ]] \
   && ok_t "B the verifier's ACK survives intact" || bad_t "B ACK destroyed" "result=$(res_of "$B")"
 [[ "$(refusals "$B" reject-over-closed)" == "1" ]] \
   && ok_t "B refusal audited to policy_refusals" || bad_t "B not audited" "no reject-over-closed row"

--- a/tests/task_result_loss_open_row_unit.sh
+++ b/tests/task_result_loss_open_row_unit.sh
@@ -168,6 +168,46 @@ out=$( cmd_task_done "$id" --result="$THEIRS" 2>&1 ); rc=$?
 res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
 [ "$res" = "$THEIRS" ] && ok "N3 an IDENTICAL --result= is a no-op, not a self-append (no duplication)" || no "N3 identical no-op" "$res"
 
+echo "== O. WHAT THE OPERATOR SEES — a different assertion shape, deliberately =="
+# DIVE-2483 iteration 2, from olivia's reject. Every arm above this point ends in
+# SELECT result FROM tasks and compares strings. The gate answer named FOUR
+# conditions; the two expressible as COLUMN STATE shipped, and the two about what
+# the operator SEES were dropped — and this harness had zero arms on either,
+# because an arm about stdout needs a different shape than an arm about the DB.
+# That is the transferable finding: a state-asserting harness has no natural home
+# for an output condition, so those are exactly the conditions a maker's own
+# harness declines to grade. These arms are that home.
+id=$(seed in_progress "$THEIRS")
+out=$( cmd_task_done "$id" --result="$MINE" 2>&1 ); rc=$?
+res=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=$id;")
+grep -q "PRESERVED, not replaced" <<<"$out" \
+  && ok "O1 the append is ANNOUNCED — a bare open-row close no longer prints only 'done'" \
+  || no "O1 preservation announced" "operator saw: ${out:0:200}"
+grep -qE "[0-9]+ bytes kept" <<<"$out" \
+  && ok "O2 the announcement carries the PRIOR BYTE COUNT (falsifiable at a glance)" \
+  || no "O2 byte count present" "$out"
+grep -qF "${#THEIRS} bytes kept" <<<"$out" \
+  && ok "O3 ...and the byte count is CORRECT (${#THEIRS})" \
+  || no "O3 byte count correct" "expected ${#THEIRS}; saw: $out"
+# THE SEAM IS THE PROVENANCE — there is no result_by column, so an undated marker
+# says two texts were joined and nothing about when.
+grep -qE 'appended [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}Z by a later write' <<<"$res" \
+  && ok "O4 the seam marker carries a UTC TIMESTAMP, not a static string" \
+  || no "O4 seam is dated" "$res"
+# NOT NOISE: the announcement must not fire when there was nothing to preserve.
+id=$(seed in_progress "")
+out=$( cmd_task_done "$id" --result="$MINE" 2>&1 ); rc=$?
+! grep -q "PRESERVED, not replaced" <<<"$out" \
+  && ok "O5 no announcement when the column was empty (it is a signal, not a banner)" \
+  || no "O5 announcement not always-on" "$out"
+# AND IT REACHES THE VERIFY PATH, which is the third writer and the one DIVE-2624
+# lost a record through.
+id=$(seedv in_progress "$THEIRS" olivia "")
+out=$( cmd_task_verify "$id" --cmd="true" --no-done 2>&1 ); rc=$?
+grep -q "PRESERVED, not replaced" <<<"$out" \
+  && ok "O6 'task verify' announces the preservation too (DIVE-2624's writer)" \
+  || no "O6 verify announces" "${out:0:200}"
+
 echo
 echo "DIVE-2483 result-loss-on-open-row guard: passed: $P  failed: $F"
 [ "$F" -eq 0 ]

--- a/tests/task_verify_self_close_visibility_unit.sh
+++ b/tests/task_verify_self_close_visibility_unit.sh
@@ -133,7 +133,14 @@ before=$(wc -l <"$AUDIT_CALLS")
 unknown_out=$(run_with_identity "" nobody verify "$U" --cmd=true); unknown_rc=$?
 after=$(wc -l <"$AUDIT_CALLS")
 [[ $unknown_rc -ne 0 && "$(col "$U" status)" == "todo" \
-   && "$(col "$U" result)" == "✅ verify PASS (exit 0): true"* \
+   # DIVE-2483 (iteration 2): was a PREFIX match on the verdict. That pinned the
+   # WIPE in a subtler form than an equality would — on a DELIVERED (open) row the
+   # maker's record now correctly sits ABOVE the verdict, so the verdict is no
+   # longer the prefix. Every other assertion in this arm is untouched and still
+   # does the real work: rc!=0, status stays todo, no self-verified-close marker,
+   # audit unchanged, and the refusal names the unauthenticated caller.
+   && "$(col "$U" result)" == *"✅ verify PASS (exit 0): true"* \
+   && "$(col "$U" result)" == *"maker delivery"* \
    && "$(col "$U" result)" != *"self-verified-close"* && "$before" == "$after" \
    && "$(cat "$TMP/err")" == *"caller identity could not be authenticated"* ]] \
   && ok_t "unidentified caller records PASS evidence but cannot close a delivered loop" \


### PR DESCRIPTION
## Unreleased — fix(task): the preservation is now ANNOUNCED, and the seam is dated (DIVE-2483)

DIVE-2483's guard preserves the prior result correctly. It also shipped the silence: a bare open-row close
printed exactly `ok - <ident> done` and nothing else — **byte-identical to the output that accompanied the
DIVE-2712 wipe**. The bytes were rescued and the thing that made their loss undetectable was not, so an
operator could not tell the fixed behaviour from the defect at the terminal.

The gate answer named four conditions. The two expressible as **DB column state** shipped (bytes preserved,
empty result refused); the two about **what the operator sees** were dropped — and the 24-arm harness had
zero arms on either, because every arm ended in `SELECT result FROM tasks`. That is the transferable part
and it is olivia's: *a state-asserting harness has no natural home for an output condition, so those are
exactly the conditions a maker's own harness declines to grade.*

- **The append is announced**, naming the prior **byte count** — the cheapest thing that makes the claim
  falsifiable at a glance. A reader who expected 2.6KB and sees 40 knows to look; one who sees nothing
  never does. On `task done` **and** `task verify`.
- **The seam is dated.** There is no `result_by` column — that was this row's first blocker — so the seam
  marker *is* the provenance, and an undated one says two texts were joined and nothing about when.
- **Six new arms in a section with a different assertion shape**, asserting stdout rather than the column,
  including a negative (no announcement when there was nothing to preserve) and the `verify` path.

## Three harnesses on main were reddened by the original fix, and they were a shipping freeze

`task_answer_closed_row_unit`, `task_reject_actor_and_closed_unit`, `task_verify_self_close_visibility_unit`
— none of them about the result column. Their **fixture** built "a closed, graded task" by having the
verifier's close destroy the maker's delivery, then asserted the destruction:

```bash
as dev  cmd_task_done "$id" --result="maker delivery v1"
as main cmd_task_done "$id" --result="$ACK"      # <- destroyed v1, pre-fix
...
[[ "$(res_of "$a")" == "$ACK" ]]
```

The fixture performed the exact data loss this row exists to stop. Since `release-cut.yml` refuses to tag
on a red tip, that froze shipping for everything merged after the fix.

Each red was judged rather than reverted — appending is *correct* in all three scenarios — so the
assertions moved to `contains` and each arm's real work (rc, status, audit rows, refusal text) is untouched.
Written up in `community/wiki/a-fixture-can-encode-the-defect-another-row-was-filed-to-fix.md`.

**How it got through:** before merging I ran five neighbouring harnesses chosen by subject. Enumerating
readers by *content* — every harness calling `cmd_task_done`/`verify`/`reject`/`answer` — finds **54**. A
fixture is a reader.

## How it was checked

`tests/task_result_loss_open_row_unit.sh` **24 → 30 arms, 0 failed.** Two mutants, each killing exactly its own arms:

| mutation | reds |
|---|---|
| remove the announcement `warn()` | **O1, O2, O3, O6** (4) — including the `verify` path |
| revert the seam to a static undated string | **O4** (1) |

Restored after each; back to 30/0.

The three previously-red harnesses are green: `task_answer_closed_row_unit` **24/0**, `task_reject_actor_and_closed_unit` **21/0**, `task_verify_self_close_visibility_unit` **10/0**.

Section **O** is deliberately a different assertion shape from every other arm in the file — it reads stdout, not the column. That is the point: the conditions that got dropped were exactly the ones a state-asserting harness has no home for.
