### PR TITLE
ci(full-sweep): distinguish a skipped job from an untriggered workflow, for the next reader (DIVE-2789)

### DIFF
--- a/.github/workflows/full-sweep.yml
+++ b/.github/workflows/full-sweep.yml
@@ -128,6 +128,17 @@ on:
 # does not touch the surface. Making it required needs a separate always-reporting
 # gate job, which is DIVE-2790's shape, not this row's.
 #
+# AND IF YOU ARE HERE TO ARGUE "just require it, it reports skipped anyway" — those
+# are two different mechanisms and this file contains both, which is exactly why they
+# get conflated. A job SKIPPED BY AN `if:` (the harness-verdict jobs below) reports a
+# conclusion of `skipped`, so branch protection is satisfied by it. A workflow NEVER
+# TRIGGERED by a `paths:` filter creates NO CHECK AT ALL — there is nothing to report
+# a conclusion, and that is the pending-forever case. Only the second one applies to
+# this trigger. Observed on PR #507, the first real run: the four harness-verdict jobs
+# appear in the check list as `skipping`, while a PR that touches none of the paths
+# above produces no full-sweep check whatsoever. Do not reason from the first to the
+# second (DIVE-2789, main's request, 2026-08-05).
+#
 # So: a red here is a signal a human has to read, not a control that stops a merge.
 # That is strictly more than the zero we had — the break in (A) and (B) above was on
 # NO surface anybody looked at before merging — and it is less than it sounds like.


### PR DESCRIPTION
Comment-only follow-up to DIVE-2789 (#507). One file, +11 lines, no behaviour change.

## Why a comment earns its own PR

`full-sweep.yml` now contains **both** mechanisms that can make a job absent from a PR's check list, and they are one word apart in conversation:

- a job **skipped by an `if:`** — the four `harness-verdict-*` jobs — reports a conclusion of `skipped`, and branch protection is satisfied by it;
- a workflow **never triggered by a `paths:` filter** creates **no check at all**, so there is nothing to report a conclusion. That is the pending-forever case, and it is the only one that applies to this trigger.

The file already explains that the sweep stays advisory because requiring a paths-filtered check would wedge every PR that legitimately does not touch the surface. The gap was that the *next* reader can look at the `skipping` entries in a real check list and conclude the opposite — "just require it, it reports skipped anyway" — from the same file that says it is unrequirable. The comment is written at that person, opens by addressing them, and names both mechanisms rather than only the one that applies.

## Both halves are now observed, not argued

- **#507**, the first real run: the four `harness-verdict-*` jobs appear in the check list as `skipping`.
- **#511**, a PR whose diff is `README.md` alone: **no full-sweep check whatsoever** — while eleven other checks ran on it, which is what makes the absence evidence rather than an unloaded workflow.

## Provenance

Requested by main after reviewing #507; branched by dev at `f83abde`; gated separately as `access` on DIVE-2789 rather than folded into the earlier grant, because it is a different property and a **permanent** change where that grant named two short-lived probes. A lead asking for work and a lead authorising it are different acts, and dev declined to treat the first as the second.

Pushed by main: `.github/workflows/` is the path the delegated rail cannot write (DIVE-2262).
