### PR TITLE
fix(loop): name the ceiling halt in map --wait instead of collapsing it onto escalated (DIVE-2126)

### DIFF
--- a/src/cmd_loop.sh
+++ b/src/cmd_loop.sh
@@ -985,7 +985,11 @@ cmd_loop_map() {
     [[ "$(db "SELECT kill_requested FROM loop_runs WHERE loop_id=$(sqlq "$loop_id");")" == "1" ]] && { halt="killed"; break; }
     spent=$(_loop_ceiling_check "$loop_id" "$eff_ceiling") && crc=0 || crc=$?
     (( crc == 2 )) && { halt="spend-unreadable"; break; }   # DIVE-2304: unreadable spend halts, never continues
-    (( crc == 1 )) && { halt="escalated"; break; }
+    # DIVE-2126: keep the wire status folded to "escalated", but name the
+    # actual stop cause. A timeout lands on the same status, so "escalated"
+    # here erased the one fact a caller needs to decide whether to raise the
+    # ceiling or investigate a stalled map.
+    (( crc == 1 )) && { halt="ceiling"; break; }
     # dispatch up to the concurrency cap
     while (( live < eff_conc && next < n )); do
       local elem; elem=$(printf '%s' "$over" | jq -r ".[$next] | if type==\"string\" then . else (.|tojson) end")
@@ -1037,8 +1041,8 @@ cmd_loop_map() {
       >/dev/null 2>&1 || true
   fi
   ok "loop ${loop_id} map ${status_final}: ${ok_n} ok / ${failed_n} failed / ${n} total" \
-     '{loopId:$l, handle:$l, status:$s, topology:"map", total:($t|tonumber), ok:($ok|tonumber), failed:($f|tonumber), concurrency:($cc|tonumber), results:$res, ceiling:($c|tonumber), tokensSpent:($sp|tonumber)}' \
-     --arg l "$loop_id" --arg s "$status_final" --arg t "$n" --arg ok "$ok_n" --arg f "$failed_n" --arg cc "$eff_conc" \
+     '{loopId:$l, handle:$l, status:$s, haltReason:$hr, topology:"map", total:($t|tonumber), ok:($ok|tonumber), failed:($f|tonumber), concurrency:($cc|tonumber), results:$res, ceiling:($c|tonumber), tokensSpent:($sp|tonumber)}' \
+     --arg l "$loop_id" --arg s "$status_final" --arg hr "$halt" --arg t "$n" --arg ok "$ok_n" --arg f "$failed_n" --arg cc "$eff_conc" \
      --argjson res "$out_arr" --arg c "$eff_ceiling" --arg sp "${spent:-0}"
   return 0
 }

--- a/tests/loop_batch_unit.sh
+++ b/tests/loop_batch_unit.sh
@@ -51,6 +51,40 @@ proj=$(db "SELECT key FROM projects WHERE key='dive' AND status='active';")
 ( cmd_loop_until_dry --agent=main --round=x >/dev/null 2>&1 ); [[ $? -ne 0 ]] && ok_t "until-dry: missing --dedup-key fails" || bad_t "ud key" "exit 0"
 ( cmd_loop_collect >/dev/null 2>&1 ); [[ $? -ne 0 ]] && ok_t "collect: missing --handles fails" || bad_t "collect handles" "exit 0"
 
+# ---- DIVE-2126: map ceiling halt is observable and actually reached ----
+# This is the sixth collapsed-halt site found after DIVE-2083/DIVE-2105, but
+# unlike those siblings there was no map ceiling case to repair. Two independent
+# mechanisms can otherwise make the assertion lie:
+#   1. the product can label a real breach "escalated", indistinguishable from
+#      timeout in the existing status field; haltReason is the discriminator;
+#   2. the real refresher recomputes spend from agent transcripts this isolated
+#      harness does not own, replacing the poked value with 0 so the case times
+#      out. Stub the producer, not the ceiling decision, so tokens_spent remains
+#      the input the product reads.
+_loop_refresh_spend() { db "SELECT COALESCE(tokens_spent,0) FROM loop_runs WHERE loop_id='$1';"; }
+( cmd_loop_map --agent=main --do='CEILING_HOLD ITEM={}' --over='[1]' \
+    --ceiling=1000 --timeout=8 --stage=DIVE-2126-ceiling >"$TMP/map-ceil.out" 2>"$TMP/map-ceil.err" ) &
+map_bgpid=$!
+map_lid=""
+for _ in $(seq 1 100); do
+  map_lid=$(db "SELECT loop_id FROM loop_runs WHERE topology='map' AND stage='DIVE-2126-ceiling' ORDER BY started_at DESC LIMIT 1;")
+  [[ -n "$map_lid" ]] && break
+  sleep 0.1
+done
+if [[ -n "$map_lid" ]]; then
+  db "UPDATE loop_runs SET tokens_spent=5000 WHERE loop_id=$(sqlq "$map_lid");"
+else
+  bad_t "map ceiling setup" "poll timed out — the map row never appeared, so no ceiling breach was created"
+fi
+wait "$map_bgpid"; map_wait_rc=$?
+map_cst=$(jq -r '.data.status' "$TMP/map-ceil.out" 2>/dev/null)
+map_chr=$(jq -r '.data.haltReason' "$TMP/map-ceil.out" 2>/dev/null)
+if [[ "$map_wait_rc" == "0" && "$map_cst" == "escalated" && "$map_chr" == "ceiling" ]]; then
+  ok_t "map: ceiling breach → status=escalated, haltReason=ceiling (not timeout)"
+else
+  bad_t "map ceiling halt" "wait_rc=$map_wait_rc status=$map_cst haltReason=$map_chr out=$(cat "$TMP/map-ceil.out") err=$(cat "$TMP/map-ceil.err")"
+fi
+
 # ---- background fleet simulator: complete any loop-spawned todo task ----
 # Each map item task body contains "ITEM=<n>"; we echo it back so we can assert
 # index-alignment. until-dry finder tasks get a round-specific canned array.


### PR DESCRIPTION
Delivers DIVE-2126: `loop map --wait` collapsed its ceiling halt onto `escalated` and returned
no `haltReason`, so a caller could not tell a real ceiling breach from a timeout.

## What changed

`halt` becomes `ceiling` instead of `escalated` at the ceiling-breach branch, and the JSON gains
`haltReason`. **The wire status is deliberately unchanged**: `status_final` is still `escalated`,
so nothing downstream that keys on `status` moves.

That compatibility is guaranteed structurally, not just demonstrated. `cmd_loop.sh:1033` is

```bash
case "$halt" in killed) status_final="killed";; *) status_final="escalated";; esac
```

— the catch-all maps **every** non-killed halt to `escalated`, so the contract cannot break for
any future halt token either. The test asserts it for the ceiling case; the `case` statement is
why that holds in general.

`ceiling` is not a new word: it is already the vocabulary at `:1153` for until-dry's
`exit_reason`. One name for one concept, rather than a second spelling of it.

## Verification

Verifier main2, reproduced on a clean `git-archive` extraction rather than relayed from the
maker: `tests/loop_batch_unit.sh` **12/0**, harness rc 0, and **three mutants each sole-red on
the new assertion only** —

1. revert the product change (`halt=ceiling` → `escalated`);
2. drop `haltReason` from the map `--wait` JSON;
3. drop the `_loop_refresh_spend` test stub → the case times out instead of breaching.

Mutant 3 is the interesting one. The real refresher recomputes spend from agent transcripts the
isolated harness does not own, which would replace the poked value with 0 and turn a ceiling
breach into a timeout — the exact confusion this row exists to remove, occurring inside the test
for it. The harness stubs the **producer** of the input rather than the ceiling decision under
test, so `tokens_spent` stays the input the product actually reads.

Opened by main on behalf of maker codex, which holds no GitHub credential; branch pushed on the
delegated rail. Graded before this PR existed — main2's PASS is against `ff69ad0`, which is this
PR's head unchanged.
