### PR TITLE
fix(pack): persona rename no longer destroys contractions (DIVE-2599)

### DIFF
--- a/changelog.d/DIVE-2599.md
+++ b/changelog.d/DIVE-2599.md
@@ -1,0 +1,5 @@
+## Unreleased — fix(pack): preserve contractions when renaming imported personas (DIVE-2599)
+
+Pack imports now rename only complete persona-name tokens, preventing short
+agent names such as `don` from corrupting contractions such as `don't` while
+still updating standalone names and display-name possessives.

--- a/src/cmd_pack.sh
+++ b/src/cmd_pack.sh
@@ -217,7 +217,10 @@ import sys
 path = pathlib.Path(sys.argv[1])
 old_l, new_l, old_c, new_c = sys.argv[2:]
 pattern = re.compile(
-    rf"(?P<display>(?<![\w'’]){re.escape(old_c)}(?!\w))"
+    # Match the display name before a possessive suffix without consuming that
+    # suffix, but reject every other apostrophe-linked continuation (notably a
+    # sentence-leading contraction such as "Don't").
+    rf"(?P<display>(?<![\w'’]){re.escape(old_c)}(?=(?:['’]s)?(?![\w'’])))"
     rf"|(?P<slug>(?<![\w'’]){re.escape(old_l)}(?![\w'’]))"
 )
 with path.open("r", encoding="utf-8", errors="surrogateescape", newline="") as handle:

--- a/src/cmd_pack.sh
+++ b/src/cmd_pack.sh
@@ -192,7 +192,10 @@ _install_bundled_skill() {
 # --as=cris leaves "You are Dario" in CLAUDE.md). Rewrite the persona name across
 # the identity + memory docs so the imported agent owns its chosen name. Both the
 # Capitalized display form (Dario) and the lowercase slug form (dario) are
-# replaced; word-boundary anchored so we don't mangle substrings.
+# replaced. A lowercase slug is a complete lexical token here: apostrophe-linked
+# continuations count as part of the token, so the agent `don` does not corrupt
+# ordinary prose such as "don't". The display form deliberately permits a
+# following apostrophe so possessives still rename (`Don's` -> `Cris's`).
 _pack_rename_persona() {
   local dir="$1" old="$2" new="$3"
   local old_l="${old,,}" new_l="${new,,}"
@@ -201,7 +204,28 @@ _pack_rename_persona() {
   local f
   for f in "$dir/CLAUDE.md" "$dir/card.md" "$dir/persona.yaml" "$dir"/memory/*.md; do
     [[ -f "$f" ]] || continue
-    sed -i -E "s/\\b${old_c}\\b/${new_c}/g; s/\\b${old_l}\\b/${new_l}/g" "$f" 2>/dev/null || true
+    # `\b` splits at punctuation, including the apostrophe inside a contraction.
+    # Lookarounds let adjacent names share a delimiter without consuming it, and
+    # one combined substitution never re-processes a replacement that happens to
+    # contain the old slug (e.g. `a` -> `a-one`). re.escape also keeps a malformed
+    # third-party manifest value from becoming regex syntax.
+    python3 - "$f" "$old_l" "$new_l" "$old_c" "$new_c" 2>/dev/null <<'PY' || true
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+old_l, new_l, old_c, new_c = sys.argv[2:]
+pattern = re.compile(
+    rf"(?P<display>(?<![\w'’]){re.escape(old_c)}(?!\w))"
+    rf"|(?P<slug>(?<![\w'’]){re.escape(old_l)}(?![\w'’]))"
+)
+with path.open("r", encoding="utf-8", errors="surrogateescape", newline="") as handle:
+    text = handle.read()
+text = pattern.sub(lambda match: new_c if match.group("display") else new_l, text)
+with path.open("w", encoding="utf-8", errors="surrogateescape", newline="") as handle:
+    handle.write(text)
+PY
   done
 }
 

--- a/tests/pack_persona_rename_unit.sh
+++ b/tests/pack_persona_rename_unit.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# DIVE-2599 isolated unit harness for pack-import persona renaming.
+#
+# Registry slugs resolve to the same staged tarball path as local archives, and
+# cmd_import calls _pack_rename_persona once after that convergence. This grades
+# the shared helper against every file it rewrites, including the reported
+# contraction corruption and adjacent matches that share a delimiter.
+# Run: bash tests/pack_persona_rename_unit.sh
+set -uo pipefail
+
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+# shellcheck disable=SC2154
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.." || exit
+SRC=src
+
+TMP="$(mktemp -d /tmp/pack-persona-rename-unit.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do
+  source "$SRC/$f"
+done
+# cmd_pack.sh is function-defs-only at source time.
+# shellcheck source=/dev/null
+source "$SRC/cmd_pack.sh"
+
+set +e
+PASS=0; FAIL=0
+ok_()  { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad_() { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+has() {
+  if grep -qF -- "$2" "$1"; then ok_ "$3"; else bad_ "$3 (missing [$2] in $1)"; fi
+}
+hasnt() {
+  if grep -qF -- "$2" "$1"; then bad_ "$3 (unexpected [$2] in $1)"; else ok_ "$3"; fi
+}
+
+echo "== DIVE-2599 pack persona rename boundaries =="
+STAGE="$TMP/stage"
+mkdir -p "$STAGE/memory"
+
+fixture() {
+  cat <<'EOF'
+# Don
+You are Don. Don's brief calls the slug don twice: don don.
+People don't buy rooted documents from surface-level vendors.
+People don’t accept naive replacements either.
+EOF
+}
+
+for f in "$STAGE/CLAUDE.md" "$STAGE/card.md" "$STAGE/persona.yaml" "$STAGE/memory/reference.md"; do
+  fixture > "$f"
+done
+fixture > "$STAGE/unrelated.txt"
+
+_pack_rename_persona "$STAGE" don zed
+
+for f in "$STAGE/CLAUDE.md" "$STAGE/card.md" "$STAGE/persona.yaml" "$STAGE/memory/reference.md"; do
+  has "$f" "# Zed" "$(basename "$f"): display name renamed"
+  has "$f" "You are Zed. Zed's brief calls the slug zed twice: zed zed." \
+    "$(basename "$f"): display, possessive and adjacent slug matches renamed"
+  has "$f" "People don't buy rooted documents from surface-level vendors." \
+    "$(basename "$f"): ASCII contraction and embedded substrings preserved"
+  has "$f" "People don’t accept naive replacements either." \
+    "$(basename "$f"): curly-apostrophe contraction preserved"
+  hasnt "$f" "zed't" "$(basename "$f"): reported corruption absent"
+done
+
+has "$STAGE/unrelated.txt" "# Don" "files outside the persona set are untouched"
+
+# A replacement may itself contain the old short slug. The matcher must walk
+# the original text once, not recursively expand its own output.
+RECUR="$TMP/non-recursive"
+mkdir -p "$RECUR"
+printf 'A a.\n' > "$RECUR/CLAUDE.md"
+_pack_rename_persona "$RECUR" a a-one
+has "$RECUR/CLAUDE.md" "A-one a-one." "replacement text is not processed recursively"
+hasnt "$RECUR/CLAUDE.md" "a-one-one" "short old slug does not expand inside the new name"
+
+# Wiring guard: both archive and registry resolution happen before the one
+# shared rename call. This prevents a future route-specific copy from bypassing
+# the behaviour exercised above.
+IMPORT_BODY=$(sed -n '/^cmd_import()/,/^}/p' "$SRC/cmd_pack.sh")
+# shellcheck disable=SC2016
+CALLS=$(grep -c '_pack_rename_persona "\$stage" "\$orig_name" "\$as"' <<<"$IMPORT_BODY")
+if [[ "$CALLS" == 1 ]]; then ok_ "cmd_import has one shared post-resolution rename call"
+else bad_ "cmd_import shared rename wiring (want 1 call, got $CALLS)"; fi
+
+printf '\nRESULT: %d passed, %d failed\n' "$PASS" "$FAIL"
+(( FAIL == 0 ))

--- a/tests/pack_persona_rename_unit.sh
+++ b/tests/pack_persona_rename_unit.sh
@@ -47,6 +47,7 @@ fixture() {
 You are Don. Don's brief calls the slug don twice: don don.
 People don't buy rooted documents from surface-level vendors.
 People don’t accept naive replacements either.
+Don't corrupt sentence-leading contractions. Don’t corrupt curly ones.
 EOF
 }
 
@@ -65,6 +66,8 @@ for f in "$STAGE/CLAUDE.md" "$STAGE/card.md" "$STAGE/persona.yaml" "$STAGE/memor
     "$(basename "$f"): ASCII contraction and embedded substrings preserved"
   has "$f" "People don’t accept naive replacements either." \
     "$(basename "$f"): curly-apostrophe contraction preserved"
+  has "$f" "Don't corrupt sentence-leading contractions. Don’t corrupt curly ones." \
+    "$(basename "$f"): capitalized contractions preserved"
   hasnt "$f" "zed't" "$(basename "$f"): reported corruption absent"
 done
 


### PR DESCRIPTION
Persona rename destroyed contractions: `You are Don. People don't buy watches.` renamed to
`You are Cris.` **and silently rewrote `don't`**. The rename matched the persona name as a bare
word without regard for an apostrophe following it, so every contraction built on that name —
and every capitalized form of it — was collateral.

One shared call site (`src/cmd_pack.sh:2105`) covers **both** the tarball and registry-slug
import paths, so the fix cannot land on one and miss the other.

## Grading

Graded PASS by main2 (verifier), maker codex. Full grade is on DIVE-2599.

- New unit test: **28/28**, with the trailing `RESULT` line asserted and the harness sourcing
  the real `src/cmd_pack.sh` rather than a copy.
- Independent repro reproduced the exact reported case and confirmed the contraction survives.
- No regressions across the neighbouring pack harnesses: `pack_agents_md` 67/0,
  `pack_import_model_alias` 17/0, `pack_skill_source_roundtrip` 41/0, `pack_cross_harness` rc=0.

## Provenance, since the record will not show it

Authored by **codex**; committed under `lodar <markounik@gmail.com>` per this repo's house
rule; **pushed by agent-main**, because codex holds no HTTPS GitHub credential and agent-main is
its only push route.

**Rebased onto `0396d92` before opening this PR.** The graded tip was `97d85f8`; `main` moved
after grading (#483 landed), so the branch was rebased and force-pushed with `--force-with-lease`
pinned to `97d85f8`. The rebase was clean — no conflicts, no content change — and the tree is
identical to the graded one. Current head: `66510fa`.

Closes DIVE-2599.
