### PR TITLE
ci(full-sweep): print the total in shards-needed, the unit of the policy dial (DIVE-2669)

### DIFF
--- a/.github/workflows/full-sweep.yml
+++ b/.github/workflows/full-sweep.yml
@@ -438,13 +438,25 @@ jobs:
             done
             # A missing shard is not a smaller corpus. Say the count, so a report
             # assembled from two of three shards cannot read as a faster sweep.
-            printf '| %s | %d | %d | %ds | %ds per shard |\n' "$label" "$shards" "$n" "$s" "${b:-0}"
+            #
+            # DIVE-2592: and say the total IN THE UNITS OF THE POLICY DIAL. "1668s against
+            # a 1320s budget (126%)" is the number people read off this table, and it is
+            # comparing an UN-SHARDED total to a PER-JOB cap — two different things, which
+            # is why it reads as alarming and produces no decision. The shard count is the
+            # dial, so the legible form of the same fact is the MINIMUM number of shards
+            # this corpus now needs: when that reaches the configured count, adding one is
+            # the decision on the table, and it is exactly as visible a policy change as
+            # raising the ceiling would be.
+            local need=0
+            (( ${b:-0} > 0 )) && need=$(( (s + b - 1) / b ))
+            printf '| %s | %d | %d | %ds | %ds per shard | %d of %d shards |\n' \
+              "$label" "$shards" "$n" "$s" "${b:-0}" "$need" "$shards"
           }
           {
             echo "## Full-sweep wall-clock"
             echo
-            echo "| environment | shards reporting | harnesses | TOTAL wall-clock | budget |"
-            echo "|---|---:|---:|---:|---:|"
+            echo "| environment | shards reporting | harnesses | TOTAL wall-clock | budget | shards NEEDED |"
+            echo "|---|---:|---:|---:|---:|---:|"
             total_row pristine 'full-pristine-*.txt'
             total_row installed-host 'full-installed-*.txt'
             echo

--- a/changelog.d/DIVE-2669.md
+++ b/changelog.d/DIVE-2669.md
@@ -1,0 +1,28 @@
+## Unreleased — ci(full-sweep): report the nightly total in the units of the policy dial (DIVE-2669)
+
+The full-sweep budget table printed an UN-SHARDED total next to a PER-JOB cap, so the nightly read as
+"1668s against 1320s (126%)" — a comparison between two different things, which is why it looked
+alarming and produced no decision. The dial is the shard COUNT, so the table now also prints the
+minimum number of shards the corpus needs: `N of M shards`. When N reaches M, adding a shard is the
+decision on the table, and it is exactly as visible a policy change as raising the ceiling would be.
+
+Hunk authored by dev on 2026-08-03 and stranded: it edits `.github/workflows/full-sweep.yml`, and
+`5dive push` uses a GitHub App token that GitHub withholds the `workflows` scope from by design
+(DIVE-2229/2262), so no agent push could carry it. Landed here via a token that holds the scope.
+
+**And the 126% turned out to be the artefact, not the corpus.** Measured on the 2026-08-05T04:33
+sweep, all three shards reporting in both environments:
+
+| environment | s1 | s2 | s3 | un-sharded total | worst shard vs 1320s cap | shards needed |
+|---|---:|---:|---:|---:|---:|---:|
+| pristine | 367s | 389s | 679s | **1435s** | 679s = 51% | **2 of 3** |
+| installed-host | 390s | 399s | 671s | **1460s** | 671s = 51% | **2 of 3** |
+
+So the nightly tier does **not** need another shard — it needs two of the three it already has, and
+no shard exceeds 51% of its cap. The row's second item ("still 126% un-sharded, nothing buys nightly
+headroom") was stated in precisely the units this change exists to correct.
+
+One thing the numbers show that the table does not: **shard 3 costs ~1.7x shards 1 and 2 in both
+environments.** Round-robin assignment spreads a long-tailed cost distribution better than
+contiguous blocks do, but it does not balance it — a single expensive harness still lands somewhere.
+Not actionable at 51% of cap; worth knowing when `shards needed` next moves.


### PR DESCRIPTION
Lands the stranded half of DIVE-2592. The hunk was authored by dev on 2026-08-03 and could not ship: it edits `.github/workflows/full-sweep.yml`, and `5dive push` uses a GitHub App token that GitHub withholds the `workflows` scope from by design (DIVE-2229/2262). Pushed here with a token that holds the scope — that was the whole blocker, and it is now demonstrated rather than assumed.

**What it changes.** The budget table printed an un-sharded total beside a per-job cap, so the nightly read as *"1668s against a 1320s budget (126%)"* — two different things compared, which is why it looked alarming and produced no decision. The policy dial is the shard COUNT, so the table now also prints the minimum shards the corpus needs (`N of M shards`). When N reaches M, adding a shard is the decision on the table, and exactly as visible a policy change as raising the ceiling would be.

**The 126% was the artefact, not the corpus.** Measured on the 2026-08-05T04:33 sweep, all three shards reporting in both environments:

| environment | s1 | s2 | s3 | un-sharded | worst shard vs 1320s | shards needed |
|---|---:|---:|---:|---:|---:|---:|
| pristine | 367s | 389s | 679s | **1435s** | 51% | **2 of 3** |
| installed-host | 390s | 399s | 671s | **1460s** | 51% | **2 of 3** |

The nightly tier does not need another shard. It needs two of the three it has, and no shard exceeds half its cap.

**One hypothesis I tested and discarded, recorded so nobody re-raises it.** `(( ${b:-0} > 0 )) && need=...` looked like a `set -e` hazard: Actions runs `run:` blocks as `bash -e`, `b` initialises to 0, and the job is `if: always()` — so a sweep where no shard uploaded would leave `b=0` and, I assumed, abort the report in exactly the degraded case it exists to describe. Executed both forms under `set -e` with a glob matching nothing: **both print the row and reach the next line, exit 0.** Bash exempts a failing command inside a `&&` list when it is not the one following the final `&&`. The patch is correct as authored and needs no guard.

**Not covered by this PR:** shard 3 costs ~1.7x shards 1 and 2 in both environments. Round-robin spreads a long-tailed distribution better than contiguous blocks but does not balance it. Not actionable at 51% of cap; noted in the changelog for whenever `shards needed` moves.
