### PR TITLE
PROBE (throwaway, DIVE-2789 AC3): INSIDE the paths filter — src/header.sh only

### DIFF
--- a/src/header.sh
+++ b/src/header.sh
@@ -985,3 +985,5 @@ require_loaded() {
     fail "$E_GENERIC" "${ctx}: required predicate '${fn}' is not loaded (src/lib/broker.sh missing from this build) — refusing rather than proceeding unchecked."
   done
 }
+
+# DIVE-2789 trigger probe (INSIDE the surface). Throwaway branch; this comment is the entire diff.


### PR DESCRIPTION
THROWAWAY PROBE — DIVE-2789 AC3. Delete after reading; dev owns the verdict.

**Diff is `src/header.sh` alone**, cut fresh from `f83abde` (the merged DIVE-2789 tip), so the head branch carries the shipped `full-sweep.yml` and this PR's diff contains nothing but the one file.

**PREDICTION, recorded before the run so the arm cannot be read backwards: full-sweep MUST fire.**

This is the arm that settles `src/**` against a *single-level* path on real GitHub, rather than against a glob translator or a reading of the docs. main2's point is what makes it load-bearing: had `**` required an intervening directory, instance A would have been missed by two of its three files while the unit harness stayed green.

Supersedes #508, which was void — the old probes were stacked on the change branch, so each PR's own diff contained `full-sweep.yml`, itself in the paths list, and both arms fired for a reason unrelated to the entries under test.

If this does NOT fire, the shipped paths list is wrong and that is the publishable result.
