### PR TITLE
fix(agent): distinguish registry fetch failures from a missing pack (DIVE-2600)

### DIFF
--- a/changelog.d/DIVE-2600.md
+++ b/changelog.d/DIVE-2600.md
@@ -1,0 +1,7 @@
+## Unreleased — fix(agent): report registry fetch failures without claiming a slug is absent (DIVE-2600)
+
+`agent import <slug>` and `agent inspect <slug>` now distinguish a successfully
+fetched index with no matching pack from an unreachable index, a malformed
+index, and a listed pack whose manifest could not be fetched. Transient HTTP or
+transport failures therefore report registry uncertainty instead of the false
+`no pack in the registry` diagnosis.

--- a/src/cmd_pack.sh
+++ b/src/cmd_pack.sh
@@ -42,19 +42,76 @@ _report_import() {
     -d "{\"slug\":\"$slug\"}" >/dev/null 2>&1
 }
 
-_marketplace_index() { curl -fsSL --max-time 20 "$(_marketplace_base)/index.json" 2>/dev/null; }
+# Fetch one required marketplace object while preserving the failure class.
+# Returns: 0=2xx, 1=HTTP 404, 2=other HTTP non-2xx, 3=timeout, 4=transport.
+_marketplace_get_required() {
+  local url="$1" out="$2" http rc
+  if http=$(curl -sSL --max-time 20 -o "$out" -w '%{http_code}' "$url" 2>/dev/null); then
+    case "$http" in
+      2??) return 0 ;;
+      404) return 1 ;;
+      *)   return 2 ;;
+    esac
+  else
+    rc=$?
+    (( rc == 28 )) && return 3
+    return 4
+  fi
+}
+
+_marketplace_index() {
+  local tmp rc
+  tmp=$(mktemp)
+  if _marketplace_get_required "$(_marketplace_base)/index.json" "$tmp"; then
+    cat "$tmp"
+    rm -f "$tmp"
+    return 0
+  else
+    rc=$?
+    rm -f "$tmp"
+    return "$rc"
+  fi
+}
 
 # Resolve registry pack <slug> → a local .tar.gz (same shape `agent export` writes,
-# so cmd_import's existing flow is unchanged). Echoes the path; returns 1 if absent.
+# so cmd_import's existing flow is unchanged). Echoes the path. The return value
+# deliberately preserves WHICH registry step failed so callers never turn a
+# transient fetch failure into the much stronger claim that the slug does not exist:
+#   1 = the fetched, valid index has no such slug
+#   2/3/4/5 = index HTTP 404 / other non-2xx / timeout / transport
+#   6 = the fetched index is malformed
+#   7/8/9/10 = manifest HTTP 404 / other non-2xx / timeout / transport
+#   11 = the fetched files could not be assembled locally
 _marketplace_fetch_pack() {
-  local slug="$1" base idx entry path
+  local slug="$1" base idx entry path rc
   base=$(_marketplace_base)
-  idx=$(_marketplace_index) || return 1
+  if idx=$(_marketplace_index); then
+    :
+  else
+    rc=$?
+    case "$rc" in
+      1) return 2 ;;
+      2) return 3 ;;
+      3) return 4 ;;
+      *) return 5 ;;
+    esac
+  fi
+  jq -e '.packs | type == "array"' >/dev/null 2>&1 <<<"$idx" || return 6
   entry=$(jq -e --arg s "$slug" '.packs[] | select(.slug==$s)' <<<"$idx" 2>/dev/null) || return 1
-  path=$(jq -r '.path // empty' <<<"$entry"); [[ -n "$path" ]] || return 1
+  path=$(jq -r '.path // empty' <<<"$entry"); [[ -n "$path" ]] || return 6
   local dl; dl=$(mktemp -d)
-  curl -fsSL --max-time 20 "$base/$path/manifest.json" -o "$dl/manifest.json" 2>/dev/null \
-    || { rm -rf "$dl"; return 1; }
+  if _marketplace_get_required "$base/$path/manifest.json" "$dl/manifest.json"; then
+    :
+  else
+    rc=$?
+    rm -rf "$dl"
+    case "$rc" in
+      1) return 7 ;;
+      2) return 8 ;;
+      3) return 9 ;;
+      *) return 10 ;;
+    esac
+  fi
   local f
   for f in CLAUDE.md card.md avatar.png; do
     curl -fsSL --max-time 20 "$base/$path/$f" -o "$dl/$f" 2>/dev/null || true
@@ -92,8 +149,28 @@ _marketplace_fetch_pack() {
     done < <(jq -r '.memoryFiles[]? // empty' "$dl/manifest.json" 2>/dev/null)
   fi
   local out; out=$(mktemp --suffix=.tar.gz)
-  tar -czf "$out" -C "$dl" . 2>/dev/null || { rm -rf "$dl" "$out"; return 1; }
+  tar -czf "$out" -C "$dl" . 2>/dev/null || { rm -rf "$dl" "$out"; return 11; }
   rm -rf "$dl"; echo "$out"
+}
+
+# Render the classified fetch failure. Kept in one helper because both the
+# read-only inspect path and the provisioning import path resolve registry slugs.
+_marketplace_fetch_pack_fail() {
+  local slug="$1" rc="$2"
+  case "$rc" in
+    1) fail "$E_NOT_FOUND" "no pack '$slug' in the registry index (browse: 5dive agent marketplace ls)" ;;
+    2) fail "$E_NOT_FOUND" "character-pack registry index returned HTTP 404 ($(_marketplace_base)/index.json)" ;;
+    3) fail "$E_GENERIC" "character-pack registry index returned a non-2xx HTTP response ($(_marketplace_base)/index.json)" ;;
+    4) fail "$E_GENERIC" "timed out fetching the character-pack registry index ($(_marketplace_base)/index.json)" ;;
+    5) fail "$E_GENERIC" "transport failure fetching the character-pack registry index ($(_marketplace_base)/index.json)" ;;
+    6) fail "$E_GENERIC" "character-pack registry index is malformed ($(_marketplace_base))" ;;
+    7) fail "$E_NOT_FOUND" "pack '$slug' is listed in the registry index, but its manifest returned HTTP 404 (registry is inconsistent)" ;;
+    8) fail "$E_GENERIC" "pack '$slug' is listed in the registry index, but its manifest returned a non-2xx HTTP response" ;;
+    9) fail "$E_GENERIC" "pack '$slug' is listed in the registry index, but its manifest fetch timed out" ;;
+    10) fail "$E_GENERIC" "pack '$slug' is listed in the registry index, but its manifest had a transport failure" ;;
+    11) fail "$E_GENERIC" "pack '$slug' was fetched, but could not be assembled locally" ;;
+    *) fail "$E_GENERIC" "could not resolve pack '$slug' from the character-pack registry (unexpected fetch status $rc)" ;;
+  esac
 }
 
 # _pack_skill_refs <skills-dir> -> JSON array of skill specs for the manifest.
@@ -963,8 +1040,13 @@ cmd_inspect() {
   local resolved_tmp=""
   if [[ ! -f "$pack" ]]; then
     if [[ "$pack" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
-      resolved_tmp=$(_marketplace_fetch_pack "$pack") \
-        || fail "$E_NOT_FOUND" "no pack '$pack' in the registry (browse: 5dive agent marketplace ls)"
+      local fetch_rc
+      if resolved_tmp=$(_marketplace_fetch_pack "$pack"); then
+        :
+      else
+        fetch_rc=$?
+        _marketplace_fetch_pack_fail "$pack" "$fetch_rc"
+      fi
       pack="$resolved_tmp"
     else
       fail "$E_NOT_FOUND" "pack not found: $pack"
@@ -1995,8 +2077,13 @@ cmd_import() {
     if [[ "$pack" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
       step "Resolving '$pack' from the character-pack registry"
       import_slug="$pack"   # remember the registry slug for opt-in --report-import
-      resolved_tmp=$(_marketplace_fetch_pack "$pack") \
-        || fail "$E_NOT_FOUND" "no pack '$pack' in the registry (browse: 5dive agent marketplace ls)"
+      local fetch_rc
+      if resolved_tmp=$(_marketplace_fetch_pack "$pack"); then
+        :
+      else
+        fetch_rc=$?
+        _marketplace_fetch_pack_fail "$pack" "$fetch_rc"
+      fi
       pack="$resolved_tmp"
     else
       fail "$E_NOT_FOUND" "pack not found: $pack"

--- a/tests/pack_registry_fetch_errors_unit.sh
+++ b/tests/pack_registry_fetch_errors_unit.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# DIVE-2600 — a registry transport failure must never be reported as evidence
+# that a by-slug pack does not exist. This harness drives the real resolver with
+# deterministic index/curl stubs and grades every classified outcome plus both
+# consumers (inspect and import).
+# TIER: core
+# Run: bash tests/pack_registry_fetch_errors_unit.sh
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.." || exit 1
+
+TMP="$(mktemp -d /tmp/pack-registry-errors.XXXXXX)"
+
+# shellcheck disable=SC1091
+source src/header.sh
+# shellcheck disable=SC1091
+source src/lib/error_codes.sh
+# shellcheck disable=SC1091
+source src/lib/output.sh
+# shellcheck disable=SC1091
+source src/cmd_pack.sh
+set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+check_rc() {
+  local want="$1" label="$2" got
+  shift 2
+  "$@" >/dev/null 2>&1; got=$?
+  if [[ "$got" -eq "$want" ]]; then
+    ok_t "$label"
+  else
+    bad_t "$label" "want=$want got=$got"
+  fi
+}
+
+# 0. Drive the real HTTP seam once: curl rc and HTTP status are separate signals.
+CURL_MODE="ok"
+curl() {
+  local out="" arg prev=""
+  for arg in "$@"; do
+    [[ "$prev" == "-o" ]] && out="$arg"
+    prev="$arg"
+  done
+  case "$CURL_MODE" in
+    ok)        printf '%s' '{"packs":[]}' >"$out"; printf '200' ;;
+    http404)   printf '%s' 'not found' >"$out"; printf '404' ;;
+    http503)   printf '%s' 'unavailable' >"$out"; printf '503' ;;
+    timeout)   return 28 ;;
+    transport) return 7 ;;
+  esac
+}
+OUT=$(_marketplace_index); RC=$?
+[[ $RC -eq 0 && "$OUT" == '{"packs":[]}' ]] \
+  && ok_t "HTTP 200 index returns its body" \
+  || bad_t "HTTP 200 index body" "rc=$RC out=$OUT"
+CURL_MODE=http404;   check_rc 1 "HTTP 404 index has its own status" _marketplace_index
+CURL_MODE=http503;   check_rc 2 "other HTTP non-2xx index has its own status" _marketplace_index
+CURL_MODE=timeout;   check_rc 3 "curl timeout remains distinguishable" _marketplace_index
+CURL_MODE=transport; check_rc 4 "curl transport failure remains distinguishable" _marketplace_index
+
+# 1. The index itself did not arrive: each observable failure class remains
+# distinct, and none is turned into evidence that the slug is absent.
+_marketplace_index() { return 3; }
+check_rc 4 "index timeout is classified as registry timeout" \
+  _marketplace_fetch_pack atlas
+_marketplace_index() { return 2; }
+check_rc 3 "index HTTP non-2xx is classified separately from timeout" \
+  _marketplace_fetch_pack atlas
+_marketplace_index() { return 1; }
+check_rc 2 "index HTTP 404 is classified separately from missing slug" \
+  _marketplace_fetch_pack atlas
+_marketplace_index() { return 4; }
+check_rc 5 "index transport failure preserves uncertainty" \
+  _marketplace_fetch_pack atlas
+
+# 2. Only a successfully fetched, structurally valid index can prove absence.
+_marketplace_index() { printf '%s' '{"packs":[]}'; }
+check_rc 1 "valid index without the slug is classified as not found" \
+  _marketplace_fetch_pack atlas
+
+# 3. A response body without the registry's packs array is malformed, not proof
+# of absence (e.g. a proxy error document that still arrived with curl rc 0).
+_marketplace_index() { printf '%s' '{"message":"upstream unavailable"}'; }
+check_rc 6 "malformed index is not classified as missing slug" \
+  _marketplace_fetch_pack atlas
+
+# 4. The slug can be present while its required object fetch fails. That is an
+# inconsistent/unavailable registry object, not "no pack".
+_marketplace_index() {
+  printf '%s' '{"packs":[{"slug":"atlas","path":"packs/atlas"}]}'
+}
+curl() { printf '404'; return 0; }
+check_rc 7 "listed slug with HTTP 404 manifest is an inconsistent registry" \
+  _marketplace_fetch_pack atlas
+curl() { return 28; }
+check_rc 9 "listed slug with manifest timeout stays distinct from absence" \
+  _marketplace_fetch_pack atlas
+curl() { return 7; }
+check_rc 10 "listed slug with manifest transport failure preserves uncertainty" \
+  _marketplace_fetch_pack atlas
+
+# 5. Non-vacuity: the same seam can resolve a pack. The curl stub writes the
+# required manifest; optional registry files may be absent without failing.
+curl() {
+  local out="" arg prev="" write_status=0
+  for arg in "$@"; do
+    [[ "$prev" == "-o" ]] && out="$arg"
+    [[ "$prev" == "-w" ]] && write_status=1
+    prev="$arg"
+  done
+  (( write_status )) || return 22
+  [[ "$out" == */manifest.json ]] || return 22
+  printf '%s' '{"skills":[],"includes":{"memory":false}}' >"$out"
+  printf '200'
+}
+OUT=$(_marketplace_fetch_pack atlas); RC=$?
+if [[ $RC -eq 0 && -f "$OUT" ]] && tar -tzf "$OUT" | grep -q './manifest.json'; then
+  ok_t "valid indexed pack resolves to a readable tarball"
+else
+  bad_t "successful resolution control" "rc=$RC out=$OUT"
+fi
+rm -f "$OUT"
+
+# 6. Creator-facing errors name the measured category. Capture fail() in a
+# subshell because it exits by contract.
+message_for() {
+  (_marketplace_fetch_pack_fail atlas "$1") 2>&1
+}
+OUT=$(message_for 1); RC=$?
+if [[ $RC -eq "$E_NOT_FOUND" && "$OUT" == *"no pack 'atlas' in the registry index"* ]]; then
+  ok_t "absence error says the slug is absent from a fetched index"
+else
+  bad_t "absence error wording" "rc=$RC out=$OUT"
+fi
+
+for classified in \
+  '2|registry index returned HTTP 404' \
+  '3|registry index returned a non-2xx HTTP response' \
+  '4|timed out fetching the character-pack registry index' \
+  '5|transport failure fetching the character-pack registry index' \
+  '6|registry index is malformed' \
+  '7|is listed in the registry index, but its manifest returned HTTP 404' \
+  '8|is listed in the registry index, but its manifest returned a non-2xx HTTP response' \
+  '9|is listed in the registry index, but its manifest fetch timed out' \
+  '10|is listed in the registry index, but its manifest had a transport failure'
+do
+  RC_KIND="${classified%%|*}"; WANT="${classified#*|}"
+  OUT=$(message_for "$RC_KIND"); RC=$?
+  WANT_RC="$E_GENERIC"
+  [[ "$RC_KIND" == 2 || "$RC_KIND" == 7 ]] && WANT_RC="$E_NOT_FOUND"
+  if [[ $RC -eq "$WANT_RC" && "$OUT" == *"$WANT"* && "$OUT" != *"no pack 'atlas'"* ]]; then
+    ok_t "fetch class $RC_KIND reports uncertainty without claiming absence"
+  else
+    bad_t "fetch class $RC_KIND message" "rc=$RC out=$OUT"
+  fi
+done
+
+# 7. Wiring: both by-slug consumers call the shared classified renderer. These
+# assertions pin the two real call sites so a correct but orphan helper is red.
+INSPECT_ARM=$(sed -n '/^cmd_inspect()/,/^}/p' src/cmd_pack.sh)
+IMPORT_ARM=$(sed -n '/^cmd_import()/,/^}/p' src/cmd_pack.sh)
+if [[ "$INSPECT_ARM" == *'_marketplace_fetch_pack_fail "$pack" "$fetch_rc"'* ]]; then
+  ok_t "agent inspect routes resolver failures through the classifier"
+else
+  bad_t "inspect classifier wiring"
+fi
+if [[ "$IMPORT_ARM" == *'_marketplace_fetch_pack_fail "$pack" "$fetch_rc"'* ]]; then
+  ok_t "agent import routes resolver failures through the classifier"
+else
+  bad_t "import classifier wiring"
+fi
+
+echo
+printf 'DIVE-2600 registry fetch classification: %d passed, %d failed\n' "$PASS" "$FAIL"
+(( FAIL == 0 )) || exit 1


### PR DESCRIPTION
`agent`'s registry path conflated *"the registry answered and has no such entry"* with *"the
registry could not be reached"*, so a transport failure read as a missing pack.

## Grading

**Graded PASS by main2** (verifier), maker codex, verified locally:

- New `tests/pack_registry_fetch_errors_unit.sh` **27/27**, `HARNESS-RC=0`.
- All 9 `tests/pack_*.sh` green; `corpus_tier_budget` 80/80, `harness_rc_corpus_contract` 7/7,
  `envelope_tier_provenance` 24/24.
- `shellcheck` clean over the new region (`cmd_pack.sh` 40–180); harness-tree-guard 0; pii-scan clean.
- The three sibling `_marketplace_index` consumers plus `cmd_hire` already said "could not reach"
  and were never affected.
- Bundle is gitignored since DIVE-2091, so no bundle-drift risk.

**Remote CI was UNVERIFIED at grading time** — the branch did not exist on origin, so main2
explicitly did *not* call it ready-to-merge. This PR exists so CI can run on the pushed head;
only that clears the merge.

## Provenance, since the record will not show it

Authored by **codex**; committed under `lodar <markounik@gmail.com>` per this repo's house rule;
**pushed by agent-main**. Both codex and main2 disclosed the same blocker independently — no push
credential (`could not read Username for https://github.com`) — and agent-main is the only route.

Base is `120a083`; `main` has since moved to `aa0e144`. Branch protection here is `strict: false`,
so a non-descended head merges — no rebase performed and none owed.

Refs DIVE-2600.
