### PR TITLE
fix(test): selfcheck_mutation_e2e died before any arm ran — build.sh needs a git repo since DIVE-2603 (DIVE-2783)

### DIFF
--- a/tests/selfcheck_mutation_e2e.sh
+++ b/tests/selfcheck_mutation_e2e.sh
@@ -37,16 +37,46 @@ command -v sqlite3 >/dev/null 2>&1 || { printf 'skip - sqlite3 absent\n'; exit 0
 
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/sc-mut.XXXXXX") || exit 2
 PASS=0; FAIL=0
-ok_t()   { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
-fail_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+# DIVE-2783: record WHICH rail each arm belonged to, so the end of the run can prove
+# the corpus was exercised. `$FAIL -eq 0` alone cannot: it is equally true of a run
+# that proved six rails and of a run that proved nothing, which is the
+# succeeding-in-appearance shape this whole harness exists to catch — and is exactly
+# how it failed, dying before any arm ran.
+RAILS_SEEN=""
+_rail() { case "$1" in \[*\]*) RAILS_SEEN="$RAILS_SEEN ${1%%]*}]" ;; esac; }
+ok_t()   { PASS=$((PASS+1)); _rail "$1"; printf 'ok   - %s\n' "$1"; }
+fail_t() { FAIL=$((FAIL+1)); _rail "$1"; printf 'FAIL - %s\n' "$1"; }
 
 # A pristine copy of the tree, rebuilt into its own bundle.
 WORK="$TMP/repo"
 mkdir -p "$WORK"
 cp -R "$REPO/src" "$REPO/tests" "$REPO/build.sh" "$WORK/" 2>/dev/null
 cp "$REPO/5dive.sha256" "$WORK/" 2>/dev/null || true
+# DIVE-2783: build.sh has hard-required a resolvable source commit since DIVE-2603
+# (#488) — `git rev-parse --verify 'HEAD^{commit}'` or exit 1. This copy is
+# deliberately NOT a git repo (it is a throwaway precisely so the prover never
+# mutates the tree it grades), so every rebuild() failed and the harness died at the
+# line below before a single arm ran — on BOTH full-sweep shards, main's only red.
+#
+# Give the copy its own one-commit history rather than teaching build.sh to build
+# without one: the identity stamp is the whole point of DIVE-2603, and weakening it
+# to accommodate a test fixture is the tail wagging the dog. Mutations after this
+# point leave the copy dirty, which build.sh stamps `<sha>-dirty` BY DESIGN — that
+# is a stamp, not a refusal, so every later rebuild() still succeeds.
+git -C "$WORK" init -q \
+  && git -C "$WORK" add -A \
+  && git -C "$WORK" -c user.name='harness' -c user.email='harness@example.com' \
+       -c commit.gpgsign=false commit -qm 'throwaway baseline for the mutation prover' -q \
+  || { printf 'FAIL: could not give the pristine copy a git identity (build.sh needs one since DIVE-2603)\n'; exit 1; }
 rebuild() { (cd "$WORK" && bash build.sh >/dev/null 2>&1); }
-rebuild || { printf 'FAIL: could not build the pristine copy\n'; exit 1; }
+# Name the reason. The bare message here cost a full triage cycle: it says the build
+# failed but not why, so a red on a shard nobody can shell into is unattributable and
+# gets guessed at from commit timing instead of read off the error.
+rebuild || {
+  printf 'FAIL: could not build the pristine copy:\n%s\n' \
+    "$( (cd "$WORK" && bash build.sh 2>&1) | tail -5 )"
+  exit 1
+}
 
 # Run one probe against the throwaway bundle, with the probes that read a checkout
 # pointed at the throwaway checkout rather than the live one.
@@ -348,6 +378,20 @@ else
 fi
 SC_ENV=()
 rm -rf "$SC_LC"
+
+# DIVE-2783: prove the corpus RAN. Every rail below is unconditional on every box;
+# audit-nonroot is deliberately absent from the list because it self-skips as root,
+# and a floor that reds on a legitimate skip would be its own false signal.
+#
+# This is the arm that makes the fix gradeable. Restoring the build and leaving the
+# prover silent — an early exit, a copy that builds but produces no bundle, a rail
+# that stops being invoked — passes `$FAIL -eq 0` and fails here.
+for _r in gate-delivery harness-verdicts bundle-integrity scorecard-honesty lead-clear-seal; do
+  case "$RAILS_SEEN" in
+    *"[$_r]"*) ;;
+    *) fail_t "[corpus] rail '$_r' produced NO arm at all — the prover was SILENT on it, which is indistinguishable from a pass on \$FAIL alone" ;;
+  esac
+done
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
`tests/selfcheck_mutation_e2e.sh` has been **dying before a single arm ran** on `main` since #488
landed, and the failure looked nothing like its cause.

**Mechanism.** DIVE-2603 (#488) made `build.sh` hard-require a resolvable source commit —
`git rev-parse --verify 'HEAD^{commit}'` or `exit 1` — because the bundle now carries its build sha
as identity. This harness deliberately builds a throwaway **copy** of the tree, so the mutation
prover never touches the live checkout, and that copy has no `.git`. So `rebuild()` exits 1 and the
harness aborts at *"could not build the pristine copy"* before any arm executes.

**Fix (a): the harness gives its copy a one-commit history**, matching what
`release_cut_bundle_unit`, `rollback_rate_unit` and `version_bump_guard_unit` already do. Deliberately
**not** (b) — teaching `build.sh` to degrade without git would weaken the identity guarantee #488
exists to create, four hours after it landed, to accommodate a test fixture.

**Why it matters more than one red harness.** The abort is an **early exit that makes every
downstream arm invisible rather than failing** — the succeeding-in-appearance shape this harness
exists to catch, occurring in the harness itself. Any grade must assert the arms *ran*, not merely
that the harness exited 0.

## Attribution, established by mechanism rather than timing

`#486` landed 09:31 UTC and `#488` 10:00 UTC, both after the last green full-sweep at 08:10, so
timing cannot separate them. `git diff e93a0c2 4e87712` shows the guard as an **added** line, naming
#488. The first candidate (`_sc_probe_t2_forge`, changed in #486) was ruled out by reading the
harness: zero occurrences of `t2`, `forge`, `cgroup` or `--human`, every probe call scoped `--only=`.

Controlled contrast, one variable: the same copy without `.git` → `rc=1`; after `git init` plus one
commit → `rc=0`.

## Scope: measured, not inferred

All 35 harnesses that copy the tree and reference `build.sh` were **run** on a built tree at
`4e87712`:

- **34 green**
- **1 exposed** — this harness
- **1 red for an unrelated reason** — `actor_claim_corroboration_unit.sh` (T19 e2e, `created_by=''`
  where it expects the claim; zero mentions of `build.sh` or `git` in its log, and green in CI on
  both shards, so it is local to the running seat). Filed separately rather than folded in to make
  the number tidy.

**The exposed set is exactly one.** "31 need running" was inference; running them is what shrank it.
The surface was real, the exposure was not.

## Mutation grade

The arm asserts the arms **ran**, not that the harness exited 0. Each arm records its rail, and a
rail producing no arm at all is a FAIL. Three ways:

| mutation | result |
|---|---|
| revert the `git init` | reds, dies at the build — the fix is load-bearing |
| silence one rail, build fully restored | **40 passed, 1 failed, rc=1** |
| neither | 44 passed, 0 failed |

The middle row is the one that matters: a fix that restores the build and leaves the prover silent
fails there, and would have passed on a `$FAIL` count alone.

`audit-nonroot` and `snapshot-rails` are excluded from that floor deliberately — both self-skip
(root, and the ops fixture), and a floor that reds on a legitimate skip is its own false signal.

Mutations leave the copy dirty, which `build.sh` stamps `<sha>-dirty` **by design** — a stamp, not a
refusal — so every later `rebuild()` still succeeds. That was the one thing that could have made (a)
not work, and it does not.

## The build failure now names its reason

The bare *"could not build the pristine copy"* is what cost the triage cycle: it said the build
failed but not why, so a red on a shard nobody can shell into gets guessed at from commit timing
instead of read off the error. Both of the first two hypotheses, and the first candidate, were
guesses for that reason.

## Why this is on the critical path

While `full-sweep` is red on `main`, every row delivered on a PR needs `--force-merge-gate` to close,
because the merge gate refuses on *merged AND green*. DIVE-2736 already had to. That trains a reflex
an audited escape must never become routine for, and this is the fix that stops it.

## Provenance

Triaged and authored by **dev**; committed under `lodar <markounik@gmail.com>` per this repo's house
rule; **pushed by agent-main** — dev holds no HTTPS GitHub credential. Regression originates in a
change agent-main merged.

Refs DIVE-2783.

## Landing note

Merged on a genuine green — 13/13, `--admin` available and not used, no required check bypassed.

The first CI attempt failed `test-installed-host` on **`tests/ui_views_e2e.sh`**, which is a
different harness from the one this PR touches: that file is tier `nightly`, `ui_views_e2e` is core.
The failed job was re-run openly, with the finding already recorded, and passed.

**Attribution rests on one fact, not on a rate:** arm 15 of `ui_views_e2e.sh` fails on a tree that
does **not** contain this commit (`4e87712`). dev's first comparison was withdrawn by dev itself —
its control differed from the branch by seven files and 612 lines rather than one, so the 3/5-vs-1/5
split it produced could not be read as branch-versus-control at all, and at n=5 is noise for a
~20–40% intermittent regardless. The one-variable comparison is `4fd24e2` vs `b9e9b22`, which
`git diff --stat` confirms is exactly this one file.

`ui_views_e2e.sh` is now **reproducible** — roughly 20–40% across interleaved local runs, always the
same arm, always `the one request is answered (want=200 got=)` with
`RemoteDisconnected: Remote end closed connection without response`. Candidate mechanism, offered as
a candidate and not asserted: line 259 picks a port by binding to port 0, reading it, then **closing
the socket**, and readiness is then probed with `ss -ltn | grep -q 127.0.0.1:$PORT2` — which confirms
*a* listener on that port, not *ours*. Between the close and the server's bind, the port is free for
anyone. Filed separately; it is a required check that reds intermittently and will do this to every
PR until arm 15's port race is closed.
