### PR TITLE
fix(tasks-db): fresh and migrated schemas must converge (DIVE-2197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,19 @@ branch does not exist on the remote. Fleet coverage on this host went **1 → 22
 23**; the remaining one is a worktree owned by a uid this session cannot assume, and
 its origin is a local path whose target is guarded.
 
+## v0.19.0 — fix(tasks-db): fresh and migrated schemas must converge (DIVE-2197)
+
+`tasks_db_init` now runs additive reconciliation for fresh stores as well as
+existing ones, then verifies the resulting `tasks` column set. This restores six
+columns that the canonical fresh schema omitted (`delivery_ref`, `delivered_at`,
+`parked_at`, `park_reason`, `escalated_at`, `escalated_by`) and turns a failed
+`ALTER TABLE` into a loud initialization failure instead of a healthy-looking
+partial schema.
+
+The isolated restore harness asserts all six columns on a fresh `STATE_DIR` and
+injects a failure into the `delivery_ref` ALTER. Removing only the resulting-set
+assertion makes that arm red, proving the refusal is connected to the source path.
+
 ## v0.19.0 — fix(heartbeat): surface a recurring instance that was never started (DIVE-2693)
 
 The stall sweep keys on `handoff_delivered_at`. A materialized recurring instance

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -1050,15 +1050,18 @@ tasks_db_init() {
     # Only a genuinely fresh box (no sentinel, no snapshot) gets a new schema.
     if _tasks_board_existed; then
       _tasks_board_recover
-      _tasks_db_migrate            # bring the restored snapshot up to current schema
     else
       sqlite3 -cmd ".timeout 5000" "$TASKS_DB" < <(_tasks_schema) >/dev/null \
         || fail "$E_GENERIC" "failed to initialise tasks db at $TASKS_DB"
       chmod 0660 "$TASKS_DB" 2>/dev/null || true
     fi
-  else
-    _tasks_db_migrate
   fi
+  # DIVE-2197: fresh and restored stores need the same additive reconciliation
+  # as an existing store. The canonical CREATE TABLE historically omitted six
+  # additive columns, and skipping this call made an isolated STATE_DIR report a
+  # healthy-but-partial schema. _tasks_db_migrate now verifies the result, so a
+  # failed ALTER is loud instead of being hidden by its idempotency guard.
+  _tasks_db_migrate
   # DIVE-1479: stamp the durable "this board exists" sentinel (idempotent). On a
   # pre-existing board this is the one-time backfill so a later wipe is caught.
   _tasks_mark_initialized
@@ -1073,6 +1076,7 @@ _tasks_db_migrate() {
   cols=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
          "SELECT name FROM pragma_table_info('tasks');" 2>/dev/null)
   local c
+  local -a required_columns=()
   # Each entry: "<column> <type>". Add new additive columns here; existing
   # rows backfill to NULL. Pure expand (no contract), so old queries/rows are
   # untouched and a downgrade still reads/writes the table fine.
@@ -1105,6 +1109,7 @@ _tasks_db_migrate() {
            'human_evidence TEXT' \
            'derived_actor TEXT' \
            'floor_provenance TEXT'; do
+    required_columns+=("${c%% *}")
     # DIVE-2418: herestring, NOT a pipe. `printf | grep -q` lets grep exit on its
     # first match while printf is still writing, and printf then takes SIGPIPE and
     # emits "write error: Broken pipe" on stderr. This runs from tasks_db_init on
@@ -1129,6 +1134,21 @@ _tasks_db_migrate() {
         "ALTER TABLE tasks ADD COLUMN ${c};" >/dev/null 2>&1 || true
     fi
   done
+  # DIVE-2197: `|| true` above is necessary for duplicate-column races between
+  # concurrent initializers, but it must not turn every other ALTER failure into
+  # success. Re-read the schema after the attempts and assert the anchor: every
+  # additive column is present. This also grades a genuinely fresh store because
+  # tasks_db_init now sends that path through this reconciliation.
+  local final_cols
+  final_cols=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
+               "SELECT name FROM pragma_table_info('tasks');" 2>/dev/null)
+  local -a missing_columns=()
+  for c in "${required_columns[@]}"; do
+    grep -qx "$c" <<<"$final_cols" || missing_columns+=("$c")
+  done
+  ((${#missing_columns[@]} == 0)) || fail "$E_GENERIC" \
+    "tasks db schema incomplete after migration — missing columns: ${missing_columns[*]} (DIVE-2197)"
+
   # OSS-11 precedent-lookup index (idempotent; harmless if the columns just
   # backfilled to NULL above — an all-NULL ask_shape simply never matches).
   sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \

--- a/tests/tasks_db_restore_guard_unit.sh
+++ b/tests/tasks_db_restore_guard_unit.sh
@@ -171,6 +171,49 @@ out=$(TASKS_BACKUP_DIR="$paired_backups" tasks_db_init 2>&1); rc=$?
 [[ "$(row_count)" == "3" ]] && ok "paired: explicit TASKS_BACKUP_DIR still restores" \
   || bad "paired: rows=$(row_count) ($out)"
 
+# --- Case 9 (DIVE-2197): a fresh schema contains all six additive columns -----
+# These lived only in the migration list, while a genuinely fresh STATE_DIR
+# skipped migration. The result was a green init over a partial tasks table.
+fresh_tree
+out=$(tasks_db_init 2>&1); rc=$?
+required='delivered_at delivery_ref escalated_at escalated_by park_reason parked_at'
+actual=$(sqlite3 "$TASKS_DB" \
+  "SELECT name FROM pragma_table_info('tasks')
+    WHERE name IN ('delivery_ref','delivered_at','parked_at','park_reason','escalated_at','escalated_by')
+    ORDER BY name;" 2>/dev/null | tr '\n' ' ' | sed 's/ $//')
+[[ $rc -eq 0 && "$actual" == "$required" ]] \
+  && ok "fresh schema: all six additive columns are present" \
+  || bad "fresh schema: init returned a partial tasks table" "rc=$rc got=[$actual] want=[$required] out=$out"
+
+# --- Case 10 (DIVE-2197): one ALTER fails -> init fails loudly ----------------
+fresh_tree
+real_sqlite=$(command -v sqlite3)
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/sqlite3" <<'SQLITE_SHIM'
+#!/usr/bin/env bash
+if [[ "${DIVE2197_FAIL_COLUMN:-}" == "delivery_ref" \
+      && "$*" == *"ALTER TABLE tasks ADD COLUMN delivery_ref"* ]]; then
+  exit 1
+fi
+exec "$DIVE2197_REAL_SQLITE" "$@"
+SQLITE_SHIM
+chmod +x "$TMP/bin/sqlite3"
+out=$(DIVE2197_FAIL_COLUMN=delivery_ref DIVE2197_REAL_SQLITE="$real_sqlite" \
+      PATH="$TMP/bin:$PATH" tasks_db_init 2>&1); rc=$?
+actual=$("$real_sqlite" "$TASKS_DB" \
+  "SELECT name FROM pragma_table_info('tasks')
+    WHERE name IN ('delivery_ref','delivered_at','parked_at','park_reason','escalated_at','escalated_by')
+    ORDER BY name;" 2>/dev/null | tr '\n' ' ' | sed 's/ $//')
+[[ $rc -ne 0 ]] \
+  && ok "failed ALTER: tasks_db_init fails instead of accepting a partial schema" \
+  || bad "failed ALTER: init silently returned success" "rc=$rc out=$out"
+grep -q 'schema incomplete.*delivery_ref' <<<"$out" \
+  && ok "failed ALTER: refusal names the missing column" \
+  || bad "failed ALTER: refusal does not identify the hole" "out=$out"
+[[ "$actual" == 'delivered_at escalated_at escalated_by park_reason parked_at' ]] \
+  && ok "failed ALTER: mutation applied and only delivery_ref remains absent" \
+  || bad "failed ALTER: mutation precondition/result is not the intended one-column hole" "got=[$actual]"
+
 echo
 echo "tasks-db restore guard: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Delivers DIVE-2197: `tasks_db_init` silently omitted six columns in an isolated `STATE_DIR`,
because the additive `ALTER`s were `|| true` — so a partial schema reported as a good one.

## What changed

`tasks_db_init` now runs additive reconciliation for **fresh** stores as well as existing ones,
then **verifies the resulting column set**. That restores six columns the canonical fresh schema
omitted — `delivery_ref`, `delivered_at`, `parked_at`, `park_reason`, `escalated_at`,
`escalated_by` — and turns a failed `ALTER TABLE` into a loud initialization failure instead of a
healthy-looking partial schema.

The distinction that makes this more than a missing-column fix: **running the migration is not
the same claim as the schema being right.** `|| true` on each `ALTER` meant the init reported
success for having *attempted* the work. Checking the resulting set is the only assertion that
survives an `ALTER` failing for a reason nobody predicted.

## Verification

Verifier main2, reproduced independently rather than relayed — a baseline probe against
`origin/main` gives a fresh isolated `STATE_DIR` with **rc=0, 63 columns, and zero of the six**;
the branch gives **rc=0, 71 columns, all six**. That baseline is what makes the fix legible: the
defect's signature is a *successful* init, so a green run proves nothing without the column count
beside it.

The isolated restore harness asserts all six columns on a fresh `STATE_DIR` and injects a failure
into the `delivery_ref` ALTER. Removing only the resulting-set assertion makes that arm red,
which proves the refusal is wired to the source path rather than passing for an unrelated reason.

## Rebase note

Rebased from `1275a24a` onto `1bde9dc` by main; codex holds no GitHub credential. The only
conflict was `CHANGELOG.md`, where main had gained DIVE-2788's entry — both entries are kept.
Verified before pushing that the commit's own diff to `src/lib/tasks_db.sh` and
`tests/tasks_db_restore_guard_unit.sh` is **byte-identical** to what main2 graded; only the
CHANGELOG hunk moved.
