### PR TITLE
fix(agent): read agent config unprivileged first, with a breaker and one warn (DIVE-2791)

### DIFF
--- a/src/cmd_agent.sh
+++ b/src/cmd_agent.sh
@@ -240,16 +240,159 @@ cmd_list() {
   fi
 }
 
+# --- Unprivileged-first reads, with a circuit breaker (DIVE-2791) -----------
+#
+# These resolvers are cosmetic survey columns, and they are called once PER AGENT
+# on a fleet-wide sweep (`agent list`, `compose`). Reaching for `sudo` by reflex
+# made a scoped agent emit one denial per agent per sweep: 224 `command not
+# allowed` lines in 24h on the control plane (164 agent-codex + 26 agent-dev3),
+# all of them `sudo jq`/`sudo sed` against other agents' settings.json. Each
+# denial is a syslog line and, where sudoers sets `mail_no_perms`, a mail to root
+# — a reporter's box ran that chain for 9 days and landed its IP on Spamhaus CSS
+# and XBL. No compromise; volume to a nonexistent recipient just reads as abuse.
+#
+# Two rules keep that from recurring:
+#   1. Ask root only when the direct read genuinely cannot answer. Readability is
+#      the test, NOT emptiness — an empty `model` is a legitimate value (the
+#      runtime falls back to its built-in pick), so escalating on "" would sudo
+#      for every unset agent forever.
+#   2. Latch off after PRIV_READ_MAX_DENIALS consecutive refusals. A grant is
+#      written against the COMMAND, so a refusal for agent-A's file predicts a
+#      refusal for agent-B's; we spend a few before latching only because a
+#      per-target sudoers rule is expressible.
+
+# Consecutive sudo refusals tolerated before we stop asking for the rest of the
+# window. Cache TTL bounds how long a latched breaker outlives a sudoers change.
+PRIV_READ_MAX_DENIALS="${PRIV_READ_MAX_DENIALS:-3}"
+PRIV_READ_TTL="${PRIV_READ_TTL:-900}"
+
+# Where the denial count lives. It MUST be a file rather than a shell variable:
+# every caller invokes these resolvers as `model=$(resolve_agent_model …)`, and a
+# subshell cannot write a variable back to its parent — a variable-held counter
+# would reset on every agent and the breaker would never latch at all. Keyed by
+# the caller's OWN cache dir, so the count also carries across the ~8 sweeps a
+# day that produced the flood, and never lets one uid touch another's state.
+_priv_state_file() {
+  local base="${XDG_CACHE_HOME:-${HOME:-}/.cache}"
+  [[ "$base" == /* ]] || return 1
+  [[ -d "$base/5dive" ]] || mkdir -p "$base/5dive" 2>/dev/null || return 1
+  printf '%s/5dive/privread-denials' "$base"
+}
+
+# Current consecutive-denial count, or 0 when unknown/expired.
+_priv_denials() {
+  local f n mt now
+  f=$(_priv_state_file) || { printf 0; return; }
+  [[ -r "$f" ]] || { printf 0; return; }
+  mt=$(stat -c %Y "$f" 2>/dev/null) || mt=0
+  now=$(date +%s 2>/dev/null) || now=0
+  # A stale latch must expire: a sudoers grant can be widened between sweeps and
+  # nothing here would otherwise notice. TTL resolved locally for the same reason
+  # the denial bound is (an unset global would make this `> 0` — expire always).
+  local ttl="${PRIV_READ_TTL:-900}"
+  [[ "$ttl" =~ ^[1-9][0-9]*$ ]] || ttl=900
+  if (( now > 0 && mt > 0 && now - mt > ttl )); then
+    rm -f "$f" 2>/dev/null || true
+    printf 0; return
+  fi
+  read -r n <"$f" 2>/dev/null || n=0
+  [[ "$n" =~ ^[0-9]+$ ]] || n=0
+  printf '%s' "$n"
+}
+
+# Record an escalation outcome. `ok` clears the latch (root works here), `denied`
+# advances it and emits exactly ONE warn line for the window — a silently
+# degraded read that mails root once a minute is the worst of both, so the
+# operator gets told once and never spammed. A command that ran and merely failed
+# (absent file, bad JSON) is NOT a denial and must not latch the breaker.
+_priv_note() {
+  local outcome="$1" f n
+  f=$(_priv_state_file) || return 0
+  case "$outcome" in
+    ok)     rm -f "$f" 2>/dev/null || true ;;
+    denied)
+      n=$(_priv_denials); n=$(( n + 1 ))
+      printf '%s\n' "$n" >"$f" 2>/dev/null || true
+      if (( n == 1 )); then
+        local max="${PRIV_READ_MAX_DENIALS:-3}"
+        [[ "$max" =~ ^[1-9][0-9]*$ ]] || max=3
+        printf '5dive: warn: reading another agent'"'"'s config needs root and this grant was refused as %s; model/effort will show "—" for agents whose files are not readable. Suppressing further attempts after %s (DIVE-2791).\n' \
+          "$(id -un 2>/dev/null || printf '?')" "$max" >&2
+      fi
+      ;;
+  esac
+  return 0
+}
+
+# Run a read-only command, unprivileged FIRST, escalating to `sudo -n` only when
+# the direct read cannot answer AND the breaker is closed.
+#   $1   the path whose readability decides whether root is needed at all
+#   $2.. the command; its stdout is the value
+# ALWAYS exits 0 with the value on stdout ("" when unavailable), because every
+# caller assigns it under the bundle's `set -e` (see DIVE-230).
+priv_read() {
+  local guard="$1"; shift
+  # Already root, or readable as us — our own home, a world-readable config, or a
+  # root-invoked sweep. The direct read is authoritative: "" means unset.
+  if (( EUID == 0 )) || [[ -r "$guard" ]]; then
+    "$@" 2>/dev/null || true
+    return 0
+  fi
+  # Resolve the bound LOCALLY. `(( n >= PRIV_READ_MAX_DENIALS ))` with the constant
+  # unset is `0 >= 0` — TRUE — which reads as "breaker already latched" and disables
+  # escalation entirely, silently returning "" for every agent. That is a quiet loss
+  # of function with no warn line, and it depends only on bundle source order, so the
+  # function must not rely on a global having been assigned first.
+  local max="${PRIV_READ_MAX_DENIALS:-3}"
+  [[ "$max" =~ ^[1-9][0-9]*$ ]] || max=3
+  local n; n=$(_priv_denials)
+  (( n >= max )) && { printf ''; return 0; }
+  local out err rc=0
+  err=$(mktemp 2>/dev/null) || { printf ''; return 0; }
+  # `-n` matters independently of the routing: without it a box that would prompt
+  # hangs a survey column behind a password read it can never satisfy.
+  out=$(sudo -n "$@" 2>"$err") || rc=$?
+  if (( rc == 0 )); then
+    _priv_note ok
+  elif grep -qiE 'not allowed|password is required|not in the sudoers|may not run|no tty' "$err" 2>/dev/null; then
+    _priv_note denied
+  fi
+  rm -f "$err" 2>/dev/null || true
+  printf '%s' "$out"
+  return 0
+}
+
 # Resolve the coding-CLI version string for an agent type from its TYPE_BIN
 # binary. Best-effort: returns "" if the binary is missing or doesn't answer
 # --version in time. Runs as `claude` (owns the binaries + their caches) through
 # a login shell so node/nvm-based CLIs (codex) inherit their PATH, capped at 5s
-# so a wedged CLI can't hang `info`.
+# so a wedged CLI can't hang `info`. DIVE-2791: when the binary is already
+# executable as us there is nothing to escalate for — that path was emitting
+# `sudo bash` denials for a string we could read directly.
 resolve_cli_version() {
   local type="$1"
   local bin="${TYPE_BIN[$type]:-}"
   [[ -n "$bin" ]] || { printf ''; return; }
-  timeout 5 sudo -u claude bash -lc "$(printf '%q' "$bin") --version 2>/dev/null | head -1" 2>/dev/null || printf ''
+  local q; q=$(printf '%q' "$bin")
+  if (( EUID == 0 )) || [[ -x "$bin" ]]; then
+    timeout 5 bash -lc "$q --version 2>/dev/null | head -1" 2>/dev/null || printf ''
+    return 0
+  fi
+  local max="${PRIV_READ_MAX_DENIALS:-3}"
+  [[ "$max" =~ ^[1-9][0-9]*$ ]] || max=3
+  local n; n=$(_priv_denials)
+  (( n >= max )) && { printf ''; return 0; }
+  local err out rc=0
+  err=$(mktemp 2>/dev/null) || { printf ''; return 0; }
+  out=$(timeout 5 sudo -n -u claude bash -lc "$q --version 2>/dev/null | head -1" 2>"$err") || rc=$?
+  if (( rc == 0 )); then
+    _priv_note ok
+  elif grep -qiE 'not allowed|password is required|not in the sudoers|may not run|no tty' "$err" 2>/dev/null; then
+    _priv_note denied
+  fi
+  rm -f "$err" 2>/dev/null || true
+  printf '%s' "$out"
+  return 0
 }
 
 # Resolve the model an agent is configured to use, read from the per-type
@@ -268,18 +411,21 @@ resolve_agent_model() {
   # read it as "agent missing". The `|| true` on every file read keeps the
   # contract: absent value → "" → exit 0. (sed|head needs it too: under
   # `pipefail` a missing config.toml propagates sed's non-zero status.)
+  # DIVE-2791: every arm goes through priv_read, which reads directly when it can
+  # and asks root only when the file is genuinely unreadable as us. The guard path
+  # and the command's own path argument are the same file by construction.
+  local f
   case "$type" in
     claude)
-      sudo jq -r '.model // empty' "$home/.claude/settings.json" 2>/dev/null || true ;;
-    codex)
-      { sudo sed -nE 's/^[[:space:]]*model[[:space:]]*=[[:space:]]*"?([^"#]*[^"# ])"?.*/\1/p' \
-        "$home/.codex/config.toml" 2>/dev/null | head -1; } || true ;;
-    grok)
-      { sudo sed -nE 's/^[[:space:]]*model[[:space:]]*=[[:space:]]*"?([^"#]*[^"# ])"?.*/\1/p' \
-        "$home/.grok/config.toml" 2>/dev/null | head -1; } || true ;;
+      f="$home/.claude/settings.json"
+      priv_read "$f" jq -r '.model // empty' "$f" ;;
+    codex|grok)
+      f="$home/.${type}/config.toml"
+      { priv_read "$f" sed -nE 's/^[[:space:]]*model[[:space:]]*=[[:space:]]*"?([^"#]*[^"# ])"?.*/\1/p' \
+        "$f" | head -1; } || true ;;
     antigravity)
-      sudo jq -r '.model // .selectedModel // empty' \
-        "$home/.gemini/antigravity-cli/settings.json" 2>/dev/null || true ;;
+      f="$home/.gemini/antigravity-cli/settings.json"
+      priv_read "$f" jq -r '.model // .selectedModel // empty' "$f" ;;
     *) printf '' ;;
   esac
 }
@@ -290,9 +436,11 @@ resolve_agent_model() {
 # "—"/null rather than treat empty as an error.
 resolve_agent_effort() {
   local type="$1" name="$2"
+  local f
   case "$type" in
     claude)
-      sudo jq -r '.effortLevel // empty' "/home/agent-${name}/.claude/settings.json" 2>/dev/null || true ;;
+      f="/home/agent-${name}/.claude/settings.json"
+      priv_read "$f" jq -r '.effortLevel // empty' "$f" ;;
     *) printf '' ;;
   esac
 }

--- a/tests/agent_priv_read_breaker_unit.sh
+++ b/tests/agent_priv_read_breaker_unit.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# DIVE-2791 — a read-only survey column must not ask root by reflex, and must stop
+# asking once refused.
+#
+# THE DEFECT: resolve_agent_model/resolve_agent_effort/resolve_cli_version each reached
+# straight for `sudo`, and they run once PER AGENT on every fleet sweep (`agent list`,
+# `compose`). On a scoped agent that is one refusal per agent per sweep — measured 29
+# syslog lines from a SINGLE `agent list` as agent-dev3, and 224 in 24h across the host.
+# A reporter's box ran the same chain for 9 days; each refusal became a mail to a root
+# address that resolved off-box, ~39,400 delivery attempts to a nonexistent recipient,
+# and the IP landed on Spamhaus CSS + XBL. No compromise — volume to a nonexistent
+# recipient is just indistinguishable from abuse at the receiving end.
+#
+# THE MEASURED MECHANISM, because it is the part that is easy to get wrong: the syslog
+# line comes from calling sudo WITHOUT `-n`. Verified as agent-dev3 against a file it
+# cannot read:
+#     sudo    jq …  -> "a password is required" AND logs `command not allowed`
+#     sudo -n jq …  -> "a password is required" and logs NOTHING
+# So `-n` is what removes the mail, the breaker is what removes the wasted spawns, and
+# readability-first is what makes the value correct for a caller who can just read it.
+# All three are load-bearing and they fix different halves.
+#
+# ARMS T3-T6/T8 EXECUTE the real functions sourced from src/cmd_agent.sh — they are not
+# grep assertions about them. They stub `sudo` on PATH, which means they prove the ROUTING
+# and the BREAKER and can say nothing whatever about a sudoers decision — see
+# community/wiki/a-stubbed-sudo-cannot-see-a-sudoers-argv-denial.md. The end-to-end host
+# measurement needs a second, differently-scoped uid and so cannot live in a harness at
+# all; it is recorded on the row and here:
+#     control (old bundle, agent-dev3, one `agent list`) : 29 sudo lines, 29 denials
+#     treatment cold breaker                            : 3 sudo calls, 0 sudo lines, 1 warn
+#     treatment warm breaker                            : 0 sudo calls, 0 sudo lines
+#     as root, old vs new `agent list --json`           : byte-identical, 18 rows / 13 models
+# That is a deliberate coverage limit, not a claim these arms prove the host behaviour.
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+set +e -o pipefail
+TMP="$(mktemp -d)"
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+SRC="$ROOT/src/cmd_agent.sh"
+
+pass=0; fail=0
+ok_t()  { printf 'ok   - %s\n' "$1"; pass=$((pass+1)); }
+bad_t() { printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; fail=$((fail+1)); }
+
+[[ -s "$SRC" ]] \
+  && ok_t 'T0 cmd_agent.sh is present — the arms below are not reading an empty file' \
+  || { bad_t 'T0 cmd_agent.sh missing — every arm is vacuous' "src=$SRC"; echo "-----"; \
+       echo "agent_priv_read_breaker_unit: $pass passed, $fail failed"; exit 1; }
+
+# Source ONLY the helper block. cmd_agent.sh is not sourceable standalone (it expects the
+# bundle's globals), so pull the four functions out by name into a subshell-safe file.
+# If the extraction stops matching the source, T1 fails loudly rather than silently
+# testing nothing — a harness whose subject moved must report a finding, not a pass.
+sed -n '/^_priv_state_file()/,/^}/p;/^_priv_denials()/,/^}/p;/^_priv_note()/,/^}/p;/^priv_read()/,/^}/p' \
+  "$SRC" > "$TMP/helpers.sh"
+helper_count=$(grep -cE '^(_priv_state_file|_priv_denials|_priv_note|priv_read)\(\)' "$TMP/helpers.sh")
+if [[ "$helper_count" == 4 ]]; then
+  ok_t 'T1 all four helpers extracted (state_file, denials, note, priv_read)'
+else
+  bad_t 'T1 helper extraction found the wrong number of functions — arms below are not testing the shipped code' \
+        "expected 4, got $helper_count"
+fi
+
+# shellcheck disable=SC1091
+( set -e; . "$TMP/helpers.sh" ) 2>/dev/null \
+  && ok_t 'T2 the extracted helper block is syntactically sourceable' \
+  || bad_t 'T2 extracted helpers do not source' ''
+
+export XDG_CACHE_HOME="$TMP/cache"
+
+# ---- T3: readable file -> read DIRECTLY, and an empty value stays empty --------------
+# The escalation trigger must be READABILITY, not emptiness. A claude agent with no
+# `model` key is a legitimate empty; escalating on "" would sudo for every unset agent on
+# every sweep forever — the exact shape of the original flood.
+run_t3() {
+  . "$TMP/helpers.sh"
+  local f="$TMP/readable.json"; printf '{"other":1}\n' >"$f"
+  # A stub `sudo` on PATH turns any escalation into a hard, visible failure.
+  printf '#!/usr/bin/env bash\necho ESCALATED >&2\nexit 99\n' >"$TMP/bin/sudo"
+  chmod +x "$TMP/bin/sudo"; PATH="$TMP/bin:$PATH"
+  local out; out=$(priv_read "$f" jq -r '.model // empty' "$f" 2>"$TMP/t3.err")
+  [[ -z "$out" ]] || { echo "value=[$out]"; return 1; }
+  grep -q ESCALATED "$TMP/t3.err" && return 2
+  return 0
+}
+mkdir -p "$TMP/bin"
+( run_t3 ) >"$TMP/t3.log" 2>&1; t3=$?
+case "$t3" in
+  0) ok_t 'T3 a readable file is read directly and an empty value does NOT escalate' ;;
+  2) bad_t 'T3 escalated to sudo for a file it could read — the reflex is back' "$(cat "$TMP/t3.log")" ;;
+  *) bad_t 'T3 direct read returned the wrong value' "$(cat "$TMP/t3.log")" ;;
+esac
+
+# ---- T4: unreadable file -> escalates, and the escalation carries -n ----------------
+# `-n` is the difference between a silent refusal and a syslog line, so assert the flag
+# is on the actual argv, not merely present somewhere in the file.
+run_t4() {
+  . "$TMP/helpers.sh"
+  mkdir -p "$TMP/bin4"
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >>"%s/argv"\nexit 1\n' "$TMP" >"$TMP/bin4/sudo"
+  chmod +x "$TMP/bin4/sudo"; PATH="$TMP/bin4:$PATH"
+  priv_read "/nonexistent-unreadable/settings.json" jq -r '.model' /nonexistent-unreadable/settings.json >/dev/null 2>&1
+  [[ -s "$TMP/argv" ]] || return 1
+  head -1 "$TMP/argv" | grep -q -- '^-n ' || return 2
+  return 0
+}
+( run_t4 ) >"$TMP/t4.log" 2>&1; t4=$?
+case "$t4" in
+  0) ok_t 'T4 an unreadable file escalates, and the sudo call passes -n (no syslog line, no mail)' ;;
+  1) bad_t 'T4 never escalated for an unreadable file — the value would be silently lost' "$(cat "$TMP/t4.log")" ;;
+  2) bad_t 'T4 escalated WITHOUT -n — this is the flag that emits the denial line' "$(head -1 "$TMP/argv" 2>/dev/null)" ;;
+  *) bad_t 'T4 unexpected failure' "$(cat "$TMP/t4.log")" ;;
+esac
+
+# ---- T5: the breaker latches, and it latches ACROSS SUBSHELLS -----------------------
+# The regression that makes this whole fix inert: every caller invokes the resolvers as
+# `model=$(resolve_agent_model …)`, so a counter held in a shell VARIABLE is written in a
+# subshell and discarded. It would read as working in isolation and never latch in
+# production. This arm calls priv_read inside `$( )` — the way the real callers do.
+run_t5() {
+  . "$TMP/helpers.sh"
+  mkdir -p "$TMP/bin5"
+  printf '#!/usr/bin/env bash\necho CALL >>"%s/calls"\necho "sudo: a password is required" >&2\nexit 1\n' "$TMP" >"$TMP/bin5/sudo"
+  chmod +x "$TMP/bin5/sudo"; PATH="$TMP/bin5:$PATH"
+  export PRIV_READ_MAX_DENIALS=3
+  local i v
+  for i in 1 2 3 4 5 6 7 8; do
+    v=$(priv_read "/nonexistent-unreadable/a$i.json" jq -r .model "/nonexistent-unreadable/a$i.json" 2>/dev/null)
+  done
+  local calls; calls=$(grep -c CALL "$TMP/calls" 2>/dev/null || echo 0)
+  echo "calls=$calls"
+  [[ "$calls" == 3 ]] || return 1
+  return 0
+}
+( run_t5 ) >"$TMP/t5.log" 2>&1; t5=$?
+if [[ "$t5" == 0 ]]; then
+  ok_t 'T5 the breaker latches at PRIV_READ_MAX_DENIALS across subshell callers (8 agents -> 3 sudo calls)'
+else
+  bad_t 'T5 breaker did not bound the sudo calls — 8 unreadable agents must cost 3 attempts, not 8' \
+        "$(cat "$TMP/t5.log")"
+fi
+
+# ---- T6: exactly ONE warn line, however many agents are swept ------------------------
+# A silently degraded read is bad; a degraded read that warns once per agent per minute is
+# worse than the bug. The operator gets told once.
+run_t6() {
+  . "$TMP/helpers.sh"
+  mkdir -p "$TMP/bin6"
+  printf '#!/usr/bin/env bash\necho "sudo: a password is required" >&2\nexit 1\n' >"$TMP/bin6/sudo"
+  chmod +x "$TMP/bin6/sudo"; PATH="$TMP/bin6:$PATH"
+  export PRIV_READ_MAX_DENIALS=3
+  local i
+  for i in 1 2 3 4 5 6; do
+    priv_read "/nonexistent-unreadable/b$i.json" jq -r .model "/nonexistent-unreadable/b$i.json" >/dev/null
+  done
+}
+export XDG_CACHE_HOME="$TMP/cache6"
+( run_t6 ) >/dev/null 2>"$TMP/t6.err"
+warns=$(grep -c 'DIVE-2791' "$TMP/t6.err" 2>/dev/null || echo 0)
+if [[ "$warns" == 1 ]]; then
+  ok_t 'T6 exactly one warn line for a whole sweep (not one per agent)'
+else
+  bad_t 'T6 wrong number of warn lines — expected exactly 1' "got $warns"
+fi
+
+# ---- T7: no unconditional sudo left in the three resolvers --------------------------
+# ANCHOR against the reflex returning to these functions specifically. Scoped to the
+# resolver bodies, so an unrelated privileged WRITE elsewhere in the file cannot red it.
+res_block=$(sed -n '/^resolve_cli_version()/,/^}/p;/^resolve_agent_model()/,/^}/p;/^resolve_agent_effort()/,/^}/p' "$SRC")
+if printf '%s\n' "$res_block" | grep -qE '(^|[^-[:alnum:]_])sudo[[:space:]]+(-u[[:space:]]+[[:alnum:]_-]+[[:space:]]+)?(jq|sed|bash|cat)'; then
+  bad_t 'T7 a resolver still calls sudo directly on a read — routing bypassed' \
+        "$(printf '%s\n' "$res_block" | grep -nE 'sudo[[:space:]]+' | head -3)"
+else
+  ok_t 'T7 ANCHOR no resolver reaches for sudo directly; reads go through priv_read / the -n guard'
+fi
+
+# ---- T8: an UNSET bound must not disable escalation ---------------------------------
+# Found by this harness on first run, and it is the reason the bound is resolved inside
+# the function rather than read from the global. `(( n >= PRIV_READ_MAX_DENIALS ))` with
+# the constant unset is `0 >= 0` — TRUE — so priv_read read as "already latched" and
+# returned "" for every agent without ever calling sudo and without a warn line. The
+# bundle assigns the constant at top level so it is set in production, but the failure
+# depends only on source order and is completely silent, which is exactly the class this
+# row exists to remove. This arm sources the FUNCTIONS ONLY, deliberately reproducing
+# that context.
+run_t8() {
+  . "$TMP/helpers.sh"
+  unset PRIV_READ_MAX_DENIALS PRIV_READ_TTL
+  mkdir -p "$TMP/bin8"
+  printf '#!/usr/bin/env bash\necho CALL >>"%s/calls8"\nexit 1\n' "$TMP" >"$TMP/bin8/sudo"
+  chmod +x "$TMP/bin8/sudo"; PATH="$TMP/bin8:$PATH"
+  priv_read "/nonexistent-unreadable/c.json" jq -r .model "/nonexistent-unreadable/c.json" >/dev/null 2>&1
+  [[ -s "$TMP/calls8" ]] || return 1
+  return 0
+}
+export XDG_CACHE_HOME="$TMP/cache8"
+( run_t8 ) >"$TMP/t8.log" 2>&1; t8=$?
+if [[ "$t8" == 0 ]]; then
+  ok_t 'T8 escalation still happens with PRIV_READ_MAX_DENIALS unset (bound defaults inside the function)'
+else
+  bad_t 'T8 an unset bound silently disabled escalation — 0 >= 0 is true; default the bound locally' \
+        "$(cat "$TMP/t8.log")"
+fi
+
+echo "-----"
+echo "agent_priv_read_breaker_unit: $pass passed, $fail failed"
+rc=0; [[ $fail -eq 0 ]] || rc=1
+exit "$rc"


### PR DESCRIPTION
## What

`resolve_agent_model` / `resolve_agent_effort` / `resolve_cli_version` in `src/cmd_agent.sh` each
reached straight for `sudo`, and they run once **per agent** on every fleet sweep (`agent list`,
`compose`). On a scoped agent that is one refusal per agent per sweep — **29 syslog lines from a
single `agent list`**, 224 in 24h across the control plane. Where sudoers sets `mail_no_perms` each
line is also a mail to root; a reporter's box ran that chain for 9 days, ~39,400 delivery attempts
to an address that did not exist off-box, and the IP landed on **Spamhaus CSS and XBL**. No
compromise, five internal addresses total — volume to a nonexistent recipient is just
indistinguishable from abuse at the receiving end.

## The mechanism, which is sharper than "it sudos too much"

The syslog line comes from invoking sudo **without `-n`**. Measured as a scoped agent against a
file it cannot read:

```
sudo    jq -r .model <other-agent>/settings.json
  -> stderr "a terminal is required…" + "a password is required"
  -> journal: <agent> : command not allowed ; … COMMAND=/usr/bin/jq …

sudo -n jq -r .model <other-agent>/settings.json
  -> stderr "a password is required"
  -> journal: NOTHING
```

Same refusal, same exit code. **One logs and one does not.** So the three parts of this change fix
three different halves, and all are load-bearing:

| part | removes |
|---|---|
| `sudo -n` | the syslog line, therefore the mail |
| circuit breaker (latches after N refusals) | the wasted process spawns, and the log lines on a box where sudo *does* log |
| read unprivileged first | the escalation entirely, for a caller who could just read the file |

Escalation is keyed on **readability, not emptiness**. An unset `model` is a legitimate empty
value, so escalating on `""` would sudo for every unset agent on every sweep forever — the
original flood shape.

## Two traps this had to avoid

- **The breaker cannot live in a shell variable.** Every caller invokes these as
  `model=$(resolve_agent_model …)`; a subshell cannot write a variable back to its parent, so a
  variable-held counter resets per agent and never latches — correct in isolation, inert in
  production. State is a file under the caller's own `XDG_CACHE_HOME`.
- **`(( n >= PRIV_READ_MAX_DENIALS ))` with the constant unset is `0 >= 0` — true**, which reads as
  "already latched" and silently disables escalation for every agent with no warn line. The bundle
  assigns it at top level so production was safe, but the failure depends only on source order and
  is completely silent. Both bounds now default *inside* the functions. **The new harness caught
  this on its first run.**

Knobs: `PRIV_READ_MAX_DENIALS` (3), `PRIV_READ_TTL` (900s, so a widened sudoers grant is picked up
rather than latched off forever).

## Measured

One `agent list` as a genuinely scoped agent, counted off an absolute journal cursor:

| arm | sudo journal lines | warns | breaker |
|---|---|---|---|
| old bundle | **29** | 0 | n/a |
| new, cold | **0** | 1 | latched at 3 |
| new, warm (x2) | **0** | 0 | latched |
| as root, `agent list --json` old vs new | — | — | **byte-identical**, 18 rows / 13 models |

Two of my own probes were nearly false greens and are worth naming: the first count used a sliding
`--since "-1min"` window and reported **delta = -17** (entries aged out faster than new ones
arrived — a sliding window cannot measure a delta); and the first "root values identical" was a
**diff of two empty files**, because the jq had missed the `{ok,data}` envelope. Counting the
substring `not allowed` is a third trap — it scores `-n`'s different refusal text as a pass, so the
final numbers count *all* sudo entries for the uid.

## Tests

`tests/agent_priv_read_breaker_unit.sh` — core tier, **9 arms, 0.32s**.

T3-T6/T8 execute the real functions against a stubbed `sudo`, so they prove the routing and the
breaker and **can say nothing about a sudoers decision** (see
`community/wiki/a-stubbed-sudo-cannot-see-a-sudoers-argv-denial.md`). The host before/after needs a
second, differently-scoped uid and cannot live in a harness at all; it is recorded on the row with
that coverage limit stated in the header rather than asserted.

**Mutation-tested:** reintroducing a bare `sudo jq` in a resolver reds T7; making the breaker
non-persistent reds T5 and T6.

## Scope

DIVE-2791 was filed as one row attributing the 224 denials to the telegram plugin's 60s
`reconcileNeedsBanner` poll. The count was right and the attribution was wrong, so the row split:
this PR is **A**, the CLI reader, which owns the volume. **B** — hardening the plugin's
`read5diveJson`, which does sudo unconditionally under a real 60s timer — is a separate follow-up
with the acceptance criterion as originally filed.

## Not in this PR

`tests/actor_claim_corroboration_unit.sh` fails `T19 e2e: created_by=''` — **identically on a clean
`origin/main` worktree** (23 passed / 1 failed either side), so it is pre-existing and not touched
here. Worth its own row: with no built `./5dive` it *skips* T19-T21 and reports `14 passed, 0
failed, RC=0`, so the differing arm count is the only tell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
