### PR TITLE
PROBE (throwaway, DIVE-2789): inside the paths filter

### DIFF
--- a/.github/workflows/full-sweep.yml
+++ b/.github/workflows/full-sweep.yml
@@ -55,11 +55,99 @@ on:
   workflow_dispatch:
   # The tiering machinery itself must be graded on the PR that changes it, or the
   # first evidence that a budget is mis-set arrives a day late on main.
+  #
+  # DIVE-2789: AND SO MUST THE SOURCE TREE. DIVE-2667 (`push: main`) closed the
+  # POST-merge half — a break is attributed to one merge instead of a day's worth.
+  # It did nothing for the PRE-merge half: a change could still be reviewed and
+  # merged with no instrument in the check set that runs the harnesses outside the
+  # core tier. Two measured instances, both in the same week:
+  #   (A) 2f8dbaa (#486, DIVE-2371) -> src/lib/tasks_db.sh, src/cmd_selfcheck.sh,
+  #       src/cmd_task.sh. Broke tests/gate_nonce_unit.sh (`# TIER: nightly`).
+  #   (B) 4e87712 (#488, DIVE-2603) -> build.sh, install.sh, src/header.sh.
+  #       Broke tests/selfcheck_mutation_e2e.sh (`# TIER: nightly`).
+  #
+  # WHY THE LIST IS THIS BROAD, AND WHY THAT IS THE HONEST ANSWER RATHER THAN A LAZY
+  # ONE. DIVE-2785 proposed a "risk-triggered" narrow surface. The union of what the
+  # two instances ACTUALLY touched is build.sh, install.sh and src/** — a narrower
+  # list misses src/cmd_*.sh (A) or src/header.sh and install.sh (B). Measured over
+  # the seven days to 2026-08-05: 131 of 181 first-parent merges (72%) touch this
+  # surface. So "risk-triggered" and "every PR" are the same trigger at the same
+  # cost, and any list narrow enough to feel cheap is narrow enough to have missed
+  # one of the two instances we already have. Naming that plainly is the point.
+  #
+  # WHAT IT COSTS, MEASURED, NOT ASSERTED. Not dollars: the repo is public and every
+  # job here is `ubuntu-latest`, so standard runners are free. The cost is wall-clock
+  # and queue contention. Rate, measured from unit-tests.yml's own pull_request runs
+  # (it has no paths filter, so every one of them is a push to an open PR branch):
+  # 100 runs across 57 DISTINCT branches over 2026-08-04T07:09Z..08-05T17:55Z, a
+  # 34.8h window = ~69 pushes and ~39 branches/day. BRANCHES is the figure that
+  # matters, because the concurrency group below is keyed on the ref, so repeated
+  # pushes to one branch collapse into one sweep. At the 72% surface-touch rate that
+  # is ~28 sweeps/day. The window is what the API paginates to, NOT a calendar day —
+  # per-day counts off that page are floors on both ends and reading one as a full
+  # day understates the rate, which is the direction that flatters this change.
+  #
+  # WHY NOT A `--tier=nightly` BRANCH RUN, which was the recommended option going in.
+  # It was the right thing to COST before shipping, and the cost killed it. Summed
+  # from the per-harness timings of full-sweep run 31019560760 (main, 609210d,
+  # SUCCESS), classified through tests/lib/tier.sh:
+  #     pristine        324 harnesses 1481s | nightly subset 81 harnesses 1210s (81%)
+  #     installed-host  324 harnesses 1594s | nightly subset 81 harnesses 1306s (81%)
+  # The nightly subset IS the corpus: core is 270s/288s of it. A nightly-only branch
+  # run buys 18-19% of wall-clock and costs a third run selector with its own budget
+  # dial — a second place the PR path and the sweep path can drift apart, which is
+  # the defect tests/lib/tier.sh exists to prevent. 18% is not worth that, so this
+  # ships the tier that already exists.
   pull_request:
     paths:
       - 'tests/lib/tier.sh'
       - 'scripts/run-harnesses.sh'
       - '.github/workflows/full-sweep.yml'
+      # DIVE-2789: the measured union of the two known instances. Keep this list and
+      # tests/full_sweep_pr_trigger_unit.sh in step — that harness fails if either
+      # instance's file list stops being covered.
+      - 'build.sh'
+      - 'install.sh'
+      - 'src/**'
+
+# DIVE-2789: THIS SWEEP IS ADVISORY ON A PR. IT DOES NOT BLOCK A MERGE.
+#
+# Read from the API, not inferred from this file — `gh api
+# repos/5dive-ai/5dive/branches/main/protection`, 2026-08-05. The required contexts
+# are exactly: test, test-installed-host, shellcheck, docker-install, scan, check,
+# supply-chain-guard. No job in this workflow is among them, and `strict` is false.
+# BOTH mechanisms were checked, because classic protection is not the only one that
+# can make a context required and the other one is invisible to the endpoint above:
+# `repos/5dive-ai/5dive/rulesets` and `.../rules/branches/main` both return `[]`, so
+# classic protection is the whole answer today. If a ruleset ever appears, re-read
+# this — a required context added there would not show up in the list above.
+#
+# It stays advisory ON PURPOSE, not by omission. This trigger is paths-filtered, so
+# it is ABSENT from ~28% of PRs — and GitHub leaves a required check that never
+# reports PENDING FOREVER, so requiring it would wedge every PR that legitimately
+# does not touch the surface. Making it required needs a separate always-reporting
+# gate job, which is DIVE-2790's shape, not this row's.
+#
+# So: a red here is a signal a human has to read, not a control that stops a merge.
+# That is strictly more than the zero we had — the break in (A) and (B) above was on
+# NO surface anybody looked at before merging — and it is less than it sounds like.
+# Do not read "full-sweep runs on branches" as "a regression outside the core tier
+# can no longer land".
+#
+# AND TWO THINGS THIS DOES NOT COVER AT ALL, because the next author reads this
+# comment and would otherwise inherit a false premise:
+#   * THE RELEASE PATH. `release-cut.yml` runs on schedule and workflow_dispatch
+#     only — never on a PR. A change to the release flow still merges behind fully
+#     green checks and is first exercised when somebody needs a release. That is
+#     this same defect one rail over, and 4e87712 (DIVE-2603) is the live instance:
+#     full-sweep on 33c6c80 was GREEN in both environments and the cut still failed
+#     on `bundle-integrity`. Tracked as DIVE-2798.
+#   * THE SELFCHECK PROBE CLASS. What failed in that incident is a `5dive selfcheck`
+#     probe invoked by the release workflow (src/cmd_selfcheck.sh), which the harness
+#     corpus never reaches in either tier. This workflow runs THE CORPUS. A branch
+#     sweep would have gone green on 33c6c80 exactly as the real sweep did.
+# This row closes ONE axis — a regression in the harness corpus, outside the core
+# tier, on a branch — with ONE instrument class, the corpus.
 
 # DIVE-2667: what makes `push: main` affordable, and WHAT IT COSTS TO BUY THAT.
 #
@@ -220,6 +308,18 @@ jobs:
   harness-verdict-pristine:
     runs-on: ubuntu-latest
     needs: full-pristine
+    # DIVE-2789: NOT ON A PULL REQUEST. The PR trigger above puts the whole corpus
+    # on a branch; it does not put a SECOND whole pass on one. The verdict probe
+    # re-runs every harness once per injected mutation, so these four jobs roughly
+    # double the workflow's cost, and the argument for skipping them on a PR is the
+    # one already written above in this file rather than a new one: the PR-shaped
+    # case — a harness added or edited in a diff whose exit status is not wired to
+    # its own assertions — is caught at the moment of introduction by unit-tests.yml's
+    # `changed-harnesses`; and the union's invariant is a whole-corpus,
+    # cross-environment claim that NO SINGLE PR CAN MAKE OR BREAK. Both still run on
+    # every push to main, on the nightly, and on dispatch, which is where they were
+    # sound in the first place.
+    if: github.event_name != 'pull_request'
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -260,6 +360,18 @@ jobs:
   harness-verdict-installed:
     runs-on: ubuntu-latest
     needs: full-installed-host
+    # DIVE-2789: NOT ON A PULL REQUEST. The PR trigger above puts the whole corpus
+    # on a branch; it does not put a SECOND whole pass on one. The verdict probe
+    # re-runs every harness once per injected mutation, so these four jobs roughly
+    # double the workflow's cost, and the argument for skipping them on a PR is the
+    # one already written above in this file rather than a new one: the PR-shaped
+    # case — a harness added or edited in a diff whose exit status is not wired to
+    # its own assertions — is caught at the moment of introduction by unit-tests.yml's
+    # `changed-harnesses`; and the union's invariant is a whole-corpus,
+    # cross-environment claim that NO SINGLE PR CAN MAKE OR BREAK. Both still run on
+    # every push to main, on the nightly, and on dispatch, which is where they were
+    # sound in the first place.
+    if: github.event_name != 'pull_request'
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -347,6 +459,18 @@ jobs:
   harness-verdict-slow:
     runs-on: ubuntu-latest
     needs: full-pristine
+    # DIVE-2789: NOT ON A PULL REQUEST. The PR trigger above puts the whole corpus
+    # on a branch; it does not put a SECOND whole pass on one. The verdict probe
+    # re-runs every harness once per injected mutation, so these four jobs roughly
+    # double the workflow's cost, and the argument for skipping them on a PR is the
+    # one already written above in this file rather than a new one: the PR-shaped
+    # case — a harness added or edited in a diff whose exit status is not wired to
+    # its own assertions — is caught at the moment of introduction by unit-tests.yml's
+    # `changed-harnesses`; and the union's invariant is a whole-corpus,
+    # cross-environment claim that NO SINGLE PR CAN MAKE OR BREAK. Both still run on
+    # every push to main, on the nightly, and on dispatch, which is where they were
+    # sound in the first place.
+    if: github.event_name != 'pull_request'
     timeout-minutes: 60
     env:
       # One name per slow harness, comma-separated — the probe's own --only format.
@@ -392,6 +516,18 @@ jobs:
   harness-verdict-union:
     runs-on: ubuntu-latest
     needs: [harness-verdict-pristine, harness-verdict-installed, harness-verdict-slow]
+    # DIVE-2789: NOT ON A PULL REQUEST. The PR trigger above puts the whole corpus
+    # on a branch; it does not put a SECOND whole pass on one. The verdict probe
+    # re-runs every harness once per injected mutation, so these four jobs roughly
+    # double the workflow's cost, and the argument for skipping them on a PR is the
+    # one already written above in this file rather than a new one: the PR-shaped
+    # case — a harness added or edited in a diff whose exit status is not wired to
+    # its own assertions — is caught at the moment of introduction by unit-tests.yml's
+    # `changed-harnesses`; and the union's invariant is a whole-corpus,
+    # cross-environment claim that NO SINGLE PR CAN MAKE OR BREAK. Both still run on
+    # every push to main, on the nightly, and on dispatch, which is where they were
+    # sound in the first place.
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,19 @@ decision to add one is ever wrong on its own merits. See
 | tier | runs | budget |
 |---|---|---|
 | `core` (**the default**) | every PR, both CI environments | **300s** per job |
-| `nightly` | `full-sweep.yml` (03:17 UTC + dispatch) | **1320s** per job, corpus split across 3 shards |
+| `nightly` | `full-sweep.yml` — 03:17 UTC, dispatch, **every push to main** (DIVE-2667), and **every PR touching `build.sh`, `install.sh` or `src/**`** (DIVE-2789) | **1320s** per job, corpus split across 3 shards |
+
+- **The PR trigger is ADVISORY. It does not block a merge**, and it is deliberately not
+  a required context: it is paths-filtered, so it is absent from ~28% of PRs, and GitHub
+  leaves a required check that never reports pending forever. A red there is a signal to
+  read, not a gate. It also covers ONE axis — a regression in the harness corpus outside
+  the core tier — and **not** the release path (`release-cut.yml` never runs on a PR) or
+  the selfcheck probe class, which the corpus never reaches. Do not read "full-sweep runs
+  on branches" as "a tree-level regression can no longer land behind a green PR".
+- **The nightly tier is not a cheap subset**: 25% of the corpus by file count and **81%
+  of it by wall-clock** (1210s of 1481s, measured DIVE-2789), because membership is
+  selected on cost. Cost any plan that leans on the core/nightly split in seconds, not in
+  files — `community/wiki/a-demoted-tier-is-not-a-cheap-subset-it-holds-almost-all-the-cost.md`.
 
 - **A new harness is `core` unless you say otherwise.** Nothing to write.
 - **Over budget, CI FAILS** (`exit 4`, distinct from a test failure's `exit 1`) and

--- a/src/header.sh
+++ b/src/header.sh
@@ -985,3 +985,5 @@ require_loaded() {
     fail "$E_GENERIC" "${ctx}: required predicate '${fn}' is not loaded (src/lib/broker.sh missing from this build) — refusing rather than proceeding unchecked."
   done
 }
+
+# DIVE-2789 trigger probe: this comment is the entire diff. Throwaway branch.

--- a/tests/full_sweep_pr_trigger_unit.sh
+++ b/tests/full_sweep_pr_trigger_unit.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# DIVE-2789 — the PRE-MERGE half of the full-sweep gap: full-sweep.yml's
+# `on.pull_request.paths` list, and the two things about it that rot silently.
+#
+# WHY A HARNESS AND NOT JUST A REVIEWED DIFF. A `paths:` filter that matches
+# NOTHING still produces a green PR. Every way this trigger can be wrong presents
+# as "CI was green": a typo in a glob, a list narrowed in a later cleanup because
+# the sweep felt expensive, a job that stops running on the event it was added for.
+# None of those produce a red anywhere. So the arms below grade the filter against
+# the FILE LISTS OF THE TWO COMMITS THAT MOTIVATED IT, which is the one claim that
+# cannot be satisfied by an empty match.
+#
+#   the filter must FIRE       arms 1-2: every file 2f8dbaa (#486, DIVE-2371) and
+#                              4e87712 (#488, DIVE-2603) touched in the source tree
+#                              is matched. These are the two measured instances of
+#                              a nightly-tier harness broken by a merge whose PR was
+#                              green; a list that stops covering either has given up
+#                              the only coverage anybody demonstrated it needed.
+#   and it must NOT fire       arm 3: paths OUTSIDE the claimed surface do not match.
+#                              A list that matched everything would pass arms 1-2 and
+#                              mean nothing.
+#   the MATCHER can fail       arm 4: the glob translator is re-run against a
+#                              deliberately narrow list and must REJECT the instance
+#                              file lists. Without this, arms 1-2 are also satisfied
+#                              by a matcher that returns True unconditionally.
+#   the cost decision holds    arm 5: the four harness-verdict jobs (a SECOND whole
+#                              pass over the corpus) stay off the pull_request event.
+#                              Dropping that `if:` roughly doubles the trigger's cost
+#                              silently — nothing goes red, the queue just gets worse.
+#   the caveats survive        arms 6-8: the workflow comment must still say this
+#                              sweep is ADVISORY on a PR, and must still name the two
+#                              axes it does NOT cover (the release path, and the
+#                              selfcheck probe class). Those sentences are the whole
+#                              defence against the next author reading "full-sweep
+#                              runs on branches" as "a regression outside the core
+#                              tier can no longer land" — which is false, and was
+#                              false the day this shipped (see DIVE-2798).
+#
+# NO NETWORK, NO ROOT, NO BUILT BUNDLE. Pure parse of a file in this tree.
+#
+# Run: bash tests/full_sweep_pr_trigger_unit.sh
+set -uo pipefail
+
+# DIVE-2211 / DIVE-2286: name the tree this harness grades. Sourced BEFORE the cd
+# so ${BASH_SOURCE[0]} still resolves relative to tests/.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+REPO="$PWD"
+WF="$REPO/.github/workflows/full-sweep.yml"
+
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+no(){ FAIL=$((FAIL+1)); printf 'NOT OK - %s\n' "$1"; }
+
+[[ -r "$WF" ]] || { no "full-sweep.yml is readable"; printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"; exit 1; }
+
+# --------------------------------------------------------------------------------
+# Arms 1-4: the paths filter, graded against the two instances.
+#
+# The glob translator implements GitHub's filter-pattern rules, not fnmatch's:
+# `**` crosses `/`, a single `*` does not, and a pattern with no wildcard and no
+# trailing `/` matches that exact path. Getting this wrong in the LENIENT direction
+# is what arm 4 exists to catch.
+# --------------------------------------------------------------------------------
+python3 - "$WF" <<'PY'
+import sys, re, yaml
+
+wf = yaml.safe_load(open(sys.argv[1]))
+# `on` is the YAML 1.1 boolean True once safe_load has had it. Accept either.
+trig = wf.get('on', wf.get(True))
+paths = (trig or {}).get('pull_request', {}).get('paths') or []
+
+def to_re(pat):
+    out, i = '', 0
+    while i < len(pat):
+        c = pat[i]
+        if c == '*':
+            if pat[i:i+2] == '**':
+                out += '.*'; i += 2; continue
+            out += '[^/]*'; i += 1; continue
+        out += re.escape(c); i += 1
+    return re.compile('^' + out + '$')
+
+def matches(pats, path):
+    return any(to_re(p).match(path) for p in pats)
+
+# The SOURCE-TREE files of each instance. Workflow and tests/ files are excluded on
+# purpose: they are not what this list is claiming to cover, and including them
+# would let an unrelated entry satisfy the arm.
+INSTANCES = {
+    '2f8dbaa #486 DIVE-2371': [
+        'src/lib/tasks_db.sh', 'src/cmd_selfcheck.sh', 'src/cmd_task.sh',
+    ],
+    '4e87712 #488 DIVE-2603': [
+        'build.sh', 'install.sh', 'src/header.sh',
+    ],
+}
+OUTSIDE = [
+    'README.md',
+    'CHANGELOG.md',
+    'community/wiki/index.md',
+    'docs/anything.md',
+    'tests/gate_nonce_unit.sh',          # tests/ is NOT in the surface (only tests/lib/tier.sh)
+    'scripts/pii-scan.sh',               # scripts/ is NOT in the surface (only run-harnesses.sh)
+]
+NARROW = ['src/lib/**']                  # arm 4's deliberately insufficient control
+
+P = F = 0
+def ok(m):
+    global P; P += 1; print('ok   - ' + m)
+def no(m):
+    global F; F += 1; print('NOT OK - ' + m)
+
+if not paths:
+    no('on.pull_request.paths is a non-empty list (an absent filter is not a broad one)')
+else:
+    ok('on.pull_request.paths parses to a non-empty list (%d entries)' % len(paths))
+
+for name, files in INSTANCES.items():
+    missed = [f for f in files if not matches(paths, f)]
+    if missed:
+        no('instance %s: paths filter would NOT fire for %s' % (name, ', '.join(missed)))
+    else:
+        ok('instance %s: every source file it touched is covered (%s)' % (name, ', '.join(files)))
+
+leaks = [p for p in OUTSIDE if matches(paths, p)]
+if leaks:
+    no('paths filter is over-broad — it matches %s, so arms 1-2 prove nothing' % ', '.join(leaks))
+else:
+    ok('paths filter does NOT match %d files outside the claimed surface' % len(OUTSIDE))
+
+# Arm 4: the matcher must be able to say no. If a narrow list still "covers" both
+# instances, the translator is lenient and every arm above is vacuous.
+still = [n for n, fs in INSTANCES.items() if all(matches(NARROW, f) for f in fs)]
+if still:
+    no('the glob matcher is vacuous — %s reads as covered by %s' % (', '.join(still), NARROW))
+else:
+    ok('the glob matcher rejects %s for both instances (arms 1-2 are not vacuous)' % NARROW)
+
+# Arm 5: the second whole-corpus pass stays off the PR event.
+jobs = wf.get('jobs', {})
+for j in ('harness-verdict-pristine', 'harness-verdict-installed',
+          'harness-verdict-slow', 'harness-verdict-union'):
+    cond = str(jobs.get(j, {}).get('if', ''))
+    if 'pull_request' in cond and '!=' in cond:
+        ok('%s is excluded from the pull_request event (cost: a second full pass)' % j)
+    else:
+        no('%s no longer carries `if: github.event_name != \'pull_request\'` (got %r)' % (j, cond))
+
+print('\n%d passed, %d failed' % (P, F))
+sys.exit(1 if F else 0)
+PY
+if (( $? == 0 )); then ok "paths filter + verdict-job exclusion (see arms above)"; else no "paths filter + verdict-job exclusion (see arms above)"; fi
+
+# --------------------------------------------------------------------------------
+# Arms 6-8: the caveats. These are PROSE, and that is exactly why they need an arm —
+# a sentence nothing grades is a sentence the next cleanup deletes.
+# --------------------------------------------------------------------------------
+if grep -qi 'ADVISORY ON A PR' "$WF"; then
+  ok 'the workflow says IN THOSE WORDS that the PR sweep is advisory, not a merge gate'
+else
+  no 'the workflow no longer states that the PR sweep is ADVISORY — a sweep read as a control is the defect class this row exists to close'
+fi
+
+if grep -q 'release-cut.yml' "$WF"; then
+  ok 'the workflow names the RELEASE PATH as an axis it does not cover'
+else
+  no 'the workflow no longer names release-cut.yml as uncovered (DIVE-2798 is the live counterexample)'
+fi
+
+if grep -q 'cmd_selfcheck.sh' "$WF"; then
+  ok 'the workflow names the SELFCHECK PROBE class as an instrument the corpus never reaches'
+else
+  no 'the workflow no longer names the selfcheck probe class as uncovered'
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+(( FAIL == 0 ))


### PR DESCRIPTION
THROWAWAY PROBE — DIVE-2789, delete after reading.

Grades the new full-sweep pull_request paths filter against real GitHub, which the unit harness cannot substitute for: a paths filter that matches nothing still yields a green PR, so green CI is not evidence the trigger works.

Touches src/header.sh (INSIDE the paths filter).
Expected: full-sweep MUST appear on this PR.

The negative arm cannot share a branch with the positive one, because a pull_request paths filter is evaluated against the PR diff. Hence two PRs. dev reads both runs, records the directions on the main PR (#507 or as opened), then closes these and tears the branches down.
