### PR TITLE
DIVE-2798: make the bundle stamp an identity assertion so a release commit can satisfy bundle-integrity

### DIFF
--- a/src/cmd_selfcheck.sh
+++ b/src/cmd_selfcheck.sh
@@ -604,8 +604,46 @@ _sc_probe_bundle_integrity() {
   # bundle is a self-consistent lie — the pair agrees and neither is the code.
   local tmpb; tmpb=$(mktemp "${TMPDIR:-/tmp}/5dive-bundle.XXXXXX" 2>/dev/null)
   if [[ -n "$tmpb" ]] && (cd "$root" && BUILD_OUT="$tmpb" bash build.sh >/dev/null 2>&1); then
-    cmp -s "$tmpb" "$root/5dive" \
-      || bad+=("./5dive is not what src/ builds — the bundle and the commit it claims are different code")
+    # DIVE-2798: A BUNDLE CANNOT CARRY THE SHA OF THE COMMIT THAT CONTAINS IT.
+    # DIVE-2603 made build.sh stamp FIVE_BUILD_SHA=HEAD; the release flow builds
+    # the bundle, then commits it onto a NEW commit. A rebuild here therefore
+    # stamps THAT commit, while the tracked bundle names the commit it was built
+    # from — which is the release commit's first parent, exactly the identity
+    # install.sh's legacy_release_build_sha() already documents and reads. So a
+    # raw `cmp` made the stamp and this probe jointly unsatisfiable on every
+    # release commit, i.e. precisely where the probe matters most: it blocked the
+    # v0.19.3 cut with a true byte difference nobody could ever satisfy.
+    #
+    # The stamp is NOT waived. It moves from a byte comparison to an identity
+    # assertion: every other byte must still match src/ exactly, and the stamp
+    # itself must name a commit this checkout can corroborate. Waiving it would
+    # pass a forged stamp; this fails one. Comparing the tracked stamp against
+    # git — rather than against the REBUILT stamp — also drops a second, quieter
+    # trap: an untracked file on the runner makes the rebuild stamp `<sha>-dirty`
+    # and would fail a naive stamp-to-stamp check for a reason that is not the
+    # bundle's fault.
+    local stamp_rx='^readonly FIVE_BUILD_SHA="[^"]*"$'
+    local n_stamp; n_stamp=$(grep -cE "$stamp_rx" "$root/5dive" 2>/dev/null) || true
+    if [[ "$n_stamp" != "1" ]]; then
+      bad+=("the tracked bundle carries ${n_stamp:-0} FIVE_BUILD_SHA lines rather than exactly one, so its build identity cannot be read or compared")
+    elif ! cmp -s "$tmpb" "$root/5dive"; then
+      if diff -q <(grep -vE "$stamp_rx" "$tmpb") <(grep -vE "$stamp_rx" "$root/5dive") >/dev/null 2>&1; then
+        # Only the stamp line differs — legitimate on a release commit, a lie anywhere else.
+        local _tracked _head _parent
+        _tracked=$(grep -m1 -E "$stamp_rx" "$root/5dive" | sed -E 's/.*="([^"]*)".*/\1/')
+        _head=$(git -C "$root" rev-parse --verify 'HEAD^{commit}' 2>/dev/null) || _head=""
+        _parent=$(git -C "$root" rev-parse --verify 'HEAD^1^{commit}' 2>/dev/null) || _parent=""
+        if [[ -z "$_head" ]]; then
+          bad+=("./5dive differs from src/ only in its build stamp, but git cannot resolve HEAD here, so the stamp names nothing this checkout can check")
+        elif [[ "$_tracked" == "$_head" || ( -n "$_parent" && "$_tracked" == "$_parent" ) ]]; then
+          : # the bundle names the commit it was built from; the release commit is its child
+        else
+          bad+=("./5dive claims FIVE_BUILD_SHA=${_tracked:-missing}, which is neither this commit (${_head:0:12}) nor its first parent (${_parent:0:12}) — the bundle names a build identity this checkout cannot corroborate")
+        fi
+      else
+        bad+=("./5dive is not what src/ builds — the bundle and the commit it claims are different code")
+      fi
+    fi
   else
     bad+=("build.sh could not be run, so the bundle could not be shown to match src/")
   fi

--- a/src/cmd_selfcheck.sh
+++ b/src/cmd_selfcheck.sh
@@ -623,14 +623,14 @@ _sc_probe_bundle_integrity() {
     # and would fail a naive stamp-to-stamp check for a reason that is not the
     # bundle's fault.
     local stamp_rx='^readonly FIVE_BUILD_SHA="[^"]*"$'
-    local n_stamp; n_stamp=$(grep -cE "$stamp_rx" "$root/5dive" 2>/dev/null) || true
+    local n_stamp; n_stamp=$(grep -cE "$stamp_rx" "$root/5dive" 2>/dev/null) || n_stamp=0
     if [[ "$n_stamp" != "1" ]]; then
       bad+=("the tracked bundle carries ${n_stamp:-0} FIVE_BUILD_SHA lines rather than exactly one, so its build identity cannot be read or compared")
     elif ! cmp -s "$tmpb" "$root/5dive"; then
       if diff -q <(grep -vE "$stamp_rx" "$tmpb") <(grep -vE "$stamp_rx" "$root/5dive") >/dev/null 2>&1; then
         # Only the stamp line differs — legitimate on a release commit, a lie anywhere else.
         local _tracked _head _parent
-        _tracked=$(grep -m1 -E "$stamp_rx" "$root/5dive" | sed -E 's/.*="([^"]*)".*/\1/')
+        _tracked=$(grep -m1 -E "$stamp_rx" "$root/5dive" | sed -E 's/.*="([^"]*)".*/\1/') || _tracked=""
         _head=$(git -C "$root" rev-parse --verify 'HEAD^{commit}' 2>/dev/null) || _head=""
         _parent=$(git -C "$root" rev-parse --verify 'HEAD^1^{commit}' 2>/dev/null) || _parent=""
         if [[ -z "$_head" ]]; then

--- a/tests/selfcheck_mutation_e2e.sh
+++ b/tests/selfcheck_mutation_e2e.sh
@@ -221,6 +221,71 @@ mut_bundle() {
 }
 assert_mutation bundle-integrity "the tracked checksum describes another bundle" mut_bundle "different generations"
 
+# ── rail 4b: THE RELEASE-COMMIT SHAPE (DIVE-2798) ────────────────────────────
+# The shape this harness never built, and the reason a green corpus still could not
+# cut v0.19.3. `release-cut.yml` commits the source, builds the bundle (stamped with
+# that source commit), then commits the BUNDLE onto a second commit. So on the commit
+# that gets tagged, HEAD is the bundle commit and the bundle names HEAD^ — and the
+# probe's rebuild stamps HEAD. A raw `cmp` is unsatisfiable there BY CONSTRUCTION:
+# a bundle cannot carry the sha of the commit that contains it.
+#
+# Every arm below runs in that shape rather than in the working-tree shape, because
+# the defect is invisible in the working-tree shape — which is precisely why every
+# PR was green and the failure waited for a release. And the shape is BUILT here, not
+# asserted: the arms after it must still go red, or "release commits pass" would be
+# indistinguishable from "the probe stopped checking".
+_release_commit_shape() {   # leaves $WORK at: HEAD = bundle commit, bundle stamped HEAD^
+  git -C "$WORK" add -A >/dev/null 2>&1 || return 1
+  git -C "$WORK" -c user.name='harness' -c user.email='harness@example.com' \
+      -c commit.gpgsign=false commit -qm 'release: assign version before bundle build' >/dev/null 2>&1 || return 1
+  (cd "$WORK" && bash build.sh >/dev/null 2>&1) || return 1
+  git -C "$WORK" add -A -f 5dive 5dive.sha256 >/dev/null 2>&1 || return 1
+  git -C "$WORK" -c user.name='harness' -c user.email='harness@example.com' \
+      -c commit.gpgsign=false commit -qm 'release: bundle built from the parent' >/dev/null 2>&1 || return 1
+}
+if _release_commit_shape; then
+  _rc_head=$(git -C "$WORK" rev-parse HEAD)
+  _rc_parent=$(git -C "$WORK" rev-parse 'HEAD^1')
+  _rc_stamp=$(grep -m1 -E '^readonly FIVE_BUILD_SHA="[^"]*"$' "$WORK/5dive" | sed -E 's/.*="([^"]*)".*/\1/')
+  # The fixture must actually BE the shape, or the arms below prove nothing about it.
+  [[ "$_rc_stamp" == "$_rc_parent" && "$_rc_stamp" != "$_rc_head" ]] \
+    && ok_t "[bundle-integrity] fixture IS the release shape: bundle stamps HEAD^ (${_rc_stamp:0:12}), not HEAD (${_rc_head:0:12})" \
+    || fail_t "[bundle-integrity] fixture is NOT the release shape (stamp=${_rc_stamp:0:12} head=${_rc_head:0:12} parent=${_rc_parent:0:12}) — every arm below would be vacuous"
+
+  probe bundle-integrity
+  [[ $RC -eq 0 ]] \
+    && ok_t "[bundle-integrity] PASSES on a release commit (DIVE-2798: the cut is no longer self-blocking)" \
+    || fail_t "[bundle-integrity] still red on a release commit — the v0.19.3 blocker is not fixed: $OUT"
+
+  # ACCEPTANCE, and the whole point: a stale bundle must STILL be caught in this
+  # shape. If tolerating the stamp had widened into tolerating the bundle, this is
+  # where it shows, so it is asserted here rather than only in the working-tree shape.
+  printf '\n# DIVE-2798 staleness probe\n' >> "$WORK/src/cmd_selfcheck.sh"
+  probe bundle-integrity
+  [[ $RC -ne 0 ]] && grep -q 'is not what src/ builds' <<<"$OUT" \
+    && ok_t "[bundle-integrity] a STALE bundle is still RED on a release commit (not weakened to a no-op)" \
+    || fail_t "[bundle-integrity] stale bundle passed on a release commit — the fix is a no-op: $OUT"
+  git -C "$WORK" checkout -q -- src/cmd_selfcheck.sh 2>/dev/null || true
+
+  # And the stamp itself is ASSERTED, not exempted: a bundle whose only difference
+  # from src/ is a stamp naming a commit this checkout cannot corroborate is a
+  # forged identity, and comparing modulo the stamp without this arm would pass it.
+  # The checksum is regenerated so the red can only come from the identity check.
+  sed -i -E 's/^readonly FIVE_BUILD_SHA="[^"]*"$/readonly FIVE_BUILD_SHA="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"/' "$WORK/5dive"
+  sha256sum "$WORK/5dive" | awk '{print $1}' > "$WORK/5dive.sha256"
+  probe bundle-integrity
+  [[ $RC -ne 0 ]] && grep -q 'cannot corroborate' <<<"$OUT" \
+    && ok_t "[bundle-integrity] a FORGED build stamp is RED (the stamp is asserted, not waived)" \
+    || fail_t "[bundle-integrity] a bundle claiming a foreign build sha passed: $OUT"
+
+  restore
+  probe bundle-integrity
+  [[ $RC -eq 0 ]] && ok_t "[bundle-integrity] green again once restored (release shape left no residue)" \
+    || fail_t "[bundle-integrity] did not recover after the release-shape arms: $OUT"
+else
+  fail_t "[bundle-integrity] could not build the release-commit fixture — DIVE-2798 is UNPROVEN, not passing"
+fi
+
 # ── rail 5: the audit log, PRIVILEGED half ───────────────────────────────────
 # Same mutation as rail 2, measured from the other side. Skipped-not-silent when
 # there is no passwordless sudo: naming what went unproven is the entire point of


### PR DESCRIPTION
Unblocks the release cut. `release-cut` run 31008577021 failed on `bundle-integrity` because DIVE-2603 made `build.sh` stamp `FIVE_BUILD_SHA=$(git rev-parse HEAD)` — and the release flow commits that bundle onto a NEW commit, so a rebuild stamps a different sha and `cmp` fails. A bundle cannot carry the sha of the commit that contains it.

dev's fix asserts identity rather than comparing bytes: every other byte still matches `src/` exactly, and the tracked stamp must name HEAD or HEAD^1. Same cost, strictly more checked — and it avoids the `<sha>-dirty` trap a naive stamp-to-stamp check would hit when an untracked file sits on the runner.

Verified by dev on the real path, not a fixture: release-cut's two-commit sequence replayed in throwaway clones, probe rc=1 pre-fix (reproducing the exact failure) and rc=0 with it; `selfcheck_mutation_e2e` now builds the release-commit shape and asserts the probe passes, a STALE bundle is still red, and a FORGED stamp is red. 49/0.

Full detail on DIVE-2798.