### PR TITLE
fix(tests): give task_set_body's closed-task fixture a close reason (DIVE-2773 follow-up)

### DIFF
--- a/tests/task_set_body_unit.sh
+++ b/tests/task_set_body_unit.sh
@@ -91,7 +91,7 @@ run set_body "$tid" "template instructions live here" >/dev/null
 
 # --- T6: refused on a closed (done) task
 id4=$(run add --assignee=alice --no-verify -- "closeable task" | jf '.data.id')
-run done "$id4" >/dev/null
+run done "$id4" --result="closed in fixture setup (DIVE-2773: a first close must carry a reason)" >/dev/null
 e6=$(run set_body "$id4" "too late"); rc=$?
 [[ $rc -ne 0 ]] && printf '%s' "$e6" | grep -q "already done" \
   && ok_t "set-body refuses a closed (done) task" || bad_t "set-body refuses a closed task" "rc=$rc $e6"


### PR DESCRIPTION
fix(tests): give task_set_body's closed-task fixture a close reason (DIVE-2773 follow-up)

DIVE-2773 landed a guard refusing a FIRST close with no reason, and adapted the 11
harnesses that closed a fixture row bare. task_set_body_unit.sh was the twelfth and
was missed, so full-sweep went red on the merge commit (0b46c05) in both
environments — full-pristine (3) and full-installed-host (3), same single harness.

T6 needs a CLOSED row to prove `set-body` refuses one. Its setup closed the row with
a bare `run done "$id4"`, which the new predicate now refuses, so the row stayed open
and both of T6's arms failed: the refusal never fired, and the body was therefore
writable. 13 passed / 2 failed.

One line, matching the convention used for the other eleven.

WHY IT WAS MISSED, which is the part worth keeping: this harness is nightly-tier, and
nothing runs the FULL tier on a branch. DIVE-2773's PR was green across all 13 checks
including changed-harnesses, because changed-harnesses only runs harnesses the diff
TOUCHES and this one was not touched. So a nightly-tier regression landed behind a
fully green PR with nobody at fault. That is DIVE-2785 exactly, and DIVE-2789 is the
row that closes it.

Checked: 15 passed / 0 failed with this line, 13/2 without it (positive control run
both ways, not just the passing direction). tests/task_done_over_closed_result_unit.sh
was the other candidate the pattern sweep turned up and it passes unmodified — its
bare closes are arms that assert the refusal, not fixture setup.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
