### PR TITLE
DIVE-2773: a FIRST close must carry a reason on both verbs; a cancel no longer deletes a live human gate

### DIFF
--- a/changelog.d/DIVE-2773.md
+++ b/changelog.d/DIVE-2773.md
@@ -1,0 +1,53 @@
+## Unreleased — fix(task): a FIRST close must carry a reason, on both verbs; a cancel no longer deletes a live human gate (DIVE-2773)
+
+Filed as an asymmetry — *"`task done --result=` refuses an empty value; `task cancel --result=`
+accepts one"* — and that mechanism was **wrong**, which changes the fix. `_task_guard_result_over_closed`
+returns early when the row carries no result yet (`-z "$_cl_prev"`): with nothing recorded there
+are no bytes at risk, which is correct for destroy-protection and means **a first close with a
+blank reason was accepted by BOTH verbs all along**. Shipping "give `cancel` the check `done`
+already has" would have delivered destroy-protection that misses every blank first close and
+leaves `done`, the commoner verb, exactly as open.
+
+The measurement that stands: **seven empty-result cancels on the board in three days, every one a
+daily recurring row**, arriving in bursts — three inside 186 seconds. DIVE-2472 was the same act by
+the same actor on the same template *with* a reason ("a stale dated instance, not work declined")
+and is still explicable six days on; DIVE-2683 and DIVE-2737 are not.
+
+- **A first close now requires a non-empty `--result=`, on `done` and `cancel` alike.** A new
+  predicate, not a ported one: *this row is being closed and nothing has ever been written about
+  why*. The refusal names the SHAPE of a good reason, because a caller under load writes "n/a"
+  unless told otherwise. **No flag bypasses it** — the population is exactly callers clearing a
+  board at speed, and a flag is what they reach for.
+- **Scoped so no false refusal is possible.** A maker→verifier *delivery* routes and returns before
+  the check, so a bare `task done` handoff is untouched; an already-closed row keeps its
+  long-standing idempotent bare re-close (rc=0 no-op); a row that already carries text is the other
+  guard's population.
+- **Both close verbs now refuse over a PENDING gate.** The empty cancel of DIVE-2758 also destroyed
+  a **live tier-2 human gate** — the buttons were retired ~8 minutes after the gate reached its
+  audience, on lodar's own surface decision, and the row still reads `answer: — pending`. A cancel
+  does not answer a gate; it deletes the question. This fires **with a good reason attached** and is
+  a stronger condition than the one above, not a case of it. `DIVE-555`'s refusal text, which named
+  `task cancel` as the sanctioned way out of a gated row, no longer does — it was publishing the
+  exact route DIVE-2758 took. Both refusals name `5dive task need <id> --withdraw`, a **recorded
+  withdrawal rather than an answer put in anyone's mouth**; refusing without naming it would leave a
+  gated row with no close verb at all and send the next agent to invent one.
+- **`task reject` now routes through the shared result guard** instead of a private copy of the
+  predicate DIVE-2483 replaced. Its own preservation fired only when the row was `done` — but a row
+  delivered to a verifier is `todo` **by design**, so on the *ordinary* bounce the branch never
+  fired and the bare UPDATE **replaced the maker's result** with the rejection text, silently. This
+  is DIVE-2762's finding one verb over: the guard keyed on closed-ness while the population is
+  carries-a-result. `reject` was never one of the shared guard's three call sites and so survived
+  the fix meant to kill the class, wearing a `DIVE-2067` marker that made it look handled. It asks
+  the guard to APPEND, which is what keeps DIVE-2112's legitimate reopen (the recorded verifier
+  withdrawing their own grade) working. **Observable change to the record:** on a closed row,
+  reject now writes the shared guard's `--- appended by a later close (DIVE-2464) ---` seam
+  instead of its private `--- superseded result (DIVE-2067, preserved) ---` one. The marker
+  changed and the guarantee did not — and it now also fires on the delivered-`todo` row, where
+  reject previously preserved nothing at all. `task verify`'s closed path still writes the
+  DIVE-2067 marker, so a grep for superseded records wants both strings.
+
+`tests/task_close_needs_a_reason_unit.sh`. Arms B and D are the ones a port-of-the-existing-check
+leaves red while looking like a fix; F/G are the non-vacuity half (a bare re-close still lands, a
+delivery is not a close); K builds the delivered-`todo` cell through the real rail, because that
+state is exactly what the old private predicate missed. Write-up:
+`community/wiki/a-guard-cited-by-name-covers-less-than-its-name-claims.md`.

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -3561,15 +3561,113 @@ _task_status_cmd() {
   # a task that still has an UNANSWERED human gate — that's how DIVE-535's
   # public-publish approval got bypassed (the task was marked done while its
   # approval gate sat 'pending', so the public ship happened with no recorded
-  # sign-off). Block the close: the gate must be answered (`task answer`) or the
-  # task abandoned (`task cancel`, which legitimately closes a gated task).
+  # sign-off). Block the close: the gate must be answered (`task answer`) or
+  # WITHDRAWN (`task need --withdraw`).
   # Verifier routing already returned above; only a real `done` reaches here.
-  if [[ "$verb" == "done" ]]; then
+  #
+  # DIVE-2773: this refusal used to name `task cancel` as the legitimate way out,
+  # and that is now false — cancel is refused over a live gate too, immediately
+  # below. It was never as safe as it read: a cancel does not ANSWER the gate, it
+  # deletes the question, and it silently retires the human's buttons on the way
+  # (_task_gate_retire_buttons, further down this same function). Naming it here
+  # published the route that DIVE-2758 took.
+  if [[ "$verb" == "done" || "$verb" == "cancel" ]]; then
     local _gt _ga
     _gt=$(db "SELECT COALESCE(need_type,'')        FROM tasks WHERE id=${id};")
     _ga=$(db "SELECT COALESCE(need_answered_at,'') FROM tasks WHERE id=${id};")
     if [[ -n "$_gt" && -z "$_ga" ]]; then
-      policy_refuse "$E_CONFLICT" done-over-open-gate DIVE-555 "$ident" "$ident has a pending '${_gt}' gate awaiting a human — answer it (5dive task answer $ident ...) or abandon the task (5dive task cancel $ident) instead of marking done. A gated/public ship must not close ahead of its gate (DIVE-555)."
+      if [[ "$verb" == "done" ]]; then
+        policy_refuse "$E_CONFLICT" done-over-open-gate DIVE-555 "$ident" "$ident has a pending '${_gt}' gate awaiting a human — answer it (5dive task answer $ident ...), or withdraw it if it is genuinely moot (5dive task need $ident --withdraw), instead of marking done. A gated/public ship must not close ahead of its gate (DIVE-555)."
+      fi
+      # DIVE-2773: THE CANCEL HALF, and it is a STRONGER condition than the
+      # reason requirement below rather than a case of it — it fires with a
+      # perfectly good reason attached.
+      #
+      # MEASURED (main, 2026-08-05): the 06:18:33 empty cancel of DIVE-2758 also
+      # destroyed a LIVE tier-2 human gate — `agent-olivia gate button retire
+      # [ok]` twice at that timestamp, ~8 minutes after the gate reached
+      # marketing, on lodar's own surface decision, and the row still reads
+      # `answer: — pending`. So the loss was not merely the record of a decision:
+      # it was the AFFORDANCE BY WHICH A HUMAN COULD STILL MAKE ONE. A reason
+      # field cannot repair that, which is why this is not folded into the check
+      # below.
+      #
+      # WHY IT REFUSES RATHER THAN WARNS: the retire is already silent-by-design
+      # (best-effort, `|| true`, no stderr), and the operator population here is
+      # exactly callers clearing a board at speed. A warning is read after the
+      # write; the buttons are gone by then.
+      #
+      # THE EXITS ARE NAMED ON PURPOSE, against the DIVE-2067 rule that a refusal
+      # should not publish a route around itself — because here the alternative is
+      # WORSE than a published route. Refusing `done` (DIVE-555) and `cancel`
+      # (this) with no exit leaves a gated row with NO close verb at all, so the
+      # next agent invents one: a raw UPDATE, a --force flag request, or an
+      # `answer` typed on the human's behalf, which is the forgery DIVE-1117's
+      # tier floor exists to prevent. `--withdraw` is the honest exit and it is
+      # recorded as a withdrawal in gate_history, never as an answer. See
+      # community/wiki/a-default-action-that-terminates-on-a-human-held-surface-is-a-queue.md.
+      local _cg_filer; _cg_filer=$(db "SELECT COALESCE(NULLIF(gate_filed_by,''), assignee, '') FROM tasks WHERE id=${id};")
+      policy_refuse "$E_CONFLICT" cancel-over-open-gate DIVE-2773 "$ident" \
+        "$ident has a PENDING '${_gt}' gate still awaiting a human, and a cancel does not answer it — it deletes the question and silently retires the human's buttons on the way out (measured on DIVE-2758: a live tier-2 gate on lodar's own surface decision was retired by an empty cancel and still reads 'pending' with nobody having answered). Abandoning the WORK is legitimate; abandoning the QUESTION out from under the person it was asked of is not. Retire the gate explicitly first, then cancel: '5dive task need $ident --withdraw' (a recorded withdrawal, not an answer put in anyone's mouth) — filed by '${_cg_filer:-unknown}', so their lead can withdraw it too. If the question still matters, let them answer it instead: '5dive task answer $ident --value=...'."
+    fi
+  fi
+  # DIVE-2773: A FIRST CLOSE REQUIRES A NON-EMPTY REASON, ON BOTH VERBS.
+  #
+  # This is NOT the DIVE-2483/DIVE-2464 guard ported to `cancel`, and the
+  # difference is the whole ticket. That guard is DESTROY-protection: its own
+  # first lines return early when the row carries no result yet
+  # (`if [[ -z "$_cl_prev" ... ]]`), because with nothing recorded there are no
+  # bytes at risk. Correct for what it does — and it means a FIRST close with a
+  # blank reason was accepted by BOTH verbs all along (demonstrated by olivia on
+  # scratch row DIVE-2774: open row, `task done --result=""`, rc=0, empty result
+  # stored). Shipping "give cancel the check done already has" would have
+  # delivered destroy-protection that misses every blank first close and leaves
+  # `done`, the commoner verb, exactly as open. So this is a new predicate keyed
+  # on the other thing entirely: THIS ROW IS BEING CLOSED AND NOTHING HAS EVER
+  # BEEN WRITTEN ABOUT WHY.
+  #
+  # MEASURED POPULATION (main, from lifecycle_events, actor column read not
+  # inferred): seven empty-result cancels in three days, five by main and two by
+  # olivia, EVERY ONE of them a daily recurring row, arriving in bursts — three
+  # inside 186 seconds on 08-05, two inside 23 seconds on 08-04. The record they
+  # left is unreadable: DIVE-2472 was the same act by the same actor on the same
+  # template WITH a reason ("a stale dated instance, not work declined") and is
+  # still explicable six days on; DIVE-2683 and DIVE-2737 are not. Identical
+  # verb, identical author, opposite legibility, and the only difference is
+  # whether the field was filled.
+  #
+  # NO FLAG BYPASSES THIS, deliberately. The population is precisely callers
+  # clearing a board at speed, and a flag is what they reach for; an escape hatch
+  # would be taken by exactly the people this exists to slow down. The cost of
+  # being wrong is one sentence.
+  #
+  # SCOPE, kept narrow so no false refusal is possible:
+  #   * only a REAL close — a maker→verifier delivery routes and returns above,
+  #     so a bare `task done` handoff is untouched;
+  #   * only a FIRST close — an already done/cancelled row keeps its long-standing
+  #     idempotent bare re-close (rc=0 no-op). "First" is meant literally;
+  #   * only when the column is empty AND nothing is being written. A row that
+  #     already carries text is the other guard's population, and a close that
+  #     supplies text is what this asks for.
+  if [[ "$verb" == "done" || "$verb" == "cancel" ]]; then
+    local _fc_st _fc_prev
+    _fc_st=$(db   "SELECT COALESCE(status,'') FROM tasks WHERE id=${id};")
+    _fc_prev=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=${id};")
+    if [[ "$_fc_st" != "done" && "$_fc_st" != "cancelled" && -z "$_fc_prev" && -z "$result" ]]; then
+      # NAME THE SHAPE OF A GOOD REASON, not just the flag. The useful cancel
+      # reasons say what was NOT concluded — main's own DIVE-2472 text is the
+      # model — and a caller under load writes "n/a" unless told otherwise, which
+      # satisfies a non-empty check while recording nothing. A refusal that only
+      # says "pass --result" buys the string and not the sentence.
+      local _fc_shape _fc_past="closed"
+      [[ "$verb" == "cancel" ]] && _fc_past="cancelled"
+      if [[ "$verb" == "cancel" ]]; then
+        _fc_shape="Say what was NOT concluded, not just that you stopped: 'CANCELLED as a stale dated instance, not as work declined — an overnight recap cannot usefully be back-sent three days later' (DIVE-2472) is still readable six days later; 'n/a' and 'done' are not. If the row is a stale recurring instance, say so; if the work was declined, say why."
+      else
+        _fc_shape="Say what the reader needs — what shipped or what was concluded, and where to look (a PR, a sha, a file). The dashboard and this row's creator read this field and nothing else."
+      fi
+      policy_refuse "$E_VALIDATION" close-without-reason DIVE-2773 "$ident" \
+        "$ident is being ${_fc_past} for the first time and nothing has ever been recorded about why — '5dive task ${verb}' here would close it with a permanently blank result. The ledger keeps only a sha256 of that field, so an empty one is indistinguishable from one nobody ever wrote and the loss is undetectable afterwards (DIVE-2483's reasoning, which is about the COLUMN, not the verb). Pass '--result=<why>' (or '--result-file=<path>'). ${_fc_shape} No flag bypasses this."
     fi
   fi
   # DIVE-1830 merge-gate (opt-in): a task that declared DELIVERED WORK cannot
@@ -4364,6 +4462,19 @@ $_body"
   # retired at answer time, and re-editing would only add a "not modified" row.
   # Independent of --notify (that flag governs the human's ✅/⚠️ ping, a different
   # question from whether a dead control is still on their screen).
+  #
+  # DIVE-2773: THIS IS NOW UNREACHABLE BY CONSTRUCTION and is kept anyway, which is
+  # a claim that needs its reasons stated rather than left for the next reader to
+  # rediscover. Both close verbs are refused above while a gate is unanswered, so
+  # no `done`/`cancel` can arrive here with `need_answered_at IS NULL`; the retire
+  # WIRING is still exercised by `task answer`, `task need --withdraw`, a re-filed
+  # gate and `task park`, which are the paths that legitimately moot a question.
+  # It stays because it is idempotent and free on the reachable path (the SELECT
+  # returns nothing), and because it is the backstop if either refusal above is
+  # ever scoped narrower — a close that lands on a live gate must not leave a
+  # button that looks answerable. Its old test arm was inverted rather than
+  # deleted (tests/gate_button_retire_unit.sh): over a live gate the cancel is
+  # refused and the button must SURVIVE, because the question is still open.
   if [[ "$verb" == "done" || "$verb" == "cancel" ]]; then
     local _open_gate
     _open_gate=$(db "SELECT 1 FROM tasks WHERE id=${id} AND need_type IS NOT NULL AND need_answered_at IS NULL;" 2>/dev/null || echo "")
@@ -4853,16 +4964,45 @@ cmd_task_reject() {
     policy_refuse "$E_CONFLICT" reject-over-closed DIVE-2112 "$ident" \
       "$ident is already done and was graded by '${vfier}', not by you ('${_rj_actor}'). Reopening it here would discard that grade and file the reopen under '${vfier}''s name. '${vfier}' can reopen their own grade; anyone else should raise a NEW task citing $ident."
   fi
-  _rj_prev=$(db "SELECT COALESCE(result,'') FROM tasks WHERE id=${id};")
   # (3) attribute to the REAL actor, never to the recorded verifier by assumption.
   local fb_txt="❌ ${_rj_actor} rejected (iteration ${iter}): ${feedback:-no feedback given}"
-  # (4) never silently discard a landed record.
-  if [[ "$_rj_st" == 'done' && -n "$_rj_prev" ]]; then
-    # ONE marker, deliberately shared with the verify path (olivia, DIVE-2112: "extend,
-    # do not fork the marker") so a single grep finds every superseded record. The
-    # ticket in the string names the CONVENTION's origin, not this call site.
-    fb_txt="${fb_txt}"$'\n'"--- superseded result (DIVE-2067, preserved) ---"$'\n'"${_rj_prev}"
-  fi
+  # (4) never silently discard a landed record — VIA THE SHARED GUARD, not a
+  # private copy of it.
+  #
+  # DIVE-2773. `reject` cannot write a BLANK (a missing --feedback substitutes
+  # "no feedback given" above), so it is not in the first-close-needs-a-reason
+  # population at all. Its defect was the other one, and it is DIVE-2762 EXACTLY,
+  # one verb over: the hand-rolled preservation this replaces read
+  #
+  #     if [[ "$_rj_st" == 'done' && -n "$_rj_prev" ]]; then ... fi
+  #
+  # so the preservation FIRED ONLY ON A `done` ROW. A row delivered to a verifier
+  # is `todo` BY DESIGN — that is the rail's own contract, a correct `task done`
+  # delivers it, status stays todo, assignee moves to the verifier. So on the
+  # ORDINARY reject path, the one the loop manufactures on every bounce, `_rj_st`
+  # is 'todo', the branch did not fire, and the bare UPDATE below replaced the
+  # MAKER'S RESULT with the rejection text. No warning, no marker, no audit of
+  # the overwritten value.
+  #
+  # That is DIVE-2762's finding verbatim: the guard keyed on CLOSED-NESS while
+  # the population is CARRIES-A-RESULT. DIVE-2483 repaired exactly that for
+  # done/deliver/verify by routing all three through
+  # `_task_guard_result_over_closed`. `cmd_task_reject` was never one of its call
+  # sites; it kept a private copy of the OLD, WRONG predicate and so survived the
+  # fix meant to kill the class — while wearing a DIVE-2067 marker that made it
+  # look handled. Fixing a class in three places and leaving a fourth hand-rolled
+  # copy is how this got here, which is why the remedy is one predicate and not a
+  # fourth condition: the next verb added inherits the guard instead of a habit.
+  #
+  # append_result=1 rather than 0, and that is load-bearing: on a CLOSED row the
+  # guard's default is to REFUSE, which would break the one legitimate reopen
+  # DIVE-2112 allows (the recorded verifier withdrawing their own grade) — the
+  # very case the old private branch existed to serve. Asking for the append is
+  # what makes this a strict widening. Note the seam puts the PRIOR text first
+  # now, where the old marker put it last; that is the shared convention's order
+  # and a single grep still finds every superseded record.
+  _task_guard_result_over_closed "$id" "$ident" reject "$fb_txt" 1 0 reject-result-over-open
+  fb_txt="$_TASK_GUARDED_RESULT"
   # DIVE-1495: a reject supersedes any still-open need-gate on this task. Leaving
   # it 'pending' (need_answered_at NULL) let the DIVE-1490 re-nag ladder keep
   # firing a question the reject already mooted (CNCL-9: lodar was re-nagged AFTER

--- a/tests/gate_button_retire_unit.sh
+++ b/tests/gate_button_retire_unit.sh
@@ -214,7 +214,14 @@ seed_gate() { # <title> -> ident on stdout; files a real gate through the real n
   printf '%s' "$ident"
 }
 
-for arm in answer withdraw done; do
+# DIVE-2773: the `done` arm was `cmd_task_cancel --result="moot"` over a LIVE gate,
+# and that close is now REFUSED on both verbs — a cancel does not answer a gate, it
+# deletes the question, and it was retiring the human's buttons on the way out
+# (measured on DIVE-2758). So the arm is inverted rather than deleted: over a still-open
+# gate the button must SURVIVE, because the question is still answerable. That is a
+# stronger assertion than the one it replaces, and the retire WIRING it used to cover is
+# still graded three ways below by the answer/withdraw/refile arms.
+for arm in answer withdraw; do
   ident=$(seed_gate "DIVE-2410 wiring arm: $arm")
   if [[ -z "$ident" ]]; then chk "wiring/$arm: seeded a gate" "yes" "no"; continue; fi
   chk "wiring/$arm: the real emitter logged a retirable delivery" "1" \
@@ -223,11 +230,28 @@ for arm in answer withdraw done; do
   case "$arm" in
     answer)   ( cmd_task_answer   "$ident" --value=A ) >/dev/null 2>&1 ;;
     withdraw) ( cmd_task_need     "$ident" --withdraw ) >/dev/null 2>&1 ;;
-    done)     ( cmd_task_cancel   "$ident" --result="moot" ) >/dev/null 2>&1 ;;
   esac
   chk "wiring/$arm: the close path retired the delivered button" \
       "tok-marketing|1234567890|15491" "$(edits)"
 done
+
+# DIVE-2773 (replaces the old `done` arm above): a cancel over a LIVE gate is refused,
+# and the button it used to strip must still be there afterwards. Both halves are
+# asserted — a refusal that left the button retired anyway would pass a bare
+# "did it refuse" check while shipping the exact harm.
+ident=$(seed_gate "DIVE-2773 wiring arm: cancel over a live gate")
+if [[ -z "$ident" ]]; then chk "wiring/cancel-refused: seeded a gate" "yes" "no"; else
+  chk "wiring/cancel-refused: the real emitter logged a retirable delivery" "1" \
+      "$(_task_gate_deliveries "$ident" | grep -c '15491')"
+  reset_edits
+  ( cmd_task_cancel "$ident" --result="moot" ) >/dev/null 2>&1; _c2773_rc=$?
+  chk "wiring/cancel-refused: the cancel is REFUSED over a live gate" "refused" \
+      "$( (( _c2773_rc != 0 )) && echo refused || echo "landed rc=$_c2773_rc" )"
+  chk "wiring/cancel-refused: the human's button SURVIVES (the question is still answerable)" \
+      "" "$(edits)"
+  chk "wiring/cancel-refused: ...and the gate is still pending" "decision/pending" \
+      "$(db "SELECT COALESCE(need_type,'-')||'/'||CASE WHEN need_answered_at IS NULL THEN 'pending' ELSE 'answered' END FROM tasks WHERE ident=$(sqlq "$ident");")"
+fi
 
 # The stub above is load-bearing containment, not decoration: if cmd_send stops
 # being the resume path, this reads 0 and the next reader learns the harness lost

--- a/tests/heartbeat_reclaim_verifier_handoff_unit.sh
+++ b/tests/heartbeat_reclaim_verifier_handoff_unit.sh
@@ -85,7 +85,7 @@ _hb_agent_idle()      { return 0; }  # confident idle by default
 mk_delivered_unacked() {
   local id
   id=$(addt --assignee=dev --verifier=olivia -- "ship the widget")
-  ( cmd_task_done "$id" ) >/dev/null 2>&1
+  ( cmd_task_done "$id" --result="closed in fixture setup (DIVE-2773: a first close must carry a reason)" ) >/dev/null 2>&1
   _hb_claim_task olivia "$id" >/dev/null 2>&1
   printf '%s' "$id"
 }

--- a/tests/heartbeat_stall_sweep_unit.sh
+++ b/tests/heartbeat_stall_sweep_unit.sh
@@ -100,7 +100,7 @@ reset_all() {
 #     clears any stale-ping flag, and is untouched by the sweep (too fresh)
 reset_all
 a=$(addt --assignee=dev --verifier=olivia -- "ship the widget")
-( cmd_task_done "$a" ) >/dev/null 2>&1
+( cmd_task_done "$a" --result="closed in fixture setup (DIVE-2773: a first close must carry a reason)" ) >/dev/null 2>&1
 delivered=$(db "SELECT COALESCE(handoff_delivered_at,'NULL') FROM tasks WHERE id=${a};")
 [[ "$delivered" != "NULL" ]] \
   && ok_t "task done to a verifier stamps handoff_delivered_at" \
@@ -132,7 +132,7 @@ _hb_stall_sweep >/dev/null 2>&1
 # --- A4: acknowledged deliveries (handoff_ack_at set) are never surfaced
 reset_all
 b=$(addt --assignee=dev --verifier=olivia -- "ship the gadget")
-( cmd_task_done "$b" ) >/dev/null 2>&1
+( cmd_task_done "$b" --result="closed in fixture setup (DIVE-2773: a first close must carry a reason)" ) >/dev/null 2>&1
 db "UPDATE tasks SET handoff_delivered_at=datetime('now','-999 minutes'),
        handoff_ack_at=datetime('now') WHERE id=${b};"
 : >"$SEND_LOG"
@@ -357,7 +357,7 @@ _hb_stall_sweep >/dev/null 2>&1
 FLEET=$(mkfleet dev); IDLE_MAP=""
 reset_all
 d=$(addt --assignee=dev --verifier=olivia -- "delivered, awaiting the grade")
-( cmd_task_done "$d" ) >/dev/null 2>&1
+( cmd_task_done "$d" --result="closed in fixture setup (DIVE-2773: a first close must carry a reason)" ) >/dev/null 2>&1
 db "INSERT INTO task_prefs (key,value) VALUES ('stall_first_seen_at', datetime('now','-60 minutes'));"
 : >"$SEND_LOG"; : >"$PROBE_LOG"
 _hb_stall_sweep >/dev/null 2>&1

--- a/tests/task_cascade_unblock_unit.sh
+++ b/tests/task_cascade_unblock_unit.sh
@@ -70,7 +70,7 @@ edges() { db "SELECT COUNT(*) FROM task_deps WHERE task_id=$1;"; }
 a=$(addt --assignee=alice -- "blocker A"); b=$(addt --assignee=bob -- "dependent B")
 ( cmd_task_block "$b" --by="$a" ) >/dev/null 2>&1
 [[ "$(st "$b")" == "blocked" && "$(edges "$b")" == "1" ]] || bad_t "T1 setup" "B not blocked"
-( cmd_task_done "$a" ) >/dev/null 2>&1
+( cmd_task_done "$a" --result="closed in fixture setup (DIVE-2773: a first close must carry a reason)" ) >/dev/null 2>&1
 [[ "$(st "$b")" == "todo" && "$(edges "$b")" == "0" ]] \
   && ok_t "done blocker -> dependent flips todo, edge dropped" \
   || bad_t "single cascade" "B status=$(st "$b") edges=$(edges "$b")"
@@ -83,9 +83,9 @@ grep -q $'^bob\t' "$SEND_LOG" \
 a1=$(addt -- "A1"); a2=$(addt -- "A2"); d=$(addt --assignee=dora -- "D two-blockers")
 ( cmd_task_block "$d" --by="$a1" ) >/dev/null 2>&1
 ( cmd_task_block "$d" --by="$a2" ) >/dev/null 2>&1
-( cmd_task_done "$a1" ) >/dev/null 2>&1
+( cmd_task_done "$a1" --result="closed in fixture setup (DIVE-2773: a first close must carry a reason)" ) >/dev/null 2>&1
 half="$(st "$d")/$(edges "$d")"
-( cmd_task_done "$a2" ) >/dev/null 2>&1
+( cmd_task_done "$a2" --result="closed in fixture setup (DIVE-2773: a first close must carry a reason)" ) >/dev/null 2>&1
 full="$(st "$d")/$(edges "$d")"
 [[ "$half" == "blocked/1" && "$full" == "todo/0" ]] \
   && ok_t "two blockers: stays blocked after 1, flips after both ($half -> $full)" \
@@ -94,7 +94,7 @@ full="$(st "$d")/$(edges "$d")"
 # --- T3: CANCELLING a blocker cascades just like done
 a=$(addt -- "A cancel"); b=$(addt --assignee=bob -- "B via cancel")
 ( cmd_task_block "$b" --by="$a" ) >/dev/null 2>&1
-( cmd_task_cancel "$a" ) >/dev/null 2>&1
+( cmd_task_cancel "$a" --result="closed in fixture setup (DIVE-2773: a first close must carry a reason)" ) >/dev/null 2>&1
 [[ "$(st "$b")" == "todo" && "$(edges "$b")" == "0" ]] \
   && ok_t "cancelled blocker also cascades" || bad_t "cancel cascade" "B status=$(st "$b")"
 
@@ -102,7 +102,7 @@ a=$(addt -- "A cancel"); b=$(addt --assignee=bob -- "B via cancel")
 a=$(addt -- "A gate"); b=$(addt --assignee=bob -- "B gated")
 ( cmd_task_block "$b" --by="$a" ) >/dev/null 2>&1
 ( cmd_task_need "$b" --type=decision --options="X|Y" --ask="pick one" ) >/dev/null 2>&1
-( cmd_task_done "$a" ) >/dev/null 2>&1
+( cmd_task_done "$a" --result="closed in fixture setup (DIVE-2773: a first close must carry a reason)" ) >/dev/null 2>&1
 [[ "$(st "$b")" == "blocked" && "$(edges "$b")" == "0" ]] \
   && ok_t "need-gated dependent stays blocked (edge dropped, not flipped)" \
   || bad_t "gate guardrail" "B status=$(st "$b") edges=$(edges "$b")"
@@ -111,7 +111,7 @@ a=$(addt -- "A gate"); b=$(addt --assignee=bob -- "B gated")
 a=$(addt -- "A park"); b=$(addt --assignee=bob -- "B parked")
 ( cmd_task_block "$b" --by="$a" ) >/dev/null 2>&1
 db "UPDATE tasks SET parked_at=datetime('now'), park_reason='holding' WHERE id=$b;"
-( cmd_task_done "$a" ) >/dev/null 2>&1
+( cmd_task_done "$a" --result="closed in fixture setup (DIVE-2773: a first close must carry a reason)" ) >/dev/null 2>&1
 [[ "$(st "$b")" == "blocked" ]] \
   && ok_t "parked dependent stays blocked (park owns the hold)" \
   || bad_t "park guardrail" "B status=$(st "$b")"

--- a/tests/task_close_needs_a_reason_unit.sh
+++ b/tests/task_close_needs_a_reason_unit.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# TIER: nightly — 36s measured on the control-plane VM (bare `bash tests/task_close_needs_a_reason_unit.sh`,
+# built tree, 2026-08-05): does not fit the 300s PR core, where it would be 12% of the whole
+# budget on its own. Nothing here is network-priced — the cost is ~20 real `task add`/close/
+# reject round-trips through the audit, reclaim and cascade rails, and the arms that make this
+# harness worth having (F, G, K, L) are precisely the ones that need the REAL rail rather than a
+# fixture, so there is no cheaper shape that still grades the defect. Its two nearest neighbours
+# (task_close_preserves_done_at_unit.sh, 52.4s) are nightly for the same reason. Editing it always
+# runs it, so the PR that changes this guard still grades it.
+# DIVE-2773 — a FIRST close must carry a reason, on BOTH verbs; a cancel must not
+# delete a live human gate; and `task reject` must stop hand-rolling the result guard.
+#
+# THE FILING'S OWN MECHANISM WAS WRONG AND THAT IS WHY THIS HARNESS EXISTS.
+# The row was filed as "cancel accepts an EMPTY result while done refuses one".
+# It does not. `_task_guard_result_over_closed` RETURNS EARLY when the row carries
+# no result yet — with nothing recorded there are no bytes at risk, which is
+# correct for destroy-protection and means a blank FIRST close was accepted by
+# BOTH verbs all along (olivia, on scratch row DIVE-2774: open row,
+# `task done --result=""`, rc=0, empty result stored). So arms A-D grade a NEW
+# predicate — "this row is being closed and nothing has ever been written about
+# why" — and B/D exist specifically because a port of the existing check to
+# `cancel` would leave them RED while looking like a fix.
+#
+# WHAT THE MEASUREMENT WAS, since the guard is only worth its cost against it:
+# seven empty-result cancels on the board in three days, every one a daily
+# recurring row, arriving in bursts (three inside 186 seconds). DIVE-2472 was the
+# same act by the same actor on the same template WITH a reason and is still
+# explicable six days on; DIVE-2683 and DIVE-2737 are not.
+#
+# ARMS E-G ARE THE NON-VACUITY HALF and are not decoration. A guard that refused
+# everything would pass every refusal arm here; E (a close WITH a reason lands),
+# F (a bare RE-close stays the rc=0 no-op it has always been) and G (a
+# maker→verifier delivery is not a close and must not be caught) are what make
+# the refusals mean something narrower than "closes are broken".
+#
+# Run: bash tests/task_close_needs_a_reason_unit.sh
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades.
+# NOTE the absence of `2>/dev/null` — the helper's stderr line IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+# DIVE-2518: impersonate through the SEALED seam, not via USER=.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
+
+SRC=src
+TMP="$(mktemp -d /tmp/task-close-reason-unit.XXXXXX)"
+
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh lib/registry.sh \
+         lib/disk.sh lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_push.sh cmd_org.sh \
+         cmd_project.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1; mkdir -p "$TASKS_DIR"
+set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n       %s\n' "$1" "${2:-}"; }
+
+tasks_db_init
+as() { local who="$1"; shift; ( actor_seam_as "${who}"; "$@" ) 2>"$TMP"/err; }
+
+status_of()   { db "SELECT status                        FROM tasks WHERE ident=$(sqlq "$1");"; }
+res_of()      { db "SELECT COALESCE(result,'')           FROM tasks WHERE ident=$(sqlq "$1");"; }
+assignee_of() { db "SELECT COALESCE(assignee,'')         FROM tasks WHERE ident=$(sqlq "$1");"; }
+gate_ans_of() { db "SELECT COALESCE(need_answered_at,'') FROM tasks WHERE ident=$(sqlq "$1");"; }
+
+add() { JSON_MODE=1 cmd_task_add "$@" 2>"$TMP"/err | jq -r '.data.ident // empty'; }
+
+# ── instrument: without impersonation the actor-scoped guards make arms vacuous
+actor_is() { ( actor_seam_as "$1"; task_actor ); }
+[[ "$(actor_is dev2)" == "dev2" ]] \
+  && ok_t "INSTRUMENT: harness impersonates an actor (task_actor -> dev2)" \
+  || bad_t "INSTRUMENT: actor impersonation broken" "got '$(actor_is dev2)' — arms are vacuous"
+
+# ── A: `task cancel --result=""` on a first close is REFUSED ──────────────────
+# The shape measured seven times in three days.
+A=$(add "A empty cancel" --assignee=dev)
+as dev cmd_task_cancel "$A" --result="" >/dev/null; a_rc=$?
+(( a_rc != 0 )) && [[ "$(status_of "$A")" == "todo" ]] \
+  && ok_t "A: empty-result FIRST cancel refused (rc=$a_rc), row left open" \
+  || bad_t "A: empty-result first cancel was accepted" "rc=$a_rc status=$(status_of "$A")"
+
+# ── B: the SAME on `done` — the arm a port-of-the-existing-check leaves red ───
+B=$(add "B empty done" --assignee=dev)
+as dev cmd_task_done "$B" --result="" >/dev/null; b_rc=$?
+(( b_rc != 0 )) && [[ "$(status_of "$B")" == "todo" ]] \
+  && ok_t "B: empty-result FIRST done refused (rc=$b_rc) — the DIVE-2774 demo, now closed" \
+  || bad_t "B: empty-result first done was accepted (DIVE-2774 shape survives)" "rc=$b_rc status=$(status_of "$B")"
+
+# ── C/D: a BARE first close (no --result at all) is the same event ────────────
+# `--result=""` and an absent flag both leave the column permanently blank, and
+# the ledger keeps only a sha256 of it, so neither is distinguishable afterwards
+# from a reason nobody ever wrote.
+C=$(add "C bare done" --assignee=dev)
+as dev cmd_task_done "$C" >/dev/null; c_rc=$?
+(( c_rc != 0 )) && [[ "$(status_of "$C")" == "todo" ]] \
+  && ok_t "C: BARE first done refused (rc=$c_rc)" \
+  || bad_t "C: bare first done was accepted" "rc=$c_rc status=$(status_of "$C")"
+
+D=$(add "D bare cancel" --assignee=dev)
+as dev cmd_task_cancel "$D" >/dev/null; d_rc=$?
+(( d_rc != 0 )) && [[ "$(status_of "$D")" == "todo" ]] \
+  && ok_t "D: BARE first cancel refused (rc=$d_rc)" \
+  || bad_t "D: bare first cancel was accepted" "rc=$d_rc status=$(status_of "$D")"
+
+# ── E: NON-VACUITY — a close WITH a reason still lands, on both verbs ─────────
+E=$(add "E done with a reason" --assignee=dev)
+as dev cmd_task_done "$E" --result="shipped as #123" >/dev/null; e_rc=$?
+(( e_rc == 0 )) && [[ "$(status_of "$E")" == "done" && "$(res_of "$E")" == "shipped as #123" ]] \
+  && ok_t "E: a first done WITH a reason lands and stores it" \
+  || bad_t "E: a reasoned first done did not land" "rc=$e_rc status=$(status_of "$E") result='$(res_of "$E")'"
+
+E2=$(add "E2 cancel with a reason" --assignee=dev)
+as dev cmd_task_cancel "$E2" --result="stale dated instance, not work declined" >/dev/null; e2_rc=$?
+(( e2_rc == 0 )) && [[ "$(status_of "$E2")" == "cancelled" ]] \
+  && ok_t "E2: a first cancel WITH a reason lands" \
+  || bad_t "E2: a reasoned first cancel did not land" "rc=$e2_rc status=$(status_of "$E2")"
+
+# ── F: NON-VACUITY — a BARE RE-close is still the rc=0 no-op it always was ────
+# "First" is meant literally. tests/task_close_preserves_done_at_unit.sh (arm B)
+# depends on this bare re-close landing; refusing it here would silently make
+# that harness's done_at arm vacuous rather than red.
+as dev cmd_task_done "$E" >/dev/null; f_rc=$?
+(( f_rc == 0 )) && [[ "$(status_of "$E")" == "done" ]] \
+  && ok_t "F: a bare RE-close of an already-closed row stays rc=0 (idempotency preserved)" \
+  || bad_t "F: the bare re-close regressed" "rc=$f_rc status=$(status_of "$E")"
+
+# ── G: NON-VACUITY — a maker→verifier DELIVERY is not a close ─────────────────
+# `task done` on a row whose verifier differs from its assignee routes and
+# returns BEFORE the reason check. Catching it here would refuse every handoff on
+# the loop rail, which is the way this guard could have done real damage.
+G=$(add "G delivery is not a close" --assignee=mk --verifier=vfy)
+as mk cmd_task_done "$G" >/dev/null; g_rc=$?
+(( g_rc == 0 )) && [[ "$(assignee_of "$G")" == "vfy" && "$(status_of "$G")" != "done" ]] \
+  && ok_t "G: a bare maker→verifier delivery still ROUTES, not refused (assignee -> vfy)" \
+  || bad_t "G: the reason guard caught a delivery" "rc=$g_rc assignee=$(assignee_of "$G") status=$(status_of "$G")"
+
+# ── H: a cancel over a LIVE unanswered gate is refused ────────────────────────
+# The gate columns are set as a FIXTURE rather than through `task need`: this arm
+# grades the close guard's predicate (need_type set, need_answered_at NULL), and
+# routing it through the filing path would drag the tier floor and the ping rails
+# into an assertion that is not about them. Arm I then uses the REAL
+# `need --withdraw` verb, so the exit the refusal names is exercised for real.
+H=$(add "H cancel over a live gate" --assignee=dev)
+db "UPDATE tasks SET need_type='decision', ask='surface: fleet or personal?',
+      need_answered_at=NULL, gate_filed_by='dev', tier=2 WHERE ident=$(sqlq "$H");"
+# The fixture must actually BE the shape under test, or every arm below reads as
+# a pass for the wrong reason. `db` prints sqlite's error and returns 0, so an
+# unchecked UPDATE that names a column the schema does not have (the first draft
+# of this arm used `need_ask`) leaves the row UNGATED and the refusal arms then
+# grade an ordinary cancel.
+[[ "$(db "SELECT COALESCE(need_type,'')||'/'||COALESCE(need_answered_at,'-') FROM tasks WHERE ident=$(sqlq "$H");")" == "decision/-" ]] \
+  && ok_t "H/REACHABILITY: the fixture row really carries a PENDING gate" \
+  || bad_t "H/REACHABILITY: gate fixture did not take — arms H/H2/I are vacuous" \
+           "got '$(db "SELECT COALESCE(need_type,'')||'/'||COALESCE(need_answered_at,'-') FROM tasks WHERE ident=$(sqlq "$H");")'"
+as dev cmd_task_cancel "$H" --result="abandoning this" >/dev/null; h_rc=$?
+(( h_rc != 0 )) && [[ "$(status_of "$H")" == "todo" ]] \
+  && ok_t "H: cancel over a live gate refused (rc=$h_rc) EVEN WITH a good reason — the stronger condition" \
+  || bad_t "H: cancel deleted a live human gate" "rc=$h_rc status=$(status_of "$H")"
+
+# ── H2: and `done` over the same row is still refused (DIVE-555 control) ──────
+# Both close verbs refused is the state that makes arm I load-bearing: without a
+# reachable withdraw, this row would have NO close verb at all and the next agent
+# would invent one.
+as dev cmd_task_done "$H" --result="abandoning this" >/dev/null; h2_rc=$?
+(( h2_rc != 0 )) \
+  && ok_t "H2: done over the same live gate still refused (DIVE-555 intact, rc=$h2_rc)" \
+  || bad_t "H2: DIVE-555 regressed" "rc=$h2_rc"
+
+# ── I: THE NAMED EXIT IS REACHABLE — withdraw, then the cancel lands ──────────
+# A refusal that names an exit which does not work is worse than one that names
+# none: it spends the operator's trust and then makes them improvise.
+as dev cmd_task_need "$H" --withdraw >/dev/null; i_rc=$?
+# A withdrawal CLEARS need_type (and archives the gate to gate_history); it does
+# NOT stamp need_answered_at, which is the point — a withdrawal is not an answer,
+# so nothing is recorded as having been answered by anyone. Asserting on
+# need_answered_at (the first draft of this arm) reads a withdrawal as a failure.
+i_type=$(db "SELECT COALESCE(need_type,'') FROM tasks WHERE ident=$(sqlq "$H");")
+i_ans=$(gate_ans_of "$H")
+(( i_rc == 0 )) && [[ -z "$i_type" && -z "$i_ans" ]] \
+  && ok_t "I/REACHABILITY: 'task need --withdraw' clears the gate (rc=0, need_type NULL) WITHOUT recording an answer" \
+  || bad_t "I/REACHABILITY: the exit named in the refusal does not work" "rc=$i_rc need_type='$i_type' need_answered_at='$i_ans'"
+as dev cmd_task_cancel "$H" --result="withdrew the gate, then abandoned the work" >/dev/null; i2_rc=$?
+(( i2_rc == 0 )) && [[ "$(status_of "$H")" == "cancelled" ]] \
+  && ok_t "I: after the withdrawal the cancel lands (rc=0)" \
+  || bad_t "I: the row is wedged — neither close verb works after a withdrawal" "rc=$i2_rc status=$(status_of "$H")"
+
+# ── K: `task reject` on a DELIVERED (todo) row PRESERVES the maker's result ───
+# THE DIVE-2762 CLASS, ONE VERB OVER. reject kept a PRIVATE copy of the old,
+# wrong predicate — `if [[ $st == 'done' && -n $prev ]]` — so its preservation
+# fired only on a CLOSED row. A delivered row is `todo` by design, so on the
+# ORDINARY bounce (the one the loop manufactures every iteration) the branch did
+# not fire and the bare UPDATE replaced the maker's record with the rejection
+# text. Built through the REAL rail — deliver, then bounce — because the whole
+# defect is that the rail's own state (`todo`) is the one the old predicate missed.
+K=$(add "K reject preserves a delivered result" --assignee=mk --verifier=vfy)
+as mk cmd_task_done "$K" --result="MAKER-RECORD: built X, see PR #9" >/dev/null
+k_delivered_st=$(status_of "$K")
+[[ "$k_delivered_st" == "todo" && "$(res_of "$K")" == *"MAKER-RECORD"* ]] \
+  && ok_t "K/REACHABILITY: the delivered row is 'todo' and carries the maker's result — the exact cell the old predicate skipped" \
+  || bad_t "K/REACHABILITY: fixture is not the delivered shape" "status=$k_delivered_st result='$(res_of "$K")'"
+as vfy cmd_task_reject "$K" --feedback="missing the migration" >/dev/null; k_rc=$?
+k_res=$(res_of "$K")
+(( k_rc == 0 )) && [[ "$k_res" == *"MAKER-RECORD: built X, see PR #9"* ]] \
+  && ok_t "K: the maker's result SURVIVES the reject (preserved under a seam)" \
+  || bad_t "K: reject destroyed the maker's result on the ordinary bounce" "rc=$k_rc result='$k_res'"
+[[ "$k_res" == *"missing the migration"* ]] \
+  && ok_t "K2: ...and the verifier's feedback is recorded alongside it" \
+  || bad_t "K2: the feedback was lost" "result='$k_res'"
+
+# ── L: no regression on the shape the OLD private branch did handle ───────────
+# The recorded verifier withdrawing their own grade (DIVE-2112) reopens a CLOSED
+# row. The shared guard's default on a closed row is to REFUSE, so this arm is
+# what pins that reject asks it to APPEND instead.
+L=$(add "L reject over a closed row" --assignee=mk --verifier=vfy)
+as mk cmd_task_done "$L" --result="MAKER-RECORD-L" >/dev/null
+as vfy cmd_task_done "$L" --result="VERIFIER-GRADE-L: pass" >/dev/null
+[[ "$(status_of "$L")" == "done" ]] \
+  && ok_t "L/REACHABILITY: the row is CLOSED and graded before the reject" \
+  || bad_t "L/REACHABILITY: fixture never closed" "status=$(status_of "$L")"
+as vfy cmd_task_reject "$L" --feedback="withdrawing my grade" >/dev/null; l_rc=$?
+l_res=$(res_of "$L")
+(( l_rc == 0 )) && [[ "$l_res" == *"VERIFIER-GRADE-L: pass"* && "$l_res" == *"withdrawing my grade"* ]] \
+  && ok_t "L: a verifier reopening their own closed grade still preserves it (not refused, not replaced)" \
+  || bad_t "L: the closed-row reject regressed" "rc=$l_rc result='$l_res'"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/task_close_preserves_done_at_unit.sh
+++ b/tests/task_close_preserves_done_at_unit.sh
@@ -94,10 +94,14 @@ d_at=$(doneat_of "$D")
   || bad_t "D: first cancel did not stamp done_at" "status=$(status_of "$D") done_at='$d_at'"
 
 # ── B: a BARE repeat `task done` PRESERVES the first close timestamp ──────────
-# Bare (no --result) on purpose: that is the shape DIVE-2464's result guard does
-# not refuse, so the write actually lands and this arm is not vacuous.
+# The REPEAT is bare on purpose: that is the shape neither result guard refuses,
+# so the write actually lands and this arm is not vacuous.
+# DIVE-2773: the FIRST close now needs a reason (a first close with a blank one
+# is refused on both verbs), so it carries a --result here. Only the first close
+# moved — a bare re-close is explicitly exempt, which is what this arm grades and
+# why the change did not cost this harness an assertion.
 B=$(add "B bare re-done preserves done_at" --assignee=dev)
-as dev cmd_task_done "$B" >/dev/null
+as dev cmd_task_done "$B" --result="first close" >/dev/null
 backdate "$B"
 as dev cmd_task_done "$B" >/dev/null; b_rc=$?
 b_at=$(doneat_of "$B")
@@ -110,7 +114,7 @@ b_at=$(doneat_of "$B")
 
 # ── C: `task cancel` after a done PRESERVES the first close timestamp ─────────
 C=$(add "C cancel-after-done preserves done_at" --assignee=dev)
-as dev cmd_task_done "$C" >/dev/null
+as dev cmd_task_done "$C" --result="first close" >/dev/null   # DIVE-2773: first close needs a reason
 backdate "$C"
 as dev cmd_task_cancel "$C" >/dev/null; c_rc=$?
 c_at=$(doneat_of "$C")

--- a/tests/task_deliver_merge_gate_unit.sh
+++ b/tests/task_deliver_merge_gate_unit.sh
@@ -197,7 +197,7 @@ out=$(cmd_task_deliver DIVE-201 --pr="$PR" 2>&1); rc=$?
 #     (non-zero, E_CONFLICT), and the task stays open. --------------------------
 # DIVE-201 now sits with assignee==verifier (dev), so done reaches the merge-gate.
 export GH_STUB_STATE="OPEN" GH_STUB_MERGED=""
-out=$(cmd_task_done DIVE-201 2>&1); rc=$?
+out=$(cmd_task_done DIVE-201 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq $E_CONFLICT ]] \
   && ok_t "Tb done on an unmerged delivery PR is REFUSED (E_CONFLICT)" \
   || bad_t "Tb refused rc" "rc=$rc (want $E_CONFLICT) out=$out"
@@ -210,7 +210,7 @@ out=$(cmd_task_done DIVE-201 2>&1); rc=$?
 
 # --- Tc: same task, but gh now reports MERGED + a mergedAt → closes for real. ---
 GH_STUB_STATE="MERGED" GH_STUB_MERGED="2026-07-23T10:00:00Z" \
-  out=$(cmd_task_done DIVE-201 2>&1); rc=$?
+  out=$(cmd_task_done DIVE-201 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-201)" == "done" ]] \
   && ok_t "Tc done on a MERGED delivery PR closes the task" \
   || bad_t "Tc close" "rc=$rc status=$(statusof DIVE-201) out=$out"
@@ -225,7 +225,7 @@ cmd_task_set_branch DIVE-210 feat/dive-210-thing >/dev/null 2>&1
   || bad_t "Tc2 precond set-branch wrote the Branch: line" "body=$(db "SELECT body FROM tasks WHERE ident='DIVE-210';")"
 [[ -z "$(drefof DIVE-210)" ]] || bad_t "Tc2 precond no delivery_ref" "dref=$(drefof DIVE-210)"
 export GH_STUB_STATE="" GH_STUB_MERGED=""
-out=$(cmd_task_done DIVE-210 2>&1); rc=$?
+out=$(cmd_task_done DIVE-210 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq $E_CONFLICT && "$(statusof DIVE-210)" != "done" ]] \
   && ok_t "Tc2 done refused when the Branch: head has no merged PR (E_CONFLICT)" \
   || bad_t "Tc2 refused" "rc=$rc (want $E_CONFLICT) status=$(statusof DIVE-210) out=$out"
@@ -236,7 +236,7 @@ out=$(cmd_task_done DIVE-210 2>&1); rc=$?
 # --- Tc3: same Branch:-bound task, but gh now reports a merged PR for the head
 #     → closes. ----------------------------------------------------------------
 export GH_STUB_STATE="MERGED" GH_STUB_MERGED="2026-07-23T11:00:00Z"
-out=$(cmd_task_done DIVE-210 2>&1); rc=$?
+out=$(cmd_task_done DIVE-210 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-210)" == "done" ]] \
   && ok_t "Tc3 done closes once the Branch: head has a merged PR" \
   || bad_t "Tc3 close" "rc=$rc status=$(statusof DIVE-210) out=$out"
@@ -246,7 +246,7 @@ out=$(cmd_task_done DIVE-210 2>&1); rc=$?
 # No verifier so done is a real close (verifier==assignee==main path: verifier '').
 seed_task DIVE-202 main ''
 GH_STUB_STATE="OPEN" GH_STUB_MERGED="" \
-  out=$(cmd_task_done DIVE-202 2>&1); rc=$?
+  out=$(cmd_task_done DIVE-202 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-202)" == "done" ]] \
   && ok_t "Td plain task (no delivery_ref) closes unchanged" \
   || bad_t "Td regression" "rc=$rc status=$(statusof DIVE-202) out=$out"
@@ -415,7 +415,7 @@ db "UPDATE tasks SET assignee='main', status='in_progress', handoff_rejected_at=
   && ok_t "Tga re-delivery bumps the counter and leaves the binding at its old iteration" \
   || bad_t "Tga stale gap created" "iter=$(iterof DIVE-270) bind=$(binditerof DIVE-270)"
 export GH_STUB_STATE="MERGED" GH_STUB_MERGED="2026-08-04T00:00:00Z"
-out=$( actor_seam_as dev; cmd_task_done DIVE-270 2>&1 ); rc=$?
+out=$( actor_seam_as dev; cmd_task_done DIVE-270 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1 ); rc=$?
 [[ $rc -eq $E_CONFLICT ]] \
   && ok_t "Tga close on a STALE binding is REFUSED even though the PR is MERGED" \
   || bad_t "Tga refused rc" "rc=$rc (want $E_CONFLICT) out=$out"
@@ -438,7 +438,7 @@ db "UPDATE tasks SET assignee='main', status='in_progress', handoff_rejected_at=
 [[ "$(iterof DIVE-271)" == "2" && "$(binditerof DIVE-271)" == "2" ]] \
   && ok_t "Tgb re-pointing the binding stamps it at the NEW iteration (no false refuse)" \
   || bad_t "Tgb re-point stamp" "iter=$(iterof DIVE-271) bind=$(binditerof DIVE-271)"
-out=$( actor_seam_as dev; cmd_task_done DIVE-271 2>&1 ); rc=$?
+out=$( actor_seam_as dev; cmd_task_done DIVE-271 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1 ); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-271)" == "done" ]] \
   && ok_t "Tgb close on a RE-POINTED binding is ACCEPTED and the task closes" \
   || bad_t "Tgb accepted" "rc=$rc status=$(statusof DIVE-271) out=$out"
@@ -460,7 +460,7 @@ out=$( actor_seam_as dev; cmd_task_done DIVE-271 2>&1 ); rc=$?
 [[ "$(iterof DIVE-270)" == "2" && "$(binditerof DIVE-270)" == "2" ]] \
   && ok_t "Tgd the printed remedy stamps the binding at the CURRENT iteration, no bump" \
   || bad_t "Tgd remedy did not move the stamp" "iter=$(iterof DIVE-270) bind=$(binditerof DIVE-270)"
-out=$( actor_seam_as dev; cmd_task_done DIVE-270 2>&1 ); rc=$?
+out=$( actor_seam_as dev; cmd_task_done DIVE-270 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1 ); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-270)" == "done" ]] \
   && ok_t "Tgd following the refusal's OWN remedy makes the close succeed" \
   || bad_t "Tgd remedy is inert — false refuse on a correctly-bound row" "rc=$rc status=$(statusof DIVE-270) out=$out"
@@ -482,7 +482,7 @@ db "UPDATE tasks SET assignee='main', status='in_progress' WHERE ident='DIVE-273
 [[ "$(iterof DIVE-273)" == "$(binditerof DIVE-273)" ]] \
   && ok_t "Tge same-pass re-delivery keeps stamp == counter (no silent bind>iter)" \
   || bad_t "Tge stamp outran the counter" "iter=$(iterof DIVE-273) bind=$(binditerof DIVE-273)"
-out=$( actor_seam_as dev; cmd_task_done DIVE-273 2>&1 ); rc=$?
+out=$( actor_seam_as dev; cmd_task_done DIVE-273 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1 ); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-273)" == "done" ]] \
   && ok_t "Tge and the close is ACCEPTED (bind>iter would have been unflaggable, not refused)" \
   || bad_t "Tge same-pass close" "rc=$rc status=$(statusof DIVE-273) out=$out"
@@ -493,7 +493,7 @@ out=$( actor_seam_as dev; cmd_task_done DIVE-273 2>&1 ); rc=$?
 seed_task DIVE-272 main dev
 cmd_task_deliver DIVE-272 --pr="$PR" >/dev/null 2>&1
 db "UPDATE tasks SET delivery_ref_iteration=NULL, iteration=7 WHERE ident='DIVE-272';"
-out=$( actor_seam_as dev; cmd_task_done DIVE-272 2>&1 ); rc=$?
+out=$( actor_seam_as dev; cmd_task_done DIVE-272 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1 ); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-272)" == "done" ]] \
   && ok_t "Tgc a NULL binding-iteration (legacy row) is NOT treated as stale" \
   || bad_t "Tgc legacy row false-refused" "rc=$rc status=$(statusof DIVE-272) out=$out"

--- a/tests/task_done_ack_before_merge_gate_unit.sh
+++ b/tests/task_done_ack_before_merge_gate_unit.sh
@@ -139,7 +139,7 @@ as_agent maker cmd_task_deliver "$tid" --pr="$PR1" >/dev/null 2>"$TMP/err"
   || bad_t "T1 precondition" "$(db "SELECT * FROM tasks WHERE id=$tid;")"
 
 export GH_STUB_STATE="OPEN" GH_STUB_MERGED=""
-out=$(as_agent verifier cmd_task_done "$tid" 2>&1); rc=$?
+out=$(as_agent verifier cmd_task_done "$tid" --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq "$E_CONFLICT" && "$out" == *"DIVE-1830"* ]] \
   && ok_t "T2 done-before-start is refused by the merge gate exactly as before (E_CONFLICT, DIVE-1830)" \
   || bad_t "T2 refusal" "rc=$rc (want $E_CONFLICT) out=$out"
@@ -174,7 +174,7 @@ _hb_stall_sweep >/dev/null 2>&1
 # T4: the SAME task later merges for real -> `done` closes exactly as before —
 # proves the ack fix changed no acceptance, only the ack side-effect.
 export GH_STUB_STATE="MERGED" GH_STUB_MERGED="2026-08-01T00:00:00Z"
-out=$(as_agent verifier cmd_task_done "$tid" 2>&1); rc=$?
+out=$(as_agent verifier cmd_task_done "$tid" --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq 0 && "$(statusof "$tid")" == "done" ]] \
   && ok_t "T4 done still closes once the PR is merged (unchanged acceptance)" \
   || bad_t "T4 close" "rc=$rc status=$(statusof "$tid") out=$out"
@@ -193,7 +193,7 @@ as_agent maker cmd_task_deliver "$tid2" --pr="$PR2" >/dev/null 2>"$TMP/err"
   && ok_t "T5 precondition: delivered, unacked" \
   || bad_t "T5 precondition" "ack=$(ackof "$tid2")"
 
-out5=$(as_agent intruder cmd_task_done "$tid2" 2>&1); rc5=$?
+out5=$(as_agent intruder cmd_task_done "$tid2" --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc5=$?
 [[ $rc5 -ne 0 ]] \
   && ok_t "T5 a non-assigned-verifier's done attempt is refused (DIVE-2007)" \
   || bad_t "T5 not refused" "rc=$rc5 out=$out5"

--- a/tests/task_merge_gate_autodetect_unit.sh
+++ b/tests/task_merge_gate_autodetect_unit.sh
@@ -104,7 +104,7 @@ before=$( (JSON_MODE=0 cmd_task_show DIVE-901) 2>/dev/null )
 [[ "$before" == *"delivery_ref = absent"* ]] \
   && ok_t "T1 DIVE-2316 precondition: task show reports the binding absent" \
   || bad_t "T1 precondition display" "$before"
-out=$(cmd_task_done DIVE-901 2>&1); rc=$?
+out=$(cmd_task_done DIVE-901 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq $E_CONFLICT && "$(statusof DIVE-901)" != "done" ]] \
   && ok_t "T1 open PR naming the ident in its TITLE blocks the close" \
   || bad_t "T1 title match blocks" "rc=$rc status=$(statusof DIVE-901) out=$out"
@@ -117,7 +117,7 @@ after=$( (JSON_MODE=0 cmd_task_show DIVE-901) 2>/dev/null )
 # --- T2: an OPEN PR whose HEAD BRANCH names the ident BLOCKS (title doesn't). --
 seed DIVE-902
 export GH_STUB_PRLIST='[{"number":902,"headRefName":"feat/DIVE-902-fix","title":"unrelated title"}]'
-out=$(cmd_task_done DIVE-902 2>&1); rc=$?
+out=$(cmd_task_done DIVE-902 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq $E_CONFLICT && "$(statusof DIVE-902)" != "done" ]] \
   && ok_t "T2 open PR naming the ident in its HEAD BRANCH blocks the close" \
   || bad_t "T2 branch match blocks" "rc=$rc status=$(statusof DIVE-902) out=$out"
@@ -130,7 +130,7 @@ out=$(cmd_task_done DIVE-902 2>&1); rc=$?
 #     the ident is matched at word boundaries, not as a bare substring. ---------
 seed DIVE-202
 export GH_STUB_PRLIST='[{"number":2021,"headRefName":"feat/DIVE-2021","title":"DIVE-2021 thing"},{"number":2029,"headRefName":"feat/DIVE-2029-x","title":"DIVE-2029 other"}]'
-out=$(cmd_task_done DIVE-202 2>&1); rc=$?
+out=$(cmd_task_done DIVE-202 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-202)" == "done" ]] \
   && ok_t "T2b DIVE-2021/2029 PRs do NOT false-block the shorter DIVE-202 close" \
   || bad_t "T2b substring false-block" "rc=$rc status=$(statusof DIVE-202) out=$out"
@@ -139,7 +139,7 @@ out=$(cmd_task_done DIVE-202 2>&1); rc=$?
 #     prefix-sharing sibling PR is also open — boundary match, not over-loose. --
 seed DIVE-203
 export GH_STUB_PRLIST='[{"number":2031,"headRefName":"feat/DIVE-2031","title":"DIVE-2031 sibling"},{"number":203,"headRefName":"feat/x","title":"DIVE-203 real fix"}]'
-out=$(cmd_task_done DIVE-203 2>&1); rc=$?
+out=$(cmd_task_done DIVE-203 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq $E_CONFLICT && "$(statusof DIVE-203)" != "done" ]] \
   && ok_t "T2c exact ident 'DIVE-203 ...' blocks despite an open DIVE-2031 sibling" \
   || bad_t "T2c exact-ident still blocks" "rc=$rc status=$(statusof DIVE-203) out=$out"
@@ -148,7 +148,7 @@ out=$(cmd_task_done DIVE-203 2>&1); rc=$?
 #     lowercase; match is case-insensitive so the uppercase ident still hits). --
 seed DIVE-204
 export GH_STUB_PRLIST='[{"number":204,"headRefName":"dive-204-fix","title":"unrelated title"}]'
-out=$(cmd_task_done DIVE-204 2>&1); rc=$?
+out=$(cmd_task_done DIVE-204 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq $E_CONFLICT && "$(statusof DIVE-204)" != "done" ]] \
   && ok_t "T2d lowercase branch 'dive-204-fix' blocks the uppercase-ident close" \
   || bad_t "T2d case-insensitive branch match" "rc=$rc status=$(statusof DIVE-204) out=$out"
@@ -157,7 +157,7 @@ out=$(cmd_task_done DIVE-204 2>&1); rc=$?
 #     (the fixture has no ident in title/headRefName -> client-side filter drops it)
 seed DIVE-903
 export GH_STUB_PRLIST='[{"number":903,"headRefName":"feat/other","title":"follow-up work"}]'
-out=$(cmd_task_done DIVE-903 2>&1); rc=$?
+out=$(cmd_task_done DIVE-903 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-903)" == "done" ]] \
   && ok_t "T3 body-only mention (no title/branch match) closes normally" \
   || bad_t "T3 body-only does not block" "rc=$rc status=$(statusof DIVE-903) out=$out"
@@ -165,7 +165,7 @@ out=$(cmd_task_done DIVE-903 2>&1); rc=$?
 # --- T4: no matching PR at all -> a legitimate no-code close proceeds. ---------
 seed DIVE-904
 export GH_STUB_PRLIST='[]'
-out=$(cmd_task_done DIVE-904 2>&1); rc=$?
+out=$(cmd_task_done DIVE-904 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-904)" == "done" ]] \
   && ok_t "T4 no matching PR => research/docs/no-code close proceeds" \
   || bad_t "T4 no-match closes" "rc=$rc status=$(statusof DIVE-904) out=$out"
@@ -177,7 +177,7 @@ out=$(cmd_task_done DIVE-904 2>&1); rc=$?
 seed DIVE-905
 export GH_STUB_PRLIST='[{"number":905,"headRefName":"feat/DIVE-905","title":"DIVE-905 thing"}]'
 export GH_STUB_HANG=7   # > the gate's `timeout 5s` -> killed -> empty -> fail-open
-out=$(cmd_task_done DIVE-905 2>&1); rc=$?
+out=$(cmd_task_done DIVE-905 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 unset GH_STUB_HANG
 [[ $rc -eq 0 && "$(statusof DIVE-905)" == "done" ]] \
   && ok_t "T5 fail-open: a gh that hangs past the timeout does NOT block the fleet" \
@@ -190,7 +190,7 @@ unset GH_STUB_HANG
 seed DIVE-907
 export GH_STUB_PRLIST='[{"number":907,"headRefName":"feat/DIVE-907","title":"DIVE-907 thing"}]'
 : >"$AUDIT_CALLS"
-out=$(cmd_task_done DIVE-907 --force-merge-gate 2>&1); rc=$?
+out=$(cmd_task_done DIVE-907 --result="close under test (DIVE-2773: a first close must carry a reason)" --force-merge-gate 2>&1); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-907)" == "done" ]] \
   && ok_t "T7 --force-merge-gate overrides a blocking PR and closes" \
   || bad_t "T7 override closes" "rc=$rc status=$(statusof DIVE-907) out=$out"
@@ -207,7 +207,7 @@ unset _TASK_STORE_AUDIT_FENCED
 : >"$AUDIT_CALLS"
 seed DIVE-909
 export GH_STUB_PRLIST='[{"number":909,"headRefName":"feat/DIVE-909","title":"DIVE-909 thing"}]'
-out=$(FIVEDIVE_PROD_TASKS_DB="$TMP/somewhere-else/tasks.db" cmd_task_done DIVE-909 --force-merge-gate 2>"$TMP/offstore.err"); rc=$?
+out=$(FIVEDIVE_PROD_TASKS_DB="$TMP/somewhere-else/tasks.db" cmd_task_done DIVE-909 --result="close under test (DIVE-2773: a first close must carry a reason)" --force-merge-gate 2>"$TMP/offstore.err"); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-909)" == "done" ]] \
   && ok_t "T7b off-store: the override itself still closes (fail-open on the WRITE side)" \
   || bad_t "T7b override still closes" "rc=$rc status=$(statusof DIVE-909)"
@@ -225,7 +225,7 @@ seed DIVE-908
 db "UPDATE tasks SET delivery_ref='https://github.com/5dive-ai/5dive/pull/908', delivered_at=datetime('now') WHERE ident='DIVE-908';"
 export GH_STUB_PRLIST='[]'   # auto-detect would find nothing; DIVE-1830 gate must still run
 export GH_STUB_STATE="" GH_STUB_MERGED=""
-out=$(cmd_task_done DIVE-908 2>&1); rc=$?
+out=$(cmd_task_done DIVE-908 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq $E_CONFLICT && "$(statusof DIVE-908)" != "done" ]] \
   && ok_t "T8 declared delivery_ref still gated by the DIVE-1830 (fail-closed) path" \
   || bad_t "T8 declared path intact" "rc=$rc status=$(statusof DIVE-908) out=$out"

--- a/tests/task_merge_gate_gh_resolve_unit.sh
+++ b/tests/task_merge_gate_gh_resolve_unit.sh
@@ -126,7 +126,7 @@ cmd_task_set_branch DIVE-834 feat/dive-834-thing >/dev/null 2>&1
 : >"$GH_ARGS_LOG"
 export GH_STUB_STATE="" GH_STUB_MERGED="2026-07-23T12:00:00Z" GH_STUB_AUTH_TOKEN="tok"
 NONREPO="$TMP/nonrepo"; mkdir -p "$NONREPO"
-out=$( cd "$NONREPO" && cmd_task_done DIVE-834 2>&1 ); rc=$?
+out=$( cd "$NONREPO" && cmd_task_done DIVE-834 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1 ); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-834)" == "done" ]] \
   && ok_t "T3 Branch:-bound task closes from a non-repo CWD when its head is merged" \
   || bad_t "T3 close from non-repo CWD" "rc=$rc status=$(statusof DIVE-834) out=$out"
@@ -143,7 +143,7 @@ unset GH_TOKEN GITHUB_TOKEN
 export GH_STUB_STATE="MERGED" GH_STUB_MERGED="2026-07-23T13:00:00Z" GH_STUB_AUTH_TOKEN="deleg-tok-789"
 # delivery_ref path: bind a PR url directly.
 db "UPDATE tasks SET delivery_ref='https://github.com/5dive-ai/5dive/pull/835', delivered_at=datetime('now') WHERE ident='DIVE-835';"
-out=$(cmd_task_done DIVE-835 2>&1); rc=$?
+out=$(cmd_task_done DIVE-835 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq 0 && "$(statusof DIVE-835)" == "done" ]] \
   && ok_t "T4 delivery_ref task closes when merged (resolved token, no env GH_TOKEN)" \
   || bad_t "T4 close" "rc=$rc status=$(statusof DIVE-835) out=$out"
@@ -156,7 +156,7 @@ grep -q 'TOKEN=deleg-tok-789 ARGS=pr view' "$GH_ARGS_LOG" \
 seed_task DIVE-836 main main
 db "UPDATE tasks SET delivery_ref='https://github.com/5dive-ai/5dive/pull/836', delivered_at=datetime('now') WHERE ident='DIVE-836';"
 export GH_STUB_STATE="" GH_STUB_MERGED="" GH_STUB_AUTH_TOKEN=""
-out=$(cmd_task_done DIVE-836 2>&1); rc=$?
+out=$(cmd_task_done DIVE-836 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
 [[ $rc -eq $E_CONFLICT && "$(statusof DIVE-836)" != "done" ]] \
   && ok_t "T5 unknown/empty state still BLOCKS (fail-safe, never false-close)" \
   || bad_t "T5 fail-safe" "rc=$rc status=$(statusof DIVE-836) out=$out"

--- a/tests/task_merge_gate_multirepo_unit.sh
+++ b/tests/task_merge_gate_multirepo_unit.sh
@@ -230,10 +230,15 @@ if [[ "$res" == *"merge-gate: UNVERIFIED"* && "$res" == *"AMBIGUOUS"* \
 else
   bad_t 'ambiguous must be durable in the record' "result=[$res]"
 fi
-# The stamp must also appear when the maker passed NO --result at all: that row is the
-# emptiest-looking one there is, so it is the one most in need of the disclaimer.
+# The stamp must also appear on the emptiest close the rail allows, because that row is
+# the one most in need of the disclaimer.
+# DIVE-2773: that used to be a close with NO --result at all; a FIRST close with a blank
+# reason is now refused on both verbs, so the emptiest REACHABLE shape is a minimal one.
+# The arm is adapted rather than dropped: what it grades is that the stamp APPENDS to
+# whatever the maker wrote instead of depending on there being room, and a one-word
+# result exercises that as well as an absent one did.
 seed AMB-2 'delivery is PR #6'
-run_done AMB-2
+run_done AMB-2 --result="delivered"
 res2=$(db "SELECT COALESCE(result,'') FROM tasks WHERE ident='AMB-2';")
 [[ $RC -eq 0 && "$res2" == *"merge-gate: UNVERIFIED"* ]] \
   && ok_t 'the UNVERIFIED stamp lands even on a close with no --result of its own' \

--- a/tests/task_reject_actor_and_closed_unit.sh
+++ b/tests/task_reject_actor_and_closed_unit.sh
@@ -125,8 +125,20 @@ D=$(seed_closed "D verifier reopens own grade")
 out=$(as main cmd_task_reject "$D" --feedback="I was wrong, reopening"); rc=$?
 (( rc == 0 )) && ok_t "D the grader may reopen their own grade (rc=0)" \
   || bad_t "D grader locked out" "rc=$rc $(cat "$TMP"/err)"
-[[ "$(res_of "$D")" == *"superseded result (DIVE-2067, preserved)"* ]] \
-  && ok_t "D prior result preserved under a superseded marker" || bad_t "D marker missing" "$(res_of "$D")"
+# DIVE-2773: reject no longer hand-rolls this preservation — it routes through
+# `_task_guard_result_over_closed`, the one predicate DIVE-2483 extracted, so the seam it
+# writes on a CLOSED row is that guard's DIVE-2464 marker rather than reject's private
+# DIVE-2067 copy. The MARKER CHANGED and the GUARANTEE DID NOT, so this arm asserts the
+# guarantee first and the marker second: what must never regress is that the prior record
+# survives verbatim. (`task verify`'s closed path still writes the DIVE-2067 marker; a
+# grep for superseded records wants both strings. The reason reject moved is that its
+# private predicate fired only on a `done` row, so on the ordinary delivered-`todo` bounce
+# it preserved nothing at all — see tests/task_close_needs_a_reason_unit.sh arm K.)
+[[ "$(res_of "$D")" == *"I was wrong, reopening"* ]] \
+  && ok_t "D the reject feedback is recorded" || bad_t "D feedback missing" "$(res_of "$D")"
+[[ "$(res_of "$D")" == *"appended by a later close (DIVE-2464)"* ]] \
+  && ok_t "D prior result preserved under the SHARED guard's seam (DIVE-2773: was reject's private DIVE-2067 marker)" \
+  || bad_t "D marker missing" "$(res_of "$D")"
 [[ "$(res_of "$D")" == *"the seal only grades the bundle"* ]] \
   && ok_t "D the ACK's actual TEXT survives, not just a marker" || bad_t "D ACK text lost" "$(res_of "$D")"
 

--- a/tests/task_verifier_rail_unit.sh
+++ b/tests/task_verifier_rail_unit.sh
@@ -156,7 +156,7 @@ self_out=$(run verifier "$med_id" alice); self_rc=$?
 
 closed_json=$(run add --assignee=alice --priority=low -- "already finished chore")
 closed_id=$(printf '%s' "$closed_json" | jf '.data.id')
-run done "$closed_id" >/dev/null
+run done "$closed_id" --result="chore finished (DIVE-2773: a first close must carry a reason)" >/dev/null
 cl_out=$(run verifier "$closed_id" boss); cl_rc=$?
 (( cl_rc != 0 )) && has "$(cat "$TMP"/err)$cl_out" "task reject" \
   && ok_t "T9b refuses to retro-grade a CLOSED task and points at 'task reject'" \


### PR DESCRIPTION
# DIVE-2773 — a FIRST close must carry a reason, on BOTH verbs; a cancel no longer deletes a live human gate

The row was filed as *"`task done` refuses a blank result, `task cancel` accepts one"*.
**That asymmetry does not exist.** olivia caught it; confirmed at source and empirically.
`_task_guard_result_over_closed` returns early when the row carries no result yet — it is
destroy-protection, and with nothing recorded there are no bytes at risk:

```sh
if [[ -z "$_cl_prev" || "$_cl_prev" == "$result" ]]; then
  _TASK_GUARDED_RESULT="$result"; return 0
fi
```

So a **first** close with a blank reason was accepted by both verbs all along (demonstrated on
DIVE-2774). Shipping the filed fix — *"give cancel the check done already has"* — would have
missed every blank first close and left `done`, the commoner verb, just as open, while reading
in the diff like a fix.

## What this changes (`src/cmd_task.sh`)

1. **A first close requires a non-empty reason, on both verbs.** A new predicate keyed on
   *"this row is being closed and nothing has ever been written about why"* — not a port of
   DIVE-2483's check, which returns early on exactly this population. No flag bypasses it.
   The refusal names the **shape** of a good reason (DIVE-2472's text is quoted as the model),
   because a caller under load writes "n/a" unless told otherwise.
   Scoped so no false refusal is possible: a maker→verifier **delivery** routes and returns
   above the check (a bare `task done` handoff is untouched); an already-closed row keeps its
   idempotent bare re-close; a row that already carries text is the other guard's population.

2. **Both close verbs now refuse over a PENDING gate** — kept separate from the reason
   requirement, and firing *with* a good reason attached. This is the second, worse cost: the
   06:18:33 empty cancel of DIVE-2758 destroyed a live tier-2 human gate (buttons retired, row
   still reads `pending`). A cancel does not answer a question — it deletes it.
   DIVE-555's refusal text, which named `task cancel` as its sanctioned exit, is corrected: it
   was publishing the exact route DIVE-2758 took. Both refusals name
   `5dive task need <id> --withdraw` — a recorded withdrawal, never an answer put in anyone's
   mouth — because refusing both verbs with no exit leaves a gated row with no close verb at
   all and sends the next agent to invent one.

3. **`task reject` routes through `_task_guard_result_over_closed`** instead of its private copy
   of the superseded predicate. It asks the guard to APPEND, which is load-bearing: the guard's
   default on a closed row is to REFUSE, and that would have broken DIVE-2112's legitimate
   reopen (a recorded verifier withdrawing their own grade) — the very case the private branch
   existed to serve. The private copy keyed on `status=='done'`, but a row delivered to a
   verifier is `todo` **by the rail's own contract**, so on every ordinary bounce it replaced
   the maker's result silently, wearing a `DIVE-2067` marker that made it look handled.
   Repro run rather than reasoned (arm K), through the real rail.

## Tests

`tests/task_close_needs_a_reason_unit.sh` — 19 arms, **19 passed / 0 failed** at `034ba26`
(TIER: nightly, 36s on the control-plane VM). The 19/19 was first measured at `a5fa1db` and
re-run after the rebase onto current `origin/main`; `034ba26` is the sha this PR merges, so
that is the one quoted.
Arms **B** and **D** are the ones a port-of-the-existing-check leaves red while looking like a
fix. **E/E2/F/G** are the non-vacuity half. **H/H2/I** grade the gate refusal *and* the
reachability of the exit it names. **K/L** grade the reject path against a fixture asserted to
be the exact shape the old predicate skipped.

## Blast radius — measured, not assumed

Every harness touching a close was run on this branch; anything red was re-run on a pristine
`origin/main` worktree at the same sha with the same actor. **11 harnesses adapted** (bare
fixture closes given a reason; `gate_button_retire`'s `done` arm **inverted** rather than
deleted — over a live gate the cancel is refused and the button must SURVIVE).
Two harnesses are red on pristine main too and are **not** this branch:
`actor_claim_corroboration_unit.sh`, and `task_answer_closed_row_unit.sh`
("sudo: a password is required", a scoped-agent limit).

## Two consequences named rather than left to be found

- The DIVE-2410 retire-buttons-on-close block is now **unreachable by construction** (both close
  verbs refuse above it). Kept, commented as such, and argued in place: idempotent and free on
  the reachable path, and the backstop if either refusal is later scoped narrower.
- `cmd_objective.sh:888` auto-cancels objective-owned rows and increments `OBJ_APPLIED_CANCEL`
  **unconditionally**. It always supplies a reason so (1) never bites it, but a gated row's
  auto-cancel is now refused, swallowed by its `|| true`, and still counted as applied. The
  over-count is pre-existing (the counter never checked the rc); this adds one more trigger.
  Deliberately not ridden along.
- **Observable record change:** on a closed row, `reject` now writes the shared guard's
  `--- appended by a later close (DIVE-2464) ---` seam instead of its private
  `--- superseded result (DIVE-2067, preserved) ---` one. `task verify`'s closed path still
  writes the DIVE-2067 marker, so a grep for superseded records wants **both** strings.

## Independent re-measurement by the reviewer (main)

The blast-radius sweep above was measured on the PRE-rebase base and named as such by the
author rather than buried. Closed at source instead of banked: the nine other harnesses this
diff touches were re-run on the rebased tree at `034ba26` —
`heartbeat_reclaim_verifier_handoff` 6, `heartbeat_stall_sweep` 34, `task_cascade_unblock` 16,
`task_close_preserves_done_at` 16, `task_deliver_merge_gate` 43,
`task_done_ack_before_merge_gate` 11, `task_merge_gate_autodetect` 18,
`task_merge_gate_gh_resolve` 7, `task_merge_gate_multirepo` 39 — all green, **190 arms**, on
top of the author's four (**120**). **310 arms on the sha that merges**, no stale base.

Knowledge compiled: `community/wiki/a-guard-cited-by-name-covers-less-than-its-name-claims.md`
(indexed).
