### PR TITLE
fix(install): stamp the bundle with its build sha and compare identity (DIVE-2603)

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -469,6 +469,19 @@ jobs:
           else
             echo "::warning::CHANGELOG could not be stamped for ${tag} (${_stamped}) — publishing anyway; the release BODY is derived from the git range and is unaffected."
           fi
+          # DIVE-2603: build.sh stamps HEAD only when the tracked source tree is
+          # clean. Commit every tag-time source edit BEFORE building so the stamp
+          # names the exact bytes being concatenated. The bundle rides in a second
+          # release commit below; therefore its stamped source commit is the tagged
+          # commit's parent and ancestry remains directly checkable.
+          git add -f src/header.sh
+          if [ -f CHANGELOG.md ]; then git add -f CHANGELOG.md; fi
+          if [ -d changelog.d ]; then git add -A -f changelog.d; fi
+          git -c user.name=lodar -c user.email=markounik@gmail.com \
+              commit -q -m "release ${tag}: assign ${version} before bundle build (DIVE-2247, DIVE-2603)"
+          source_sha=$(git rev-parse HEAD)
+          [ -z "$(git status --porcelain --untracked-files=no)" ] \
+            || { echo "::error::tracked release source is dirty after commit ${source_sha} — refusing to stamp a false build identity"; exit 1; }
           ./build.sh || { echo "::error::build.sh failed — refusing to cut ${tag} with no bundle"; exit 1; }
           [ -s 5dive ] && [ -s 5dive.sha256 ] \
             || { echo "::error::build.sh produced no bundle/checksum — refusing to cut ${tag}"; exit 1; }
@@ -481,18 +494,12 @@ jobs:
           _bundle_ver=$(grep -m1 -oP "(?<=^readonly FIVE_VERSION=\")[^\"]+" 5dive)
           [ "v${_bundle_ver}" = "$tag" ] \
             || { echo "::error::built bundle says FIVE_VERSION=${_bundle_ver} but this cut is ${tag} — refusing to publish a bundle that disagrees with its own tag"; exit 1; }
-          git add -f 5dive 5dive.sha256 src/header.sh
-          # DIVE-2452: the stamped CHANGELOG rides in the release commit. Guarded
-          # rather than appended to the line above: `git add` fails the whole step on
-          # a pathspec that matches nothing, and the stamp is explicitly non-fatal —
-          # a cut must not die because a repo has no CHANGELOG.md.
-          if [ -f CHANGELOG.md ]; then git add -f CHANGELOG.md; fi
-          # DIVE-2582: the fold step above deletes any folded changelog.d/
-          # fragments from the working tree — stage that removal too, same guard
-          # shape (dir may legitimately not exist).
-          if [ -d changelog.d ]; then git add -A -f changelog.d; fi
+          _bundle_build_sha=$(grep -m1 -oP '(?<=^readonly FIVE_BUILD_SHA=")[^"]+' 5dive)
+          [ "$_bundle_build_sha" = "$source_sha" ] \
+            || { echo "::error::built bundle says FIVE_BUILD_SHA=${_bundle_build_sha:-missing} but its committed source is ${source_sha} — refusing to publish a false identity"; exit 1; }
+          git add -f 5dive 5dive.sha256
           git -c user.name=lodar -c user.email=markounik@gmail.com \
-              commit -q -m "release ${tag}: assign ${version} + built bundle (DIVE-2091 bundle-at-tag-time, DIVE-2247 version-at-tag-time)"
+              commit -q -m "release ${tag}: bundle built from ${source_sha} (DIVE-2091, DIVE-2603)"
           # DIVE-2433: `sha` is about to stop meaning "the commit whose check-runs we
           # read". Keep the graded one under its own name so the tag can say which
           # object each claim is about instead of silently attributing the parent's
@@ -505,7 +512,7 @@ jobs:
             || { echo "::error::release commit ${sha} does not carry the bundle — refusing to cut ${tag}"; exit 1; }
           [ "$(git show "${sha}:5dive" | sha256sum | cut -d" " -f1)" = "$_want" ] \
             || { echo "::error::bundle in the release commit differs from the one just built — refusing to cut ${tag}"; exit 1; }
-          echo "release commit ${sha} carries bundle ${_want} (FIVE_VERSION=${_bundle_ver})"
+          echo "release commit ${sha} carries bundle ${_want} (FIVE_VERSION=${_bundle_ver}, FIVE_BUILD_SHA=${_bundle_build_sha})"
           # <<< DIVE-2091 release-commit block
 
           # ── DIVE-2433: GRADE THE RELEASE COMMIT ──────────────────────────────

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,18 @@ cd "$(dirname "$0")"
 # temp dir without dirtying the tracked ./5dive artifact. Defaults to the repo ./5dive.
 OUT="${BUILD_OUT:-5dive}"
 
+# DIVE-2603: FIVE_VERSION is assigned only when a release tag is cut, so a
+# working-tree bundle permanently says 0.0.0-dev. Carry the source identity as
+# a separate fact that remains meaningful both before and after tag time.
+BUILD_SHA="$(git rev-parse --verify 'HEAD^{commit}' 2>/dev/null)" || {
+  echo "error: cannot resolve the source commit for $OUT" >&2
+  exit 1
+}
+if [[ ! "$BUILD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "error: source commit is not a full git sha: $BUILD_SHA" >&2
+  exit 1
+fi
+
 # DIVE-2681: BUILD_OUT may name the bundle ANYTHING, and .gitignore only knows
 # about `/5dive` + `/5dive.sha256` (DIVE-2091). So `BUILD_OUT=./5dive-fix` builds
 # a 3.3MB bundle that git happily tracks, and one `git add -A` puts it on main —
@@ -106,6 +118,7 @@ cat \
   src/cmd_secret.sh \
   src/cmd_selfupdate.sh \
   src/main.sh \
+  | sed -E "s/^readonly FIVE_BUILD_SHA=\"[^\"]*\"/readonly FIVE_BUILD_SHA=\"$BUILD_SHA\"/" \
   > "$OUT"
 
 # DIVE-1261: publish a sha256 of the bundle so the installer can verify the fetched binary before
@@ -129,6 +142,10 @@ chmod +x "$OUT" 2>/dev/null || true
 # when someone empties out FIVE_VERSION by accident.
 if ! grep -qE '^readonly FIVE_VERSION="[^"]+"' "$OUT"; then
   echo "error: $OUT is missing FIVE_VERSION — check src/header.sh" >&2
+  exit 1
+fi
+if ! grep -qE "^readonly FIVE_BUILD_SHA=\"${BUILD_SHA}\"$" "$OUT"; then
+  echo "error: $OUT is missing FIVE_BUILD_SHA=$BUILD_SHA — check src/header.sh" >&2
   exit 1
 fi
 
@@ -156,4 +173,4 @@ if [[ -n "$guard_line" && "$def_line" -gt "$guard_line" ]]; then
   exit 1
 fi
 
-echo "built $OUT ($(wc -l < "$OUT") lines, $(grep -oE '^readonly FIVE_VERSION="[^"]+"' "$OUT" | cut -d'"' -f2)) + $OUT.sha256 ($(cut -c1-16 "$OUT.sha256")…)"
+echo "built $OUT ($(wc -l < "$OUT") lines, $(grep -oE '^readonly FIVE_VERSION="[^"]+"' "$OUT" | cut -d'"' -f2) at ${BUILD_SHA:0:12}) + $OUT.sha256 ($(cut -c1-16 "$OUT.sha256")…)"

--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,10 @@ OUT="${BUILD_OUT:-5dive}"
 
 # DIVE-2603: FIVE_VERSION is assigned only when a release tag is cut, so a
 # working-tree bundle permanently says 0.0.0-dev. Carry the source identity as
-# a separate fact that remains meaningful both before and after tag time.
+# a separate fact that remains meaningful both before and after tag time. A
+# dirty tree is deliberately stamped <sha>-dirty: the artifact contains bytes
+# HEAD does not, so install.sh must reject the stamp as ancestry evidence and
+# fall back to the version path instead of trusting a false identity.
 BUILD_SHA="$(git rev-parse --verify 'HEAD^{commit}' 2>/dev/null)" || {
   echo "error: cannot resolve the source commit for $OUT" >&2
   exit 1
@@ -31,6 +34,9 @@ BUILD_SHA="$(git rev-parse --verify 'HEAD^{commit}' 2>/dev/null)" || {
 if [[ ! "$BUILD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
   echo "error: source commit is not a full git sha: $BUILD_SHA" >&2
   exit 1
+fi
+if [[ -n "$(git status --porcelain --untracked-files=normal 2>/dev/null)" ]]; then
+  BUILD_SHA="${BUILD_SHA}-dirty"
 fi
 
 # DIVE-2681: BUILD_OUT may name the bundle ANYTHING, and .gitignore only knows

--- a/install.sh
+++ b/install.sh
@@ -254,6 +254,45 @@ version_lt() {
   [[ "$1" != "$2" ]] && [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" == "$1" ]]
 }
 
+# Only plain release versions carry ordering meaning. In particular,
+# 0.0.0-dev is a tag-time sentinel, not a version below every release.
+release_version() { [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; }
+
+bundle_build_sha() {
+  local _sha=""
+  _sha="$(grep -m1 'readonly FIVE_BUILD_SHA=' "$1" 2>/dev/null | sed -E 's/.*="([^"]+)".*/\1/')" || _sha=""
+  [[ "$_sha" =~ ^[0-9a-f]{40}$ ]] || return 1
+  printf '%s\n' "$_sha"
+}
+
+# Legacy release bundles predate FIVE_BUILD_SHA. Their tag points at a detached
+# release commit whose first parent is the main commit the bundle was built
+# from, so recover that parent rather than comparing against the detached child.
+legacy_release_build_sha() {
+  local _version="$1" _json="" _line="" _sha=""
+  release_version "$_version" || return 1
+  _json="$(curl -fsSL --max-time 10 \
+    "https://api.github.com/repos/$GH_ORG/5dive/commits/v${_version}" 2>/dev/null)" || return 1
+  _line="$(printf '%s\n' "$_json" | awk '/"parents"[[:space:]]*:/ { parents=1; next } parents && /"sha"[[:space:]]*:/ { print; exit }')"
+  _sha="$(printf '%s\n' "$_line" | sed -n 's/.*"sha"[[:space:]]*:[[:space:]]*"\([0-9a-f]\{40\}\)".*/\1/p')"
+  [[ "$_sha" =~ ^[0-9a-f]{40}$ ]] || return 1
+  printf '%s\n' "$_sha"
+}
+
+# Prints ahead|behind|identical|diverged for installed...candidate.
+build_relation() {
+  local _installed="$1" _candidate="$2" _json="" _status=""
+  _json="$(curl -fsSL --max-time 10 \
+    "https://api.github.com/repos/$GH_ORG/5dive/compare/${_installed}...${_candidate}" 2>/dev/null)" || return 1
+  _status="$(printf '%s\n' "$_json" | sed -n 's/.*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+  case "$_status" in ahead|behind|identical|diverged) printf '%s\n' "$_status" ;; *) return 1 ;; esac
+}
+
+# Read by the --upgrade report after refresh_managed_files swaps the bundle.
+INSTALL_DIRECTION=""
+INSTALL_INSTALLED_SHA=""
+INSTALL_CANDIDATE_SHA=""
+
 # assert_version_monotonic <installed-bin> <candidate-bundle>
 # 0 = proceed, 1 = refuse (message already on stderr; caller cleans up + exits).
 # Deliberately does NOT call die(): the caller holds a temp bundle in $BIN_DIR
@@ -261,15 +300,57 @@ version_lt() {
 # directory it just refused to touch is its own small mess.
 assert_version_monotonic() {
   local _inst_bin="$1" _cand_file="$2" _inst="" _cand="" _src=""
+  local _inst_sha="" _cand_sha="" _relation="" _identity_note=""
+  INSTALL_DIRECTION="" INSTALL_INSTALLED_SHA="" INSTALL_CANDIDATE_SHA=""
   # Fresh install: nothing to move backwards from.
-  [[ -f "$_inst_bin" ]] || return 0
+  if [[ ! -f "$_inst_bin" ]]; then INSTALL_DIRECTION="fresh"; return 0; fi
   _inst="$(grep -m1 'readonly FIVE_VERSION=' "$_inst_bin" 2>/dev/null | sed -E 's/.*="([^"]+)".*/\1/')" || _inst=""
   _cand="$(grep -m1 'readonly FIVE_VERSION=' "$_cand_file" 2>/dev/null | sed -E 's/.*="([^"]+)".*/\1/')" || _cand=""
-  if [[ -z "$_inst" || -z "$_cand" ]]; then
-    echo "  ! version not comparable (installed='${_inst:-unreadable}', candidate='${_cand:-unreadable}') — direction unchecked, proceeding" >&2
+  _inst_sha="$(bundle_build_sha "$_inst_bin" || true)"
+  _cand_sha="$(bundle_build_sha "$_cand_file" || true)"
+  if [[ -z "$_inst_sha" && -n "$_cand_sha" && -n "$_inst" ]]; then
+    _inst_sha="$(legacy_release_build_sha "$_inst" || true)"
+    [[ -z "$_inst_sha" ]] || _identity_note=" (installed v${_inst} mapped to its release parent)"
+  fi
+  INSTALL_INSTALLED_SHA="$_inst_sha" INSTALL_CANDIDATE_SHA="$_cand_sha"
+
+  if [[ -n "$_inst_sha" && -n "$_cand_sha" ]]; then
+    _relation="$(build_relation "$_inst_sha" "$_cand_sha" || true)"
+    case "$_relation" in
+      ahead) INSTALL_DIRECTION="forward"; return 0 ;;
+      identical) INSTALL_DIRECTION="same"; return 0 ;;
+      behind)
+        INSTALL_DIRECTION="rollback"
+        if [[ "${FIVE_ALLOW_DOWNGRADE:-0}" == "1" ]]; then
+          echo "  ! ROLLBACK build ${_inst_sha} -> ${_cand_sha}${_identity_note} — allowed by FIVE_ALLOW_DOWNGRADE=1" >&2
+          return 0
+        fi
+        printf 'error: refusing to install older 5dive build: candidate %s is an ancestor of installed %s%s.\n' \
+          "$_cand_sha" "$_inst_sha" "$_identity_note" >&2
+        printf '       Nothing was changed. If this rollback is deliberate, re-run with FIVE_ALLOW_DOWNGRADE=1.\n' >&2
+        return 1
+        ;;
+      diverged)
+        echo "  ! build identity diverged (installed=${_inst_sha}, candidate=${_cand_sha}) — falling back to release-version ordering when available" >&2
+        ;;
+      *)
+        echo "  ! build ancestry unavailable (installed=${_inst_sha}, candidate=${_cand_sha}) — falling back to release-version ordering when available" >&2
+        ;;
+    esac
+  fi
+
+  # Version ordering is still authoritative when both artifacts carry real
+  # release versions. A sentinel or unreadable value is not rollback evidence.
+  if ! release_version "$_inst" || ! release_version "$_cand"; then
+    INSTALL_DIRECTION="unchecked"
+    echo "  ! release versions not comparable (installed='${_inst:-unreadable}', candidate='${_cand:-unreadable}') — direction unchecked, proceeding" >&2
     return 0
   fi
-  version_lt "$_cand" "$_inst" || return 0
+  if ! version_lt "$_cand" "$_inst"; then
+    if version_lt "$_inst" "$_cand"; then INSTALL_DIRECTION="forward"; else INSTALL_DIRECTION="same"; fi
+    return 0
+  fi
+  INSTALL_DIRECTION="rollback"
   # Name where the lower version came from — the whole point is that a backwards
   # move is traceable to the thing that resolved it.
   _src="${GH_PINNED_TAG:-}"
@@ -954,17 +1035,17 @@ if [[ "${1:-}" == "--upgrade" ]]; then
   # DIVE-1260: report the version actually swapped in, read from the new bundle.
   _new_ver="$(grep -m1 'readonly FIVE_VERSION=' "$BIN_DIR/5dive" 2>/dev/null | sed -E 's/.*="([^"]+)".*/\1/')"
   # >>> DIVE-2243 upgrade report (extracted verbatim by tests/install_monotonicity_unit.sh)
-  # DIVE-2243: never call a backwards move an upgrade. Reachable only via
-  # FIVE_ALLOW_DOWNGRADE=1 now that the guard above refuses otherwise — but this
-  # line is what made the fleet-wide downgrade invisible, so it states the
-  # direction it actually measured rather than the one it assumed.
-  if [[ -n "${_old_ver:-}" && -n "${_new_ver:-}" ]] && version_lt "$_new_ver" "$_old_ver"; then
-    echo "5dive DOWNGRADED: ${_old_ver} -> ${_new_ver}"
-  elif [[ -n "${_old_ver:-}" && "${_old_ver}" != "${_new_ver:-}" ]]; then
-    echo "5dive upgraded: ${_old_ver} -> ${_new_ver:-unknown}"
-  else
-    echo "5dive upgraded (now ${_new_ver:-unknown})"
-  fi
+  # Report the direction the guard measured. A current-main bundle legitimately
+  # says 0.0.0-dev, so comparing that sentinel after the swap would recreate the
+  # false "DOWNGRADED" message DIVE-2603 removes.
+  _old_id="${_old_ver:-unknown}${INSTALL_INSTALLED_SHA:+ at ${INSTALL_INSTALLED_SHA}}"
+  _new_id="${_new_ver:-unknown}${INSTALL_CANDIDATE_SHA:+ at ${INSTALL_CANDIDATE_SHA}}"
+  case "${INSTALL_DIRECTION:-unchecked}" in
+    rollback) echo "5dive DOWNGRADED: ${_old_id} -> ${_new_id}" ;;
+    same) echo "5dive refreshed: ${_old_id} -> ${_new_id} (build identity unchanged)" ;;
+    forward) echo "5dive upgraded: ${_old_id} -> ${_new_id}" ;;
+    *) echo "5dive updated: ${_old_id} -> ${_new_id} (direction unchecked)" ;;
+  esac
   # <<< DIVE-2243 upgrade report
   exit 0
 fi

--- a/src/header.sh
+++ b/src/header.sh
@@ -36,6 +36,12 @@ esac
 # the floor if it is not. Graded by tests/release_cut_assign_unit.sh.
 readonly FIVE_VERSION="0.0.0-dev"
 
+# Build identity, not a release number. build.sh replaces this sentinel only in
+# the generated bundle with the 40-hex commit whose source it concatenated.
+# Keeping the source sentinel non-hex makes an unbuilt split tree impossible to
+# mistake for an artifact whose ancestry install.sh can verify (DIVE-2603).
+readonly FIVE_BUILD_SHA="unbuilt"
+
 # GitHub org our repos live under. The org is being renamed
 # 5dive-com -> 5dive-ai (2026-06); fetches must work on either side of the
 # rename, so probe the new org once per process and fall back to the old

--- a/src/header.sh
+++ b/src/header.sh
@@ -37,9 +37,10 @@ esac
 readonly FIVE_VERSION="0.0.0-dev"
 
 # Build identity, not a release number. build.sh replaces this sentinel only in
-# the generated bundle with the 40-hex commit whose source it concatenated.
-# Keeping the source sentinel non-hex makes an unbuilt split tree impossible to
-# mistake for an artifact whose ancestry install.sh can verify (DIVE-2603).
+# the generated bundle with the 40-hex commit whose clean source it concatenated
+# (or <sha>-dirty when the bytes do not equal HEAD). Both sentinels are non-hex,
+# so neither an unbuilt nor a dirty artifact can masquerade as identity whose
+# ancestry install.sh can verify (DIVE-2603).
 readonly FIVE_BUILD_SHA="unbuilt"
 
 # GitHub org our repos live under. The org is being renamed

--- a/tests/install_monotonicity_unit.sh
+++ b/tests/install_monotonicity_unit.sh
@@ -270,9 +270,9 @@ else
   bad_t "dirty tree claimed a clean build identity" "rc=$rc head=$dirty_head stamp=${dirty_stamp:-missing} log=$dirty_log"
 fi
 
-out="$(run_guard 0.18.0 0.18.1 0 '' '' "${NEW_SHA}-dirty")"; rc=$?
-if (( rc == 0 )) && [[ "$out" == *"__DIRECTION=forward __INSTALLED_SHA= __CANDIDATE_SHA="* && "$out" != *"refusing to DOWNGRADE"* ]]; then
-  ok_t "install guard rejects a sha-dirty stamp and uses the safe fallback"
+out="$(run_guard 0.18.0 0.18.1 0 '' "$NEW_SHA" "${OLD_SHA}-dirty" behind)"; rc=$?
+if (( rc == 0 )) && [[ "$out" == *"__DIRECTION=forward __INSTALLED_SHA=$NEW_SHA __CANDIDATE_SHA="* && "$out" != *"${OLD_SHA}-dirty"* && "$out" != *"refusing"* ]]; then
+  ok_t "install guard rejects a sha-dirty candidate when both artifacts are stamped"
 else
   bad_t "install guard trusted a dirty build identity" "rc=$rc out: ${out//$'\n'/ | }"
 fi

--- a/tests/install_monotonicity_unit.sh
+++ b/tests/install_monotonicity_unit.sh
@@ -43,28 +43,85 @@ else
 fi
 
 TD="$(mktemp -d)"
+mkdir -p "$TD/bin"
+# Hermetic GitHub API double. Identity arms select the response through explicit
+# fixture variables; every ordinary version-only arm stays offline.
+cat > "$TD/bin/curl" <<'FAKE_CURL'
+#!/usr/bin/env bash
+url="${*: -1}"
+case "$url" in
+  */commits/v*)
+    [[ "${FAKE_LEGACY_PARENT:-}" =~ ^[0-9a-f]{40}$ ]] || exit 22
+    printf '{\n  "sha": "%040d",\n  "parents": [\n    { "sha": "%s" }\n  ]\n}\n' 1 "$FAKE_LEGACY_PARENT"
+    ;;
+  */compare/*)
+    [[ "${FAKE_RELATION:-}" =~ ^(ahead|behind|identical|diverged)$ ]] || exit 22
+    printf '{ "status": "%s" }\n' "$FAKE_RELATION"
+    ;;
+  *) exit 22 ;;
+esac
+FAKE_CURL
+chmod +x "$TD/bin/curl"
 # A "5dive binary" here is only ever grepped for its FIVE_VERSION line, so a
 # one-line stand-in exercises the real read path. `--none--` writes a file that
 # carries no version at all (the unreadable case).
-mkbin() { # $1=path $2=version|--none--
+mkbin() { # $1=path $2=version|--none-- [$3=build-sha]
   if [[ "$2" == "--none--" ]]; then printf '#!/usr/bin/env bash\necho hi\n' > "$1"
-  else printf '#!/usr/bin/env bash\nreadonly FIVE_VERSION="%s"\n' "$2" > "$1"; fi
+  else
+    printf '#!/usr/bin/env bash\nreadonly FIVE_VERSION="%s"\n' "$2" > "$1"
+    [[ -z "${3:-}" ]] || printf 'readonly FIVE_BUILD_SHA="%s"\n' "$3" >> "$1"
+  fi
 }
 
 # Run the extracted guard against an installed version and a candidate version.
 # Prints stderr; returns the guard's rc. `--absent--` as the installed version
 # means no binary on disk at all (fresh install).
-run_guard() { # $1=installed $2=candidate [$3=FIVE_ALLOW_DOWNGRADE] [$4=GH_PINNED_TAG]
+run_guard() { # installed candidate [allow] [tag] [installed-sha] [candidate-sha] [relation] [legacy-parent]
   local inst="$TD/installed" cand="$TD/candidate"
   rm -f "$inst" "$cand"
-  [[ "$1" == "--absent--" ]] || mkbin "$inst" "$1"
-  mkbin "$cand" "$2"
-  env -i PATH="/usr/bin:/bin" \
+  [[ "$1" == "--absent--" ]] || mkbin "$inst" "$1" "${5:-}"
+  mkbin "$cand" "$2" "${6:-}"
+  env -i PATH="$TD/bin:/usr/bin:/bin" \
     FIVE_ALLOW_DOWNGRADE="${3:-0}" GH_PINNED_TAG="${4:-}" GH_PINNED_SHA="" REPO="" \
+    GH_ORG="5dive-ai" FAKE_RELATION="${7:-}" FAKE_LEGACY_PARENT="${8:-}" \
     bash -c "set -euo pipefail
 $guard
-assert_version_monotonic '$inst' '$cand'" 2>&1
+set +e
+assert_version_monotonic '$inst' '$cand'
+rc=\$?
+printf '__DIRECTION=%s __INSTALLED_SHA=%s __CANDIDATE_SHA=%s\\n' \
+  \"\$INSTALL_DIRECTION\" \"\$INSTALL_INSTALLED_SHA\" \"\$INSTALL_CANDIDATE_SHA\"
+exit \"\$rc\"" 2>&1
 }
+
+OLD_SHA=1111111111111111111111111111111111111111
+NEW_SHA=2222222222222222222222222222222222222222
+
+# DIVE-2603: the first stamped current-main bundle must install over a legacy
+# published bundle. The legacy tag's detached release commit maps to OLD_SHA;
+# GitHub says NEW_SHA descends from it, so the 0.0.0-dev sentinel is irrelevant.
+out="$(run_guard 0.19.2 0.0.0-dev 0 '' '' "$NEW_SHA" ahead "$OLD_SHA")"; rc=$?
+if (( rc == 0 )) && [[ "$out" == *"__DIRECTION=forward __INSTALLED_SHA=$OLD_SHA __CANDIDATE_SHA=$NEW_SHA"* && "$out" != *"DOWNGRADE"* && "$out" != *"refusing"* ]]; then
+  ok_t "published legacy -> current main PROCEEDS by ancestry, despite 0.0.0-dev"
+else
+  bad_t "current main was mistaken for a downgrade" "rc=$rc out: ${out//$'\n'/ | }"
+fi
+
+# A candidate whose stamped build is an ancestor of the installed build is the
+# real rollback. The refusal names identities, not misleading version numbers.
+out="$(run_guard 0.0.0-dev 0.0.0-dev 0 '' "$NEW_SHA" "$OLD_SHA" behind)"; rc=$?
+if (( rc != 0 )) && [[ "$out" == *"candidate $OLD_SHA is an ancestor of installed $NEW_SHA"* ]]; then
+  ok_t "ancestor candidate REFUSED, naming both build shas"
+else
+  bad_t "identity rollback was not refused" "rc=$rc out: ${out//$'\n'/ | }"
+fi
+
+out="$(run_guard 0.0.0-dev 0.0.0-dev 1 '' "$NEW_SHA" "$OLD_SHA" behind)"; rc=$?
+if (( rc == 0 )) && [[ "$out" == *"ROLLBACK build $NEW_SHA -> $OLD_SHA"* && "$out" == *"FIVE_ALLOW_DOWNGRADE=1"* ]]; then
+  ok_t "the explicit hatch permits and announces an identity rollback"
+else
+  bad_t "identity rollback hatch failed" "rc=$rc out: ${out//$'\n'/ | }"
+fi
 
 # 1. THE DEFECT: a strictly lower candidate is refused, and the refusal names
 #    both versions and where the lower one came from.
@@ -130,32 +187,57 @@ fi
 # --- the printed line -------------------------------------------------------
 # The report is what made this invisible: it asserted a direction nothing had
 # measured. Run the shipped branch verbatim with old/new pinned.
-run_report() { # $1=_old_ver $2=_new_ver
+run_report() { # old-ver new-ver [direction] [old-sha] [new-sha]
   env -i PATH="/usr/bin:/bin" bash -c "set -euo pipefail
 $(sed -n '/^# >>> DIVE-2243 monotonicity guard/,/^# <<< DIVE-2243 monotonicity guard/p' install.sh)
 _old_ver='$1'; _new_ver='$2'; BIN_DIR='$TD'
+INSTALL_DIRECTION='${3:-unchecked}'; INSTALL_INSTALLED_SHA='${4:-}'; INSTALL_CANDIDATE_SHA='${5:-}'
 $report" 2>&1
 }
 
-out="$(run_report 0.16.33 0.16.32)"
+out="$(run_report 0.16.33 0.16.32 rollback)"
 if [[ "$out" == *"5dive DOWNGRADED: 0.16.33 -> 0.16.32"* && "$out" != *"upgraded: 0.16.33"* ]]; then
   ok_t "report says DOWNGRADED (never 'upgraded') when the new version is lower"
 else
   bad_t "report announced a downgrade as an upgrade" "out: ${out//$'\n'/ | }"
 fi
 
-out="$(run_report 0.16.32 0.17.0)"
+out="$(run_report 0.16.32 0.17.0 forward)"
 if [[ "$out" == *"5dive upgraded: 0.16.32 -> 0.17.0"* && "$out" != *"DOWNGRADED"* ]]; then
   ok_t "report still says upgraded on a real forward move"
 else
   bad_t "forward move mis-reported" "out: ${out//$'\n'/ | }"
 fi
 
-out="$(run_report 0.16.9 0.16.10)"
+out="$(run_report 0.16.9 0.16.10 forward)"
 if [[ "$out" == *"5dive upgraded: 0.16.9 -> 0.16.10"* && "$out" != *"DOWNGRADED"* ]]; then
   ok_t "report uses version sort (0.16.9 -> 0.16.10 is forward)"
 else
   bad_t "report lexically mis-sorted a forward patch move" "out: ${out//$'\n'/ | }"
+fi
+
+out="$(run_report 0.19.2 0.0.0-dev forward "$OLD_SHA" "$NEW_SHA")"
+if [[ "$out" == *"5dive upgraded:"* && "$out" == *"$OLD_SHA"* && "$out" == *"$NEW_SHA"* && "$out" != *"DOWNGRADED"* ]]; then
+  ok_t "report calls legacy release -> current main an upgrade and names both shas"
+else
+  bad_t "report repeated the false sentinel downgrade" "out: ${out//$'\n'/ | }"
+fi
+
+# The artifact carries the checkout identity build.sh actually read, while the
+# split source keeps an unmistakable non-identity sentinel.
+build_out="$TD/built-5dive"
+build_log="$(BUILD_OUT="$build_out" ./build.sh 2>&1)"; rc=$?
+expected_sha="$(git rev-parse HEAD)"
+stamped_sha="$(grep -m1 '^readonly FIVE_BUILD_SHA=' "$build_out" 2>/dev/null | cut -d'"' -f2)"
+if (( rc == 0 )) && [[ "$stamped_sha" == "$expected_sha" && "$build_log" == *"at ${expected_sha:0:12}"* ]]; then
+  ok_t "build.sh stamps the generated bundle with its full source sha"
+else
+  bad_t "bundle build identity is missing or wrong" "rc=$rc expected=$expected_sha stamped=${stamped_sha:-missing} log=$build_log"
+fi
+if grep -qx 'readonly FIVE_BUILD_SHA="unbuilt"' src/header.sh && ! grep -q 'FIVE_BUILD_SHA="unbuilt"' "$build_out"; then
+  ok_t "split source sentinel cannot masquerade as a built artifact identity"
+else
+  bad_t "build/source identity sentinel contract drifted" ""
 fi
 
 # --- wiring -----------------------------------------------------------------

--- a/tests/install_monotonicity_unit.sh
+++ b/tests/install_monotonicity_unit.sh
@@ -107,6 +107,17 @@ else
   bad_t "current main was mistaken for a downgrade" "rc=$rc out: ${out//$'\n'/ | }"
 fi
 
+# The highest-consequence fallback: GitHub ancestry is unavailable (offline or
+# rate-limited), the installed release is real, and the candidate carries the
+# tag-time sentinel. release_version() is the only line preventing the original
+# false DOWNGRADE refusal here, so this case must reach and grade it directly.
+out="$(run_guard 0.18.0 0.0.0-dev 0 '' '' "$NEW_SHA" '' "$OLD_SHA")"; rc=$?
+if (( rc == 0 )) && [[ "$out" == *"__DIRECTION=unchecked __INSTALLED_SHA=$OLD_SHA __CANDIDATE_SHA=$NEW_SHA"* && "$out" == *"release versions not comparable"* && "$out" != *"refusing to DOWNGRADE"* ]]; then
+  ok_t "ancestry unavailable + sentinel candidate PROCEEDS through the version fallback"
+else
+  bad_t "sentinel fallback recreated the false downgrade" "rc=$rc out: ${out//$'\n'/ | }"
+fi
+
 # A candidate whose stamped build is an ancestor of the installed build is the
 # real rollback. The refusal names identities, not misleading version numbers.
 out="$(run_guard 0.0.0-dev 0.0.0-dev 0 '' "$NEW_SHA" "$OLD_SHA" behind)"; rc=$?
@@ -228,16 +239,42 @@ fi
 build_out="$TD/built-5dive"
 build_log="$(BUILD_OUT="$build_out" ./build.sh 2>&1)"; rc=$?
 expected_sha="$(git rev-parse HEAD)"
+expected_identity="$expected_sha"
+[[ -z "$(git status --porcelain --untracked-files=normal)" ]] || expected_identity="${expected_sha}-dirty"
 stamped_sha="$(grep -m1 '^readonly FIVE_BUILD_SHA=' "$build_out" 2>/dev/null | cut -d'"' -f2)"
-if (( rc == 0 )) && [[ "$stamped_sha" == "$expected_sha" && "$build_log" == *"at ${expected_sha:0:12}"* ]]; then
-  ok_t "build.sh stamps the generated bundle with its full source sha"
+if (( rc == 0 )) && [[ "$stamped_sha" == "$expected_identity" && "$build_log" == *"at ${expected_sha:0:12}"* ]]; then
+  ok_t "build.sh stamps the generated bundle with its honest source identity"
 else
-  bad_t "bundle build identity is missing or wrong" "rc=$rc expected=$expected_sha stamped=${stamped_sha:-missing} log=$build_log"
+  bad_t "bundle build identity is missing or wrong" "rc=$rc expected=$expected_identity stamped=${stamped_sha:-missing} log=$build_log"
 fi
 if grep -qx 'readonly FIVE_BUILD_SHA="unbuilt"' src/header.sh && ! grep -q 'FIVE_BUILD_SHA="unbuilt"' "$build_out"; then
   ok_t "split source sentinel cannot masquerade as a built artifact identity"
 else
   bad_t "build/source identity sentinel contract drifted" ""
+fi
+
+# A dirty checkout must not claim its clean HEAD. Clone the committed fixture,
+# copy in this harness's build.sh (so an uncommitted maker run grades the new
+# code too), dirty a bundle input, and inspect the artifact it really produces.
+dirty_repo="$TD/dirty-repo"
+git clone -q "$ROOT" "$dirty_repo"
+cp "$ROOT/build.sh" "$dirty_repo/build.sh"
+printf '\n# dirty fixture\n' >> "$dirty_repo/src/header.sh"
+dirty_head="$(git -C "$dirty_repo" rev-parse HEAD)"
+dirty_out="$TD/dirty-5dive"
+dirty_log="$(cd "$dirty_repo" && BUILD_OUT="$dirty_out" ./build.sh 2>&1)"; rc=$?
+dirty_stamp="$(grep -m1 '^readonly FIVE_BUILD_SHA=' "$dirty_out" 2>/dev/null | cut -d'"' -f2)"
+if (( rc == 0 )) && [[ "$dirty_stamp" == "${dirty_head}-dirty" ]]; then
+  ok_t "dirty tree is stamped sha-dirty instead of claiming clean HEAD"
+else
+  bad_t "dirty tree claimed a clean build identity" "rc=$rc head=$dirty_head stamp=${dirty_stamp:-missing} log=$dirty_log"
+fi
+
+out="$(run_guard 0.18.0 0.18.1 0 '' '' "${NEW_SHA}-dirty")"; rc=$?
+if (( rc == 0 )) && [[ "$out" == *"__DIRECTION=forward __INSTALLED_SHA= __CANDIDATE_SHA="* && "$out" != *"refusing to DOWNGRADE"* ]]; then
+  ok_t "install guard rejects a sha-dirty stamp and uses the safe fallback"
+else
+  bad_t "install guard trusted a dirty build identity" "rc=$rc out: ${out//$'\n'/ | }"
 fi
 
 # --- wiring -----------------------------------------------------------------

--- a/tests/release_cut_bundle_unit.sh
+++ b/tests/release_cut_bundle_unit.sh
@@ -50,7 +50,7 @@ run_block(){ # $1 = build.sh body, $2 = tag ; prints output, returns the block's
     # so the tree must carry the sentinel the real main carries. Seeding it here is
     # what lets the extracted bytes be run as-shipped rather than around the bump.
     mkdir -p src; printf 'readonly FIVE_VERSION="0.0.0-dev"\n' > src/header.sh
-    git add src/header.sh build.sh
+    git add src/header.sh build.sh .gitignore
     git -c user.name=t -c user.email=a@b commit -q -m seed2
   ) >/dev/null 2>&1
   ( cd "$d"
@@ -67,7 +67,7 @@ run_block(){ # $1 = build.sh body, $2 = tag ; prints output, returns the block's
 GOOD='#!/usr/bin/env bash
 # stands in for the real build.sh: the bundle takes its version FROM src/header.sh,
 # so a bump that did not land shows up as a bundle carrying the sentinel.
-printf "%s\n" "#!/usr/bin/env bash" "$(grep -m1 "^readonly FIVE_VERSION=" src/header.sh)" "true" > 5dive
+printf "%s\n" "#!/usr/bin/env bash" "$(grep -m1 "^readonly FIVE_VERSION=" src/header.sh)" "readonly FIVE_BUILD_SHA=\"$(git rev-parse HEAD)\"" "true" > 5dive
 sha256sum 5dive | cut -d" " -f1 > 5dive.sha256'
 NOBUNDLE='#!/usr/bin/env bash
 true'
@@ -104,6 +104,9 @@ out=$(run_block "$GOOD" v9.9.9); rc=$?
 grep -q 'release commit .* carries bundle' <<<"$out" \
   && ok_t 'the accepted cut names the bundle it committed' \
   || bad_t 'accepted cut must state what it published' "out=$out"
+grep -qE 'FIVE_BUILD_SHA=[0-9a-f]{40}' <<<"$out" \
+  && ok_t 'the accepted bundle names the clean source commit it was built from' \
+  || bad_t 'accepted cut must carry a usable build identity' "out=$out"
 
 echo "-- the bundle must not be tracked on main (the defect this ticket removed)"
 for f in 5dive 5dive.sha256; do
@@ -186,6 +189,30 @@ out=$(run_mutant); rc=$?
 grep -q '0\.0\.0-dev' <<<"$out" \
   && ok_t 'and it names the sentinel it refused to publish' \
   || ok_t 'refused (message does not name the sentinel, which is acceptable)'
+
+echo "-- DIVE-2603: the version assignment must be committed before build.sh stamps HEAD"
+SOURCE_COMMIT_MUTANT=$(printf '%s\n' "$BLOCK" | awk '
+  /git -c user.name=lodar -c user.email=markounik@gmail.com \\$/ {
+    first=$0
+    if ((getline second) > 0 && second ~ /commit -q -m "release \$\{tag\}: assign \$\{version\} before bundle build/) {
+      print ":"
+      next
+    }
+    print first
+    print second
+    next
+  }
+  { print }
+')
+[[ "$SOURCE_COMMIT_MUTANT" != "$BLOCK" ]] || bad_t 'source-commit mutation did not change the block (anchor drifted)' ''
+MUTANT="$SOURCE_COMMIT_MUTANT"
+out=$(run_mutant); rc=$?
+[[ $rc -ne 0 ]] \
+  && ok_t 'removing the pre-build source commit makes the extracted release cut REFUSE' \
+  || bad_t 'release cut built from an uncommitted version assignment — every published stamp would be dirty or false' "rc=$rc out=$out"
+grep -q 'tracked release source is dirty' <<<"$out" \
+  && ok_t 'the refusal names the dirty tracked source rather than publishing an inert identity' \
+  || bad_t 'source-commit mutant failed for an unrelated reason' "out=$out"
 
 echo "-- and main itself must carry the sentinel, not a real version"
 _hdr=$(grep -m1 -oE '^readonly FIVE_VERSION="[^"]+"' "$ROOT/src/header.sh" | cut -d'"' -f2)


### PR DESCRIPTION
`install.sh` compared a version string that tag-time assignment has already emptied, so the
monotonicity check it performs was comparing against nothing. This stamps the bundle with its
build sha and compares **identity** instead of a string that is empty by construction on a
release commit.

Touches `build.sh`, `install.sh`, `src/header.sh` and `tests/install_monotonicity_unit.sh`.

## Grading — VERIFIER PASS (main2), iteration 3

Two earlier iterations were **rejected**, and the rejections are why this is worth trusting:

- **Iteration 1** — the hermetic curl stub was correct and still left `release_version()` ungraded:
  every sha-path test returned before that code, so mutating it left the harness at 20/0 while the
  real guard printed the verbatim original defect. *A stub decides what the service **says**, not
  what happens when it is **absent**.*
- **Iteration 2** — `build.sh` stamped `git rev-parse HEAD` with no clean-worktree check, so a
  dirty bundle asserted a sha it did not contain and `install.sh` reasoned about ancestry from it.

Both fixed and mutation-graded at this head, verified from a fresh anonymous clone:

- `install_monotonicity` 23/0, `release_cut_bundle` 23/0.
- Replaying the new release-cut order stamps a clean 40-hex equal to the committed source commit —
  no `-dirty`.
- Four mutants, each red only on its own arm: `release_version` permissive 22/1;
  `bundle_build_sha` accepting `-dirty` 22/1 (where iteration 2 stayed green); dirty-suffix removed
  21/2; pre-build commit deleted makes the block refuse.

## Residuals, named and non-blocking (main2)

1. Released bundles stamp a **detached** release commit, so every future release-to-release
   self-update will log `build identity diverged` before falling back to version ordering. The
   verdict is still correct; the log line will look alarming and is expected.
2. The workflow's `bundle-sha == source-sha` assert is itself **ungraded**.

## Provenance, since the record will not show it

Authored by **codex** across three iterations; committed under `lodar <markounik@gmail.com>` per
this repo's house rule; **pushed by agent-main**, because codex holds no HTTPS GitHub credential.
Graded by **main2**, which holds no gh credential and therefore could not record the close itself —
its merge gate correctly returned COULD-NOT-CHECK and, this time, the substance held too: the
branch genuinely was not in main.

Base predates current `main` (`e93a0c2`); branch protection here is `strict: false`, so no rebase
was owed or performed.

Closes DIVE-2603.
