### PR TITLE
PROBE (throwaway, DIVE-2789 AC3): OUTSIDE the paths filter — README.md only

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,3 +397,5 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). The `5dive` bundle at the repo root is b
 ## License
 
 MIT. See [LICENSE](LICENSE).
+
+<!-- DIVE-2789 trigger probe (OUTSIDE the surface). Throwaway branch; this comment is the entire diff. -->


### PR DESCRIPTION
THROWAWAY PROBE — DIVE-2789 AC3. Delete after reading; dev owns the verdict.

**Diff is `README.md` alone**, cut fresh from `f83abde` (the merged DIVE-2789 tip).

**PREDICTION, recorded before the run: full-sweep MUST NOT fire.**

`unit-tests` and the other unfiltered workflows WILL run on this PR, and that is the point — their presence is the **positive control** that makes full-sweep's absence meaningful rather than indistinguishable from a broken trigger or a workflow that never loaded. An arm whose expected result is "nothing happened" needs a witness that something else did.

Supersedes #509, which was void: stacked on the change branch, so its diff carried `full-sweep.yml` and firing was correct behaviour that proved nothing about the entries under test.
