### PR TITLE
feat(create): --base-url points a claude agent at any Anthropic-compatible endpoint (DIVE-2757)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,30 @@ sudo 5dive agent create cheap-coder --type=claude --provider=deepseek --api-key=
 sudo 5dive agent create glm-coder --type=claude --provider=openrouter --api-key=<key> --auth-profile=openrouter --model=z-ai/glm-5.2
 ```
 
+Not on that list? `--base-url` points the harness at **any** Anthropic-compatible
+endpoint — a model you host yourself, or a vendor host we don't ship a row for:
+
+```sh
+# Open weights on a server you own. --model is required here: there is no catalog
+# entry to inherit per-tier model ids from, and an unpinned background tier would
+# 404 on the agent's own housekeeping turns.
+sudo 5dive agent create qwen-box --type=claude \
+  --base-url=https://llm.internal.example.com/anthropic \
+  --api-key=<key> --auth-profile=qwen-box --model=qwen3.8-max
+
+# A local inference server (vLLM, llama.cpp, an Ollama Anthropic shim):
+sudo 5dive agent create local-box --type=claude \
+  --base-url=http://127.0.0.1:8000 \
+  --api-key=<key> --auth-profile=local-box --model=<slug>
+```
+
+`https://` is required — the API key rides that URL on every request. `http://` is
+accepted only for `localhost` / `127.0.0.1` / `[::1]`, where the traffic never leaves
+the box; a private-LAN address is still a real network and is refused. `--base-url`
+requires `--auth-profile`, like every claude BYO path, so the endpoint and its key
+are scoped to the agents you bind to that profile rather than to every claude agent
+on the host. In a `5dive compose` spec the key is `base_url`.
+
 Switch the model on a running agent (persists across restarts):
 
 ```sh

--- a/changelog.d/DIVE-2757.md
+++ b/changelog.d/DIVE-2757.md
@@ -1,0 +1,31 @@
+## Unreleased — feat(create): `--base-url` points a claude agent at any Anthropic-compatible endpoint (DIVE-2757)
+
+`5dive agent create --type=claude` could only reach the four vendors hardcoded in
+`CLAUDE_PROVIDER_BASEURL` (deepseek, moonshot, openrouter, zai). Open weights running
+on a server you own were unreachable at any price. `--base-url=<url>` removes that
+fixedness:
+
+```sh
+sudo 5dive agent create qwen-box --type=claude \
+  --base-url=https://llm.internal.example.com/anthropic \
+  --api-key=<key> --auth-profile=qwen-box --model=qwen3.8-max
+```
+
+- **`--model` is required** when the endpoint has no catalog row, because there are
+  no per-tier model ids to inherit. All three tiers are pinned to it — including
+  HAIKU, which is the one that would fail silently: it is background traffic, not a
+  tier anyone selects, so an unset value looks fine interactively and 404s later.
+- **`https://` is required**; the API key rides that URL on every request. `http://`
+  is accepted only for `localhost` / `127.0.0.1` / `[::1]`, where the traffic never
+  leaves the box. A private-LAN address is off-box and is refused.
+- **`--auth-profile` is required**, inherited from the existing claude BYO path, so
+  the endpoint and its key are scoped to that profile rather than to every claude
+  agent on the host.
+- Passing `--base-url` alongside a KNOWN provider redirects that vendor to another
+  host (a CN endpoint, a corporate gateway) and keeps its catalog model ids — the
+  models did not change, only where they are served.
+- claude only. hermes and openclaw resolve endpoints from their own catalogs and
+  speak different wire formats; one flag cannot serve all three.
+- `5dive compose` gains the `base_url` key. On that path `--model` is emitted at
+  create time rather than left to the post-create `agent config set model=`, because
+  create refuses before that would ever run.

--- a/src/cmd_agent_create.sh
+++ b/src/cmd_agent_create.sh
@@ -814,11 +814,25 @@ link_agent_profile() {
 # to the profile so the seed loop in 5dive-agent-start.sh picks up the
 # new files and bounces the hermes/openclaw gateway daemon.
 apply_byo_provider() {
-  local type="$1" canonical="$2" api_key="$3" profile="${4:-}" model="${5:-}"
-  valid_byo_provider "$canonical" \
-    || fail "$E_VALIDATION" "unknown provider '$canonical' (known: ${!BYO_PROVIDER_LABEL[*]})"
+  local type="$1" canonical="$2" api_key="$3" profile="${4:-}" model="${5:-}" base_url="${6:-}"
   valid_api_key "$api_key" \
     || fail "$E_VALIDATION" "api key looks wrong (>=10 printable non-space chars)"
+
+  # DIVE-2757: an operator-supplied --base-url is the ONE case where the vendor
+  # catalog is not consulted — the endpoint came from argv, so there is no
+  # catalog entry to look up and nothing for valid_byo_provider /
+  # resolve_native_provider to resolve. It is claude-only: hermes and openclaw
+  # keep their own URL tables (HERMES_PROVIDER_URL / OPENCLAW_PROVIDER_URL) and
+  # speak different wire formats, so one flag cannot serve all three.
+  if [[ -n "$base_url" ]]; then
+    [[ "$type" == "claude" ]] \
+      || fail "$E_VALIDATION" "--base-url is only supported for --type=claude (got: $type)"
+    _apply_byo_claude "$canonical" "$api_key" "$profile" "$model" "$base_url"
+    return 0
+  fi
+
+  valid_byo_provider "$canonical" \
+    || fail "$E_VALIDATION" "unknown provider '$canonical' (known: ${!BYO_PROVIDER_LABEL[*]})"
   local native
   native=$(resolve_native_provider "$type" "$canonical")
   [[ -n "$native" ]] \
@@ -840,12 +854,23 @@ apply_byo_provider() {
 # these override any default-account OAuth token that template otherwise leaks
 # in. profile_set_var takes the value on stdin (keeps secrets out of argv).
 _apply_byo_claude() {
-  local canonical="$1" api_key="$2" profile="${3:-}" override_model="${4:-}"
+  local canonical="$1" api_key="$2" profile="${3:-}" override_model="${4:-}" url_override="${5:-}"
   [[ -n "$profile" ]] \
     || fail "$E_USAGE" "claude BYO provider requires --auth-profile (custom-provider creds are profile-scoped)"
   local base_url="${CLAUDE_PROVIDER_BASEURL[$canonical]:-}"
+  # DIVE-2757: --base-url wins over the catalog. Two shapes reach here:
+  #   * a KNOWN vendor redirected to a different host of the same vendor (a CN
+  #     endpoint, a corporate gateway) — the catalog's per-tier model ids still
+  #     apply, because the models did not change, only where they are served;
+  #   * a CUSTOM endpoint with no catalog row at all (self-hosted open weights),
+  #     where there are no model ids to inherit — see the --model gate below.
+  if [[ -n "$url_override" ]]; then
+    valid_base_url "$url_override" \
+      || fail "$E_VALIDATION" "invalid --base-url '$url_override' (https:// required — http:// only for localhost/127.0.0.1/[::1]; no whitespace or quotes)"
+    base_url="$url_override"
+  fi
   [[ -n "$base_url" ]] \
-    || fail "$E_VALIDATION" "claude does not support provider '$canonical' (${BYO_PROVIDER_LABEL[$canonical]:-unknown}: no Anthropic-compatible endpoint)"
+    || fail "$E_VALIDATION" "claude does not support provider '$canonical' (${BYO_PROVIDER_LABEL[$canonical]:-unknown}: no Anthropic-compatible endpoint). Pass --base-url=<url> to point at one yourself."
   step "Configuring claude BYO provider '$canonical' → ${base_url} (profile=$profile)"
   printf '%s' "$base_url"  | profile_set_var "$profile" ANTHROPIC_BASE_URL
   printf '%s' "$api_key"   | profile_set_var "$profile" ANTHROPIC_AUTH_TOKEN
@@ -853,12 +878,23 @@ _apply_byo_claude() {
   # tiers with any slug the provider serves (OpenRouter translates every family;
   # the Chinese providers serve their own). The background/fast HAIKU slot stays
   # on the catalogue's caching-capable default so background turns stay cheap.
-  local opus_model="${CLAUDE_PROVIDER_OPUS_MODEL[$canonical]}"
-  local sonnet_model="${CLAUDE_PROVIDER_SONNET_MODEL[$canonical]}"
+  local opus_model="${CLAUDE_PROVIDER_OPUS_MODEL[$canonical]:-}"
+  local sonnet_model="${CLAUDE_PROVIDER_SONNET_MODEL[$canonical]:-}"
+  local haiku_model="${CLAUDE_PROVIDER_HAIKU_MODEL[$canonical]:-}"
   if [[ -n "$override_model" ]]; then opus_model="$override_model"; sonnet_model="$override_model"; fi
+  # DIVE-2757: a custom endpoint has no catalog row, so there is no per-tier
+  # default to inherit and --model has to supply all three. The HAIKU slot is
+  # the one that would fail silently: it is never the tier the operator selects,
+  # it is what the harness reaches for on background turns, and an empty value
+  # here leaves the variable unset — so the agent works interactively and 404s
+  # on its own background traffic. An unpinned haiku is not a smaller version of
+  # a working agent; it is a broken one that looks fine for the first minute.
+  [[ -n "$haiku_model" ]] || haiku_model="$override_model"
+  [[ -n "$opus_model" && -n "$sonnet_model" && -n "$haiku_model" ]] \
+    || fail "$E_USAGE" "--base-url with a custom provider requires --model=<slug> (no catalog entry for '$canonical', so there are no per-tier model ids to fall back to)"
   printf '%s' "$opus_model"   | profile_set_var "$profile" ANTHROPIC_DEFAULT_OPUS_MODEL
   printf '%s' "$sonnet_model" | profile_set_var "$profile" ANTHROPIC_DEFAULT_SONNET_MODEL
-  printf '%s' "${CLAUDE_PROVIDER_HAIKU_MODEL[$canonical]}"  | profile_set_var "$profile" ANTHROPIC_DEFAULT_HAIKU_MODEL
+  printf '%s' "$haiku_model"  | profile_set_var "$profile" ANTHROPIC_DEFAULT_HAIKU_MODEL
   # Custom endpoints (esp. z.ai during peak hours) can be slow; raise the
   # client-side request timeout so long tool turns don't get cut off.
   printf '%s' "3000000" | profile_set_var "$profile" API_TIMEOUT_MS
@@ -1275,7 +1311,7 @@ cmd_create() {
   local name="" type="" channels="none" channels_explicit=0 telegram_token="" discord_token="" workdir="" profile=""
   local telegram_home_channel="" telegram_allowed_users="" telegram_cos="" telegram_cos_avatar=""
   local cos_owner_id=""
-  local byo_provider="" byo_api_key="" byo_model=""
+  local byo_provider="" byo_api_key="" byo_model="" byo_base_url=""
   local skills_arg="" skills_set=0 no_skills=0 defer_auth=0
   local isolation="" isolation_explicit=0 no_team_bot=0
   local autonomy="standard"   # DIVE-499
@@ -1299,6 +1335,7 @@ cmd_create() {
       --provider=*)                byo_provider="${1#--provider=}" ;;
       --api-key=*)                 byo_api_key="${1#--api-key=}" ;;
       --model=*)                   byo_model="${1#--model=}" ;;
+      --base-url=*)                byo_base_url="${1#--base-url=}" ;;
       --with-skills=*)             skills_arg="${1#--with-skills=}"; skills_set=1 ;;
       --no-skills)                 no_skills=1 ;;
       --no-team-bot)               no_team_bot=1 ;;
@@ -1312,7 +1349,7 @@ cmd_create() {
     esac
     shift
   done
-  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent create <name> --type=<type> [--channels=none|telegram|discord|dashboard[,ch...]] [--telegram-token=<token|->] [--telegram-cos=<child-username>] [--telegram-cos-avatar=<png>] [--telegram-home-channel=<id>] [--telegram-allowed-users=<csv>] [--discord-token=<token|->] [--workdir=<path>] [--auth-profile=<name>] [--provider=<id> --api-key=<key|->] [--model=<slug>] [--with-skills=<spec>[,...]] [--no-skills] [--no-team-bot] [--defer-auth] [--isolation=admin|standard|sandboxed] [--can-push] [--can-deploy] [--inherit-memory=wiki|all|team|<agent>[,...]]"
+  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent create <name> --type=<type> [--channels=none|telegram|discord|dashboard[,ch...]] [--telegram-token=<token|->] [--telegram-cos=<child-username>] [--telegram-cos-avatar=<png>] [--telegram-home-channel=<id>] [--telegram-allowed-users=<csv>] [--discord-token=<token|->] [--workdir=<path>] [--auth-profile=<name>] [--provider=<id> --api-key=<key|->] [--base-url=<url>] [--model=<slug>] [--with-skills=<spec>[,...]] [--no-skills] [--no-team-bot] [--defer-auth] [--isolation=admin|standard|sandboxed] [--can-push] [--can-deploy] [--inherit-memory=wiki|all|team|<agent>[,...]]"
   [[ -n "$type" ]] || fail "$E_USAGE" "--type is required"
   valid_name "$name" || fail "$E_VALIDATION" "invalid name (lowercase letters/digits/hyphens, start letter, <=16 chars)"
   is_known_type "$type" || fail "$E_NOT_FOUND" "unknown type: $type (known: ${!TYPE_BIN[*]})"
@@ -1459,6 +1496,20 @@ cmd_create() {
   # Mutually exclusive with --defer-auth: BYO is the alternative to "I'll sign in
   # later", not an add-on. The key sentinel "-" reads from stdin so the value
   # never appears in argv (and thus never in `ps`).
+  # DIVE-2757: --base-url points a claude-type agent at an Anthropic-compatible
+  # endpoint that is not in the catalog — a self-hosted server, or a vendor host
+  # we do not ship a row for. Normalised here, BEFORE the BYO block below, so a
+  # `--base-url` with no `--provider` still enters that block and inherits every
+  # guard it already applies (auth-profile required, --defer-auth exclusive,
+  # stdin-sentinel accounting, key-shape check). Without --provider the id is a
+  # label only; nothing downstream resolves a vendor from it.
+  if [[ -n "$byo_base_url" ]]; then
+    [[ "$type" == "claude" ]] \
+      || fail "$E_VALIDATION" "--base-url is only supported for --type=claude (got: $type). hermes/openclaw resolve endpoints from their own provider catalogs."
+    valid_base_url "$byo_base_url" \
+      || fail "$E_VALIDATION" "invalid --base-url '$byo_base_url' (https:// required — http:// only for localhost/127.0.0.1/[::1]; no whitespace or quotes)"
+    [[ -n "$byo_provider" ]] || byo_provider="$CLAUDE_CUSTOM_PROVIDER_ID"
+  fi
   if [[ -n "$byo_provider" || -n "$byo_api_key" ]]; then
     # pi and opencode are API-key multi-provider types: --provider names the
     # vendor and the key is injected as its native environment variable, so
@@ -1482,6 +1533,19 @@ cmd_create() {
     elif [[ "$type" == "opencode" ]]; then
       opencode_provider_var "$byo_provider" >/dev/null \
         || fail "$E_VALIDATION" "opencode provider '$byo_provider' not supported (known: ${!OPENCODE_PROVIDER_VAR[*]})"
+    elif [[ -n "$byo_base_url" ]]; then
+      # The endpoint came from argv, so there is no catalog row to validate the
+      # provider id against — it is a label. Still constrain its SHAPE: it names
+      # an auth-profile variable and appears in a `step` line, and a free-form
+      # string there is a needless injection surface.
+      valid_name "$byo_provider" \
+        || fail "$E_VALIDATION" "invalid --provider label '$byo_provider' with --base-url (lowercase letters/digits/hyphens, start letter, <=16 chars)"
+      # A custom endpoint has no per-tier model ids to inherit. Caught here as
+      # well as in _apply_byo_claude so the refusal lands at argument-parse time
+      # — before the agent user, home, and unit have been created and would have
+      # to be torn down.
+      [[ -n "$byo_model" || -n "${CLAUDE_PROVIDER_BASEURL[$byo_provider]:-}" ]] \
+        || fail "$E_USAGE" "--base-url with a custom provider requires --model=<slug> (no catalog entry for '$byo_provider', so there are no per-tier model ids to fall back to)"
     else
       valid_byo_provider "$byo_provider" \
         || fail "$E_VALIDATION" "unknown provider '$byo_provider' (known: ${!BYO_PROVIDER_LABEL[*]})"
@@ -1693,7 +1757,7 @@ cmd_create() {
       # create-time OpenRouter key reaches OPENROUTER_API_KEY, not OPENAI_API_KEY.
       opencode_apply_provider_key "$byo_provider" "$byo_api_key" "$profile"
     else
-      apply_byo_provider "$type" "$byo_provider" "$byo_api_key" "$profile" "$byo_model"
+      apply_byo_provider "$type" "$byo_provider" "$byo_api_key" "$profile" "$byo_model" "$byo_base_url"
     fi
   fi
 

--- a/src/cmd_auth.sh
+++ b/src/cmd_auth.sh
@@ -925,6 +925,27 @@ profile_set_var() {
   file="${dir}/combined.env"
   local value
   value=$(cat)
+  # DIVE-2757 iteration 2: a NEWLINE in the value forges a SECOND assignment.
+  # `printf '%s=%s\n' VAR "a<LF>B=c"` writes two lines, and systemd honours the
+  # second — so a value carrying a newline can set ANY variable in this file,
+  # ANTHROPIC_AUTH_TOKEN included. Found by the accept-path arm olivia required
+  # on this row, on its first run; the refusal arms could not see it because
+  # they grade the INPUT and this is a property of the WRITER.
+  #
+  # Refuse rather than strip or escape. Stripping silently changes the operator's
+  # value, and an EnvironmentFile has no quoting that makes a literal newline
+  # safe — there is no correct multi-line assignment to preserve here. Every
+  # legitimate caller passes a URL, a token, a model slug or a number, none of
+  # which contain one.
+  #
+  # This is defence in DEPTH, not the only guard: `valid_base_url` already
+  # rejects whitespace on the --base-url input. But that guard is on ONE input
+  # of one caller, and this writer serves every profile variable there is —
+  # a control on one path is absent on the parallel one unless it sits at the
+  # write.
+  if [[ "$value" == *$'\n'* ]]; then
+    fail "$E_VALIDATION" "profile_set_var: refusing to write ${var} — the value contains a newline, which would forge a second assignment in ${file} (systemd honours it). Pass a single-line value."
+  fi
   local tmp
   tmp=$(mktemp "${file}.XXXXXX")
   grep -v "^${var}=" "$file" 2>/dev/null > "$tmp" || true

--- a/src/cmd_compose.sh
+++ b/src/cmd_compose.sh
@@ -68,7 +68,7 @@ if not isinstance(defaults, dict):
 # Known per-agent keys (v1 + v2). Unknown → warn, not fail (forward-compat).
 KNOWN = {
     "type","channels","telegram_token","discord_token","workdir","skills",
-    "no_skills","defer_auth","isolation","auth_profile","provider","api_key",
+    "no_skills","defer_auth","isolation","auth_profile","provider","api_key","base_url",
     "role","instructions","instructions_file","model","effort","reports_to","goals",
     "pack",  # DIVE-536: import a character pack (5dive agent import <slug>) instead
              # of a bare create — the pack supplies persona+skills+model/effort.
@@ -152,7 +152,7 @@ _compose_resolve_path() {
 _compose_create_args() {
   local spec="$1" name="$2" spec_dir="$3"
   printf '%s\n' "$name"
-  local type channels tg_token dc_token workdir profile isolation provider api_key
+  local type channels tg_token dc_token workdir profile isolation provider api_key base_url
   type=$(jq      -r '.type             // empty' <<<"$spec")
   channels=$(jq  -r '.channels         // empty' <<<"$spec")
   tg_token=$(jq  -r '.telegram_token   // empty' <<<"$spec")
@@ -162,6 +162,7 @@ _compose_create_args() {
   isolation=$(jq -r '.isolation        // empty' <<<"$spec")
   provider=$(jq  -r '.provider         // empty' <<<"$spec")
   api_key=$(jq   -r '.api_key          // empty' <<<"$spec")
+  base_url=$(jq  -r '.base_url         // empty' <<<"$spec")
   local no_skills defer_auth
   no_skills=$(jq  -r '.no_skills  // false' <<<"$spec")
   defer_auth=$(jq -r '.defer_auth // false' <<<"$spec")
@@ -179,6 +180,17 @@ _compose_create_args() {
   [[ -n "$isolation" ]] && printf '%s\n' "--isolation=${isolation}"
   [[ -n "$provider"  ]] && printf '%s\n' "--provider=${provider}"
   [[ -n "$api_key"   ]] && printf '%s\n' "--api-key=${api_key}"
+  # DIVE-2757: a self-hosted endpoint has no catalog row, so `agent create`
+  # requires --model in the SAME call — it cannot be left to the post-create
+  # `agent config set model=` that _compose_wire_role does for every other
+  # agent, because create refuses before that ever runs. Emitted only on the
+  # base_url path so no existing spec changes behaviour.
+  if [[ -n "$base_url" ]]; then
+    printf '%s\n' "--base-url=${base_url}"
+    local _cmodel
+    _cmodel=$(jq -r '.model // empty' <<<"$spec")
+    [[ -n "$_cmodel" ]] && printf '%s\n' "--model=${_cmodel}"
+  fi
 
   # Skills: comma-join the array. --no-skills wins (cmd_create's parser
   # treats them as mutually exclusive at the call site).

--- a/src/header.sh
+++ b/src/header.sh
@@ -829,6 +829,51 @@ valid_byo_provider() {
   [[ -n "${BYO_PROVIDER_LABEL[$1]:-}" ]]
 }
 
+# The canonical id a claude BYO agent carries when its endpoint came from
+# --base-url rather than from the CLAUDE_PROVIDER_BASEURL catalog. It is a
+# LABEL, not a vendor: nothing keys a model default or a native provider id off
+# it, and it is deliberately absent from BYO_PROVIDER_LABEL so the pickers that
+# enumerate that table (init step 6, the dashboard tiles) do not offer a vendor
+# with no endpoint behind it (DIVE-2757).
+CLAUDE_CUSTOM_PROVIDER_ID="custom"
+
+# Validate an operator-supplied Anthropic-compatible endpoint for claude BYO.
+#
+# This value is written into an auth profile's combined.env and loaded by
+# systemd as an EnvironmentFile, so the syntactic rules are not cosmetic: a
+# newline forges a second variable in that file, and whitespace or a quote
+# changes how systemd parses the line. Reject anything but a bare URL.
+#
+# SCHEME. https:// is required, because the agent's API key rides this URL on
+# every request and a plaintext http:// endpoint puts it on the wire. The one
+# exception is a loopback host — a local inference server (vLLM, llama.cpp,
+# Ollama's anthropic shim) is reached over http://127.0.0.1 and never leaves the
+# box, so requiring TLS there would refuse the most common self-hosted shape for
+# no gain. A private-LAN address is NOT exempt: it is off-box, it is a real
+# network, and "the LAN is trusted" is exactly the assumption that is wrong.
+valid_base_url() {
+  local url="$1" host=""
+  [[ -n "$url" ]] || return 1
+  (( ${#url} <= 512 )) || return 1
+  # No whitespace (incl. newline/tab), quotes, backslash, or shell metacharacters.
+  # Single-quoted so nothing in the class is expanded; `-` is last, `]` absent.
+  # `]` must be first in the class and `-` last for both to be literal.
+  local _re='^[]A-Za-z0-9._~:/?#@!$&*+,;=%[-]+$'
+  [[ "$url" =~ $_re ]] || return 1
+  case "$url" in
+    https://*) return 0 ;;
+    http://*)
+      # Strip scheme, then any /path or ?query — what remains is host[:port].
+      host="${url#http://}"; host="${host%%/*}"; host="${host%%\?*}"
+      # A bracketed IPv6 literal is full of colons, so the port strip has to
+      # respect the brackets or `[::1]:8080` truncates to `[:`.
+      if [[ "$host" == \[*\]* ]]; then host="${host%%\]*}]"; else host="${host%:*}"; fi
+      [[ "$host" == "127.0.0.1" || "$host" == "localhost" || "$host" == "[::1]" ]]
+      return $? ;;
+    *) return 1 ;;
+  esac
+}
+
 # --- Claude (Claude Code) harness BYO custom-provider catalog -----------------
 # The claude harness can be pointed at any third-party provider that ships an
 # Anthropic Messages-API-compatible endpoint by overriding ANTHROPIC_BASE_URL +

--- a/tests/claude_custom_base_url_unit.sh
+++ b/tests/claude_custom_base_url_unit.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# DIVE-2757: `agent create --base-url=<url>` — point a claude-type agent at an
+# Anthropic-compatible endpoint that is NOT in the CLAUDE_PROVIDER_BASEURL
+# catalog (self-hosted open weights, a vendor host we ship no row for).
+#
+# Grades three things the feature is worthless without:
+#   1. valid_base_url's scheme policy — https anywhere, http ONLY on loopback,
+#      and no character that could forge a second line in combined.env.
+#   2. _apply_byo_claude writes the OPERATOR's url and pins all THREE tiers,
+#      including HAIKU. Haiku is the one that fails silently: it is background
+#      traffic, not the tier anyone selects, so an unset value looks fine
+#      interactively and 404s later.
+#   3. A custom provider with no --model is REFUSED, not defaulted.
+#
+# No root, network, credentials, users, or runtime state are touched.
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -f "${capture:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+
+# shellcheck disable=SC1091
+source src/lib/error_codes.sh   # E_USAGE / E_VALIDATION — without these every
+                                # `fail "$E_..."` dies on `set -u` FIRST, and a
+                                # refusal arm then "passes" on an unbound
+                                # variable instead of on the guard it grades.
+# shellcheck disable=SC1091
+source src/header.sh
+# shellcheck disable=SC1091
+source src/lib/validation.sh
+# shellcheck disable=SC1091
+source src/lib/agent_setup.sh
+# shellcheck disable=SC1091
+source src/cmd_agent_create.sh
+
+capture=$(mktemp)
+step() { :; }
+warn() { :; }
+profile_set_var() {
+  local profile="$1" var="$2" value
+  value=$(cat)
+  printf 'PROFILE %s %s=%s\n' "$profile" "$var" "$value" >>"$capture"
+}
+# fail() is the CLI's exit path and it EXITS — a stub that merely `return 1`s
+# would let the function run on past its own refusal and write the profile
+# anyway, so the harness would grade a code path production never takes. Keep
+# the exit and run each refusal arm in a SUBSHELL instead.
+fail() { printf 'FAIL[%s] %s\n' "$1" "$2" >&2; exit "$1"; }
+
+fails=0 rc=0
+ok()  { printf '  ok   %s\n' "$1"; }
+bad() { printf '  FAIL %s\n' "$1"; fails=$((fails+1)); }
+
+# --- 1. valid_base_url ------------------------------------------------------
+echo "valid_base_url: scheme + shape policy"
+for u in \
+  "https://llm.example.com/anthropic" \
+  "https://llm.example.com:8443/v1/anthropic" \
+  "http://localhost:8000" \
+  "http://127.0.0.1:8000/anthropic" \
+  "http://[::1]:8000/anthropic" \
+; do
+  if valid_base_url "$u"; then ok "accepts $u"; else bad "rejected valid url: $u"; fi
+done
+
+# Rejections. Each is a distinct failure mode, not five spellings of one.
+#  - plaintext to an OFF-BOX host puts the API key on the wire
+#  - a private-LAN address is off-box too: "the LAN is trusted" is the wrong
+#    assumption, and it is the one an exemption here would bake in
+#  - a newline forges a second variable in the systemd EnvironmentFile
+#  - a space/quote changes how systemd parses the line
+#  - a non-http scheme is not an endpoint this harness can speak to
+for u in \
+  "http://llm.example.com/anthropic" \
+  "http://192.0.2.10:8000" \
+  "https://llm.example.com/a
+FOO=bar" \
+  "https://llm.example.com /anthropic" \
+  "https://llm.example.com/\"x" \
+  "ftp://llm.example.com" \
+  "llm.example.com/anthropic" \
+  "" \
+; do
+  if valid_base_url "$u"; then bad "accepted INVALID url: $(printf '%q' "$u")"
+  else ok "rejects $(printf '%q' "$u")"; fi
+done
+
+# --- 2. the operator's url and all three tiers reach the profile ------------
+echo "_apply_byo_claude: custom endpoint wins and pins every tier"
+: >"$capture"
+_apply_byo_claude custom sk-selfhost-123456 qa-prof qwen3.8-max "https://llm.example.com/anthropic"
+assert_line() {
+  if grep -qxF "$1" "$capture"; then ok "$1"; else bad "missing: $1"; fi
+}
+assert_line 'PROFILE qa-prof ANTHROPIC_BASE_URL=https://llm.example.com/anthropic'
+assert_line 'PROFILE qa-prof ANTHROPIC_AUTH_TOKEN=sk-selfhost-123456'
+assert_line 'PROFILE qa-prof ANTHROPIC_DEFAULT_OPUS_MODEL=qwen3.8-max'
+assert_line 'PROFILE qa-prof ANTHROPIC_DEFAULT_SONNET_MODEL=qwen3.8-max'
+# The one that would have been empty: no catalog row means no haiku default.
+assert_line 'PROFILE qa-prof ANTHROPIC_DEFAULT_HAIKU_MODEL=qwen3.8-max'
+# The shared-account neutralisers still fire on this path.
+assert_line 'PROFILE qa-prof CLAUDE_CODE_OAUTH_TOKEN='
+assert_line 'PROFILE qa-prof ANTHROPIC_API_KEY='
+
+# --- 2b. a KNOWN vendor redirected to another host keeps its catalog models --
+# Redirecting z.ai to a different host changes WHERE the models are served, not
+# WHICH models exist, so the catalog's per-tier ids must survive the override.
+echo "_apply_byo_claude: known vendor + --base-url keeps catalog model ids"
+: >"$capture"
+_apply_byo_claude zai sk-zai-123456 qa-prof2 "" "https://open.bigmodel.cn/api/anthropic"
+assert_line 'PROFILE qa-prof2 ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthropic'
+assert_line "PROFILE qa-prof2 ANTHROPIC_DEFAULT_OPUS_MODEL=${CLAUDE_PROVIDER_OPUS_MODEL[zai]}"
+assert_line "PROFILE qa-prof2 ANTHROPIC_DEFAULT_HAIKU_MODEL=${CLAUDE_PROVIDER_HAIKU_MODEL[zai]}"
+
+# --- 3. refusals ------------------------------------------------------------
+echo "_apply_byo_claude: refusals"
+: >"$capture"
+rc=0; ( _apply_byo_claude custom sk-selfhost-123456 qa-prof "" "https://llm.example.com/anthropic" ) 2>/dev/null || rc=$?
+# The CODE, not merely non-zero: an unbound variable also exits non-zero, and
+# that is exactly how this arm first passed while grading nothing.
+if (( rc == E_USAGE )); then ok "custom provider with no --model is refused (exit $rc)"
+else bad "expected exit $E_USAGE for missing --model, got $rc"; fi
+# Positive control for the assertion above: the same call WITH a model passes,
+# so the refusal is attributable to the missing model and not to the arm being
+# broken in some other way.
+: >"$capture"
+if ( _apply_byo_claude custom sk-selfhost-123456 qa-prof m1 "https://llm.example.com/anthropic" ) 2>/dev/null; then
+  ok "positive control: same call with --model succeeds"
+else
+  bad "positive control FAILED — the no-model refusal above proves nothing"
+fi
+
+: >"$capture"
+rc=0; ( _apply_byo_claude custom sk-selfhost-123456 qa-prof m1 "http://llm.example.com" ) 2>/dev/null || rc=$?
+if (( rc == E_VALIDATION )); then ok "off-box http:// endpoint is refused (exit $rc)"
+else bad "expected exit $E_VALIDATION for off-box http://, got $rc"; fi
+
+# apply_byo_provider gates --base-url to claude only.
+rc=0; ( apply_byo_provider hermes custom sk-test-123456 qa-prof m1 "https://x.example.com" ) 2>/dev/null || rc=$?
+if (( rc == E_VALIDATION )); then ok "--base-url is refused for non-claude types (exit $rc)"
+else bad "expected exit $E_VALIDATION for --base-url on hermes, got $rc"; fi
+
+# --- 4. the custom id is NOT a vendor --------------------------------------
+# It must stay out of BYO_PROVIDER_LABEL, or every picker that enumerates that
+# table offers a vendor with no endpoint behind it.
+if valid_byo_provider "$CLAUDE_CUSTOM_PROVIDER_ID"; then
+  bad "CLAUDE_CUSTOM_PROVIDER_ID leaked into BYO_PROVIDER_LABEL"
+else
+  ok "custom id is a label, not a catalog vendor"
+fi
+
+echo
+if (( fails )); then echo "$fails failed"; exit 1; fi
+echo "all assertions passed"

--- a/tests/claude_custom_base_url_unit.sh
+++ b/tests/claude_custom_base_url_unit.sh
@@ -160,7 +160,7 @@ fi
 #
 # Driven through the REAL profile_set_var (src/cmd_auth.sh), not a re-typed
 # copy, so the arm grades the writer that ships.
-. "$REPO_ROOT/src/cmd_auth.sh" 2>/dev/null || . ./src/cmd_auth.sh
+. ./src/cmd_auth.sh
 _ap_root=$(mktemp -d); export FIVE_STATE_DIR="$_ap_root"
 _ap_dir="$_ap_root/profiles/acceptarm"; mkdir -p "$_ap_dir"
 _ap_env="$_ap_dir/combined.env"; : > "$_ap_env"

--- a/tests/claude_custom_base_url_unit.sh
+++ b/tests/claude_custom_base_url_unit.sh
@@ -151,6 +151,74 @@ else
   ok "custom id is a label, not a catalog vendor"
 fi
 
+# --- 5. THE ACCEPT PATH (DIVE-2757 iteration 2, olivia's reject) -------------
+# Every arm above this line is a REFUSAL. 11 refusals / 0 creates means the YES
+# path was unexercised, and the YES path is where this feature actually writes:
+# six assignments into a systemd EnvironmentFile that the agent reads at boot.
+# A malformed file there does not refuse — the agent comes up and fails later,
+# which is the exact failure this row pins haiku to prevent.
+#
+# Driven through the REAL profile_set_var (src/cmd_auth.sh), not a re-typed
+# copy, so the arm grades the writer that ships.
+. "$REPO_ROOT/src/cmd_auth.sh" 2>/dev/null || . ./src/cmd_auth.sh
+_ap_root=$(mktemp -d); export FIVE_STATE_DIR="$_ap_root"
+_ap_dir="$_ap_root/profiles/acceptarm"; mkdir -p "$_ap_dir"
+_ap_env="$_ap_dir/combined.env"; : > "$_ap_env"
+# minimal stand-in for the writer's contract: replace any prior VAR= line, append.
+# Drive the REAL profile_set_var from src/cmd_auth.sh — a re-typed copy would
+# grade the copy, and a copy of a writer is exactly what drifts away from the
+# guard it is supposed to be testing. Only the root-owned side effects are stubbed.
+ensure_profile_dir() { printf '%s' "$_ap_dir"; }
+chown() { :; }; chmod() { :; }
+_ap_set() { profile_set_var acceptarm "$1"; }
+
+_AP_URL="https://weights.example.com/v1"
+_AP_MODEL="qwen3.8-max"
+printf '%s' "$_AP_URL"   | _ap_set ANTHROPIC_BASE_URL
+printf '%s' "sk-test"    | _ap_set ANTHROPIC_AUTH_TOKEN
+printf '%s' "$_AP_MODEL" | _ap_set ANTHROPIC_DEFAULT_OPUS_MODEL
+printf '%s' "$_AP_MODEL" | _ap_set ANTHROPIC_DEFAULT_SONNET_MODEL
+printf '%s' "$_AP_MODEL" | _ap_set ANTHROPIC_DEFAULT_HAIKU_MODEL
+printf '%s' "3000000"    | _ap_set API_TIMEOUT_MS
+
+# 5a. ALL THREE TIERS PINNED. haiku is the one that fails silently — it is never
+# the tier an operator selects, it is what background turns reach for.
+_ap_missing=""
+for _t in OPUS SONNET HAIKU; do
+  grep -q "^ANTHROPIC_DEFAULT_${_t}_MODEL=${_AP_MODEL}$" "$_ap_env" || _ap_missing="$_ap_missing $_t"
+done
+if [[ -z "$_ap_missing" ]]; then ok "accept path pins all three model tiers"
+else bad "accept path left tier(s) unpinned:$_ap_missing"; fi
+
+# 5b. WELL-FORMED: every line is exactly one KEY=VALUE, no blanks, no strays.
+_ap_bad=$(grep -cvE '^[A-Z_][A-Z0-9_]*=' "$_ap_env" || true)
+if [[ "$_ap_bad" == "0" ]]; then ok "EnvironmentFile is well-formed (every line one KEY=VALUE)"
+else bad "EnvironmentFile has $_ap_bad malformed line(s)"; fi
+
+# 5c. NEWLINE FORGERY IS AN ACCEPT-PATH PROPERTY. The refusal arms shape-check
+# the URL; this checks what happens if one gets through — a value carrying a
+# newline must not become a SECOND assignment the agent would honour.
+_ap_before=$(cat "$_ap_env")
+if ( printf '%s' "https://evil.example.com/v1
+ANTHROPIC_AUTH_TOKEN=stolen" | _ap_set ANTHROPIC_BASE_URL ) >/dev/null 2>&1; then
+  bad "newline value was ACCEPTED by profile_set_var (it must refuse)"
+else
+  if [[ "$(cat "$_ap_env")" == "$_ap_before" ]]; then
+    ok "a newline value is REFUSED and the EnvironmentFile is left untouched"
+  else
+    bad "profile_set_var refused but still modified the file"
+  fi
+fi
+# positive control: the same writer still accepts an ordinary single-line value,
+# so the arm above grades the newline and not a writer that refuses everything.
+if printf '%s' "https://ok.example.com/v1" | _ap_set ANTHROPIC_BASE_URL 2>/dev/null \
+   && grep -q '^ANTHROPIC_BASE_URL=https://ok.example.com/v1$' "$_ap_env"; then
+  ok "positive control: an ordinary single-line value still writes"
+else
+  bad "positive control failed — the writer refuses valid values too"
+fi
+rm -rf "$_ap_root"
+
 echo
 if (( fails )); then echo "$fails failed"; exit 1; fi
 echo "all assertions passed"


### PR DESCRIPTION
## What

`5dive agent create --type=claude --base-url=<url>` — point a claude agent at **any**
Anthropic-compatible endpoint, including one you host yourself.

```sh
sudo 5dive agent create qwen-box --type=claude \
  --base-url=https://llm.internal.example.com/anthropic \
  --api-key=<key> --auth-profile=qwen-box --model=qwen3.8-max
```

Before this, a claude-type agent could reach exactly the four vendors hardcoded in
`CLAUDE_PROVIDER_BASEURL` (deepseek, moonshot, openrouter, zai). Open weights on a
server you own were unreachable at any price. DIVE-2756 adds a *fifth entry* to that
map; this is the structural half that removes its fixedness. Shipping one does not
make the other unnecessary.

## The gates, and why each one

The row asked for a decision on whether an arbitrary `--base-url` should be gated —
it points customer traffic **and the API key** at an operator-supplied host. Answers:

| gate | why |
|---|---|
| `https://` required | the key rides that URL on every request. `http://` is accepted only for `localhost` / `127.0.0.1` / `[::1]`, where traffic never leaves the box. **A private-LAN address is refused** — it is a real network, and "the LAN is trusted" is exactly the assumption an exemption would bake in. |
| `--auth-profile` required | inherited free from the existing claude BYO path, so the endpoint and its key scope to that profile rather than to every claude agent on the host. This is the pairing the row suggested considering. |
| `--model` required (custom endpoints) | there is no catalog row to inherit per-tier ids from. Pins **all three** tiers. |
| URL shape-checked | it lands in a systemd `EnvironmentFile`; a newline there forges a second variable. |
| claude only | hermes/openclaw keep their own URL tables (`HERMES_PROVIDER_URL` / `OPENCLAW_PROVIDER_URL`) and speak different wire formats. One flag cannot serve all three. |

**The haiku tier is the one that would have failed silently.** It is background
traffic, never the tier an operator selects, so an unset value looks fine
interactively and 404s later on the agent's own housekeeping turns. That is why
`--model` fills all three slots and why the harness asserts the haiku line by name.

`--base-url` alongside a **known** provider redirects that vendor to another host (a
CN endpoint, a corporate gateway) and **keeps its catalog model ids** — the models
did not change, only where they are served.

The `custom` id stays **out** of `BYO_PROVIDER_LABEL`. It is a label, not a vendor;
in the table, every picker that enumerates it would offer a vendor with no endpoint
behind it.

## How it was checked

**Three mutations, each caught** (baseline green, mutant red):

| mutation | result |
|---|---|
| drop the haiku fallback | rc=2 |
| `valid_base_url` accepts any `http://` | rc=1, 3 FAIL lines |
| remove the claude-only gate | rc=1, 1 FAIL line |
| *(baseline, restored)* | **rc=0** |

**A bug the mutation pass surfaced in the harness itself, worth naming:** the harness
did not source `src/lib/error_codes.sh`, so every `fail "$E_USAGE"` died on `set -u`
*first*. Three refusal arms were passing on an unbound variable while grading
nothing — non-zero exit for the wrong reason, which is indistinguishable from a
refusal if you only check "did it fail". Fixed by sourcing the codes and asserting
the **exit code** (`E_USAGE` = 2, `E_VALIDATION` = 3), not merely non-zero. There is
also a positive control on the no-`--model` arm, so its refusal is attributable to
the missing model rather than to the arm being broken some other way.

**End-to-end through the built bundle**, as root, all five refusing before anything
is created (verified 0 agents made):

```
--base-url on --type=hermes    → --base-url is only supported for --type=claude (got: hermes)
custom endpoint, no --model    → requires --model=<slug> (no catalog entry for 'custom')
http:// to an off-box host     → https:// required — http:// only for localhost/127.0.0.1/[::1]
newline in the URL             → (same refusal; the injected FOO=bar never reaches the profile)
--provider='BAD LABEL'         → invalid --provider label
```

## Core tier

**CI is green — all 13 checks, including `test` and `test-installed-host`.**

`scripts/run-harnesses.sh --tier=core` is red **on this box**, and neither cause is
from this diff:

- `tests/actor_claim_corroboration_unit.sh` T19 fails identically in a **pristine
  `origin/main` worktree with a built bundle**, so it is not this change. It
  **passes in CI**, and CI does run it (4 hits in the `test` job log) — so the cause
  is *environmental*: the harness derives actor identity from the invoking OS user,
  and this host is not a runner.
  *Correcting my own earlier claim in this body:* I first wrote that main's CI does
  not surface it because the harness skips T19–T21 without a bundle. That was an
  inference, and CI has now refuted it — the bundle is present and the arm runs.
  The verified part stands (it reproduces on pristine main); the explanation was
  mine and was wrong.
- The budget red is a local reading; per `CLAUDE.md` the calibration baseline is a CI
  number and a local run printing RE-BASELINE is expected. The new harness measures
  **0.10s** — it does no network, no root, and no runtime state.

## Files

- `src/header.sh` — `valid_base_url()`, `CLAUDE_CUSTOM_PROVIDER_ID`
- `src/cmd_agent_create.sh` — flag, validation, `_apply_byo_claude` url + tier handling
- `src/cmd_compose.sh` — `base_url` key; emits `--model` at create time on that path only
- `tests/claude_custom_base_url_unit.sh` — new, core tier, 0.10s
- `README.md`, `changelog.d/DIVE-2757.md`

## Not in scope

`agent auth set` does not learn `--base-url` — an agent created this way keeps its
endpoint, but re-running `auth set` against the same profile would rewrite
`ANTHROPIC_BASE_URL` from the catalog. Worth a follow-up row; it is a different
command with a different call path.
