### PR TITLE
fix(gate): decide agent-ness structurally, not by username prefix (DIVE-2371)

### DIFF
--- a/src/cmd_selfcheck.sh
+++ b/src/cmd_selfcheck.sh
@@ -272,6 +272,12 @@ _sc_probe_t2_forge() {
     _gate_passwd_stream() { _agentrow; printf '%s\n' "$(</etc/passwd)"; }
     _gate_caller_uid() { printf '%s' "$AUID"; }
     _gate_is_root() { return 1; }
+    # DIVE-2371: authorization is now the uid test AND a STRUCTURAL cgroup test, so
+    # pin the second half for the same reason the comment above pins the first —
+    # unpinned it is answered by whoever ran the probe (an agent unit on a box, a
+    # runner cgroup in CI), and a arm that refuses for an environmental reason is
+    # not grading the floor. An ordinary agent really does live in an agent unit.
+    _gate_caller_cgroup() { printf '%s' '/system.slice/system-5dive.slice/5dive-agent@fixture.service'; }
     unset SUDO_UID
     printf 'pinned=%s\n' "$(_gate_authenticated_actor)"
     seed DIVE-990001
@@ -288,6 +294,14 @@ _sc_probe_t2_forge() {
     _gate_caller_uid() { printf '%s' "0"; }
     _gate_passwd_stream() { printf '%s\n' "$(</etc/passwd)"; }
     _gate_is_root() { return 0; }
+    # DIVE-2371: the liveness arm has to model BOTH halves or it grades a refusal.
+    # Pinned to the DASHBOARD, which is what "a real human path" concretely IS on a
+    # box: the one non-Telegram surface a customer clears from, and the surface the
+    # accept list exists for. Left unpinned this arm reads the host's real cgroup and
+    # fails on every agent box and every CI runner — the probe would then report
+    # "the floor refuses everything" fleet-wide, which is a statement about where it
+    # ran, not about the floor.
+    _gate_caller_cgroup() { printf '%s' '/system.slice/shelld.service'; }
     export SUDO_UID=0
     ( cmd_task_answer DIVE-990002 --value=A --human ) >/dev/null 2>&1
     printf 'human=%s\n' "$(by DIVE-990002)"

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -10304,7 +10304,8 @@ cmd_task_answer() {
     # sufficient — that was the sudo→--human forge (DIVE-916 threat).
     # (_hp/_su declared at function scope above — DIVE-2406 reads them at the stamp.)
     [[ -n "$human_proof" ]] && _human_nonce_verify "$id" "$human_proof" && _hp=1
-    _gate_sudo_uid_nonagent && _su=1
+    # DIVE-2371: AUTHORIZATION site — structural principal test, fails closed.
+    _gate_human_principal && _su=1
     # DIVE-1305: a verified paired-human channel proof is the fourth evidence
     # form — but _cp_ok is already gated to tier<2 above, so it can satisfy the
     # evidence rule only for a tier-1 approval/access gate (never a tier-2 hard
@@ -10469,7 +10470,8 @@ cmd_task_answer() {
     if [[ -n "$_t2_hash" ]]; then
       local _t2_hp=0 _t2_su=0
       [[ -n "$human_proof" ]] && _human_nonce_verify "$id" "$human_proof" && _t2_hp=1
-      _gate_sudo_uid_nonagent && _t2_su=1
+      # DIVE-2371: AUTHORIZATION site (tier-2 floor) — same structural test.
+      _gate_human_principal && _t2_su=1
       # DIVE-2412: THE CITATION IS THE THIRD EVIDENCE FORM, and it has to be named
       # HERE rather than only in the `human` flag it also raises. This site is what
       # decides whether a tier-2 `--human` claim was PROVED, and it is scoped to

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -2144,11 +2144,48 @@ _gate_sudo_uid_nonagent() {
 # "Ship it" 2026-08-05 07:40 knowing the consequence — a tier-2 gate can no longer
 # be cleared from a shell on the box as user claude. Telegram taps are untouched:
 # they clear through the nonce arm, not this one.
-_gate_caller_cgroup() {
-  # cgroup v2 emits a single `0::<path>` line; take everything after the last ':'.
-  local line; line=$(head -1 /proc/self/cgroup 2>/dev/null) || return 1
+# Pick the SYSTEMD line out of a /proc/<pid>/cgroup stream and print its path.
+# Split out from _gate_caller_cgroup so the line-SELECTION rule is gradable without
+# an override for the path to read — the path stays hardcoded at the one call site
+# below, because a readable-path knob on a fail-closed predicate is the same class
+# of widening surface as an accept-list knob (D1).
+#
+# WHY NOT `head -1`. That read whichever line came first. On cgroup v2 the file IS
+# the single unified `0::<path>` entry and it happens to be right; on a v1 or hybrid
+# host the file is many `<hier>:<controllers>:<path>` lines in kernel order, so the
+# first is an ARBITRARY controller whose path can differ from the systemd one. A real
+# login session then read as an unrecognised cgroup and a HUMAN was locked out of
+# their own tier-2 clear. That direction is fail-closed, which is the right default
+# and is NOT a reason to keep a known-wrong reader on a human-auth path: the installed
+# fleet is unobservable by design (no exec token, SSH stripped), so "our boxes are v2"
+# is a statement about the boxes we can see, and a lockout there has no self-service
+# path.
+#
+# NO PERMISSIVE FALLBACK. If neither line is present we return 1 and the caller
+# refuses. "Take any line we did find" is exactly what would admit an unrecognised
+# hierarchy's path into a fail-closed accept list.
+_gate_cgroup_pick_line() {
+  local line sysd="" uni=""
+  while IFS= read -r line; do
+    case "$line" in
+      *:name=systemd:*) sysd="$line" ;;   # v1/hybrid: systemd's unit-tracking hierarchy
+      0::*)             uni="$line"  ;;   # v2: the unified hierarchy
+    esac
+  done
+  # v1/hybrid FIRST: where systemd tracks units in the name=systemd hierarchy the
+  # unified line may be bare `/`. A pure-v2 host has no name=systemd line at all, so
+  # this falls through to the unified one rather than needing to detect the version.
+  line="${sysd:-$uni}"
   [[ -n "$line" ]] || return 1
-  printf '%s' "${line##*:}"
+  # Strip the two leading `<field>:` columns rather than taking everything after the
+  # LAST colon — a unit path may legitimately contain one.
+  printf '%s' "${line#*:*:}"
+}
+
+_gate_caller_cgroup() {
+  # An unreadable /proc entry fails the redirect, so this returns nonzero and the
+  # caller refuses — the "unresolved principal is not a verified one" rule.
+  _gate_cgroup_pick_line </proc/self/cgroup 2>/dev/null
 }
 
 _gate_cgroup_human_capable() {

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -2125,6 +2125,73 @@ _gate_sudo_uid_nonagent() {
   [[ "$uname" != agent-* ]]
 }
 
+# ── DIVE-2371: the STRUCTURAL half of the human-evidence test ────────────────
+# The uid test above asks "is this name absent from a list I maintain", so every
+# principal NOT enumerated is promoted to human: `claude` (an agent runtime, not
+# a person — the pre-`agent-*` session present on every box), `hello`, `dmarc`,
+# CI's `runner`, and any future service account. A human-evidence test whose
+# DEFAULT is *human* has its fail direction backwards, and on the one account
+# present everywhere it gave the wrong answer: a bare `--human` from any process
+# running as claude cleared a tier-2 gate.
+#
+# WHY A CGROUP AND NOT A BETTER NAME LIST: /proc/self/cgroup is written by systemd
+# at fork and an unprivileged process cannot rewrite its own. Crucially `sudo` does
+# NOT move cgroups, so it survives the EUID-0 hop $SUDO_UID exists for — the same
+# hop that makes that env var forgeable off-root (DIVE-1413).
+#
+# THE LIST IS ON THE ACCEPT SIDE, which is what makes it fail closed: a principal
+# nobody enumerated is REFUSED, where the uid test admitted it. lodar answered
+# "Ship it" 2026-08-05 07:40 knowing the consequence — a tier-2 gate can no longer
+# be cleared from a shell on the box as user claude. Telegram taps are untouched:
+# they clear through the nonce arm, not this one.
+_gate_caller_cgroup() {
+  # cgroup v2 emits a single `0::<path>` line; take everything after the last ':'.
+  local line; line=$(head -1 /proc/self/cgroup 2>/dev/null) || return 1
+  [[ -n "$line" ]] || return 1
+  printf '%s' "${line##*:}"
+}
+
+_gate_cgroup_human_capable() {
+  local cg; cg=$(_gate_caller_cgroup) || return 1
+  [[ -n "$cg" ]] || return 1
+
+  # ACCEPT 1 — THE DASHBOARD. It is the only non-Telegram surface a customer
+  # clears a gate from, and it has neither a nonce (the nonce is minted into
+  # Telegram callback_data, never to a browser) nor a login session. shelld is a
+  # plain system service, User=claude, no Slice=, so /system.slice/shelld.service.
+  # MEASURED on a freshly provisioned box 2026-08-05, not derived from the unit
+  # file: ControlGroup and the running process's own /proc/<pid>/cgroup agree, and
+  # shelld spawns the CLI as a PLAIN sudo child, so the answerer inherits this.
+  #
+  # HARDCODED ON PURPOSE — no env override. My first draft read this list from
+  # $FIVE_GATE_CGROUP_ACCEPT, a plain env var any non-root process sets freely: an
+  # agent could name its OWN cgroup and pass. That is the exact env-forge class
+  # DIVE-1413 hardened $SUDO_UID against, reintroduced into the predicate written
+  # to close it. A widening knob on a fail-closed accept list IS the failure mode.
+  [[ "$cg" == "/system.slice/shelld.service" ]] && return 0
+
+  # ACCEPT 2 — A REAL LOGIN SESSION, structural rather than named: a person who
+  # logs in and sudo's lands in /user.slice/user-<uid>.slice/session-<n>.scope.
+  # No unit name to forget, and no system service can manufacture one.
+  [[ "$cg" == /user.slice/*/session-*.scope ]] && return 0
+
+  # Everything else refused: agent units, the primary claude runtime, an
+  # unreadable cgroup, a non-systemd host. An unresolved principal is not a
+  # verified one — the same rule the served/expected commit checks use.
+  return 1
+}
+
+# The AUTHORIZATION predicate. Requires BOTH halves on purpose, so it can only
+# tighten: nothing the uid test refused becomes permitted, and the structural test
+# removes the principals it wrongly admitted. ATTRIBUTION does not use this —
+# `_gate_withdraw_actor` keeps the uid test, because authorization must fail closed
+# while attribution must stay TRUTHFUL, and degrading a real person's withdrawal to
+# 'none' would make the record worse rather than safer.
+_gate_human_principal() {
+  _gate_sudo_uid_nonagent || return 1
+  _gate_cgroup_human_capable
+}
+
 # ── DIVE-756: persisted closure signature (tamper-evidence) ──────────────────
 # Unlike the short-lived answer-time --proof (bound to id:type, TTL 120s, then
 # discarded), this HMAC is STORED on the row and binds the durable closure facts,

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -3,12 +3,26 @@
 # budget: the tier resolver (tests/lib/tier.sh) and the budgeted runner
 # (scripts/run-harnesses.sh).
 #
-# WHY THIS FILE IS ITSELF SMALL AND FAST, and says so. It is a harness added by the
-# row whose whole subject is that harnesses are added faster than they are retired.
-# The honest version of that is not to skip the coverage — it is to pay the budget
-# it enforces. Throwaway corpus of three one-line harnesses, no sleeps longer than
-# the assertion needs, and every arm below is one this mechanism can actually get
-# wrong.
+# TIER: nightly — 41.4s measured (GitHub Actions ubuntu-latest, core/pristine job,
+# run 30988600395, 2026-08-05). This is a META-harness: it grades the tier resolver
+# and the budgeted runner, so NO product path a customer reaches runs through it —
+# the standard nightly criterion. It costs 14% of the 300s core budget it is itself
+# grading, which makes it the strongest nightly candidate in the corpus on its own
+# merits. CLAUDE.md ranks merge and retire ahead of demotion and neither applies: it
+# has no sibling to fold into, and the mechanism it guards is live. A regression in
+# the runner is now caught within 24h instead of per-PR; that latency is acceptable
+# because the runner FAILS LOUD (exit 4 with numbers), so a break announces itself
+# rather than passing silently. If it ever starts failing OPEN, revisit this first.
+# Decision: main, 2026-08-05.
+#
+# THE "SMALL AND FAST" CLAIM THIS HEADER USED TO MAKE IS RETIRED, not quietly
+# dropped. It read: "WHY THIS FILE IS ITSELF SMALL AND FAST, and says so ... the
+# honest version is not to skip the coverage, it is to pay the budget it enforces."
+# That was true when written and is now false — at 41.4s this file is the SLOWEST in
+# core. Leaving it standing two lines above a nightly marker would be exactly the
+# stale unverified number this harness exists to catch (see the DIVE-2555 arms
+# below, which grade a demotion's claim against the clock). The coverage is still
+# paid for; it is paid nightly.
 #
 # THE ARMS, and the mutation each one would catch:
 #   1-3   default is core; an explicit `# TIER: core` is legal; a marker below the

--- a/tests/gate_cgroup_human_principal_unit.sh
+++ b/tests/gate_cgroup_human_principal_unit.sh
@@ -22,6 +22,10 @@
 #
 # Usage: ./tests/gate_cgroup_human_principal_unit.sh   (no root, no network, no db)
 set -uo pipefail
+# DIVE-2692 corpus contract: report our own rc honestly. Registered BEFORE the
+# two `exit 2` precondition guards below, so an unreadable lib or a lost accept
+# list is reported as a nonzero HARNESS-RC rather than as a silent short read.
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry

--- a/tests/gate_cgroup_human_principal_unit.sh
+++ b/tests/gate_cgroup_human_principal_unit.sh
@@ -46,10 +46,12 @@ bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 
 # Pull ONLY the two functions under test out of the shipped file, so this grades
 # real bytes without executing the rest of the library.
-SRC=$(sed -n '/^_gate_caller_cgroup()/,/^}/p;/^_gate_cgroup_human_capable()/,/^}/p' "$LIB")
+SRC=$(sed -n '/^_gate_cgroup_pick_line()/,/^}/p;/^_gate_caller_cgroup()/,/^}/p;/^_gate_cgroup_human_capable()/,/^}/p' "$LIB")
 [[ -n "$SRC" ]] || { echo "FATAL: could not extract the predicate from $LIB" >&2; exit 2; }
 grep -q 'shelld.service' <<<"$SRC" \
   || { echo "FATAL: extraction lost the accept list — the arms below would be vacuous" >&2; exit 2; }
+grep -q 'name=systemd' <<<"$SRC" \
+  || { echo "FATAL: extraction lost the line picker — the E arms below would be vacuous" >&2; exit 2; }
 eval "$SRC"
 
 # The stub: replaces the ONE unforgeable reader. Everything after it is real.
@@ -123,6 +125,60 @@ if sed 's/#.*//' "$LIB" | grep -qE '\$\{?FIVE_GATE_CGROUP|\$\{?GATE_CGROUP_ACCEP
 else
   ok_t "D1 the accept list is HARDCODED — no env var can widen it"
 fi
+
+# --- E. WHICH LINE the reader picks (the `head -1` defect) -------------------
+# Graded through _gate_cgroup_pick_line, which takes the stream on stdin, so the
+# selection rule is testable while /proc/self/cgroup stays HARDCODED at the single
+# call site — no readable-path override is introduced to make a test possible.
+pick() { _gate_cgroup_pick_line <<<"$1"; }
+
+# E1 pure v2: one unified line.
+[[ "$(pick '0::/system.slice/shelld.service')" == "/system.slice/shelld.service" ]] \
+  && ok_t "E1 v2 unified line yields its path" \
+  || bad_t "E1 v2 unified" "got '$(pick '0::/system.slice/shelld.service')'"
+
+# E2 THE LOAD-BEARING ARM. v1/hybrid, systemd line NOT first and a DIFFERENT path on
+# the line that is. `head -1` returned the pids controller's '/', so a real login
+# session read as unrecognised and the human was refused. Order is the whole point.
+_V1=$'12:pids:/\n5:memory:/user.slice\n1:name=systemd:/user.slice/user-1000.slice/session-3.scope'
+[[ "$(pick "$_V1")" == "/user.slice/user-1000.slice/session-3.scope" ]] \
+  && ok_t "E2 v1/hybrid picks the name=systemd line, not the first line" \
+  || bad_t "E2 v1/hybrid systemd line" "got '$(pick "$_V1")' — head -1 behaviour is back"
+
+# E3 the E2 path must survive into the real ACCEPT decision, not just the reader.
+_CG="$(pick "$_V1")"
+if _gate_cgroup_human_capable; then
+  ok_t "E3 the v1/hybrid login session is ACCEPTED end-to-end (reader -> accept list)"
+else
+  bad_t "E3 v1/hybrid session accepted" "the picked path '$_CG' did not satisfy the accept list"
+fi
+
+# E4 hybrid where the unified line is bare '/': the systemd hierarchy still wins.
+_HY=$'0::/\n1:name=systemd:/system.slice/shelld.service'
+[[ "$(pick "$_HY")" == "/system.slice/shelld.service" ]] \
+  && ok_t "E4 hybrid with a bare '/' unified line still resolves the unit" \
+  || bad_t "E4 hybrid bare unified" "got '$(pick "$_HY")'"
+
+# E5 NO PERMISSIVE FALLBACK: a stream with neither line REFUSES rather than
+# returning some other hierarchy's path into a fail-closed accept list.
+if pick $'3:cpu:/some/other/path\n4:blkio:/whatever' >/dev/null 2>&1; then
+  bad_t "E5 unknown hierarchy refused" "the picker returned a path for a stream with no systemd line — that is the permissive fallback"
+else
+  ok_t "E5 a stream with no systemd line is REFUSED (no permissive fallback)"
+fi
+
+# E6 an empty/unreadable stream refuses.
+if pick '' >/dev/null 2>&1; then
+  bad_t "E6 empty stream refused" "the picker accepted an empty cgroup stream"
+else
+  ok_t "E6 an empty cgroup stream is REFUSED"
+fi
+
+# E7 a colon inside the unit path is not truncated — `${line##*:}` took only the
+# tail, this takes everything after the two leading columns.
+[[ "$(pick '0::/system.slice/weird:name.service')" == "/system.slice/weird:name.service" ]] \
+  && ok_t "E7 a colon in the unit path is preserved" \
+  || bad_t "E7 colon in path" "got '$(pick '0::/system.slice/weird:name.service')'"
 
 printf '\nDIVE-2371 cgroup human-principal guard: passed: %s  failed: %s\n' "$PASS" "$FAIL"
 [[ $PASS -gt 0 ]] || { printf 'FAIL - nothing was graded\n'; exit 1; }

--- a/tests/gate_cgroup_human_principal_unit.sh
+++ b/tests/gate_cgroup_human_principal_unit.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# DIVE-2371 — grade the STRUCTURAL half of the tier-2 human-evidence test.
+#
+# WHAT WENT WRONG. `_gate_sudo_uid_nonagent` decided agent-ness by a USERNAME
+# PREFIX (`[[ "$uname" != agent-* ]]`), so every principal not enumerated was
+# promoted to human. On the one account present on every box the answer was
+# wrong: `claude` is an agent runtime, not a person, so ANY process running as
+# claude could clear a tier-2 gate with a bare `--human`. A human-evidence test
+# whose default is *human* has its fail direction backwards.
+#
+# HOW THIS GRADES IT. The predicate reads /proc/self/cgroup, which systemd writes
+# at fork and an unprivileged process cannot rewrite — and `sudo` does not move
+# cgroups, so it survives the EUID-0 hop $SUDO_UID exists for. The ONE link this
+# harness stubs is that reader (`_gate_caller_cgroup`); the accept/deny logic
+# under test is the shipped code, sourced from the shipped file. Deliberately NO
+# env override exists for the accept list — a widening knob on a fail-closed list
+# would be the same env-forge hole the predicate exists to close, so the stub is
+# a function override in-process and never a variable the product reads.
+#
+# THE LOAD-BEARING ARM IS A2 (an agent cgroup is REFUSED) and its anchor: with the
+# structural half reverted the same input is ACCEPTED again, which is the forge.
+#
+# Usage: ./tests/gate_cgroup_human_principal_unit.sh   (no root, no network, no db)
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source.
+# NOTE the absence of `2>/dev/null`. Redirecting the source's stderr would also
+# swallow the helper's own stderr line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+LIB="$REPO/src/lib/tasks_db.sh"
+[[ -r "$LIB" ]] || { echo "FATAL: $LIB unreadable — refusing to grade nothing" >&2; exit 2; }
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# Pull ONLY the two functions under test out of the shipped file, so this grades
+# real bytes without executing the rest of the library.
+SRC=$(sed -n '/^_gate_caller_cgroup()/,/^}/p;/^_gate_cgroup_human_capable()/,/^}/p' "$LIB")
+[[ -n "$SRC" ]] || { echo "FATAL: could not extract the predicate from $LIB" >&2; exit 2; }
+grep -q 'shelld.service' <<<"$SRC" \
+  || { echo "FATAL: extraction lost the accept list — the arms below would be vacuous" >&2; exit 2; }
+eval "$SRC"
+
+# The stub: replaces the ONE unforgeable reader. Everything after it is real.
+_CG=""
+_gate_caller_cgroup() { [[ -n "$_CG" ]] || return 1; printf '%s' "$_CG"; }
+
+try() { _CG="$1"; _gate_cgroup_human_capable; }
+
+# --- A. ACCEPTED -----------------------------------------------------------
+if try '/system.slice/shelld.service'; then
+  ok_t "A1 the DASHBOARD (shelld.service) is accepted — the surface with neither a nonce nor a login session"
+else
+  bad_t "A1 dashboard accepted" "shelld.service was refused; the dashboard's tier-2 clears would go offline"
+fi
+
+if try '/user.slice/user-1000.slice/session-3.scope'; then
+  ok_t "A2 a REAL LOGIN SESSION is accepted (structural, not a named unit)"
+else
+  bad_t "A2 login session accepted" "a person who ssh'd in and sudo'd was refused"
+fi
+
+# --- B. REFUSED — the forge, and everything unenumerated -------------------
+if try '/system.slice/system-5dive\x2dagent.slice/5dive-agent@main.service'; then
+  bad_t "B1 THE FORGE: an agent unit was ACCEPTED" "this is the defect DIVE-2371 exists to close"
+else
+  ok_t "B1 an AGENT unit is refused — the forge is closed"
+fi
+
+if try '/system.slice/claude-session.service'; then
+  bad_t "B2 the primary claude runtime was ACCEPTED" "'claude' is an agent runtime, not a person"
+else
+  ok_t "B2 the primary claude runtime is refused (it is the account the prefix test wrongly admitted)"
+fi
+
+if try '/system.slice/some-future-service.service'; then
+  bad_t "B3 an unenumerated service was ACCEPTED" "the accept list must fail closed"
+else
+  ok_t "B3 an UNENUMERATED service is refused — a principal nobody listed is not trusted"
+fi
+
+if try ''; then
+  bad_t "B4 an unreadable cgroup was ACCEPTED" "unresolved is not verified"
+else
+  ok_t "B4 an UNREADABLE cgroup is refused (non-systemd host, container) — fails closed"
+fi
+
+# A near-miss: the right unit name in the wrong place must not pass on substring.
+if try '/user.slice/user-1000.slice/shelld.service'; then
+  bad_t "B5 a shelld.service name outside system.slice was ACCEPTED" "the match must be exact, not a substring"
+else
+  ok_t "B5 the accept match is EXACT — shelld.service elsewhere in the tree does not pass"
+fi
+
+# --- C. ANCHOR — prove B1 grades the FIX and not the fixture ---------------
+# Revert the structural half: the pre-DIVE-2371 authorization path consulted only
+# the uid test, so the agent cgroup above was never consulted at all. Model that
+# by restoring "no structural test" and re-running the same input.
+_gate_cgroup_human_capable_PREFIX_ERA() { return 0; }   # what the old path effectively did
+if _CG='/system.slice/system-5dive\x2dagent.slice/5dive-agent@main.service'; _gate_cgroup_human_capable_PREFIX_ERA; then
+  ok_t "C1 ANCHOR: with the structural half absent the SAME agent cgroup passes — B1 grades the fix, not the fixture"
+else
+  bad_t "C1 ANCHOR" "the reverted form refused too; B1 may be passing for an unrelated reason"
+fi
+
+# --- D. the accept list must not be reachable from the environment ---------
+# Strip comments first: the file DISCUSSES the env var it deliberately does not
+# read, and a grep over prose grades the explanation instead of the code. (This
+# arm failed on its own first run for exactly that reason.)
+if sed 's/#.*//' "$LIB" | grep -qE '\$\{?FIVE_GATE_CGROUP|\$\{?GATE_CGROUP_ACCEPT'; then
+  bad_t "D1 the accept list reads an ENV VAR" "a widening knob on a fail-closed list is the env-forge hole this predicate exists to close (DIVE-1413)"
+else
+  ok_t "D1 the accept list is HARDCODED — no env var can widen it"
+fi
+
+printf '\nDIVE-2371 cgroup human-principal guard: passed: %s  failed: %s\n' "$PASS" "$FAIL"
+[[ $PASS -gt 0 ]] || { printf 'FAIL - nothing was graded\n'; exit 1; }
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/gate_channel_session_t2_unit.sh
+++ b/tests/gate_channel_session_t2_unit.sh
@@ -83,6 +83,16 @@ audit_log() { :; }
 # 1 = false = an agent-* caller contributes no sudo-uid evidence.
 _PIN_SUDO_HUMAN=1
 _gate_sudo_uid_nonagent() { return "$_PIN_SUDO_HUMAN"; }
+# DIVE-2371: authorization = this uid test AND a STRUCTURAL cgroup test
+# (`_gate_human_principal`). CS13 flips the pin to the non-agent case, so the
+# second half has to follow the SAME switch — otherwise CS13 reads the host's real
+# cgroup, the sudo-uid evidence never appears alongside the channel-session, and
+# the differential pin this file relies on silently stops being differential.
+# Stub the READER only; the accept/deny logic stays the shipped bytes.
+_gate_caller_cgroup() {
+  if [[ "$_PIN_SUDO_HUMAN" == "0" ]]; then printf '%s' '/system.slice/shelld.service'
+  else printf '%s' '/system.slice/system-5dive.slice/5dive-agent@dev.service'; fi
+}
 # DIVE-2601: the `id -un` stub that used to sit here was measured at ZERO
 # invocations across a full run of this file — nothing asks it, so it named a
 # caller nobody read. Deleted rather than left as documentation of a control that

--- a/tests/gate_enforce_env_bypass_unit.sh
+++ b/tests/gate_enforce_env_bypass_unit.sh
@@ -152,10 +152,17 @@ getent() {
 }
 _gate_passwd_stream() { _agentrow; printf '%s\n' "$(</etc/passwd)"; }
 _gate_caller_uid() { printf '%s' "$CALLER_UID"; }
-as_agent()        { FAKE_CALLER="agent-dev"; CALLER_UID="$AGENT_UID"; unset SUDO_UID; _gate_is_root() { return 1; }; }
+as_agent()        { FAKE_CALLER="agent-dev"; CALLER_UID="$AGENT_UID"; unset SUDO_UID; _gate_is_root() { return 1; }
+                    _gate_caller_cgroup() { printf '%s' '/system.slice/system-5dive.slice/5dive-agent@dev.service'; }; }
 # The human-on-box / dashboard-exec path: a NON-agent SUDO_UID, trusted only at EUID 0
 # (DIVE-1413), which is why the root seam is stubbed rather than the assertion weakened.
-as_human_on_box() { FAKE_CALLER="root"; CALLER_UID=0; export SUDO_UID=0; _gate_is_root() { return 0; }; }
+# DIVE-2371 added the STRUCTURAL half — `_gate_human_principal` is the uid test AND
+# `_gate_cgroup_human_capable` — so this persona now has to carry a human-capable
+# cgroup too. Without it L2 ("a REAL human path still clears") reads the host's real
+# cgroup and reds, which grades the fixture rather than the bypass this file is about.
+# Stub the READER only; the accept/deny logic stays the shipped bytes.
+as_human_on_box() { FAKE_CALLER="root"; CALLER_UID=0; export SUDO_UID=0; _gate_is_root() { return 0; }
+                    _gate_caller_cgroup() { printf '%s' '/system.slice/shelld.service'; }; }
 as_agent
 
 # The two preconditions every arm below inherits, asserted through the REAL resolvers

--- a/tests/gate_lead_clear_stamp_unit.sh
+++ b/tests/gate_lead_clear_stamp_unit.sh
@@ -97,6 +97,17 @@ _gate_clear_lead_denied_reason() { printf 'n/a'; }
 # The two human-evidence forms. Default: NEITHER present — the DIVE-2400 shape.
 SUDO_NONAGENT=1
 _gate_sudo_uid_nonagent() { return "$SUDO_NONAGENT"; }
+# DIVE-2371: the authorization sites now call `_gate_human_principal` = this uid
+# test AND a STRUCTURAL cgroup test. Drive the second half off the SAME switch, or
+# the SUDO_NONAGENT=0 arms below read the HOST's real cgroup, the sudo-uid evidence
+# form silently disappears, and the harness reds as "the fix must not demote an
+# evidenced human answer" — a true statement about the fixture, not about the code.
+# Stub the READER only; the accept/deny logic stays shipped bytes, and no env
+# override exists on purpose (a widening knob is the forge class DIVE-2371 closes).
+_gate_caller_cgroup() {
+  if [[ "$SUDO_NONAGENT" == "0" ]]; then printf '%s' '/system.slice/shelld.service'
+  else printf '%s' '/system.slice/system-5dive.slice/5dive-agent@dev.service'; fi
+}
 reset() { : >"$AUDIT_CALLS"; unset _TASK_STORE_AUDIT_FENCED; }
 
 # A routed approval gate: `task need` does the routing from preferences we cannot

--- a/tests/gate_nonce_unit.sh
+++ b/tests/gate_nonce_unit.sh
@@ -190,6 +190,21 @@ out=$(SUDO_UID="$AGENT_UID" cmd_task_answer DIVE-400 --value=approved --human --
 [[ "$(answered DIVE-400)" == "open" && $rc -ne 0 ]] && ok_t "T4 DIVE-950: --proof no longer clears (form b dropped)" \
   || bad_t "T4 --proof dropped" "rc=$rc state=$(answered DIVE-400) out=$out"
 
+# DIVE-2371: authorization is now the uid test AND a structural cgroup test, and
+# this file's uid stubs cannot reach that read. Unpinned, T5 below (a human-on-box
+# clearing with no proof) is refused, its pre-existing `fail 6` exits this
+# UNSUBSHELLED harness, and the file truncates at 12 of 19 arms with rc=6 — no
+# summary, no HARNESS-RC, and nothing that greps for a FAIL line notices.
+#
+# Pinned to the DASHBOARD/drop surface these arms DESCRIBE, once, rather than
+# inherited from whatever ran the suite (the DIVE-2365 rule this file already
+# applies to the caller uid). The refusal arms below are unaffected: T6 is refused
+# on the agent SUDO_UID and T8 on the DIVE-394 caller guard, neither of which this
+# touches. Cgroup coverage itself belongs to gate_cgroup_human_principal_unit.sh —
+# this file grades the NONCE and SUDO_UID evidence forms, and it should grade them
+# without the structural half silently deciding every arm.
+_gate_caller_cgroup() { printf '%s' '/system.slice/shelld.service'; }
+
 # --- T5: (c) non-agent SUDO_UID clears with NO proof (drop / human-on-box) ----
 seed_task DIVE-500; cmd_task_need DIVE-500 --type=secret --ask="drop key" --secret-key=FIXTURE_TOKEN --connector=fixture >/dev/null 2>&1
 SUDO_UID=0 cmd_task_answer DIVE-500 --human --from=drop >/dev/null 2>&1

--- a/tests/gate_sudo_uid_forge_unit.sh
+++ b/tests/gate_sudo_uid_forge_unit.sh
@@ -158,6 +158,18 @@ out=$(SUDO_UID="$CLAUDE_UID" cmd_task_answer DIVE-9601 --value=approved --human 
   && ok_t "T-FORGE non-root agent forging SUDO_UID=claude is REJECTED end-to-end" \
   || bad_t "T-FORGE forge rejected" "rc=$rc state=$(answered DIVE-9601) out=$out"
 
+# DIVE-2371: from here down the arms assert that a HUMAN path still CLEARS, and
+# authorization is now the uid test AND a structural cgroup test. The uid stubs
+# above cannot reach that read, so unpinned both arms below are refused, the
+# refusal's pre-existing `fail 6` exits this UNSUBSHELLED harness, and the file
+# truncates after T-FORGE at rc=6 — 6 ok, no summary, no HARNESS-RC. It reads as a
+# pass to anything that greps for a FAIL line, which is how it survived my own
+# sweep. Both remaining arms describe the SAME surface — shelld: T-SHELLD is the
+# dashboard exec, and T-DROP is root via the sudo drop that shelld spawns the CLI
+# through — so one accepted pin covers both, and it is the surface the accept list
+# exists for. Stub the READER only; accept/deny stays the shipped bytes.
+_gate_caller_cgroup() { printf '%s' '/system.slice/shelld.service'; }
+
 # T-DROP: the DIVE-931 drop context (root, SUDO_UID=claude, --from=drop) still clears.
 IS_ROOT=1; REAL_UID="0"; REAL_UN="root"
 seed_gate DIVE-9602 secret
@@ -173,6 +185,22 @@ SUDO_UID="" cmd_task_answer DIVE-9603 --value=approved --human >/dev/null 2>&1
 [[ "$(answered DIVE-9603)" == "closed" ]] \
   && ok_t "T-SHELLD non-root real-claude (dashboard exec) still clears end-to-end" \
   || bad_t "T-SHELLD shelld clears" "still $(answered DIVE-9603)"
+
+# T-CGROUP: DIVE-2371's half of this file's own subject. T-SHELLD above is the
+# dashboard clearing with real uid=claude; this is the SAME uid and the SAME gate
+# shape from an AGENT cgroup, and it must be REFUSED. Before DIVE-2371 `claude` was
+# trusted by name, so this input cleared — that was the forge this row closed, and
+# without this arm nothing in this file (the SUDO_UID forge harness) pins it.
+# Subshelled because the refusal is a `fail 6` exit by design.
+IS_ROOT=0; REAL_UID="$CLAUDE_UID"; REAL_UN="claude"
+seed_gate DIVE-9604 approval
+_cg_prev=$(declare -f _gate_caller_cgroup)
+_gate_caller_cgroup() { printf '%s' '/system.slice/system-5dive.slice/5dive-agent@dev.service'; }
+_tcg_out=$( SUDO_UID="" cmd_task_answer DIVE-9604 --value=approved --human 2>&1 ); _tcg_rc=$?
+eval "$_cg_prev"
+[[ "$(answered DIVE-9604)" != "closed" && $_tcg_rc -ne 0 ]] \
+  && ok_t "T-CGROUP real-claude from an AGENT cgroup is REFUSED (the DIVE-2371 forge)" \
+  || bad_t "T-CGROUP agent cgroup refused" "rc=$_tcg_rc state=$(answered DIVE-9604) out=$_tcg_out"
 
 echo "-----"
 printf 'gate_sudo_uid_forge_unit: %d passed, %d failed\n' "$PASS" "$FAIL"

--- a/tests/gate_t2_nonce_proof_unit.sh
+++ b/tests/gate_t2_nonce_proof_unit.sh
@@ -351,11 +351,24 @@ cmd_task_need DIVE-508 --type=decision --tier=2 --options="A|B" \
   --ask="which rollout order" --from=dev >/dev/null 2>&1
 SAVED_UID="$SUDO_UID"; export SUDO_UID=0   # root: a real, non-agent uid
 _gate_is_root() { return 0; }
+# DIVE-2371: the non-agent evidence form now needs a STRUCTURAL half too
+# (`_gate_human_principal` = the uid test AND `_gate_cgroup_human_capable`). This
+# arm describes the dashboard exec / human-on-box, which IS the accepted surface,
+# so flip the cgroup with the uid — otherwise the answer below reads the host's
+# real cgroup and S15 grades the fixture. Scoped to S15 and restored with the uid
+# below, so S16/S17 keep the agent pin. The precond on the next line deliberately
+# still asserts the UID half alone: it is what it names.
+_gate_caller_cgroup() { printf '%s' '/system.slice/shelld.service'; }
 _gate_sudo_uid_nonagent \
   && ok_t "S15 precond: the real resolver accepts SUDO_UID=0 as non-agent evidence" \
   || bad_t "S15 precond" "_gate_sudo_uid_nonagent refused SUDO_UID=0 under the root seam"
 out=$(cmd_task_answer DIVE-508 --value=A --from=main --human 2>&1); rc=$?
 export SUDO_UID="$SAVED_UID"
+# Restore the AGENT side of the structural half with the uid. Pinned explicitly
+# rather than left to read the host, so S16/S17 grade the same on a box and on a
+# runner — the DIVE-2365 lesson that a property true by accident of who ran the
+# suite is not a property at all.
+_gate_caller_cgroup() { printf '%s' '/system.slice/system-5dive.slice/5dive-agent@dev.service'; }
 agent_caller_on                            # back to the AGENT pin for S16/S17 below
 [[ $rc -eq 0 && "$(answered DIVE-508)" == "closed" ]] \
   && ok_t "S15 a non-agent SUDO_UID still clears with no nonce (forms stay equivalent)" \

--- a/tests/gate_tier2_decision_nonce_unit.sh
+++ b/tests/gate_tier2_decision_nonce_unit.sh
@@ -132,6 +132,27 @@ _pin_check="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
   || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected a NON-agent caller\n' "$_PIN_UID" "'$_pin_check'"; exit 1; }
 export SUDO_UID=0
 
+# DIVE-2371: authorization acquired a SECOND, STRUCTURAL half. The answer path no
+# longer calls `_gate_sudo_uid_nonagent` directly — it calls `_gate_human_principal`,
+# = that uid test AND `_gate_cgroup_human_capable`, which reads /proc/self/cgroup.
+# NEITHER `id` pin above can reach that read. Unstubbed, T6 sees the HOST's real
+# cgroup (an agent unit on a box, a runner cgroup on CI), the tier-2 guard refuses
+# CORRECTLY, and its pre-existing `fail 6` exits this UNSUBSHELLED harness — 10 ok /
+# 0 FAIL and then truncation. That is the same rc=6 shape this file's DIVE-2610 note
+# describes for `id -u`, one predicate later, and it is why the arm below is a pin
+# and not a behaviour change: nothing about the shipped predicate is relaxed here.
+# Stub the READER only (as tests/gate_cgroup_human_principal_unit.sh does); the
+# accept/deny logic stays shipped bytes, and no env override exists on purpose — a
+# widening knob on a fail-closed accept list IS the forge class DIVE-2371 closes.
+_CGROUP_PIN='/user.slice/user-0.slice/session-1.scope'   # a real login session
+_gate_caller_cgroup() { printf '%s' "$_CGROUP_PIN"; }
+# LIVENESS, BOTH DIRECTIONS. Unstubbed this fails CLOSED (loud truncation), but a
+# stub wired to the wrong SENSE fails open — so assert the negative before T6 leans on it.
+_gate_human_principal \
+  || { printf 'NOT OK - human-principal pin inert: the pinned login-session cgroup did not read as a human principal\n'; exit 1; }
+( _CGROUP_PIN='/system.slice/system-5dive.slice/5dive-agent@dev.service'; _gate_human_principal ) \
+  && { printf 'NOT OK - human-principal pin inert: an agent cgroup read as a human principal\n'; exit 1; }
+
 seed_task() { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
 hashof()  { db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE ident='$1';"; }
 tierof()  { db "SELECT COALESCE(tier,'')             FROM tasks WHERE ident='$1';"; }
@@ -259,6 +280,19 @@ cmd_task_answer DIVE-206 --value=A --human >/dev/null 2>&1
 [[ "$(answered DIVE-206)" == "closed" ]] \
   && ok_t "T6 ordering guard: --human answer on a NONCE-BEARING tier-2 decision still clears" \
   || bad_t "T6 --human tier-2 decision still clears" "still $(answered DIVE-206) — refuse-on-NULL may have landed early"
+
+# --- T6b: DIVE-2371 — T6's PARTNER, and the reason T6 stays an ORDERING guard rather
+#     than quietly becoming a "human principals clear" guard. Identical input to T6,
+#     identical uid pins, ONLY the cgroup differs: an agent unit must be REFUSED.
+#     Together the pair says minting changed nothing about WHO can answer while the
+#     structural half decides who that is. Subshelled: the refusal is a `fail 6` by design.
+seed_task DIVE-216
+cmd_task_need DIVE-216 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 >/dev/null 2>&1
+_t6b_out=$( _CGROUP_PIN='/system.slice/system-5dive.slice/5dive-agent@dev.service'
+            cmd_task_answer DIVE-216 --value=A --human 2>&1 ); _t6b_rc=$?
+[[ "$(answered DIVE-216)" == "open" && $_t6b_rc -ne 0 ]] \
+  && ok_t "T6b agent CGROUP on the same shape is REFUSED (the bare --human tier-2 forge)" \
+  || bad_t "T6b agent cgroup refused" "rc=$_t6b_rc state=$(answered DIVE-216) out=$_t6b_out — structural half not reached on the answer path"
 
 # --- T7: the pre-existing DIVE-1117 floor is untouched — a BARE-AGENT answer on
 #     the same shape is still refused. Pairs with T6: together they pin the answer

--- a/tests/gate_tier2_floor_unit.sh
+++ b/tests/gate_tier2_floor_unit.sh
@@ -104,6 +104,15 @@ tierof()  { db "SELECT COALESCE(tier,'') FROM tasks WHERE ident='$1';"; }
 # own header claims, rather than weakening an assertion.
 export SUDO_UID=0
 _gate_is_root() { return 0; }
+# DIVE-2371: the human-evidence test grew a STRUCTURAL half — the authorization
+# sites now call `_gate_human_principal` = the uid test AND `_gate_cgroup_human_capable`.
+# Same reasoning as the root seam directly above, one predicate later: the caller
+# this harness DESCRIBES is the dashboard exec / post-sudo human-on-box, and that
+# surface is an ACCEPTED cgroup, so pin it rather than weaken an assertion. Left
+# unpinned, T2 reads the host's real cgroup (an agent unit, or a CI runner), the
+# tier-2 guard refuses correctly, and the arm grades the fixture instead of the
+# floor. Stub the READER only; accept/deny stays the shipped bytes.
+_gate_caller_cgroup() { printf '%s' '/system.slice/shelld.service'; }
 
 touch "$GATE_PROOF_ENFORCE"   # enforcement ON for the floor tests
 

--- a/tests/gate_tier2_nonce_evidence_unit.sh
+++ b/tests/gate_tier2_nonce_evidence_unit.sh
@@ -66,6 +66,27 @@ _human_nonce_mint() { printf '%s' "$KNOWN_NONCE"; }
 # whether the immediate (pre-sudo) caller is an agent (the forge) or not (human/box).
 FAKE_NONAGENT=1   # 1 = non-agent (human), 0 = agent (forge)
 _gate_sudo_uid_nonagent() { [[ "$FAKE_NONAGENT" == "1" ]]; }
+# DIVE-2371: the AUTHORIZATION sites no longer ask the uid alone. They call
+# `_gate_human_principal`, which requires the uid test AND a structural cgroup
+# test, so the single switch above has to drive BOTH halves — otherwise every arm
+# below reads the HOST's real cgroup (an agent unit here, a runner cgroup on CI),
+# the tier-2 guard refuses correctly, and its pre-existing `fail 6` exits this
+# unsubshelled harness at rc=6 instead of grading. Stub the READER only, exactly
+# as tests/gate_cgroup_human_principal_unit.sh does; the accept/deny logic stays
+# the shipped bytes. Deliberately NOT an env var the product reads — a widening
+# knob on a fail-closed accept list is the forge class this row closes.
+_gate_caller_cgroup() {
+  if [[ "$FAKE_NONAGENT" == "1" ]]; then printf '%s' '/system.slice/shelld.service'
+  else printf '%s' '/system.slice/system-5dive.slice/5dive-agent@dev.service'; fi
+}
+# LIVENESS, BOTH DIRECTIONS. A stub that stops being called fails CLOSED here (the
+# real /proc read refuses and truncates, loudly), but a stub wired to the wrong
+# SENSE fails open — so assert the negative too, before any arm leans on it.
+FAKE_NONAGENT=1; _gate_human_principal \
+  || { printf 'NOT OK - human-principal pin inert: FAKE_NONAGENT=1 did not read as a human principal\n'; exit 1; }
+FAKE_NONAGENT=0; _gate_human_principal \
+  && { printf 'NOT OK - human-principal pin inert: FAKE_NONAGENT=0 read as a human principal\n'; exit 1; }
+FAKE_NONAGENT=1
 # Keep the CALLER a non-agent so the DIVE-394 caller-uid block never masks the
 # result. DIVE-2601: this was an `id -un` stub, which the derivation has not read
 # since DIVE-2330 — measured at ZERO calls here, so the caller's agent-ness was
@@ -145,8 +166,26 @@ cmd_task_need DIVE-203 --type=decision --ask="ship it?" --options="A|B" --recomm
 FAKE_NONAGENT=1
 cmd_task_answer DIVE-203 --value=A --human >/dev/null 2>&1
 [[ "$(answered DIVE-203)" == "closed" ]] \
-  && ok_t "T5 non-agent SUDO_UID (dashboard) clears tier-2 decision" \
-  || bad_t "T5 non-agent SUDO_UID clears" "still $(answered DIVE-203)"
+  && ok_t "T5 dashboard principal (non-agent uid + shelld cgroup) clears tier-2 decision" \
+  || bad_t "T5 dashboard principal clears" "still $(answered DIVE-203)"
+
+# --- T5b: DIVE-2371, THE FORGE THIS ROW CLOSES, on the AUTHORIZATION path. Same
+#     non-agent uid as T5 — only the cgroup differs — so the gate must REFUSE.
+#     Without this arm T5's green is satisfied by the uid half ALONE and the
+#     structural half is unpinned here: gate_cgroup_human_principal_unit.sh grades
+#     the predicate in isolation, nothing graded it through cmd_task_answer. This
+#     is the arm that reds if someone reverts _gate_human_principal to the uid test.
+#     Subshelled via $( ) because the refusal is a `fail 6` exit BY DESIGN.
+seed DIVE-290
+cmd_task_need DIVE-290 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 >/dev/null 2>&1
+FAKE_NONAGENT=1
+_cg_saved=$(declare -f _gate_caller_cgroup)
+_gate_caller_cgroup() { printf '%s' '/system.slice/system-5dive.slice/5dive-agent@dev.service'; }
+out=$(cmd_task_answer DIVE-290 --value=A --human 2>&1); rc=$?
+[[ "$(answered DIVE-290)" == "open" && $rc -ne 0 ]] \
+  && ok_t "T5b agent CGROUP with a non-agent uid is REFUSED (the bare --human tier-2 forge)" \
+  || bad_t "T5b agent cgroup refused" "rc=$rc state=$(answered DIVE-290) out=$out — structural half not reached on the answer path"
+eval "$_cg_saved"
 
 # --- T6: BACKWARD-COMPAT — a LEGACY tier-2 decision with NO stored nonce falls back
 #     to the DIVE-1117 provenance floor: a real human --human tap still clears even

--- a/tests/task_cascade_unblock_unit.sh
+++ b/tests/task_cascade_unblock_unit.sh
@@ -241,8 +241,17 @@ _pin_got="$(_gate_uid_to_agent "$(_gate_caller_uid)")"
   || { printf 'NOT OK - identity pin is inert: uid %s resolved to agent %s, expected %s\n' \
        "$_PIN_UID" "'$_pin_got'" "'${_pin_want:-<non-agent>}'"; exit 1; }
 
+# DIVE-2371: the human-evidence test grew a STRUCTURAL half — authorization calls
+# `_gate_human_principal` = the uid test AND `_gate_cgroup_human_capable`, and the
+# `id` stub above cannot reach the cgroup read. Unpinned, this answer is REFUSED on
+# any agent box or CI runner, A never closes, and the arm reds as a cascade failure
+# when nothing about the cascade changed. The caller this case DESCRIBES is a person
+# at a login session, which is an accepted surface, so pin it for the same scope as
+# the `id` stub. Stub the READER only; the accept list stays the shipped bytes.
+_gate_caller_cgroup() { printf '%s' '/user.slice/user-1000.slice/session-1.scope'; }
 ( cmd_task_answer "$a" --value=done --human ) >/dev/null 2>&1
 unset -f id
+unset -f _gate_caller_cgroup
 [[ "$(st "$a")" == "done" && "$(st "$b")" == "todo" && "$(edges "$b")" == "0" ]] \
   && ok_t "manual-gate 'done' answer cascades dependent blocked->todo" \
   || bad_t "manual-gate cascade" "A=$(st "$a") B=$(st "$b") edges=$(edges "$b")"


### PR DESCRIPTION
Closes the tier-2 `--human` forge. **lodar cleared the tier-2 gate "Ship it" 2026-08-05 07:40**, knowing the consequence: a tier-2 gate can no longer be cleared from a shell on the box as user `claude`.

## The defect

`_gate_sudo_uid_nonagent` asked *"is this name absent from a list I maintain"* (`[[ "$uname" != agent-* ]]`), so every principal **not** enumerated was promoted to human. On the one account present on every box the answer was wrong: `claude` is an agent runtime, not a person, so **any process running as claude cleared a tier-2 gate with a bare `--human`**. A human-evidence test whose default is *human* has its fail direction backwards.

## The structural half

`/proc/self/cgroup` is written by systemd at fork, an unprivileged process cannot rewrite its own, and **`sudo` does not move cgroups** — so it survives the EUID-0 hop `$SUDO_UID` exists for, which is the hop that makes that env var forgeable off-root (DIVE-1413).

**The list sits on the ACCEPT side**, which is what makes it fail closed:

- **accept** `/system.slice/shelld.service` — the dashboard, the only non-Telegram surface a customer clears from, and it has neither a nonce (minted into Telegram callback_data, never to a browser) nor a login session
- **accept** `/user.slice/*/session-*.scope` — a real login session, structural rather than named
- **refuse** everything else: agent units, the primary claude runtime, an unreadable cgroup, a non-systemd host

Applied to the two **authorization** sites only. `_gate_withdraw_actor` keeps the prefix test on purpose: **authorization must fail closed, attribution must stay truthful**, and degrading a real person's withdrawal to `none` makes the record worse rather than safer. It requires **both** halves, so it can only tighten — nothing the uid test refused becomes permitted. Telegram taps are untouched; they clear through the nonce arm.

## The accept value is measured, not derived

Both prior gates on DIVE-2371 were filed to avoid shipping an accept-list containing a unit nobody had observed. A probe row added to the smoke ([lodar/5dive-api#65](https://github.com/lodar/5dive-api/pull/65)) reported, from a freshly provisioned box:

```
ControlGroup=/system.slice/shelld.service  procSelfCgroup=0::/system.slice/shelld.service  user=claude
```

Unit ControlGroup and the running process's own cgroup agree, which is the pair that matters — shelld spawns the CLI as a plain `sudo` child.

## Grading

`tests/gate_cgroup_human_principal_unit.sh` — **9/9**. Load-bearing arm is **B1, an agent cgroup is REFUSED**, with an anchor (C1) proving the same input passes once the structural half is removed, so the arm grades the fix and not the fixture. B5 pins the match as exact rather than substring; B4 pins unreadable → refused.

**D1 exists because I wrote the hole first.** My draft read the accept list from `$FIVE_GATE_CGROUP_ACCEPT` — a plain env var an agent could set to its own cgroup, which is the exact forge class this predicate closes, reintroduced into the fix for it. D1 greps the shipped file to keep it out, over **non-comment lines only** (its own first run failed by matching the comment that explains the removal).

## Residual, stated rather than hidden

The accept value is confirmed on a **freshly provisioned** box. The installed fleet cannot be observed — customer-held boxes hold no exec token and SSH is stripped by design — so older boxes rest on the derivation that `shelld.service` comes from the repo template with no `Slice=`, and `update.sh` refreshes managed files nightly. That residual is exactly what lodar's gate asked about and answered.


---

## Follow-up work in this PR (dev, 2026-08-05)

Four further commits. Three are consequences of the fix above; **one is a separate corpus-policy change and is called out here so it is attributable rather than smuggled.**

**1. `86797ee` — stale test fixtures, not a resolver regression.** The three CI reds were harnesses that simulated a human by pinning the **UID half alone**, which no longer reaches the authorization decision. The correct refusal then exited an unsubshelled `cmd_task_*` call, so those harnesses *truncated* (10 ok / 0 FAIL) instead of grading. `_gate_human_principal`, `_gate_cgroup_human_capable` and `_gate_caller_cgroup` contain no `exit` and no `fail`; the `exit 6` is the pre-existing tier-2 refusal firing correctly. Six harnesses now drive the cgroup half off the same switch that already meant "is this caller a human", stubbing only the reader. Two **new** arms (`decision_nonce T6b`, `nonce_evidence T5b`) pin a non-agent UID with an **agent cgroup** as REFUSED through the authorization path, which only the predicate-level file covered before. Also adds the DIVE-2692 HARNESS-RC trap this PR's new harness was missing.

**2. `21c014c` — `_gate_caller_cgroup` read the wrong line.** It took `head -1` of `/proc/self/cgroup`. On v2 that is right by accident; on v1/hybrid the first line is an arbitrary controller whose path can differ from the systemd one, so a real login session read as unrecognised and a **human was locked out of their own tier-2 clear**. Now prefers the `name=systemd` line and falls through to `0::`, with **no permissive fallback**. Selection is split into `_gate_cgroup_pick_line` (stream on stdin) so the rule is gradable while the `/proc` path stays hardcoded — a readable-path override on a fail-closed predicate is the same widening class as an accept-list override (D1). 9/9 → 16/16.

**3. `5d6bad0` + `c01e0cd` — the same stale-fixture shape in two more places.** `task_cascade_unblock` T10, and — more seriously — **`_sc_probe_t2_forge` in `src/cmd_selfcheck.sh`**, which ships and runs on the installed fleet. Its liveness arm was refused, so the rail would have gone red **fleet-wide** reporting "the floor refuses everything" — a statement about where it ran, not about the floor. Both probe arms are now pinned, which is the probe's own DIVE-2365 lesson applied one predicate later.

**4. `057a450` — SEPARATE CHANGE: `corpus_tier_budget_unit.sh` demoted to nightly.** This is **corpus policy, not part of the security fix**, and has its own commit for that reason. Decided by **main, 2026-08-05**, on merits independent of this PR: it is a **meta-harness** grading the tier resolver and the budgeted runner, so no customer-reachable product path runs through it (the standard nightly criterion), and it costs **41.4s — 14% of the 300s core budget it is itself grading**. `CLAUDE.md` ranks merge and retire ahead of demotion; neither applies (no sibling to fold into, mechanism still live). The objection was made and recorded in the commit: demoting the guard of a currently-failing thing is a standard way to make a problem quiet — it does not apply here because the budget runner is *working*, refusing loudly with numbers, so a regression in it is caught within 24h and announces itself. **If it ever starts failing open, revisit this first.** The header's old "small and fast" claim is retired in the same edit rather than left contradicting the marker.

**Not done, deliberately:** the calibration re-baseline. The 32%-off signal is real but belongs to DIVE-2736. Re-baselining to relieve a budget is the same move as demoting to relieve one, minus the visibility.

**Outlives this PR:** main was at **99% of the core budget (238 harnesses, 297s / 300s)** *before* this branch. This demotion buys headroom for roughly one more change. 300s is lodar's number; raising it is his call.


---

## A green PR here does NOT mean a green nightly

**`gate_nonce_unit` is tier `nightly`.** Neither core job (`test`, `test-installed-host`) runs it, so **CI could not have reported it** — it truncated at 12 of 19 arms with `rc=6` and would have gone red in the nightly sweep *after* merge. It was found only by sweeping the nightly tier separately, branch `$?` against main `$?`.

**A PR's green is scoped to the tiers its jobs run.** A change to shared gate plumbing crosses that scope: `_gate_human_principal` is reached from harnesses in both tiers, and only one of them gates this PR. Anyone touching these files should sweep `nightly` as well as `core` before believing a green PR.

**And sweep on the exit code, not on the output.** A truncating harness prints no `FAIL` line and no summary, so `grep -qE "ABORT|NOT OK|[0-9]+ failed"` reads it as a pass — silence and success are identical to a text search. Two of the harnesses fixed here (`gate_sudo_uid_forge_unit`, `gate_nonce_unit`) survived exactly that sweep before being caught on `$?`. That is the same defect `harness_rc_corpus_contract_unit` / DIVE-2692 exist to catch, one level up in the instrument.

**Baseline fairly.** Comparing branch-vs-main means building the bundle in *both* worktrees: `actor_claim_corroboration_unit` T19-T21 **skip** when `./5dive` is absent, so an unbuilt baseline turns a pre-existing red into a false regression. It is red on main too, and is not touched by this PR.
