### PR TITLE
fix(push/task): a step must not report a verdict it did not compute (DIVE-2801)

### DIFF
--- a/docs/delegated-push.md
+++ b/docs/delegated-push.md
@@ -112,17 +112,50 @@ before this shipped can be re-provisioned, or you can add that one line to their
 
 From inside the repo's work tree, on the branch you want to ship:
 
-```sh
-# dry run — checks gate + author, mints nothing, pushes nothing:
-5dive push DIVE-123 --branch=my-feature --dry-run
+**First add a `Branch:` line to the task body.** This is required, not an
+alternative to `--branch` — the cleared gate binds to the branch the *task*
+declares (DIVE-1462), so a push whose task body names no branch is refused even
+when `--branch` is passed:
 
-# real push (after the task's ship gate has been answered):
-5dive push DIVE-123 --branch=my-feature
+```
+Branch: my-feature
 ```
 
-The branch can also come from a `Branch: my-feature` line in the task body
-instead of `--branch`. Point at a different repo with `--repo=https://github.com/<org>/<repo>`
-(defaults to the repo configured for your deployment).
+Then, from inside the repo's work tree:
+
+```sh
+# dry run — checks gate authority + author, mints nothing, pushes nothing:
+5dive push DIVE-123 --dry-run
+
+# real push (after the task's ship gate has been answered):
+5dive push DIVE-123
+```
+
+`--branch=my-feature` overrides *which* branch is read; it does not remove the
+need for the body line. Point at a different repo with
+`--repo=https://github.com/<org>/<repo>` (defaults to the repo configured for
+your deployment).
+
+### What the dry run does NOT check
+
+The dry run is a **rehearsal, not the performance**. It runs the agent-side
+preflight, which checks gate *authority*; the real push re-verifies everything
+inside root and additionally requires a **signed closure**. Signing needs a seat
+whose sudo grant reaches `5dive gate-proof sign` — a narrowly-scoped agent seat
+silently stores an unsigned closure when it answers a gate, and the refusal only
+surfaces at push time (DIVE-2760).
+
+So the dry run names its own limits rather than implying it checked them:
+
+- `signature verified` — the root executor ran; this is the real verdict.
+- `signature present but NOT verified here` — the closure is signed, but this
+  rehearsal did not check the signature. Normal for a dry run.
+- `closure carries NO signature — the root executor verifies it and WILL refuse
+  this push` — knowable now, so the dry run reports `would NOT push` rather than
+  previewing a push that cannot happen. Get the gate answered by a seat that can
+  sign.
+
+Confirm a closure with `sudo 5dive gate-proof verify <task>` (root only).
 
 ## Security model
 

--- a/scripts/run-harnesses.sh
+++ b/scripts/run-harnesses.sh
@@ -627,9 +627,24 @@ elif (( total_ms > EFF_MS )); then
   # DIVE-2592: SAY WHAT THIS RED IS, in the output that carries it. `exit 4` beside a
   # green assertion count cost the author of #395 an hour: it reads as systemic to the
   # person whose PR it stopped and as flake to the next reader, and it is neither.
-  printf 'NO TEST FAILED — %d of %d harnesses passed. This is a BUDGET failure (exit 4), not a\n' \
-    "$(( ${#CORPUS[@]} - ${#failed[@]} ))" "${#CORPUS[@]}"
-  printf 'test failure (exit 1): nothing in your diff is broken, the CORPUS no longer fits its cap.\n'
+  # DIVE-2801: the no-test-failed claim is only true when nothing failed, and this
+  # branch had been asserting it unconditionally — while computing "N of M" from
+  # the very `failed` array that contradicts it. On a run with 2 failures it
+  # printed "NO TEST FAILED — 241 of 243 harnesses passed", which is a verdict the
+  # printer did not compute, in the output whose whole job is to say what this red
+  # IS. Exactly the class this row exists to fix, occurring inside the measurement
+  # of it. Both facts are true at once here and the reader needs both, plus which
+  # exit code wins.
+  if (( ${#failed[@]} == 0 )); then
+    printf 'NO TEST FAILED — %d of %d harnesses passed. This is a BUDGET failure (exit 4), not a\n' \
+      "$(( ${#CORPUS[@]} - ${#failed[@]} ))" "${#CORPUS[@]}"
+    printf 'test failure (exit 1): nothing in your diff is broken, the CORPUS no longer fits its cap.\n'
+  else
+    printf '%d HARNESS(ES) ALSO FAILED — %d of %d passed. This run is BOTH over budget AND red.\n' \
+      "${#failed[@]}" "$(( ${#CORPUS[@]} - ${#failed[@]} ))" "${#CORPUS[@]}"
+    printf 'The FAILURE takes precedence and this run exits 1, not 4: fix the failing harness(es)\n'
+    printf 'first, then re-read the budget — a red run is not a trustworthy timing sample either.\n'
+  fi
   if (( confirmed )); then
     printf 'It was measured TWICE (%ds, then %ds) before this was printed, so it is not variance.\n' \
       "$first_total_s" "$total_s"

--- a/src/cmd_push.sh
+++ b/src/cmd_push.sh
@@ -366,8 +366,14 @@ cmd_push() {
     local body; body=$(db "SELECT COALESCE(body,'') FROM tasks WHERE id=${id};")
     branch=$(_push_branch_from_body "$body")
   fi
+  # DIVE-2801: name BOTH requirements. `--branch` satisfies this usage check but
+  # NOT the DIVE-1462 gate binding in _push_do, which reads the branch fresh from
+  # the task body — so offering `--branch` alone as an alternative sends the
+  # caller down a path whose only outcome is the next refusal. Same defect as the
+  # dry-run above: an early check answering on behalf of a later one it does not
+  # share a predicate with.
   [[ -n "$branch" ]] || fail "$E_USAGE" \
-    "no branch for ${ident}: pass --branch=<name> or add a 'Branch: <name>' line to the task body (push refuses to guess)."
+    "no branch for ${ident}: add a 'Branch: <name>' line to the task body (push refuses to guess). The task body is REQUIRED — the cleared gate binds to the branch the task itself declares (DIVE-1462), so --branch=<name> alone gets past this check and is then refused by that binding; pass it as well only to override which branch is read."
   case "$branch" in
     main|master|HEAD) fail "$E_VALIDATION" "refusing to push to protected branch '${branch}' — delegated push targets feature branches only." ;;
   esac
@@ -458,10 +464,27 @@ cmd_push() {
         pr_preview=" — but NOT open a PR: this account has no '_gh_do' grant, so --open-pr would warn and leave the branch for someone else to open"
       fi
     fi
-    ok "dry-run: would push ${branch}@${sha} to ${slug}${pr_preview} — target from ${repo_src} (gate cleared, author ${author_state})" \
+    # DIVE-2801: the rehearsal must not report a verdict it did not compute. This
+    # runs the preflight (require_sig=0); the real push runs the root executor
+    # (require_sig=1), so "gate cleared" alone answers for the signature check
+    # that never ran here — and that is the leg most likely to refuse. When the
+    # closure carries no signature the outcome is knowable NOW, so say so in the
+    # verb rather than previewing a push that cannot happen.
+    local sig_phrase gate_json lead
+    sig_phrase=$(broker_gate_sig_phrase push)
+    if [[ "${BROKER_GATE_SIG_STATE:-}" == "unsigned" ]]; then
+      lead="dry-run: would NOT push ${branch}@${sha} to ${slug} — REFUSED at push time"
+      gate_json="authority-ok-signature-absent"
+    else
+      lead="dry-run: would push ${branch}@${sha} to ${slug}${pr_preview}"
+      gate_json="authority-ok-signature-unverified"
+      [[ "${BROKER_GATE_SIG_STATE:-}" == "verified" ]] && gate_json="cleared"
+    fi
+    ok "${lead} — target from ${repo_src} (gate authority cleared; ${sig_phrase}; author ${author_state})" \
        "$(jq -n --arg t "$ident" --arg b "$branch" --arg s "$sha" --arg r "$slug" --arg a "$author_state" --arg rs "$repo_src" \
-             --argjson op "$open_pr" --arg pb "$pr_base_preview" \
-             '{task:$t,branch:$b,sha:$s,repo:$r,repoSource:$rs,dryRun:true,gate:"cleared",author:$a,openPr:($op==1),prBase:$pb}')"
+             --argjson op "$open_pr" --arg pb "$pr_base_preview" --arg g "$gate_json" \
+             --arg ss "${BROKER_GATE_SIG_STATE:-unknown}" \
+             '{task:$t,branch:$b,sha:$s,repo:$r,repoSource:$rs,dryRun:true,gate:$g,signature:$ss,author:$a,openPr:($op==1),prBase:$pb}')"
     return 0
   fi
 

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -10960,7 +10960,18 @@ cmd_task_answer() {
       # No audit_log here: the blocked caller is an agent user that can't write
       # the root-owned audit log anyway (it would only leak a perms error to
       # stderr). The fail + non-zero exit is the record.
-      fail "$E_AUTH_REQUIRED" "$ident is a '$nt' gate — only a human can clear it. Answer it from Telegram (tap the button) or the dashboard; an agent can't self-answer an approval/secret/manual gate."
+      # DIVE-2801: state the CALLER's standing, not a law about the gate type.
+      # "an agent can't self-answer an approval gate" is false — the gate's
+      # lead-clear seat reaches here with _lead_clear=1 and clears it with no
+      # human at all (see the branch above; DIVE-2599/2665/2654 are live
+      # instances). Human-only is the FALL-THROUGH for a caller without that
+      # standing, not the rule for the type. The old wording was read as a
+      # general rule by the agent it refused, who then rebuilt the gate around
+      # it — a refusal that describes the wrong subject sends the reader to fix
+      # the wrong thing, and unlike a wrong answer nobody audits a reason.
+      local _who_can="a human"
+      [[ -n "$_routed_rev" ]] && _who_can="'${_routed_rev}' (this gate's routed reviewer) or a human"
+      fail "$E_AUTH_REQUIRED" "$ident is a '$nt' gate and you ('${_caller}') do not hold lead-clear standing on it, so your answer is refused — this is about YOUR standing on THIS gate, not about the gate type: its lead-clear seat can answer it with no human involved. It can be cleared by ${_who_can}. A human answers from Telegram (tap the button) or the dashboard."
     fi
     # DIVE-2054: routed_reviewer is task-store state for $ident — fenced.
     # DIVE-2099: `standing=` distinguishes the two clearances that reach here.

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -10969,9 +10969,14 @@ cmd_task_answer() {
       # general rule by the agent it refused, who then rebuilt the gate around
       # it — a refusal that describes the wrong subject sends the reader to fix
       # the wrong thing, and unlike a wrong answer nobody audits a reason.
-      local _who_can="a human"
-      [[ -n "$_routed_rev" ]] && _who_can="'${_routed_rev}' (this gate's routed reviewer) or a human"
-      fail "$E_AUTH_REQUIRED" "$ident is a '$nt' gate and you ('${_caller}') do not hold lead-clear standing on it, so your answer is refused — this is about YOUR standing on THIS gate, not about the gate type: its lead-clear seat can answer it with no human involved. It can be cleared by ${_who_can}. A human answers from Telegram (tap the button) or the dashboard."
+      # ...and the same discipline applies to the REMEDY, one clause later. An
+      # unrouted gate has no lead-clear seat, so "its lead-clear seat can answer
+      # this with no human involved" is, on that gate, the identical defect in
+      # the opposite direction: a sentence true of the type and false of the row
+      # in front of the reader. Only the routed branch may claim a seat exists.
+      local _who_can="a human — this gate has no routed reviewer, so no seat holds lead-clear standing on it"
+      [[ -n "$_routed_rev" ]] && _who_can="'${_routed_rev}', this gate's routed reviewer, who holds lead-clear standing and can answer it with no human involved — or by a human"
+      fail "$E_AUTH_REQUIRED" "$ident is a '$nt' gate and you ('${_caller}') do not hold lead-clear standing on it, so your answer is refused. This is about YOUR standing on THIS gate, not a law about '$nt' gates. It can be cleared by ${_who_can}. A human answers from Telegram (tap the button) or the dashboard."
     fi
     # DIVE-2054: routed_reviewer is task-store state for $ident — fenced.
     # DIVE-2099: `standing=` distinguishes the two clearances that reach here.

--- a/src/lib/broker.sh
+++ b/src/lib/broker.sh
@@ -195,6 +195,36 @@ broker_gate_check() {
       && ! _gate_closure_verify "$id" "$gtype" "$ganswer" "$gby" "$gansweredat" "$guid" "$gsig"; then
     fail "$E_VALIDATION" "gate on ${ident} has no valid signed closure — delegated ${noun} refused (the authoritative gate record may be unsigned or tampered)."
   fi
+
+  # DIVE-2801: say WHICH predicate this call actually ran, so a caller cannot
+  # report a verdict it did not compute. The agent-side preflight passes
+  # require_sig=0 and the root executor passes 1, so a preflight that prints a
+  # flat "gate cleared" is answering for a check it never ran — and the signature
+  # is the leg most likely to stop the real write (DIVE-2760). Absence is
+  # readable HERE, without the root key: an empty `need_answer_sig` cannot pass
+  # the executor, so the preflight can predict that refusal rather than merely
+  # disclaim it. A present-but-unverified signature is disclaimed, not warned
+  # about — otherwise the honest case and the doomed case read identically and
+  # the warning is noise (the failure mode that hid this for so long).
+  if [[ "$require_sig" == "1" ]]; then
+    BROKER_GATE_SIG_STATE="verified"
+  elif [[ -z "$gsig" ]]; then
+    BROKER_GATE_SIG_STATE="unsigned"
+  else
+    BROKER_GATE_SIG_STATE="unverified"
+  fi
+  export BROKER_GATE_SIG_STATE
+}
+
+# broker_gate_sig_phrase — render BROKER_GATE_SIG_STATE for a human line. Kept
+# beside the predicate that sets it so the two cannot drift apart.
+broker_gate_sig_phrase() {
+  case "${BROKER_GATE_SIG_STATE:-}" in
+    verified)   printf '%s' "signature verified" ;;
+    unsigned)   printf '%s' "closure carries NO signature — the root executor verifies it and WILL refuse this ${1:-push}" ;;
+    unverified) printf '%s' "signature present but NOT verified here — the root executor verifies it at ${1:-push} time" ;;
+    *)          printf '%s' "signature state unknown" ;;
+  esac
 }
 
 # broker_task_target <surface> <id> — the target a task AUTHORITATIVELY declares

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -541,6 +541,25 @@ if [[ "$C2" == *"cover it"* && "$C2" == *"always.sh"* ]]; then
   ok "the budget red names the smallest set of harnesses that COVERS the overage"
 else bad "the budget red names the smallest set of harnesses that COVERS the overage" "$C2"; fi
 
+# DIVE-2801: OVER BUDGET **AND** RED. The arm above is the no-failures case; this is
+# its pair. The banner used to assert "NO TEST FAILED" unconditionally inside the
+# over-budget branch while computing "N of M" from the very `failed` array that
+# contradicts it — a real run printed "NO TEST FAILED — 241 of 243 harnesses
+# passed". That is a verdict the printer did not compute, in the output whose only
+# job is to say what the red IS, and it is the same defect this row exists to fix.
+# Both facts are true here and the reader needs both plus which exit wins.
+rm -f "$TMP"/*.seen
+printf '#!/usr/bin/env bash\nexit 1\n' > "$TMP/broken.sh"
+C3="$(bash "$RUNNER" --no-calibrate --corpus-dir="$TMP" --tier=full --budget=1 --label=t 2>&1)"; RC3=$?
+want "over budget AND a failing harness exits 1 (the failure wins, not 4)" "1" "$RC3"
+if [[ "$C3" != *"NO TEST FAILED"* ]]; then
+  ok "an over-budget run WITH failures does not claim NO TEST FAILED (DIVE-2801)"
+else bad "an over-budget run WITH failures still claims NO TEST FAILED (DIVE-2801)" "$C3"; fi
+if [[ "$C3" == *"ALSO FAILED"* && "$C3" == *"BOTH over budget AND red"* && "$C3" == *"exits 1, not 4"* ]]; then
+  ok "the both-red banner states both facts and which exit code wins (DIVE-2801)"
+else bad "the both-red banner states both facts and which exit code wins (DIVE-2801)" "$C3"; fi
+rm -f "$TMP/broken.sh"
+
 # --confirm-top may only make this gate STRICTER. The rescued corpus, confirmation
 # off, must red — an override that can turn a red green is the hatch, not the control.
 cat > "$TMP/flaps.sh" <<'FLAPS'

--- a/tests/gate_nonce_unit.sh
+++ b/tests/gate_nonce_unit.sh
@@ -235,16 +235,29 @@ touch "$GATE_PROOF_ENFORCE"
 FAKE_CALLER="agent-evil"
 seed_task DIVE-800; cmd_task_need DIVE-800 --type=manual --ask="do it" >/dev/null 2>&1
 out=$(cmd_task_answer DIVE-800 --value=done --human 2>&1); rc=$?
-[[ "$(answered DIVE-800)" == "open" && $rc -ne 0 && "$out" == *"only a human"* ]] \
+# DIVE-2801: the refusal must name the CALLER's standing, not claim a property of
+# the gate type. "only a human can clear it" was false — the gate's lead-clear
+# seat clears these with no human at all — and the agent it refused read it as a
+# general rule and rebuilt the gate around it. Assert the mechanism (refused, gate
+# still open) AND that the wording describes the caller, since pinning the old
+# sentence is what made the wrong reason durable.
+[[ "$(answered DIVE-800)" == "open" && $rc -ne 0 && "$out" == *"lead-clear standing"* ]] \
   && ok_t "T8 agent-* immediate caller blocked on manual gate (defense-in-depth)" \
   || bad_t "T8 agent-* caller blocked on manual" "rc=$rc state=$(answered DIVE-800) out=$out"
+[[ "$out" != *"only a human can clear it"* ]] \
+  && ok_t "T8 refusal does not assert a gate-type law it cannot support (DIVE-2801)" \
+  || bad_t "T8 refusal still claims 'only a human can clear it'" "out=$out"
 
 # T8b: the CONTROL. Non-agent caller, everything else identical — must NOT hit
 # the agent refusal. Without this arm T8 grades a message, not a mechanism.
 FAKE_CALLER="root"
 seed_task DIVE-801; cmd_task_need DIVE-801 --type=manual --ask="do it" >/dev/null 2>&1
 out8b=$(cmd_task_answer DIVE-801 --value=done --human 2>&1); rc8b=$?
-[[ "$out8b" != *"only a human can clear it"* ]] \
+# DIVE-2801: keyed on the phrase the refusal ACTUALLY carries now. Left on the old
+# sentence this control would pass for any build — including one where the refusal
+# fires on every caller — because the string it looked for no longer exists
+# anywhere. A control that cannot fail has stopped being a control.
+[[ "$out8b" != *"lead-clear standing"* ]] \
   && ok_t "T8b CONTROL: non-agent caller does NOT hit the agent refusal (rc=$rc8b)" \
   || bad_t "T8b non-agent caller wrongly hit the agent refusal" "rc=$rc8b out=$out8b"
 

--- a/tests/gate_t2_routed_escalate_unit.sh
+++ b/tests/gate_t2_routed_escalate_unit.sh
@@ -180,9 +180,21 @@ out=$(cmd_task_answer DIVE-302 --value=approved 2>&1); rc=$?
 [[ -z "$(_nf)" ]] \
   && ok_t "E2 no escalation ping on a non-routed gate" \
   || bad_t "E2 no ping" "notified='$(_nf)'"
-[[ "$out" == *"only a human"* || "$out" == *"tier-2 human gate"* ]] \
-  && ok_t "E2 keeps the original tier-2 refusal message" \
+# DIVE-2801 CHANGED THE EXPECTED STRING, not this arm's claim. The claim here is
+# "refused, and by the plain refusal rather than the escalation path" — it was
+# keyed on "only a human", a sentence that row deleted for being false (the
+# lead-clear seat answers these with no human). Re-keyed onto what still
+# discriminates the two paths: the standing refusal names the caller's standing,
+# and escalation would have flagged itself (E1 asserts that flag's presence).
+[[ "$out" == *"lead-clear standing"* && "$out" != *"escalated_to_human"* ]] \
+  && ok_t "E2 gets the plain standing refusal, not the escalation path" \
   || bad_t "E2 refusal message" "out=$out"
+# And the remedy it offers must fit THIS gate: DIVE-302 is unrouted, so there is
+# no lead-clear seat to point at. Asserting the absence is the whole point — the
+# type-level sentence is exactly what would reappear here.
+[[ "$out" == *"no routed reviewer"* ]] \
+  && ok_t "E2 unrouted gate is not told a lead-clear seat can answer it (DIVE-2801)" \
+  || bad_t "E2 unrouted remedy names a seat that does not exist" "out=$out"
 
 # --- E3: a routed tier-2 manual gate cleared by a real HUMAN (--human) clears normally —
 #     escalation only fires for the NON-human refusal path (DIVE-525: taps never break). -
@@ -243,6 +255,32 @@ out=$(cmd_task_answer DIVE-304 --value=approved 2>&1); rc=$?
   && ok_t "E4 enforce OFF: the human was notified with a tap — escalation fires identically to enforce ON" \
   || bad_t "E4 escalation fires with enforce OFF" "notified='$(_nf)'"
 touch "$GATE_PROOF_ENFORCE"
+
+# --- E5: DIVE-2801's POSITIVE CONTROL. Every arm above grades a caller WITHOUT
+#     lead-clear standing, so all of them would still pass against a build that
+#     refuses every caller — and that build is precisely what the old wording
+#     ("only a human can clear it") described. The row's claim is that standing,
+#     not gate type, decides; a claim about a discriminator is not tested until
+#     both sides of it are run. Same caller identity as E2, tier-1 approval gate
+#     routed to that caller: it must clear, and see no refusal at all.
+#     (Ident DIVE-306, not 305: E3b already holds 305. Seeded onto a taken ident
+#     `seed_task` hits a UNIQUE constraint, the gate filing is refused as already
+#     filed, and the arm then grades the PREVIOUS arm's leftover row — which is
+#     how the first draft of this control passed while proving nothing.)
+seed_task DIVE-306
+cmd_task_need DIVE-306 --type=approval --tier=1 --ask="ship it" >/dev/null 2>&1
+[[ "$(tierof DIVE-306)" == "1" ]] \
+  && ok_t "E5 precond: a tier-1 approval gate is filed on a FRESH ident" \
+  || bad_t "E5 precond: fixture is not the gate this arm claims" "tier='$(tierof DIVE-306)' — a collided ident would grade a leftover row"
+route_to DIVE-306 marcus
+_nf_reset
+out5=$(cmd_task_answer DIVE-306 --value=approve 2>&1); rc5=$?
+[[ "$(answered DIVE-306)" == "closed" && $rc5 -eq 0 ]] \
+  && ok_t "E5 CONTROL: the caller WITH lead-clear standing clears its own gate, no human" \
+  || bad_t "E5 standing caller could not clear" "rc=$rc5 state=$(answered DIVE-306) out=$out5"
+[[ "$out5" != *"lead-clear standing"* && "$out5" != *"only a human"* ]] \
+  && ok_t "E5 CONTROL: standing caller sees no refusal text (standing decides, not type)" \
+  || bad_t "E5 standing caller was refused" "out=$out5"
 
 echo "-----"
 printf 'gate_t2_routed_escalate_unit: %d passed, %d failed\n' "$PASS" "$FAIL"

--- a/tests/push_unit.sh
+++ b/tests/push_unit.sh
@@ -964,6 +964,66 @@ else
         "source shape gave '${_src_out:-<died before the fallback>}', unguarded control gave '${_unguarded_out:-<died, correct>}' — the source's own shape must reach the fallback AND the unguarded control must not"
 fi
 
+# ---------------------------------------------------------------------------
+# DIVE-2801: a step must not report a verdict it did not compute.
+#
+# --dry-run runs the agent-side preflight (require_sig=0); the real push runs the
+# root executor (require_sig=1). A flat "gate cleared" therefore answers for the
+# SIGNATURE check that never ran here — the leg most likely to refuse, because a
+# seat whose sudo grant does not reach `gate-proof sign` stores an unsigned
+# closure while the answer reports OK (DIVE-2760).
+#
+# The arms are deliberately PAIRED. Asserting only the warning would also pass
+# for a fix that always warns, which is worthless: a warning on every push is
+# noise, and noise is how this stayed invisible. So the positive control asserts
+# the honest case stays quiet and asserts the refusal wording is ABSENT.
+
+# 20) UNSIGNED closure -> predict the refusal rather than preview a push that
+#     cannot happen. Absence of a signature is readable at preflight without the
+#     root key, so this is a prediction, not a disclaimer.
+seed_task DIVE-990 "Branch: feature-ok" approval "2026-07-18 00:00:00" "yes" "lead:scoped" "" 0
+out=$(run_push DIVE-990 --dry-run); rc=$?
+{ [[ $rc -eq 0 ]] \
+    && grep -qi "would NOT push" <<<"$out" \
+    && grep -qi "WILL refuse" <<<"$out"; } \
+  && ok_t "unsigned closure -> dry run predicts the push-time refusal (DIVE-2801)" \
+  || bad_t "unsigned closure -> dry run predicts the push-time refusal (DIVE-2801)" "rc=$rc :: $out"
+
+# 20b) the machine-readable surface must carry it too — a script reading `gate`
+#      would otherwise still see "cleared" for a push that cannot happen.
+out=$( cd "$REPO"; JSON_MODE=1 cmd_push DIVE-990 --repo="file://$REPO" --dry-run 2>&1 ); rc=$?
+{ [[ $rc -eq 0 ]] \
+    && grep -q '"gate":"authority-ok-signature-absent"' <<<"$out" \
+    && grep -q '"signature":"unsigned"' <<<"$out"; } \
+  && ok_t "unsigned closure -> JSON gate/signature name the uncomputed check (DIVE-2801)" \
+  || bad_t "unsigned closure -> JSON gate/signature name the uncomputed check (DIVE-2801)" "rc=$rc :: $out"
+
+# 21) POSITIVE CONTROL — a SIGNED closure must still read as a clean rehearsal.
+#     This is the arm that stops the fix degrading into "always warn": a blanket
+#     warning fails HERE while arm 20 would still pass.
+seed_task DIVE-991 "Branch: feature-ok" approval "2026-07-18 00:00:00" "yes"
+out=$(run_push DIVE-991 --dry-run); rc=$?
+{ [[ $rc -eq 0 ]] \
+    && grep -qi "dry-run: would push" <<<"$out" \
+    && ! grep -qi "would NOT push" <<<"$out" \
+    && ! grep -qi "WILL refuse" <<<"$out" \
+    && grep -qi "NOT verified here" <<<"$out"; } \
+  && ok_t "signed closure -> clean rehearsal, disclaimed not warned (DIVE-2801 positive control)" \
+  || bad_t "signed closure -> clean rehearsal, disclaimed not warned (DIVE-2801 positive control)" "rc=$rc :: $out"
+
+# 22) The usage refusal must not recommend a remedy it cannot honour. `--branch`
+#     satisfies THIS check but not the DIVE-1462 gate binding in _push_do, which
+#     reads the branch from the task body — so offering it as the alternative
+#     sends the caller straight into the next refusal. Same defect, one step up.
+seed_task DIVE-992 "no branch line in this body" approval "2026-07-18 00:00:00" "yes"
+out=$(run_push DIVE-992 --dry-run 2>&1); rc=$?
+{ [[ $rc -ne 0 ]] \
+    && grep -q "Branch: <name>" <<<"$out" \
+    && grep -q "body is REQUIRED" <<<"$out" \
+    && ! grep -q "pass --branch=<name> or add" <<<"$out"; } \
+  && ok_t "branch refusal names the body requirement, not --branch alone (DIVE-2801)" \
+  || bad_t "branch refusal names the body requirement, not --branch alone (DIVE-2801)" "rc=$rc :: $out"
+
 echo "-----"
 printf 'push_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## DIVE-2801 — a step must not report a verdict it did not compute

Three surfaces, **one** defect: an early step answers on behalf of a later one whose predicate it does not share, in a sentence that reads like the whole answer.

### 1. `push --dry-run` green-lit a push the real run refuses

Measured on DIVE-2798, seconds apart:

```
5dive push DIVE-2798 --dry-run   → "OK — would push …@e24b954 … (gate cleared, …)"   rc=0
5dive push DIVE-2798             → "no valid signed closure … refused"                rc=1
```

The dry run executes the **agent-side preflight** (`require_sig=0`); the real push executes the **root executor** (`require_sig=1`, `cmd_push_do`). So the rehearsal is structurally blind to the check most likely to stop the write — and a seat whose sudo grant does not reach `gate-proof sign` stores an unsigned closure while `task answer` reports OK (DIVE-2760). A dry run that cannot see the authoritative predicate is worse than none, because its output is read as authorization.

Now the rehearsal names which predicate ran:

| state | rendered |
|---|---|
| `verified` | `signature verified` (root executor ran) |
| `unverified` | `signature present but NOT verified here` |
| `unsigned` | `closure carries NO signature — WILL refuse this push`, and the verb flips to **`would NOT push`** |

Signature **absence** is readable at preflight without the root key, so the third case is a *prediction*, not a disclaimer. A present-but-unverified signature is disclaimed, **not** warned about — otherwise the honest and doomed cases read identically and the warning becomes noise, which is precisely how this stayed invisible.

### 2. The no-branch refusal recommended a remedy it cannot honour

`--branch=<name>` satisfies the usage check but **not** the DIVE-1462 gate binding, which reads the branch from the task body. So following the refusal's own advice produces the next refusal. `docs/delegated-push.md:123` said the same thing wrongly ("instead of `--branch`") and its quickstart showed the invocation that fails.

### 3. `task answer` stated a caller property as a gate-type law

> `$ident is a '$nt' gate — only a human can clear it … an agent can't self-answer an approval/secret/manual gate.`

**False.** The human-only refusal sits inside `if [[ -n "$_caller" && "$_lead_clear" != "1" ]]` — the gate's lead-clear seat reaches it with `_lead_clear=1` and clears it with no human at all. DIVE-2599 / 2665 / 2654 are live instances: approval gates, `lead:main2`, uid 1010, no human. Human-only is the **fall-through**, not the rule.

The agent it refused read it as a general rule and rebuilt the gate around it — approval → decision → wrong authority → re-file → wrong signature. Four attempts, three agents, all downstream of a correct refusal carrying a wrong reason. It now states the caller's standing and names who can clear it.

## Tests

`push_unit` 102/0 (+4 arms) · `gate_nonce_unit` 20/0 · `broker_surface_unit` 52/0 (unchanged)

The arms are **paired on purpose**. Asserting only the warning would also pass for a fix that *always* warns — worthless, since a warning on every push is noise. So the positive control asserts a signed closure stays **quiet** and asserts the refusal wording is **absent**: a blanket warning fails there while the warning arm still passes.

`T8b` was re-keyed. It asserted absence of `"only a human can clear it"` — a string this PR deletes entirely, so left alone it would have passed for **any** build, including one where the refusal fires on every caller. Re-keyed onto the phrase the refusal now carries, and verified still discriminating by inverting the comparison in place: inverted, the suite goes 19/1 failing exactly on T8b.

## Known, not hidden

Core sweep 241/243. `actor_claim_corroboration_unit` is **pre-existing** — red in the pre-change run on this same tree, and reds on plain main once a bundle exists. `init_ux_unit` failed in the sweep and **passes in isolation** (rc=0) with no plausible link to this diff; treated as **unattributed**, not cleared. The sweep also reported a budget overage and printed `NO TEST FAILED — 241 of 243 harnesses passed`, which contradicts itself — not chased here.

Dogfooded on a live row before pushing: this branch's own build renders `gate authority cleared; signature present but NOT verified here`, which is the positive-control case in production.
