### PR TITLE
fix(task): task show exited 1 on every row with no dependency edge (DIVE-2751)

### DIFF
--- a/scripts/scan-trailing-conditional.sh
+++ b/scripts/scan-trailing-conditional.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# DIVE-2751 — find every place a function's EXIT STATUS is supplied by a
+# conditional that is allowed to be false.
+#
+#     render() { ...; [[ -n "$x" ]] && printf '%s\n' "$x"; }
+#
+# The compound returns 1 when the test is false, that becomes the function's rc,
+# and `set -euo pipefail` kills the script at the call site — AFTER the output
+# has already printed. So it reads as success to a human and failure to a script.
+#
+# WHY THIS IS A SCRIPT AND NOT A GREP. Two earlier iterations shipped a regex
+# built from the instances already found, and each time a live instance walked
+# through it:
+#   iteration 1 matched `[[ ]]` + a braced block  -> blind to `(( )) && echo`
+#   iteration 2 tested the last PHYSICAL line     -> blind to a wrapped `&& printf \`
+# Enumerating syntaxes is the defect one level up. So this works from the
+# property instead:
+#
+#   1. join line continuations, so a statement is one record whatever its width;
+#   2. find the statement that SUPPLIES the rc — walk back from the function's
+#      closing brace, and follow a bare `return` back to the statement whose $?
+#      it inherits (a bare `return` is an alias, not a statement of its own);
+#   3. ask whether that statement is an `&&` compound with a real command on the
+#      right and no `||` fallback.
+#
+# Step 3 decides by ELIMINATION, not by listing printers: strip command
+# substitutions, quoted strings and every bracketed test region, and see what
+# `&&` survives. A predicate — `[[ a && b ]]`, `[ -r f ] && [ x = y ]` — reduces
+# to nothing and is excluded structurally, because its consequent was only ever
+# another test. A pipeline is excluded too: its rc comes from the pipe's tail.
+#
+# Anything left over is a genuine judgement call and is named in ALLOWLIST below
+# with the reason, so the guard stays armed instead of being widened until quiet.
+#
+# Usage: scripts/scan-trailing-conditional.sh [file ...]   (default: src/*.sh src/lib/*.sh)
+# Exit 0 = nothing found, 1 = offenders printed to stdout, 2 = could not scan.
+set -uo pipefail
+
+# Deliberate survivors. Each is a contract that is intentionally rc-bearing and
+# whose call sites already absorb it — NOT an instance we could not fix.
+ALLOWLIST='_gate_tier2_floor_term|_compose_create_args|_gate_anon_ok'
+# _gate_tier2_floor_term - value producer; rc 1 means "named no term". Every call
+#   site absorbs it (`|| v=""`), asserted directly in task_show_exit_code_unit.sh.
+# _compose_create_args   - its only caller reads it through a process substitution
+#   (`mapfile -t args < <(...)`), where the rc never reaches errexit.
+# _gate_anon_ok          - a genuine predicate whose consequent happens to be a
+#   `command -v` probe rather than a bracket test, so elimination cannot see it
+#   is a test. Returning "is anonymous access possible" IS its contract.
+
+cd "$(dirname "$0")/.." || { echo "scan: cannot reach repo root" >&2; exit 2; }
+files=("$@")
+if (( ${#files[@]} == 0 )); then
+  shopt -s nullglob
+  files=(src/*.sh src/lib/*.sh)
+  shopt -u nullglob
+fi
+(( ${#files[@]} )) || { echo "scan: no files to scan" >&2; exit 2; }
+
+scan_one() {
+  local f="$1"
+  # Pass 1: join backslash continuations, keeping the FIRST physical line number.
+  awk '
+    { if (cont) { line = line " " $0 } else { line = $0; ln = FNR }
+      if (line ~ /\\$/) { sub(/\\[ \t]*$/, "", line); cont = 1; next }
+      cont = 0
+      printf "%d\t%s\n", ln, line }
+    END { if (cont) printf "%d\t%s\n", ln, line }
+  ' "$f" |
+  # Pass 2: structural walk.
+  awk -v FNAME="$f" -v ALLOW="$ALLOWLIST" '
+    function strip(l,   prev) {
+      # command substitutions, innermost first
+      do { prev = l; sub(/\$\([^()]*\)/, " ", l) } while (l != prev)
+      gsub(/\x27[^\x27]*\x27/, " ", l)          # single-quoted
+      gsub(/"[^"]*"/, " ", l)                   # double-quoted
+      do { prev = l; sub(/\[\[.*?\]\]/, " ", l) } while (l != prev)
+      do { prev = l; sub(/\(\([^()]*\)\)/, " ", l) } while (l != prev)
+      do { prev = l; sub(/\[ [^]]*\]/, " ", l) } while (l != prev)
+      return l
+    }
+    # Does this statement hand a false-able status to whoever inherits it?
+    function offends(raw,   s, rhs) {
+      if (raw ~ /^[ \t]*(if|while|until|elif)[ \t]/) return 0  # rc is the branch taken
+      s = strip(raw)
+      if (s !~ /&&/) return 0                    # no top-level && survived -> predicate
+      if (s ~ /\|\|/) return 0                   # a fallback makes it always succeed
+      if (s ~ /(^|[^|])\|([^|]|$)/) return 0     # pipeline: rc is the pipe tail
+      if (s ~ /(^|[; \t])(return|exit)([ \t;]|$)/) return 0   # status stated explicitly
+      rhs = s; sub(/^.*&&/, "", rhs)
+      gsub(/[ \t]/, "", rhs)
+      return (rhs != "")                         # a real command on the right
+    }
+    function noise(s) { return (s == "" || s ~ /^#/ || s == "fi" || s == "done" ||
+                                s == "esac" || s == "else" || s == ";;" || s == "}") }
+    function report(i, why,   nm) {
+      nm = fn
+      if (nm ~ "^(" ALLOW ")$") return
+      printf "%s:%d  %s  [%s]\n    %s\n", FNAME, lno[i], nm, why, substr(txt[i], 1, 120)
+      found = 1
+    }
+    { ln = $1; sub(/^[0-9]+\t/, "") }
+    /^[a-zA-Z_][a-zA-Z0-9_]*[ \t]*\([ \t]*\)[ \t]*\{/ {
+      fn = $0; sub(/[ \t]*\(.*/, "", fn); inf = 1; n = 0; next
+    }
+    inf && /^\}/ {
+      # (a) the statement that supplies the function rc
+      i = n
+      while (i >= 1) {
+        s = txt[i]; gsub(/[ \t]/, "", s)
+        if (noise(s)) { i--; continue }
+        if (s == "return" || s == "return;") { i--; continue }   # alias, keep walking
+        if (offends(txt[i])) report(i, "function rc")
+        break
+      }
+      inf = 0; next
+    }
+    inf {
+      n++; txt[n] = $0; lno[n] = ln
+      # (b) every bare `return` inherits $? from the statement before it — this is
+      # the early-return path a walk-back from `}` can never reach.
+      s = $0; gsub(/[ \t]/, "", s)
+      if (s == "return" || s == "return;") {
+        j = n - 1
+        while (j >= 1) {
+          t = txt[j]; gsub(/[ \t]/, "", t)
+          if (noise(t)) { j--; continue }
+          if (offends(txt[j])) report(j, "bare return inherits this")
+          break
+        }
+      }
+    }
+    END { exit 0 }
+  '
+}
+
+rc=0
+for f in "${files[@]}"; do
+  [[ -r "$f" ]] || { echo "scan: cannot read $f" >&2; exit 2; }
+  out=$(scan_one "$f") || { echo "scan: awk failed on $f" >&2; exit 2; }
+  if [[ -n "$out" ]]; then printf '%s\n' "$out"; rc=1; fi
+done
+exit "$rc"

--- a/scripts/scan-trailing-conditional.sh
+++ b/scripts/scan-trailing-conditional.sh
@@ -32,22 +32,50 @@
 # Anything left over is a genuine judgement call and is named in ALLOWLIST below
 # with the reason, so the guard stays armed instead of being widened until quiet.
 #
-# Usage: scripts/scan-trailing-conditional.sh [file ...]   (default: src/*.sh src/lib/*.sh)
+# SECOND MODE — `--call-sites`. An allowlist entry is only as good as the reason
+# it rests on, and iteration 3 shipped a false one: "every call site absorbs it"
+# had been checked by a grep anchored to the start of the line, so an unguarded
+# assignment written `local v; v=$(f ...)` was invisible to it while a guarded one
+# four lines away matched. Same failure mode as the two blind detectors above,
+# moved one level out — into the justification. So the justification is checked by
+# this script too: `--call-sites` masks quotes and command-substitution bodies,
+# splits on TOP-LEVEL `;` (a statement is not a line, in either direction), and
+# asks of each statement whether the substitution's rc can become the statement's.
+#
+# Usage: scripts/scan-trailing-conditional.sh [--call-sites] [file ...]
+#        (default file set: src/*.sh src/lib/*.sh src/council/*.sh scripts/*.sh
+#         plus the customer-facing runners)
 # Exit 0 = nothing found, 1 = offenders printed to stdout, 2 = could not scan.
 set -uo pipefail
 
 # Deliberate survivors. Each is a contract that is intentionally rc-bearing and
-# whose call sites already absorb it — NOT an instance we could not fix.
+# whose call sites already absorb it — NOT an instance we could not fix. Re-audited
+# call site by call site in iteration 4; `--call-sites` is what keeps these honest.
 ALLOWLIST='_gate_tier2_floor_term|_compose_create_args|_gate_anon_ok'
-# _gate_tier2_floor_term - value producer; rc 1 means "named no term". Every call
-#   site absorbs it (`|| v=""`), asserted directly in task_show_exit_code_unit.sh.
-# _compose_create_args   - its only caller reads it through a process substitution
-#   (`mapfile -t args < <(...)`), where the rc never reaches errexit.
+# _gate_tier2_floor_term - value producer; rc 1 means "named no term". FIVE call
+#   sites in src/cmd_task.sh: 7208 and 7210 absorb with `|| _floor_term=""`, 8299
+#   the same; the Rule 3 site in cmd_task_need and the `_fbt` string assembly did
+#   NOT until iteration 4 and now do. The claim is asserted by `--call-sites`
+#   below, run from task_show_exit_code_unit.sh — not by a grep, and not by prose.
+# _compose_create_args   - one call site, cmd_compose.sh:421, read through a
+#   process substitution (`mapfile -t args < <(...)`) where the rc never reaches
+#   errexit. Re-checked: `_compose_create_args` appears nowhere else in the tree.
 # _gate_anon_ok          - a genuine predicate whose consequent happens to be a
 #   `command -v` probe rather than a bracket test, so elimination cannot see it
-#   is a test. Returning "is anonymous access possible" IS its contract.
+#   is a test. Returning "is anonymous access possible" IS its contract. Two call
+#   sites, both predicate-context: cmd_task.sh:1757 is the last statement of
+#   _gate_gh_reachable (itself a predicate, so the rc is the answer) and 1989 is
+#   `_gate_anon_ok || return 1`.
 
 cd "$(dirname "$0")/.." || { echo "scan: cannot reach repo root" >&2; exit 2; }
+MODE=trailing
+while [[ ${1:-} == --* ]]; do
+  case "$1" in
+    --call-sites) MODE=callsites; shift ;;
+    --trailing)   MODE=trailing;  shift ;;
+    *) echo "scan: unknown option $1" >&2; exit 2 ;;
+  esac
+done
 files=("$@")
 if (( ${#files[@]} == 0 )); then
   shopt -s nullglob
@@ -145,10 +173,116 @@ scan_one() {
   '
 }
 
+# ---- mode 2: are the ALLOWLIST contracts actually absorbed where they are CALLED? ----
+# The rc of `v=$(f)` IS f's rc — and so is the rc of `v="text $(f) more"`, because
+# an assignment inherits its LAST command substitution. Neither is visible to a
+# detector that classifies the left side of `&&`, and neither is findable by a
+# pattern anchored to the start of a line. Decided by elimination again:
+#   * mask quoted regions and command-substitution BODIES to same-length filler,
+#     so every `;` `&&` `||` found in the mask is top level by construction;
+#   * cut the record into statements at those `;` — this is the whole point: the
+#     escapee was the second statement of `local v; v=$(f ...)`;
+#   * strip leading `then/else/do/{/!` and split each statement into && / || operands;
+#   * an operand that is a bare ASSIGNMENT containing the call, with no top-level
+#     `||` after it, is where the rc leaks. Everything else falls out structurally:
+#     a test operand's rc is the test, a `local`/`export` prefix returns the
+#     BUILTIN's status, and a call passed as an ARGUMENT hands its rc to the outer
+#     command, not to the statement.
+scan_call_sites_one() {
+  local f="$1"
+  awk '
+    { if (cont) { line = line " " $0 } else { line = $0; ln = FNR }
+      if (line ~ /\\$/) { sub(/\\[ \t]*$/, "", line); cont = 1; next }
+      cont = 0
+      printf "%d\t%s\n", ln, line }
+    END { if (cont) printf "%d\t%s\n", ln, line }
+  ' "$f" |
+  awk -v FNAME="$f" -v ALLOW="$ALLOWLIST" '
+    BEGIN { SQ = sprintf("%c", 39) }
+    # same length as the input, with quotes and $( ) bodies blanked
+    function mask(l,   i,c,n,out,inq,ind,depth) {
+      n = length(l); out = ""; inq = 0; ind = 0; depth = 0
+      for (i = 1; i <= n; i++) {
+        c = substr(l, i, 1)
+        if (depth > 0) {
+          if (c == "(") depth++; else if (c == ")") depth--
+          out = out "."; continue
+        }
+        if (inq) { if (c == SQ) inq = 0; out = out "."; continue }
+        if (ind) { if (c == "\"") ind = 0; out = out "."; continue }
+        if (c == SQ)   { inq = 1; out = out "."; continue }
+        if (c == "\"") { ind = 1; out = out "."; continue }
+        if (c == "$" && substr(l, i+1, 1) == "(") { depth = 1; out = out ".."; i++; continue }
+        out = out c
+      }
+      return out
+    }
+    function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
+    function dekeyword(s) {
+      while (s ~ /^[ \t]*(then|else|do|\{|!)([ \t]|$)/) sub(/^[ \t]*(then|else|do|\{|!)[ \t]*/, "", s)
+      return trim(s)
+    }
+    # rc of this operand comes from the call itself?
+    function leaks(op) {
+      op = dekeyword(op)
+      if (op ~ /^(if|elif|while|until|case|for)([ \t]|$)/) return 0   # condition context
+      if (op ~ /^(\[\[|\(\(|\[)([ \t]|$)/) return 0                  # rc is the test
+      if (op ~ /^(local|declare|typeset|export|readonly)[ \t]/) return 0  # builtin rc
+      if (op !~ /^[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?\+?=/) return 0   # argument to a command
+      return 1
+    }
+    { ln = $1; sub(/^[0-9]+\t/, "") }
+    {
+      raw = $0
+      if (raw ~ /^[ \t]*#/) next
+      if (raw !~ ("\\$\\((" ALLOW ")([ \t)]|$)")) next
+      m = mask(raw)
+      # cut into statements on top-level ;
+      nstmt = 0; start = 1
+      for (i = 1; i <= length(m); i++) {
+        if (substr(m, i, 1) == ";") {
+          nstmt++; stmt[nstmt] = substr(raw, start, i - start); smask[nstmt] = substr(m, start, i - start)
+          start = i + 1
+        }
+      }
+      nstmt++; stmt[nstmt] = substr(raw, start); smask[nstmt] = substr(m, start)
+      for (s = 1; s <= nstmt; s++) {
+        if (stmt[s] !~ ("\\$\\((" ALLOW ")([ \t)]|$)")) continue
+        # split the statement into && / || operands, remembering where the || are
+        nop = 0; ostart = 1; sawpipe = 0; hit = 0
+        sm = smask[s]
+        for (i = 1; i <= length(sm) - 1; i++) {
+          op2 = substr(sm, i, 2)
+          if (op2 == "&&" || op2 == "||") {
+            nop++; opnd[nop] = substr(stmt[s], ostart, i - ostart); okind[nop] = op2
+            ostart = i + 2; i++
+          }
+        }
+        nop++; opnd[nop] = substr(stmt[s], ostart); okind[nop] = ""
+        for (o = 1; o <= nop; o++) {
+          if (opnd[o] !~ ("\\$\\((" ALLOW ")([ \t)]|$)")) continue
+          if (!leaks(opnd[o])) continue
+          # a top-level || anywhere after this operand absorbs the status
+          sawpipe = 0
+          for (k = o; k <= nop; k++) if (okind[k] == "||") sawpipe = 1
+          if (sawpipe) continue
+          printf "%s:%d  rc of an allowlisted call is not absorbed\n    %s\n", FNAME, ln, substr(trim(opnd[o]), 1, 120)
+          hit = 1
+        }
+      }
+    }
+    END { exit 0 }
+  '
+}
+
 rc=0
 for f in "${files[@]}"; do
   [[ -r "$f" ]] || { echo "scan: cannot read $f" >&2; exit 2; }
-  out=$(scan_one "$f") || { echo "scan: awk failed on $f" >&2; exit 2; }
+  if [[ "$MODE" == callsites ]]; then
+    out=$(scan_call_sites_one "$f") || { echo "scan: awk failed on $f" >&2; exit 2; }
+  else
+    out=$(scan_one "$f") || { echo "scan: awk failed on $f" >&2; exit 2; }
+  fi
   if [[ -n "$out" ]]; then printf '%s\n' "$out"; rc=1; fi
 done
 exit "$rc"

--- a/scripts/scan-trailing-conditional.sh
+++ b/scripts/scan-trailing-conditional.sh
@@ -51,7 +51,19 @@ cd "$(dirname "$0")/.." || { echo "scan: cannot reach repo root" >&2; exit 2; }
 files=("$@")
 if (( ${#files[@]} == 0 )); then
   shopt -s nullglob
-  files=(src/*.sh src/lib/*.sh)
+  # src/council/*.template.sh is in the default set on purpose: src/cmd_council.sh
+  # is GENERATED from it, so guarding only the derived artifact is silently
+  # reverted by the next regen — the DIVE-2604 lesson, same file pair.
+  # install/update/build are the customer-facing runners that call into these
+  # functions (paperclip_seed_all_from_registry is reached from update.sh), and
+  # they run under `set -e` themselves.
+  # Literal names are filtered by existence — `install.sh` is present, `update.sh`
+  # ships from elsewhere. An ABSENT default is not the same event as an
+  # UNREADABLE argument: the caller naming a file it cannot read is exit 2.
+  files=()
+  for f in src/*.sh src/lib/*.sh src/council/*.sh scripts/*.sh install.sh update.sh build.sh; do
+    [[ -r "$f" ]] && files+=("$f")
+  done
   shopt -u nullglob
 fi
 (( ${#files[@]} )) || { echo "scan: no files to scan" >&2; exit 2; }

--- a/src/cmd_agent_create.sh
+++ b/src/cmd_agent_create.sh
@@ -793,6 +793,9 @@ link_agent_profile() {
   # this lib is also sourced in contexts without cmd_auth.sh.
   declare -F normalize_profile_seed_perms >/dev/null 2>&1 \
     && normalize_profile_seed_perms "$profile"
+  return 0   # DIVE-2751: the guard above is the point — in a context WITHOUT
+             # cmd_auth.sh the declare fails, and as the last statement that
+             # false test became this function's rc at five bare call sites.
 }
 
 # Write a BYO (bring-your-own) API-key credential for hermes/openclaw into

--- a/src/cmd_auth.sh
+++ b/src/cmd_auth.sh
@@ -887,6 +887,8 @@ paperclip_unseed_for_profile() {
       | .[0].value.authProfile // empty' <<<"$reg")
     [[ -n "$fallback_profile" ]] && paperclip_seed_for_type "$t" "$fallback_profile"
   done
+  return 0   # DIVE-2751: a for-loop returns its LAST iteration's status, so
+             # `claude` having no fallback profile made the whole unseed fail.
 }
 
 # paperclip_seed_all_from_registry — backfill the host-default credential
@@ -904,6 +906,9 @@ paperclip_seed_all_from_registry() {
       | .[0].value.authProfile // empty' <<<"$reg")
     [[ -n "$profile" ]] && paperclip_seed_for_type "$t" "$profile"
   done
+  return 0   # DIVE-2751: LIVE — main.sh:738 calls this bare under `paperclip-seed`
+             # (invoked from update.sh), and the loop's last iteration is `claude`,
+             # so a host with no claude auth profile exited 1 before the ok() line.
 }
 
 # profile_set_var <profile> <VAR> <VALUE> — idempotent KEY=VALUE upsert in

--- a/src/cmd_project.sh
+++ b/src/cmd_project.sh
@@ -193,7 +193,8 @@ cmd_project_show() {
   # --- DIVE-981 dependency graph + critical path ---
   if (( edges == 0 )); then
     (( n > 0 )) && printf '\nDependency graph: no task_deps recorded (%s independent task(s)).\n' "$n"
-    return
+    return 0   # DIVE-2751: a BARE `return` inherits $? from the line above, so a
+               # project with zero tasks rendered in full and then exited 1.
   fi
   printf '\nDependency graph  (%s task(s), %s layer(s), %s edge(s); \xe2\x97\x86 = critical path)\n\n' \
          "$n" "$layers" "$edges"
@@ -209,4 +210,6 @@ cmd_project_show() {
   done < <(printf '%s' "$graph" | jq -r '.[] | [.ident, .status, .title, (.layer|tostring), (.critical|tostring), .blockers] | @tsv')
   [[ -n "$chain" ]] && printf '\nCritical path:  %s  (%s step(s))\n' \
     "$chain" "$(( $(printf '%s' "$chain" | grep -o ' -> ' | wc -l) + 1 ))"
+  return 0   # DIVE-2751: a render that reached the end succeeded, whatever the
+             # last conditional chose not to print.
 }

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -7382,7 +7382,20 @@ cmd_task_need() {
         # Rule 3: a non-appealable class (money / real comms / irreversible infra)
         # is present. Name the surviving term so the refusal is actionable rather
         # than mysterious — the filer can see it is not the word they meant.
-        local _dd_term; _dd_term=$(_gate_tier2_floor_term "$_dd_residual")
+        # DIVE-2751 iteration 4 (main2): TWO defects on the one line this replaces.
+        # `$_dd_residual` occurred exactly ONCE in the whole repo — here — so it
+        # has never held a value: under `set -u` the substitution died "unbound
+        # variable" and the plain assignment inherited its rc, aborting `task need`
+        # with no message on the Rule 3 path. And the term must be read off the
+        # residual that ACTUALLY hit; concatenating the two would re-open the
+        # phantom seam match the DIVE-2224 comment above forbids, so this mirrors
+        # _gate_hit_either's own order (ask first, then title) and absorbs the rc.
+        local _dd_term=""
+        if _gate_tier2_floor_hit "$_dd_res_ask"; then
+          _dd_term=$(_gate_tier2_floor_term "$_dd_res_ask" 2>/dev/null) || _dd_term=""
+        else
+          _dd_term=$(_gate_tier2_floor_term "$_dd_res_title" 2>/dev/null) || _dd_term=""
+        fi
         warn "--discusses REFUSED: this gate names a non-appealable category (matched '${_dd_term}'). Money, outbound customer comms and irreversible infra/access stay hard-human however they are framed. Staying at tier 2."
       else
         local _dd_reviewer; _dd_reviewer=$(_gate_route_reviewer "$(task_actor "")")   # DIVE-2518: tier-flag only; see note above
@@ -8092,8 +8105,19 @@ cmd_task_need() {
         # TITLE, say so HERE. A stderr warn is not the durable surface -- the routed
         # reviewer reads this line, and "escalate if the ask really is asking for
         # that" is only actionable if they are told which term and from where.
-        local _fbt=""
-        [[ "$_floored_by_title" == "1" ]] && _fbt=" [floored_by=title: the T2 category floor matched '$(_gate_tier2_floor_term "$_ft_title")' in the TASK TITLE, not in the ask — escalate to the human if the ask really is asking for that]"
+        # DIVE-2751 iteration 4 — decided explicitly rather than left as "guarded in
+        # practice". An assignment's rc is its LAST command substitution's, so
+        # `[[ test ]] && v="...$(f)..."` hands f's status to the compound with the
+        # test TRUE. `_ft_title` is the text that just matched, so the helper does
+        # return 0 here — but "in practice" is exactly the reasoning the previous
+        # three iterations got wrong, and this false rc arrives from the RHS, where
+        # no detector that classifies the LEFT side of `&&` can ever see it. Split
+        # so the status is absorbed instead of argued about.
+        local _fbt="" _fbt_term=""
+        if [[ "$_floored_by_title" == "1" ]]; then
+          _fbt_term=$(_gate_tier2_floor_term "$_ft_title" 2>/dev/null) || _fbt_term=""
+          _fbt=" [floored_by=title: the T2 category floor matched '${_fbt_term}' in the TASK TITLE, not in the ask — escalate to the human if the ask really is asking for that]"
+        fi
         ok "$ident routed to $_reviewer for ${_rrole} ($type, tier $tier)${_rnote}${_fbt} — $ask" \
            '{id:($i|tonumber), ident:$id, status:"blocked", need_type:$ty, tier:($tr|tonumber), routed_to:$rv, delivery:$ds, notified:($ds=="delivered"), ask:$ak, recommend:(($rc|select(length>0)) // null)}' \
            --arg i "$id" --arg id "$ident" --arg ty "$type" --arg tr "$tier" --arg rv "$_reviewer" --arg ds "$_rstate" --arg ak "$ask" --arg rc "$recommend"

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -1439,6 +1439,16 @@ cmd_task_show() {
     deps=$(db "SELECT t.ident||'  ['||t.status||']  '||t.title FROM task_deps d JOIN tasks t ON t.id=d.blocked_by WHERE d.task_id=${id} ORDER BY t.id;")
     [[ -n "$deps" ]] && { echo; echo "blocked by:"; printf '%s\n' "$deps" | indent2; }
   fi
+  # DIVE-2751: the `blocked by` block above is a CONDITIONAL RENDER whose test is
+  # the last command in this function, so on a row with no dependency edge the
+  # false test became `task show`'s exit status and `set -euo pipefail` killed the
+  # script — after the row had already printed in full. That is the majority of the
+  # board, and `5dive task show <id>` is the canonical verification command a /goal
+  # stop-hook is pointed at, so a correctly-rendered row read as a failed command
+  # whose effect the trap then declared UNKNOWN. Terminate the function on its own
+  # status: a render that reached the end SUCCEEDED, whatever the last block chose
+  # not to print. Covers the --json branch too (jq's status is not a render verdict).
+  return 0
 }
 
 # DIVE-2133 — gate_history was an append-only WRITE path with no reader. Keep
@@ -8281,7 +8291,12 @@ cmd_task_need() {
     floor_note=" [tier 2 — DECLARED --needs=${needs}, a human-held capability; routed to the paired human, not to a lead or verifier]"
     warn "this gate is hard-human because you DECLARED --needs=${needs}. It bypasses lead- and verifier-routing by constant, and only the paired human can answer it. If the ask does not actually consume that capability, withdraw and re-file without --needs — do not appeal it, the declaration is yours."
   elif (( tier_floored )); then
-    floor_term=$(_gate_tier2_floor_term "${ask} $(db "SELECT COALESCE(title,'') FROM tasks WHERE id=${id};")")
+    # DIVE-2751: `_gate_tier2_floor_term` is trailing-test-terminated — it returns 1
+    # when it finds no term — so this PLAIN assignment made "the floor fired but the
+    # helper could not name the word" kill `task need` under `set -e`. The helper's
+    # own rc contract is left alone (a value producer may report "no match"); the
+    # call site absorbs it, exactly as the two sites at _floor_term above already do.
+    floor_term=$(_gate_tier2_floor_term "${ask} $(db "SELECT COALESCE(title,'') FROM tasks WHERE id=${id};")") || floor_term=""
     floor_note=" [tier forced to 2 — T2 category floor${floor_term:+: matched '$floor_term'}]"
     local _fw="this gate was FORCED to tier 2 (hard human) by the T2 category floor"
     [[ -n "$floor_term" ]] && _fw="$_fw because the ask or the task title contains '${floor_term}'"

--- a/src/cmd_usage.sh
+++ b/src/cmd_usage.sh
@@ -926,6 +926,16 @@ cmd_usage_budget_check() {
     echo "budget check: ${checked} agent(s) — ${n_soft} soft, ${n_hard} at ceiling, ${n_stop} stopped$( ((dry)) && echo ' (dry-run)')"
     (( n_unknown > 0 )) && echo "  ⚠ ${n_unknown} NOT checked — transcripts unreadable from here, burn is unknown (not 0): ${unknown_names}"
   fi
+  # DIVE-2751 (found by main2 on iteration 1): third instance, and the one with a
+  # live caller. The test above is INVERTED relative to health — n_unknown == 0 is
+  # the GOOD state — so as the last statement of this branch it returned 1 on every
+  # healthy run. cmd_heartbeat.sh's `_hb_budget_sweep` does
+  #   out=$(cmd_usage_budget_check 2>/dev/null) || return 1
+  # so the budget sweep reported failure on every healthy tick and only "succeeded"
+  # when some agent's transcripts were unreadable. My first sweep missed this
+  # because its pattern required `[[ ]]` AND a braced block; this is `(( ))` and
+  # unbraced — see the widened guard in tests/task_show_exit_code_unit.sh.
+  return 0
 }
 
 # cmd_cost — DIVE-1019 budget-focused burn view. Reuses the usage plumbing: one

--- a/src/cmd_usage.sh
+++ b/src/cmd_usage.sh
@@ -563,6 +563,12 @@ usage_render_board() {
           else empty end ]
     | .[]' --argjson b "$budgets" <<<"$data" 2>/dev/null)
   [[ -n "$over" ]] && { echo; echo "$over"; }
+  # DIVE-2751: second instance of the same shape as cmd_task_show — this trailing
+  # conditional render is the last command in the last function `cmd_usage` calls,
+  # so `5dive usage` (the default board render; `usage board` parses "board" as an
+  # AGENT name) exited 1 whenever NO agent was over its budget, i.e. on
+  # the healthy path. Measured rc=1 on the installed CLI before this fix.
+  return 0
 }
 
 # usage_render_agent — one agent: per-model breakdown + its tasks in window.

--- a/src/lib/disk.sh
+++ b/src/lib/disk.sh
@@ -43,6 +43,16 @@ disk_gb()       { awk -v kb="${1:-0}" 'BEGIN{printf "%.1f", kb/1048576}'; }
 wt_task_num() {
   local n="${1##*-}"
   [[ "$n" =~ ^[0-9]+$ ]] && printf '%s' "$n"
+  # DIVE-2751: same shape, latent rather than live. Both call sites are plain
+  # assignments (`local num; num=$(wt_task_num "$x")`), so a non-numeric ident
+  # killed the caller under `set -e` — and cmd_task.sh:199's `[[ -n "$num" ]] ||
+  # return 0` is proof the empty case was MEANT to be handled: that guard could
+  # never run. Report "no number" as empty output, not as failure.
+  # Checked before changing it, because the other call site feeds `wt_candidates`
+  # and this is a worktree-RECLAIM path with ~500 worktrees on the box:
+  # wt_candidates opens with `[[ "$num" =~ ^[0-9]+$ ]] || return 0`, so an empty
+  # value selects NOTHING. It fails closed, and the empty case stays safe.
+  return 0
 }
 
 # wt_candidates <num> — worktree dirs belonging to task <num>, one per line.

--- a/tests/task_show_exit_code_unit.sh
+++ b/tests/task_show_exit_code_unit.sh
@@ -71,7 +71,7 @@ TMP="$(mktemp -d /tmp/taskshow-rc-unit.XXXXXX)"
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh lib/actor.sh cmd_push.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh lib/broker.sh cmd_push.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done

--- a/tests/task_show_exit_code_unit.sh
+++ b/tests/task_show_exit_code_unit.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# DIVE-2751 — `task show` EXIT CODE on a row with no dependency edge.
+#
+# The defect: the last statement of cmd_task_show's human branch was a bare
+# conditional render,
+#
+#     [[ -n "$deps" ]] && { echo; echo "blocked by:"; ...; }
+#
+# so on a row with no `blocked by` edge the false test WAS the function's exit
+# status, and `set -euo pipefail` killed the script — after the row had already
+# printed in full. That is the majority of the board, and `5dive task show <id>`
+# is the canonical verification command a /goal stop-hook is pointed at, so a
+# correctly-rendered row read as a failed command whose trap then declared the
+# effect UNKNOWN.
+#
+# WHY THIS HARNESS ASSERTS rc AND NOT TEXT: every arm below already printed its
+# row on the broken build. A test that greps stdout passes on the bug. The whole
+# defect lives in $?, so $? is the assertion — and each arm additionally proves
+# the render did not go silent, because "return 0" would also be satisfied by a
+# function that prints nothing.
+#
+# Arms: no-dep (the bug) / subtasks-but-no-dep / gate-but-no-dep / --json / and
+# the WITH-dep control that was already green (so a fix that hard-codes rc=0
+# without keeping the block is still distinguishable by its text assertion).
+# Also covers the second instance of the same shape found tree-wide,
+# usage_render_board (`5dive usage` (the default board) exited 1 whenever nobody was over
+# budget), and the one unguarded `_gate_tier2_floor_term` assignment.
+#
+# Sources src/ against a throwaway tasks.db (same posture as
+# project_show_graph_unit.sh) so it NEVER touches the shared queue.
+# Run: bash tests/task_show_exit_code_unit.sh  (no root, no network).
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/taskshow-rc-unit.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"
+TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DB="$TASKS_DIR/tasks.db"
+mkdir -p "$TASKS_DIR"
+set +e   # header.sh enabled `set -e`; tests deliberately expect non-zero exits
+
+tasks_db_init
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# show <ident> [json] -> sets $SHOW_RC and $SHOW_OUT.
+#
+# Sets globals rather than printing the rc: `rc=$(show ...)` would run the whole
+# helper in a SUBSHELL and the captured stdout would never reach the parent,
+# which silently turns every text assertion below into a no-op.
+#
+# The inner subshell re-enables `set -e` so this reproduces the REAL failure
+# mode: not "the function returned 1" but "the script died before its next
+# statement". The sentinel is the proof — on the broken build it never printed.
+SHOW_OUT=""; SHOW_RC=""
+show() {
+  local ident="$1" jm="${2:-0}"
+  SHOW_OUT=$( JSON_MODE="$jm"; set -euo pipefail; cmd_task_show "$ident" 2>&1; echo "__REACHED__" )
+  SHOW_RC=$?
+}
+reached() { [[ "$SHOW_OUT" == *"__REACHED__"* ]]; }
+
+# ---- seed rows directly (bypass the verbs so no gate/actor policy is involved) ----
+mk() { # mk <title> -> global id
+  db "INSERT INTO tasks (title, assignee, created_by, kind, status)
+      VALUES ($(sqlq "$1"),'dev','dev','standard','todo');
+      SELECT last_insert_rowid();"
+}
+ident_of() { db "SELECT ident FROM tasks WHERE id=$1;"; }
+
+plain=$(mk "plain row, no deps no subtasks no gate")
+blocker=$(mk "the blocker")
+blocked=$(mk "row WITH a dependency edge")
+parent=$(mk "row with subtasks but no dependency edge")
+child=$(mk "the subtask")
+gated=$(mk "row with a human gate but no dependency edge")
+
+db "INSERT OR IGNORE INTO task_deps (task_id, blocked_by) VALUES (${blocked},${blocker});"
+db "UPDATE tasks SET parent_id=${parent} WHERE id=${child};"
+db "UPDATE tasks SET need_type='decision', ask='pick one', tier=1 WHERE id=${gated};"
+
+I_PLAIN=$(ident_of "$plain"); I_BLOCKED=$(ident_of "$blocked")
+I_PARENT=$(ident_of "$parent"); I_GATED=$(ident_of "$gated")
+
+# ================= the reported bug =================
+show "$I_PLAIN"
+[[ "$SHOW_RC" == "0" ]] && ok_t "no-dep row: task show exits 0 (DIVE-2751)" \
+  || bad_t "no-dep row exits $SHOW_RC" "$SHOW_OUT"
+reached && ok_t "no-dep row: script survives past task show" \
+  || bad_t "script died at task show on a no-dep row" "$SHOW_OUT"
+[[ "$SHOW_OUT" == *"$I_PLAIN"* ]] && ok_t "no-dep row: still renders the row" \
+  || bad_t "no-dep row rendered nothing" "$SHOW_OUT"
+
+# ================= control: the shape that was already green =================
+# Asserts BOTH halves — rc 0 AND the block still prints — so a "fix" that simply
+# deleted the conditional render would fail here instead of passing everything.
+show "$I_BLOCKED"
+[[ "$SHOW_RC" == "0" ]] && ok_t "dep row: task show exits 0 (control)" \
+  || bad_t "dep row exits $SHOW_RC" "$SHOW_OUT"
+[[ "$SHOW_OUT" == *"blocked by:"* ]] && ok_t "dep row: 'blocked by:' block still rendered" \
+  || bad_t "the blocked-by block stopped printing" "$SHOW_OUT"
+
+# ================= the other no-dep shapes olivia measured =================
+show "$I_PARENT"
+[[ "$SHOW_RC" == "0" ]] && ok_t "subtasks-but-no-dep row: exits 0" || bad_t "subtask row exits $SHOW_RC" "$SHOW_OUT"
+[[ "$SHOW_OUT" == *"subtasks:"* ]] && ok_t "subtasks-but-no-dep row: 'subtasks:' still rendered" \
+  || bad_t "the subtasks block stopped printing" "$SHOW_OUT"
+
+show "$I_GATED"
+[[ "$SHOW_RC" == "0" ]] && ok_t "gated-but-no-dep row: exits 0" || bad_t "gated row exits $SHOW_RC" "$SHOW_OUT"
+[[ "$SHOW_OUT" == *"human gate:"* ]] && ok_t "gated-but-no-dep row: 'human gate:' still rendered" \
+  || bad_t "the gate block stopped printing" "$SHOW_OUT"
+
+# ================= --json branch =================
+show "$I_PLAIN" 1
+[[ "$SHOW_RC" == "0" ]] && ok_t "no-dep row: --json exits 0" || bad_t "--json exits $SHOW_RC" "$SHOW_OUT"
+printf '%s' "${SHOW_OUT%__REACHED__}" | jq -e '.ok==true and (.data.blocked_by|length)==0' >/dev/null 2>&1 \
+  && ok_t "no-dep row: --json still emits ok envelope with blocked_by=[]" \
+  || bad_t "--json envelope wrong" "$SHOW_OUT"
+
+# ================= same shape, second site: usage_render_board (DIVE-2751) =================
+# `5dive usage` (the default board render) exited 1 on the HEALTHY path — nobody
+# over budget — for the identical reason. Sourced separately: cmd_usage.sh is not part of the task libs.
+if source "$SRC/cmd_usage.sh" 2>/dev/null && declare -F usage_render_board >/dev/null; then
+  uout=$( set -euo pipefail
+          usage_render_board '{"agents":{},"tasks":{},"total":0}' 24h '{}' >/dev/null 2>&1
+          echo "__REACHED__" )
+  urc=$?
+  [[ "$urc" == "0" ]] && ok_t "usage_render_board: exits 0 with no budget overage" \
+    || bad_t "usage_render_board exits $urc with no overage" "$uout"
+  [[ "$uout" == *"__REACHED__"* ]] && ok_t "usage_render_board: script survives past it" \
+    || bad_t "script died in usage_render_board" "$uout"
+else
+  bad_t "usage_render_board not loadable" "cmd_usage.sh did not source, or the function is gone"
+fi
+
+# ================= same family: the unguarded floor-term assignment =================
+# _gate_tier2_floor_term is itself trailing-test-terminated (rc 1 when it names
+# no term) — that contract is deliberate and unchanged. What must not happen is a
+# PLAIN assignment from it killing `task need` under set -e; the call site
+# absorbs the status. Grade the call sites, not the helper.
+if declare -F _gate_tier2_floor_term >/dev/null; then
+  ft=$( set -euo pipefail
+        v=$(_gate_tier2_floor_term "nothing in here trips any category floor") || v=""
+        printf '%s' "__REACHED__${v}" )
+  [[ "$ft" == *"__REACHED__"* ]] && ok_t "_gate_tier2_floor_term: absorbed rc does not kill set -e" \
+    || bad_t "guarded floor-term call still died" "$ft"
+  bare=$(grep -nE '^\s*[A-Za-z_]+=\$\(_gate_tier2_floor_term ' "$SRC/cmd_task.sh" \
+         | grep -v '|| *[A-Za-z_]*=""' )
+  [[ -z "$bare" ]] && ok_t "no unguarded \$(_gate_tier2_floor_term) assignment remains" \
+    || bad_t "unguarded floor-term assignment (dies under set -e when no term matches)" "$bare"
+else
+  bad_t "_gate_tier2_floor_term missing" "helper was renamed or removed"
+fi
+
+# ================= class guard: no NEW trailing conditional render =================
+# The bug is a shape, not a line. A function whose last statement is a
+# conditional render block re-introduces it silently — this is what makes the
+# class extinct rather than this one instance. Predicate functions ending in a
+# bare test are legitimate and deliberately NOT flagged: the signal is the
+# printing side effect in the `&&` block.
+offenders=""
+while IFS=: read -r f l rest; do
+  [[ -n "$f" ]] || continue
+  n=$((l+1))
+  while :; do
+    ln=$(sed -n "${n}p" "$f"); ln="${ln//[[:space:]]/}"
+    case "$ln" in ''|'#'*|fi|done|esac|else) n=$((n+1)) ;; *) break ;; esac
+    (( n > l + 40 )) && break
+  done
+  [[ "$(sed -n "${n}p" "$f")" == "}" ]] && offenders+="$f:$l:${rest# }"$'\n'
+done < <(grep -nE '^\s*\[\[[^]]*\]\]\s*&&\s*\{[^}]*(echo|printf)' "$SRC"/*.sh)
+[[ -z "$offenders" ]] && ok_t "no function ends in a trailing conditional render (class guard)" \
+  || bad_t "trailing conditional render is the last statement of a function" "$offenders"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/task_show_exit_code_unit.sh
+++ b/tests/task_show_exit_code_unit.sh
@@ -45,7 +45,15 @@
 #   paperclip_seed_all_from_registry - LIVE: main.sh:738, bare, from update.sh
 #   paperclip_unseed_for_profile     - same shape; caller absorbs with `|| true`
 #   link_agent_profile               - latent at five bare call sites
-# Plus the one unguarded `_gate_tier2_floor_term` assignment.
+# Plus TWO unguarded `_gate_tier2_floor_term` call sites, not one — the count was
+# wrong a third time, and again because the instrument could not see the miss:
+#   cmd_task_need Rule 3 - `local v; v=$(...)`, invisible to a grep anchored to the
+#                          start of the line. Its ARGUMENT was also a phantom:
+#                          `$_dd_residual` occurs exactly once in the repo, so the
+#                          path died `unbound variable` under set -u regardless.
+#   the `_fbt` assembly   - `[[ t ]] && v="...$(...)..."`; an assignment inherits
+#                          its LAST command substitution, so the false rc arrives
+#                          from the RHS where no left-side classifier can see it.
 #
 # Sources src/ against a throwaway tasks.db (same posture as
 # project_show_graph_unit.sh) so it NEVER touches the shared queue.
@@ -63,7 +71,7 @@ TMP="$(mktemp -d /tmp/taskshow-rc-unit.XXXXXX)"
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
          lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
-         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
+         lib/tasks_db.sh lib/actor.sh cmd_push.sh cmd_task.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done
@@ -182,12 +190,59 @@ if declare -F _gate_tier2_floor_term >/dev/null; then
         printf '%s' "__REACHED__${v}" )
   [[ "$ft" == *"__REACHED__"* ]] && ok_t "_gate_tier2_floor_term: absorbed rc does not kill set -e" \
     || bad_t "guarded floor-term call still died" "$ft"
-  bare=$(grep -nE '^\s*[A-Za-z_]+=\$\(_gate_tier2_floor_term ' "$SRC/cmd_task.sh" \
-         | grep -v '|| *[A-Za-z_]*=""' )
-  [[ -z "$bare" ]] && ok_t "no unguarded \$(_gate_tier2_floor_term) assignment remains" \
-    || bad_t "unguarded floor-term assignment (dies under set -e when no term matches)" "$bare"
+  # The grep that used to live here is GONE, not tightened. It was anchored to
+  # `^\s*VAR=$(...`, and that anchor is exactly why iteration 3's "every call site
+  # absorbs it" was false: the Rule 3 site in `task need` is written
+  # `local _dd_term; _dd_term=$(...)`, so what PRECEDED the assignment on the
+  # physical line hid it — while a guarded site four lines away matched and the
+  # test passed on zero hits. A statement is not a line, in either direction.
+  # The claim is now checked by the same script that grants the exemption, in
+  # --call-sites mode, graded by its own control set — see the class guard below.
+  #
+  # THE OTHER HALF of that miss was not an rc at all: the argument was
+  # `$_dd_residual`, an identifier occurring EXACTLY ONCE in the repo, so it had
+  # never held a value and the substitution died `unbound variable` under set -u
+  # before absorption could matter. A read-once name in a `set -u` script is a
+  # typo by construction, so this grades the class over the two paths touched
+  # rather than the one name — and it is mutation-graded against the pre-fix file
+  # in the control section below.
+  # Whole-line comments are dropped first: a name in a comment cannot die under
+  # set -u, and this file's own fix note names the phantom it removed.
+  phantom=$(grep -vE '^[[:space:]]*#' "$SRC/cmd_task.sh" \
+            | grep -ohE '\$\{?(_dd_|_ft_|_fbt)[a-zA-Z0-9_]*' \
+            | sed -E 's/^\$\{?//' | sort -u \
+            | while read -r v; do
+                grep -qE "(^|[ \t;(&|])${v}=" "$SRC/cmd_task.sh" || printf '%s\n' "$v"
+              done)
+  [[ -z "$phantom" ]] && ok_t "no read-once phantom identifier on the gate-term paths" \
+    || bad_t "an identifier is READ but never assigned (dies 'unbound variable' under set -u)" "$phantom"
 else
   bad_t "_gate_tier2_floor_term missing" "helper was renamed or removed"
+fi
+
+# ---- and the same path EXECUTED, not merely scanned ----
+# main2 could only prove the Rule 3 defect statically: reaching it needs a floored
+# gate, and they were not going to file one on the shared prod store to prove a
+# point. This harness already owns a throwaway tasks.db, so it can just run it —
+# a gate whose ask names money is floored, and --discusses asks to appeal that.
+# On the pre-fix text this died `line 7385: _dd_residual: unbound variable` before
+# the sentinel; the assertion is the sentinel PLUS the refusal actually naming its
+# term, so a "fix" that silences the path without answering also fails here.
+if declare -F cmd_task_need >/dev/null && declare -F _push_branch_from_body >/dev/null; then
+  r3id=$(mk "probe row for the rule 3 appeal path")
+  r3=$(ident_of "$r3id")
+  r3out=$( set -euo pipefail
+           cmd_task_need "$r3" --type=decision \
+             --ask="approve a \$500 spend on the ads account" \
+             --discusses="this is a design discussion, not a spend" 2>&1
+           echo "__REACHED__" )
+  [[ "$r3out" == *"__REACHED__"* ]] && ok_t "task need --discusses on a floored gate survives Rule 3 (executed)" \
+    || bad_t "Rule 3 path still dies before the next statement" "$r3out"
+  [[ "$r3out" == *"--discusses REFUSED"* && "$r3out" == *"matched '"*"'"* ]] \
+    && ok_t "Rule 3 refusal renders and NAMES the surviving term" \
+    || bad_t "Rule 3 refusal did not name its term (a silent fix passes the rc arm alone)" "$r3out"
+else
+  bad_t "Rule 3 arm not runnable" "cmd_task_need or _push_branch_from_body did not source"
 fi
 
 # ================= fifth+sixth instance: cmd_project_show (found by main2) ==========
@@ -403,6 +458,88 @@ neg=$(scan "$TMP/ctl/negative.sh" 2>&1)
 unreadable=$(scan "$TMP/ctl/does-not-exist.sh" 2>/dev/null; echo "rc=$?")
 [[ "$unreadable" == *"rc=2"* ]] && ok_t "unscannable input exits 2, not 0 (silence is not a pass)" \
   || bad_t "scanner reported clean on input it could not read" "$unreadable"
+
+# ============ call-site guard: the ALLOWLIST's own justification ============
+# Iterations 1 and 2 leaked through a blind DETECTOR. Iteration 3's detector was
+# sound and the leak moved one level out, into the three allowlist entries' REASON
+# — "every call site absorbs it", checked by exactly the kind of prefix regex the
+# detector had been rewritten to stop using. An exemption is only as good as its
+# justification, so the justification is a guard now, not prose.
+unabsorbed=$(scan --call-sites 2>&1)
+[[ -z "$unabsorbed" ]] && ok_t "every allowlisted rc-bearing call absorbs its status (call-site guard)" \
+  || bad_t "an allowlisted contract's rc reaches a plain assignment (dies under set -e)" "$unabsorbed"
+
+# ---- control SET for the call-site guard ----
+# Same rule as above: the positives are the shapes the REPLACED grep could not
+# see, so "it is quiet" cannot be the evidence.
+cat > "$TMP/ctl/cs-positive.sh" <<'CTL'
+same_line_local() {         # the actual escapee: prefix-blind, not shape-blind
+  local _dd_term; _dd_term=$(_gate_tier2_floor_term "$1")
+  printf '%s\n' "$_dd_term"
+}
+rhs_substitution() {        # rc arrives from the RHS — invisible to any detector
+  local _fbt=""             # that classifies the LEFT side of &&
+  _fbt=" matched '$(_gate_tier2_floor_term "$1")' in the title"
+  printf '%s\n' "$_fbt"
+}
+conditional_assign() {      # test TRUE, assignment still hands over the call's rc
+  local _cav=""
+  [[ -n "$1" ]] && _cav=$(_gate_tier2_floor_term "$1")
+  printf '%s\n' "$_cav"
+}
+wrapped_assign() {          # the statement continues onto the next physical line
+  local _wav=""
+  _wav=$(_gate_tier2_floor_term \
+      "$1")
+  printf '%s\n' "$_wav"
+}
+CTL
+cat > "$TMP/ctl/cs-negative.sh" <<'CTL'
+absorbed() {                # the documented contract
+  local v; v=$(_gate_tier2_floor_term "$1") || v=""
+  printf '%s\n' "$v"
+}
+as_argument() {             # rc goes to printf, not to this statement
+  printf 'matched %s\n' "$(_gate_tier2_floor_term "$1")"
+}
+in_condition() {            # rc is the test's, not the call's
+  if [[ -n "$(_gate_tier2_floor_term "$1")" ]]; then printf 'hit\n'; fi
+}
+builtin_prefix() {          # `local` returns the BUILTIN's status, which is 0
+  local v=$(_gate_tier2_floor_term "$1")
+  printf '%s\n' "$v"
+}
+CTL
+cspos=$(scan --call-sites "$TMP/ctl/cs-positive.sh" 2>&1)
+for shape in same_line_local rhs_substitution conditional_assign wrapped_assign; do
+  case "$shape" in
+    same_line_local)    probe='_dd_term=$(' ;;
+    rhs_substitution)   probe='_fbt=" matched' ;;
+    conditional_assign) probe='_cav=$(' ;;
+    wrapped_assign)     probe='_wav=$(' ;;
+  esac
+  [[ "$cspos" == *"$probe"* ]] && ok_t "call-site guard FIRES on $shape (positive control)" \
+    || bad_t "call-site guard is BLIND to $shape" "$cspos"
+done
+csneg=$(scan --call-sites "$TMP/ctl/cs-negative.sh" 2>&1)
+[[ -z "$csneg" ]] && ok_t "call-site guard stays silent on all four absorbing shapes (negative control)" \
+  || bad_t "call-site guard fires on an absorbed call — it would be widened-then-muted" "$csneg"
+
+# ---- mutation control for the phantom-identifier arm ----
+# The arm above is a regex, and a regex that has only ever been run on a CLEAN
+# file has not been shown to fire. Hand it the pre-fix text.
+mkdir -p "$TMP/ctl/pre"
+{ printf 'phantom_arg() {\n  local _dd_res_ask=""\n'
+  printf '  local _dd_term; _dd_term=$(_gate_tier2_floor_term "$_dd_residual")\n'
+  printf '  printf %s "$_dd_term" "$_dd_res_ask"\n' "'%s%s\\n'"
+  printf '}\n'; } > "$TMP/ctl/pre/cmd_task.sh"
+premiss=$(grep -ohE '\$\{?(_dd_|_ft_|_fbt)[a-zA-Z0-9_]*' "$TMP/ctl/pre/cmd_task.sh" \
+          | sed -E 's/^\$\{?//' | sort -u \
+          | while read -r v; do
+              grep -qE "(^|[ \t;(&|])${v}=" "$TMP/ctl/pre/cmd_task.sh" || printf '%s\n' "$v"
+            done)
+[[ "$premiss" == *"_dd_residual"* ]] && ok_t "phantom-identifier arm FIRES on the pre-fix text (mutation control)" \
+  || bad_t "phantom-identifier arm cannot see the defect it was written for" "got='$premiss'"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/task_show_exit_code_unit.sh
+++ b/tests/task_show_exit_code_unit.sh
@@ -22,16 +22,29 @@
 # Arms: no-dep (the bug) / subtasks-but-no-dep / gate-but-no-dep / --json / and
 # the WITH-dep control that was already green (so a fix that hard-codes rc=0
 # without keeping the block is still distinguishable by its text assertion).
-# FOUR instances of the shape, not two. Iteration 1 claimed "exactly one other"
-# and shipped a guard that could only see `[[ ]]` with a braced block; main2 found
-# `(( n_unknown > 0 )) && echo ...` in cmd_usage_budget_check, which failed every
-# HEALTHY heartbeat tick. The count was wrong because the instrument was narrow,
-# so the guard below now finds the last statement STRUCTURALLY and is itself
-# graded against that exact syntax by a positive control.
+#
+# NINE instances of the shape, not two. The count was wrong twice because the
+# instrument was narrower than the class each time, and each miss was found by
+# main2 re-deriving the sweep rather than reading the count:
+#   iteration 1 guard: `[[ ]]` + a braced block -> blind to `(( )) && echo`
+#   iteration 2 guard: the last PHYSICAL line   -> blind to a wrapped `&& printf \`
+# So the guard no longer lives here as a regex. scripts/scan-trailing-conditional.sh
+# joins continuations, walks back from the closing brace, follows a bare `return`
+# to the statement whose $? it inherits, and decides by ELIMINATION rather than by
+# listing printers. It is graded below by a control SET built from shapes that were
+# not yet found when it was written, plus a negative control, because a guard whose
+# only evidence is its own silence is what produced both wrong counts.
 #   cmd_task_show          - the reported bug (rc 1 on any row with no dep edge)
 #   usage_render_board     - bare `5dive usage` on the healthy no-overage path
 #   cmd_usage_budget_check - LIVE CALLER: _hb_budget_sweep, every healthy tick (main2)
 #   wt_task_num            - latent; both call sites assign plainly under set -e
+#   cmd_project_show x2    - the early `return` that inherits $? from
+#                            `(( n > 0 )) && printf` is LIVE (`5dive project show
+#                            <a project with no dependency edge>`); the trailing
+#                            wrapped `[[ ]] && printf \` is LATENT — see below
+#   paperclip_seed_all_from_registry - LIVE: main.sh:738, bare, from update.sh
+#   paperclip_unseed_for_profile     - same shape; caller absorbs with `|| true`
+#   link_agent_profile               - latent at five bare call sites
 # Plus the one unguarded `_gate_tier2_floor_term` assignment.
 #
 # Sources src/ against a throwaway tasks.db (same posture as
@@ -177,28 +190,79 @@ else
   bad_t "_gate_tier2_floor_term missing" "helper was renamed or removed"
 fi
 
-# ---- the structural detector, used by the three sections below ----
-# Defined here because the budget-check arms grade it before the class guard runs.
-cat > "$TMP/detect.awk" <<'AWK'
-/^[a-zA-Z_][a-zA-Z0-9_]*[ \t]*\([ \t]*\)[ \t]*\{/ { fn=$0; sub(/[ \t]*\(.*/,"",fn); inf=1; n=0; next }
-inf && /^\}/ {
-  for (i=n; i>=1; i--) {
-    l=buf[i]; s=l; gsub(/[ \t]/,"",s)
-    if (s=="" || s ~ /^#/ || s=="fi" || s=="done" || s=="esac" || s=="else" || s==";;" || s=="}") continue
-    # Must START a statement, or a jq continuation line and an `&&` inside an
-    # awk program string both read as shell operators. A `||` fallback makes the
-    # compound succeed regardless, so it is not this defect.
-    if (l ~ /^[ \t]*(\[\[|\(\(|\[ |test |grep |declare )/ &&    \
-        l ~ /&&/ && l !~ /\|\|/ &&                              \
-        l ~ /&&[ \t]*[{(]?[ \t]*(echo|printf|cat |indent2)/ &&  \
-        l !~ /return|exit/)
-      print FILENAME":"lno[i]"  "fn
-    break
+# ================= fifth+sixth instance: cmd_project_show (found by main2) ==========
+# The sibling of the command in this row's title. TWO sites in one function, and
+# they are NOT equally live — say which is which, because "both are live" is the
+# same kind of unchecked claim as the wrong counts:
+#   - the EARLY bare `return` inheriting $? from `(( n > 0 )) && printf` is LIVE:
+#     `5dive project show <a project with no dependency edge>` rendered in full
+#     and then printed the identical "exited 1 without reporting a reason" trap.
+#     Measured on the installed CLI before the fix, rc 0 after. Executed below.
+#   - the trailing `[[ -n "$chain" ]] && printf ... \` wrapped onto a continuation
+#     line — the shape that defeated the iteration-2 detector — is LATENT: it is
+#     only reached when edges > 0, and every graph with an edge that I could
+#     construct yields a non-empty critical chain, so the test is true. It is
+#     graded by mutation and by the detector, NOT by execution, and this note is
+#     what makes that gap refutable rather than invisible.
+if source "$SRC/cmd_org.sh" 2>/dev/null && source "$SRC/cmd_project.sh" 2>/dev/null \
+   && declare -F cmd_project_show >/dev/null; then
+  db "INSERT INTO projects (key, prefix, name) VALUES ('empty','EMP','Empty');
+      INSERT INTO projects (key, prefix, name) VALUES ('flat','FLT','Flat');
+      INSERT INTO projects (key, prefix, name) VALUES ('dag','DAG','Dag');"
+  pshow() { # -> PS_OUT / PS_RC
+    PS_OUT=$( JSON_MODE=0; set -euo pipefail; cmd_project_show "$1" 2>&1; echo "__REACHED__" )
+    PS_RC=$?
   }
-  inf=0; next
-}
-inf { n++; buf[n]=$0; lno[n]=FNR }
-AWK
+  # (a) zero tasks: `(( n > 0 ))` is false, so the bare `return` returned 1.
+  pshow empty
+  [[ "$PS_RC" == "0" ]] && ok_t "[project show] zero-task project exits 0 (early bare return)" \
+    || bad_t "[project show] zero-task project exits $PS_RC" "$PS_OUT"
+  [[ "$PS_OUT" == *"__REACHED__"* ]] && ok_t "[project show] script survives the early-return path" \
+    || bad_t "[project show] script died on the early-return path" "$PS_OUT"
+
+  # (b) tasks but no edges: the `(( n > 0 ))` block MUST still print, or `return 0`
+  #     would be satisfied by a function that silently stopped rendering.
+  f1=$(db "INSERT INTO tasks (title, assignee, created_by, project_key, kind, status)
+           VALUES ('flat one','dev','dev','flat','standard','todo');
+           SELECT last_insert_rowid();")
+  pshow flat
+  [[ "$PS_RC" == "0" ]] && ok_t "[project show] no-edge project exits 0" \
+    || bad_t "[project show] no-edge project exits $PS_RC" "$PS_OUT"
+  [[ "$PS_OUT" == *"no task_deps recorded"* ]] \
+    && ok_t "[project show] the no-deps line still renders" \
+    || bad_t "[project show] the no-deps line stopped printing" "$PS_OUT"
+
+  # (c) control — a project WITH an edge reaches the trailing wrapped conditional
+  #     and must both exit 0 and still print the Critical path line.
+  d1=$(db "INSERT INTO tasks (title, assignee, created_by, project_key, kind, status)
+           VALUES ('dag blocker','dev','dev','dag','standard','todo');
+           SELECT last_insert_rowid();")
+  d2=$(db "INSERT INTO tasks (title, assignee, created_by, project_key, kind, status)
+           VALUES ('dag blocked','dev','dev','dag','standard','todo');
+           SELECT last_insert_rowid();")
+  db "INSERT OR IGNORE INTO task_deps (task_id, blocked_by) VALUES (${d2},${d1});"
+  pshow dag
+  [[ "$PS_RC" == "0" ]] && ok_t "[project show] project WITH an edge exits 0 (control)" \
+    || bad_t "[project show] dep project exits $PS_RC" "$PS_OUT"
+  [[ "$PS_OUT" == *"Critical path:"* ]] \
+    && ok_t "[project show] the Critical path line still renders (control)" \
+    || bad_t "[project show] the Critical path line stopped printing" "$PS_OUT"
+else
+  bad_t "[project show] not loadable" "cmd_project.sh did not source, or cmd_project_show is gone"
+fi
+
+# ---- the structural detector ----
+# scripts/scan-trailing-conditional.sh. Exit 0 = clean, 1 = offenders on stdout,
+# 2 = could not scan (never a pass — a scanner that cannot run must not read as
+# silence, which is the failure this whole row is about).
+SCAN="scripts/scan-trailing-conditional.sh"
+scan() { bash "$SCAN" "$@"; }   # rc 1 is a normal "found something" here
+
+if [[ -x "$SCAN" || -r "$SCAN" ]]; then
+  ok_t "detector present ($SCAN)"
+else
+  bad_t "detector missing" "$SCAN is not readable — every arm below would read as clean"
+fi
 
 # ================= third instance: cmd_usage_budget_check (found by main2) ==========
 # Executing it needs the whole usage plan, so grade it through the detector below
@@ -207,20 +271,44 @@ AWK
 # the fix in place it must not. The live-caller consequence is what made this the
 # serious one: _hb_budget_sweep does `out=$(cmd_usage_budget_check) || return 1`,
 # and the test is inverted relative to health, so a HEALTHY tick returned 1.
-mkdir -p "$TMP/mut/lib"; : > "$TMP/mut/lib/empty.sh"
+mkdir -p "$TMP/mut"
 sed '/DIVE-2751 (found by main2 on iteration 1)/,/^  return 0$/d' "$SRC/cmd_usage.sh" > "$TMP/mut/cmd_usage.sh"
 if ! cmp -s "$SRC/cmd_usage.sh" "$TMP/mut/cmd_usage.sh"; then
   ok_t "[budget-check] the mutation applied (fix removed from the copy)"
 else
   bad_t "[budget-check] mutation did NOT apply — the arm below would prove nothing" "sed matched nothing"
 fi
-mut_hit=$(awk -f "$TMP/detect.awk" "$TMP/mut/cmd_usage.sh" "$TMP/mut"/lib/*.sh 2>/dev/null || true)
+mut_hit=$(scan "$TMP/mut/cmd_usage.sh" 2>&1)
 [[ "$mut_hit" == *cmd_usage_budget_check* ]] \
   && ok_t "[budget-check] detector names it once the fix is removed" \
   || bad_t "[budget-check] detector CANNOT see main2's instance" "hit=$mut_hit"
-live_hit=$(awk -f "$TMP/detect.awk" "$SRC/cmd_usage.sh" 2>/dev/null || true)
+live_hit=$(scan "$SRC/cmd_usage.sh" 2>&1)
 [[ "$live_hit" != *cmd_usage_budget_check* ]] \
   && ok_t "[budget-check] fixed in the live tree" || bad_t "[budget-check] still live" "$live_hit"
+
+# Same mutation grade for the two cmd_project_show sites main2 found on iteration
+# 2 — strip each `return 0` from a COPY and the detector must name the function
+# for BOTH reasons (the wrapped trailing conditional, and the bare early return).
+sed -e 's|^    return 0   # DIVE-2751: a BARE.*|    return|' \
+    -e '/# project with zero tasks rendered in full/d' \
+    "$SRC/cmd_project.sh" > "$TMP/mut/cmd_project_a.sh"
+sed '/DIVE-2751: a render that reached the end succeeded/,+1d; /^  return 0   #/d' \
+    "$SRC/cmd_project.sh" > "$TMP/mut/cmd_project_b.sh"
+for pair in "a:bare return inherits this" "b:function rc"; do
+  m="${pair%%:*}"; why="${pair#*:}"
+  if cmp -s "$SRC/cmd_project.sh" "$TMP/mut/cmd_project_$m.sh"; then
+    bad_t "[project show/$m] mutation did NOT apply" "sed matched nothing"
+  else
+    ok_t "[project show/$m] the mutation applied"
+  fi
+  hit=$(scan "$TMP/mut/cmd_project_$m.sh" 2>&1)
+  [[ "$hit" == *cmd_project_show* && "$hit" == *"$why"* ]] \
+    && ok_t "[project show/$m] detector names it as '$why' once the fix is removed" \
+    || bad_t "[project show/$m] detector cannot see it" "hit=$hit"
+done
+live_hit=$(scan "$SRC/cmd_project.sh" 2>&1)
+[[ "$live_hit" != *cmd_project_show* ]] \
+  && ok_t "[project show] fixed in the live tree" || bad_t "[project show] still live" "$live_hit"
 
 # ================= fourth instance: wt_task_num (latent, worktree reclaim) ==========
 # Cheap to execute, so execute it. A non-numeric ident must report "no number" as
@@ -240,48 +328,81 @@ else
 fi
 
 # ================= class guard: no NEW trailing conditional render =================
-# The bug is a shape, not a line, so this guard is what makes the class extinct
-# rather than the three fixes above.
+# The bug is a shape, not a line, so the sweep — not the nine fixes — is what
+# closes the class. What this guard does NOT claim is that the class is extinct:
+# two iterations made exactly that claim in the same change that shipped a blind
+# instrument, so the claim is now the control set below, not a comment.
 #
-# ITERATION 1 SHIPPED A GUARD THAT COULD NOT SEE THE CLASS IT CLAIMED TO CLOSE.
-# It grepped for `[[ ... ]] && { ...echo... }` — a bracket test AND a braced
-# block — so `(( n_unknown > 0 )) && echo ...` was invisible, and that was a live
-# third instance (cmd_usage_budget_check, failing every healthy heartbeat tick).
-# main2 caught it. The lesson is not "add `((` to the regex": enumerating test
-# syntaxes is how the first pattern went wrong. So this finds the last statement
-# STRUCTURALLY — walk back from the function's closing brace, skipping blanks,
-# comments and block closers — and only then asks whether that statement is a
-# conditional with a printing side effect and no `||` fallback.
-#
-# Predicate functions ending in a bare test stay legitimately excluded: the
-# signal is the PRINTING side effect, not the trailing test.
-# Two DELIBERATE survivors, allow-listed by name with the reason, so the guard
-# stays armed for anything new instead of being widened until it is quiet:
-#   _gate_tier2_floor_term — value producer; rc 1 means "named no term". Contract
-#     is intentional and every call site absorbs it (asserted above).
-#   _compose_create_args   — its only caller reads it through a process
-#     substitution (`mapfile -t args < <(...)`), where the rc never reaches
-#     errexit. Fragile but not live; changing its contract is not this row's job.
-offenders=$(awk -f "$TMP/detect.awk" "$SRC"/*.sh "$SRC"/lib/*.sh \
-            | grep -vE '  (_gate_tier2_floor_term|_compose_create_args)$' || true)
-[[ -z "$offenders" ]] && ok_t "no function ends in a trailing conditional render (class guard, structural)" \
-  || bad_t "trailing conditional render is the last statement of a function" "$offenders"
+# The deliberate survivors are named in the script's ALLOWLIST with their reasons
+# (_gate_tier2_floor_term, _compose_create_args, _gate_anon_ok) so the guard stays
+# armed for anything new instead of being widened until it goes quiet.
+offenders=$(scan 2>&1)
+[[ -z "$offenders" ]] && ok_t "no function's rc is supplied by a false-able conditional (class guard)" \
+  || bad_t "a conditional that may be false supplies a function's exit status" "$offenders"
 
-# The guard must be able to SEE the shape that defeated iteration 1. A guard
-# whose only evidence is its own silence is the thing this harness exists to
-# refuse — so hand it that exact syntax and require it to fire.
-mkdir -p "$TMP/canary/lib"
-cat > "$TMP/canary/fixture.sh" <<'CANARY'
-some_render() {
+# ---- the control SET ----
+# The recurring failure is a detector whose only evidence of completeness is its
+# own silence on the instances already known. So it is handed a set built from
+# the shapes that were NOT yet found when each earlier version was written — one
+# fixture per shape, each of which must be named — plus negative controls that
+# must NOT be named, so "widen it until it is quiet" also fails.
+mkdir -p "$TMP/ctl"
+cat > "$TMP/ctl/positive.sh" <<'CTL'
+arith_unbraced() {          # defeated iteration 1: (( )) with no braced block
   local n=0
-  (( n > 0 )) && echo "the unbraced arithmetic form that iteration 1 could not see"
+  (( n > 0 )) && echo "unseen by a [[ ]]-plus-brace pattern"
 }
-CANARY
-: > "$TMP/canary/lib/empty.sh"
-canary=$(awk -f "$TMP/detect.awk" "$TMP/canary"/*.sh "$TMP/canary"/lib/*.sh || true)
-[[ "$canary" == *some_render* ]] \
-  && ok_t "class guard FIRES on the (( )) unbraced form (positive control)" \
-  || bad_t "class guard is blind to the form that defeated iteration 1" "canary=$canary"
+wrapped_printf() {          # defeated iteration 2: the central [[ ]] && printf form,
+  local chain=""            # wrapped, so the last PHYSICAL line is not the statement
+  [[ -n "$chain" ]] && printf 'Critical path: %s (%s)\n' \
+    "$chain" "1"
+}
+early_bare_return() {       # unreachable by any walk-back from the closing brace
+  local n=0
+  if true; then
+    (( n > 0 )) && printf 'nothing to graph\n'
+    return
+  fi
+  printf 'graph\n'
+}
+trailing_loop() {           # a for-loop returns its LAST iteration's status
+  local t p
+  for t in a b c; do
+    p=""
+    [[ -n "$p" ]] && seed_it "$t" "$p"
+  done
+}
+CTL
+cat > "$TMP/ctl/negative.sh" <<'CTL'
+pure_predicate() {          # && lives INSIDE the test — rc IS the contract
+  [[ -n "$1" && "$1" == "$2" ]]
+}
+test_consequent() {         # consequent is only another test, so still a predicate
+  [ -r "$1" ] && [ -s "$1" ]
+}
+has_fallback() {            # a || fallback makes the compound always succeed
+  [[ -n "$1" ]] && printf '%s\n' "$1" || printf 'none\n'
+}
+pipeline_tail() {           # rc comes from the pipe's tail, not the conditional
+  { [[ -n "$1" ]] && printf '%s\n' "$1"; printf 'x\n'; } | cat
+}
+states_its_status() {       # the status is stated explicitly on the line
+  [[ -n "$1" ]] && printf '%s\n' "$1"; return 0
+}
+CTL
+pos=$(scan "$TMP/ctl/positive.sh" 2>&1)
+for shape in arith_unbraced wrapped_printf early_bare_return trailing_loop; do
+  [[ "$pos" == *"$shape"* ]] && ok_t "detector FIRES on $shape (positive control)" \
+    || bad_t "detector is BLIND to $shape" "$pos"
+done
+neg=$(scan "$TMP/ctl/negative.sh" 2>&1)
+[[ -z "$neg" ]] && ok_t "detector stays silent on all five predicate/absorbed shapes (negative control)" \
+  || bad_t "detector fires on a legitimate contract — it would be widened-then-muted" "$neg"
+
+# A scanner that cannot run must not read as clean: exit 2, never 0.
+unreadable=$(scan "$TMP/ctl/does-not-exist.sh" 2>/dev/null; echo "rc=$?")
+[[ "$unreadable" == *"rc=2"* ]] && ok_t "unscannable input exits 2, not 0 (silence is not a pass)" \
+  || bad_t "scanner reported clean on input it could not read" "$unreadable"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/task_show_exit_code_unit.sh
+++ b/tests/task_show_exit_code_unit.sh
@@ -22,9 +22,17 @@
 # Arms: no-dep (the bug) / subtasks-but-no-dep / gate-but-no-dep / --json / and
 # the WITH-dep control that was already green (so a fix that hard-codes rc=0
 # without keeping the block is still distinguishable by its text assertion).
-# Also covers the second instance of the same shape found tree-wide,
-# usage_render_board (`5dive usage` (the default board) exited 1 whenever nobody was over
-# budget), and the one unguarded `_gate_tier2_floor_term` assignment.
+# FOUR instances of the shape, not two. Iteration 1 claimed "exactly one other"
+# and shipped a guard that could only see `[[ ]]` with a braced block; main2 found
+# `(( n_unknown > 0 )) && echo ...` in cmd_usage_budget_check, which failed every
+# HEALTHY heartbeat tick. The count was wrong because the instrument was narrow,
+# so the guard below now finds the last statement STRUCTURALLY and is itself
+# graded against that exact syntax by a positive control.
+#   cmd_task_show          - the reported bug (rc 1 on any row with no dep edge)
+#   usage_render_board     - bare `5dive usage` on the healthy no-overage path
+#   cmd_usage_budget_check - LIVE CALLER: _hb_budget_sweep, every healthy tick (main2)
+#   wt_task_num            - latent; both call sites assign plainly under set -e
+# Plus the one unguarded `_gate_tier2_floor_term` assignment.
 #
 # Sources src/ against a throwaway tasks.db (same posture as
 # project_show_graph_unit.sh) so it NEVER touches the shared queue.
@@ -169,25 +177,111 @@ else
   bad_t "_gate_tier2_floor_term missing" "helper was renamed or removed"
 fi
 
+# ---- the structural detector, used by the three sections below ----
+# Defined here because the budget-check arms grade it before the class guard runs.
+cat > "$TMP/detect.awk" <<'AWK'
+/^[a-zA-Z_][a-zA-Z0-9_]*[ \t]*\([ \t]*\)[ \t]*\{/ { fn=$0; sub(/[ \t]*\(.*/,"",fn); inf=1; n=0; next }
+inf && /^\}/ {
+  for (i=n; i>=1; i--) {
+    l=buf[i]; s=l; gsub(/[ \t]/,"",s)
+    if (s=="" || s ~ /^#/ || s=="fi" || s=="done" || s=="esac" || s=="else" || s==";;" || s=="}") continue
+    # Must START a statement, or a jq continuation line and an `&&` inside an
+    # awk program string both read as shell operators. A `||` fallback makes the
+    # compound succeed regardless, so it is not this defect.
+    if (l ~ /^[ \t]*(\[\[|\(\(|\[ |test |grep |declare )/ &&    \
+        l ~ /&&/ && l !~ /\|\|/ &&                              \
+        l ~ /&&[ \t]*[{(]?[ \t]*(echo|printf|cat |indent2)/ &&  \
+        l !~ /return|exit/)
+      print FILENAME":"lno[i]"  "fn
+    break
+  }
+  inf=0; next
+}
+inf { n++; buf[n]=$0; lno[n]=FNR }
+AWK
+
+# ================= third instance: cmd_usage_budget_check (found by main2) ==========
+# Executing it needs the whole usage plan, so grade it through the detector below
+# instead — and grade it BY MUTATION, or this is just the guard agreeing with
+# itself. Strip the fix from a COPY and the detector must name the function; with
+# the fix in place it must not. The live-caller consequence is what made this the
+# serious one: _hb_budget_sweep does `out=$(cmd_usage_budget_check) || return 1`,
+# and the test is inverted relative to health, so a HEALTHY tick returned 1.
+mkdir -p "$TMP/mut/lib"; : > "$TMP/mut/lib/empty.sh"
+sed '/DIVE-2751 (found by main2 on iteration 1)/,/^  return 0$/d' "$SRC/cmd_usage.sh" > "$TMP/mut/cmd_usage.sh"
+if ! cmp -s "$SRC/cmd_usage.sh" "$TMP/mut/cmd_usage.sh"; then
+  ok_t "[budget-check] the mutation applied (fix removed from the copy)"
+else
+  bad_t "[budget-check] mutation did NOT apply — the arm below would prove nothing" "sed matched nothing"
+fi
+mut_hit=$(awk -f "$TMP/detect.awk" "$TMP/mut/cmd_usage.sh" "$TMP/mut"/lib/*.sh 2>/dev/null || true)
+[[ "$mut_hit" == *cmd_usage_budget_check* ]] \
+  && ok_t "[budget-check] detector names it once the fix is removed" \
+  || bad_t "[budget-check] detector CANNOT see main2's instance" "hit=$mut_hit"
+live_hit=$(awk -f "$TMP/detect.awk" "$SRC/cmd_usage.sh" 2>/dev/null || true)
+[[ "$live_hit" != *cmd_usage_budget_check* ]] \
+  && ok_t "[budget-check] fixed in the live tree" || bad_t "[budget-check] still live" "$live_hit"
+
+# ================= fourth instance: wt_task_num (latent, worktree reclaim) ==========
+# Cheap to execute, so execute it. A non-numeric ident must report "no number" as
+# EMPTY OUTPUT, not as a failure — cmd_task.sh:199's `[[ -n "$num" ]] || return 0`
+# is proof the empty case was meant to be handled, and errexit killed the caller
+# before that guard could run.
+if source "$SRC/lib/disk.sh" 2>/dev/null && declare -F wt_task_num >/dev/null; then
+  wtout=$( set -euo pipefail; v=$(wt_task_num "not-a-number-xyz"); printf 'REACHED[%s]' "$v" )
+  [[ "$wtout" == "REACHED[]" ]] \
+    && ok_t "[wt_task_num] non-numeric ident yields empty output, rc 0 (caller survives set -e)" \
+    || bad_t "[wt_task_num] non-numeric ident still kills the caller" "got='$wtout'"
+  wtok=$( set -euo pipefail; v=$(wt_task_num "DIVE-2751"); printf '%s' "$v" )
+  [[ "$wtok" == "2751" ]] && ok_t "[wt_task_num] still extracts the number (not silenced)" \
+    || bad_t "[wt_task_num] stopped returning the number" "got='$wtok'"
+else
+  bad_t "[wt_task_num] not loadable" "src/lib/disk.sh did not source"
+fi
+
 # ================= class guard: no NEW trailing conditional render =================
-# The bug is a shape, not a line. A function whose last statement is a
-# conditional render block re-introduces it silently — this is what makes the
-# class extinct rather than this one instance. Predicate functions ending in a
-# bare test are legitimate and deliberately NOT flagged: the signal is the
-# printing side effect in the `&&` block.
-offenders=""
-while IFS=: read -r f l rest; do
-  [[ -n "$f" ]] || continue
-  n=$((l+1))
-  while :; do
-    ln=$(sed -n "${n}p" "$f"); ln="${ln//[[:space:]]/}"
-    case "$ln" in ''|'#'*|fi|done|esac|else) n=$((n+1)) ;; *) break ;; esac
-    (( n > l + 40 )) && break
-  done
-  [[ "$(sed -n "${n}p" "$f")" == "}" ]] && offenders+="$f:$l:${rest# }"$'\n'
-done < <(grep -nE '^\s*\[\[[^]]*\]\]\s*&&\s*\{[^}]*(echo|printf)' "$SRC"/*.sh)
-[[ -z "$offenders" ]] && ok_t "no function ends in a trailing conditional render (class guard)" \
+# The bug is a shape, not a line, so this guard is what makes the class extinct
+# rather than the three fixes above.
+#
+# ITERATION 1 SHIPPED A GUARD THAT COULD NOT SEE THE CLASS IT CLAIMED TO CLOSE.
+# It grepped for `[[ ... ]] && { ...echo... }` — a bracket test AND a braced
+# block — so `(( n_unknown > 0 )) && echo ...` was invisible, and that was a live
+# third instance (cmd_usage_budget_check, failing every healthy heartbeat tick).
+# main2 caught it. The lesson is not "add `((` to the regex": enumerating test
+# syntaxes is how the first pattern went wrong. So this finds the last statement
+# STRUCTURALLY — walk back from the function's closing brace, skipping blanks,
+# comments and block closers — and only then asks whether that statement is a
+# conditional with a printing side effect and no `||` fallback.
+#
+# Predicate functions ending in a bare test stay legitimately excluded: the
+# signal is the PRINTING side effect, not the trailing test.
+# Two DELIBERATE survivors, allow-listed by name with the reason, so the guard
+# stays armed for anything new instead of being widened until it is quiet:
+#   _gate_tier2_floor_term — value producer; rc 1 means "named no term". Contract
+#     is intentional and every call site absorbs it (asserted above).
+#   _compose_create_args   — its only caller reads it through a process
+#     substitution (`mapfile -t args < <(...)`), where the rc never reaches
+#     errexit. Fragile but not live; changing its contract is not this row's job.
+offenders=$(awk -f "$TMP/detect.awk" "$SRC"/*.sh "$SRC"/lib/*.sh \
+            | grep -vE '  (_gate_tier2_floor_term|_compose_create_args)$' || true)
+[[ -z "$offenders" ]] && ok_t "no function ends in a trailing conditional render (class guard, structural)" \
   || bad_t "trailing conditional render is the last statement of a function" "$offenders"
+
+# The guard must be able to SEE the shape that defeated iteration 1. A guard
+# whose only evidence is its own silence is the thing this harness exists to
+# refuse — so hand it that exact syntax and require it to fire.
+mkdir -p "$TMP/canary/lib"
+cat > "$TMP/canary/fixture.sh" <<'CANARY'
+some_render() {
+  local n=0
+  (( n > 0 )) && echo "the unbraced arithmetic form that iteration 1 could not see"
+}
+CANARY
+: > "$TMP/canary/lib/empty.sh"
+canary=$(awk -f "$TMP/detect.awk" "$TMP/canary"/*.sh "$TMP/canary"/lib/*.sh || true)
+[[ "$canary" == *some_render* ]] \
+  && ok_t "class guard FIRES on the (( )) unbraced form (positive control)" \
+  || bad_t "class guard is blind to the form that defeated iteration 1" "canary=$canary"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
`5dive task show` exited **1 on every row with no dependency edge**, after printing the full row
correctly. A trailing conditional render evaluated to false and `set -e` took the exit status of
the last command as the script's.

## Why this is worth more than its size

The output lands first, so it reads as success to a human and as **failure to a script**. Anything
branching on `task show`'s exit status treats a perfectly good read as an error. It was hit three
separate times on 2026-08-05 — DIVE-2371, DIVE-2762 and DIVE-2362 — and each time the row rendered
completely and then died, which is exactly the shape that gets dismissed as cosmetic.

## Grading

Not yet graded. **main2 is the verifier** (re-pointed from `main`, per the standing rule that main
holds no verifier seat). Opened so the diff and CI are reachable.

## Provenance, since the record will not show it

Authored by **dev**; committed under `lodar <markounik@gmail.com>` per this repo's house rule;
**pushed by agent-main** — dev holds no HTTPS GitHub credential and agent-main is its only push
route. Base predates current `main` (`4e87712`) — it does NOT descend from it. Branch protection here is `strict: false`, so no rebase is owed; noting it so the graded tree is not mistaken for main's tip.

Refs DIVE-2751.
