### PR TITLE
fix(tasks-db): complete the canonical schema and gate the migration (DIVE-2808, supersedes #506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,19 @@ branch does not exist on the remote. Fleet coverage on this host went **1 → 22
 23**; the remaining one is a worktree owned by a uid this session cannot assume, and
 its origin is a local path whose target is guarded.
 
+## v0.19.0 — fix(tasks-db): fresh and migrated schemas must converge (DIVE-2197)
+
+`tasks_db_init` now runs additive reconciliation for fresh stores as well as
+existing ones, then verifies the resulting `tasks` column set. This restores six
+columns that the canonical fresh schema omitted (`delivery_ref`, `delivered_at`,
+`parked_at`, `park_reason`, `escalated_at`, `escalated_by`) and turns a failed
+`ALTER TABLE` into a loud initialization failure instead of a healthy-looking
+partial schema.
+
+The isolated restore harness asserts all six columns on a fresh `STATE_DIR` and
+injects a failure into the `delivery_ref` ALTER. Removing only the resulting-set
+assertion makes that arm red, proving the refusal is connected to the source path.
+
 ## v0.19.0 — fix(heartbeat): surface a recurring instance that was never started (DIVE-2693)
 
 The stall sweep keys on `handoff_delivered_at`. A materialized recurring instance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,17 +72,23 @@ previously existed only in the additive migration list (`delivery_ref`,
 `delivered_at`, `delivery_ref_iteration`, `parked_at`, `park_reason`,
 `escalated_at`, `escalated_by`, and `human_evidence`). `tasks_db_init` checks the
 current column set once and skips the full migration when it is already complete.
-The gate uses pure Bash matching and derives its requirements from the exact array
-the migration loop consumes, so it cannot become a third drifting column list.
+The gate uses pure Bash matching and derives its task-column requirements from the
+exact array the migration loop consumes, so it cannot become a third drifting
+column list. A whole-schema epoch separately covers migrations outside `tasks`:
+fresh canonical stores stamp it in their original schema invocation; older stores
+run the full migration once, prove every canonical table/column/index is present,
+then stamp it. A tasks-current store with a stale `gate_history` therefore cannot
+skip the repair.
 
 DIVE-2197's loud resulting-set assertion remains on both the migrate and skip
 paths. The isolated restore harness proves all 71 columns exist on a fresh
 `STATE_DIR`, injects a failed `delivery_ref` ALTER, forces a lying skip-gate over
-the same one-column hole, and appends a test-only column to the migration array to
-show that the gate and ALTER path follow it. On this 4-core host, 20 isolated fresh
-initializations measured a 126 ms median, 22 ms over the 104 ms pre-DIVE-2197
-baseline and within the 30 ms acceptance envelope; the full migration had measured
-517 ms.
+the same one-column hole, appends a test-only column to the migration array to show
+that the gate and ALTER path follow it, and removes a non-`tasks` migration column
+from a pre-epoch fixture to prove the full migration repairs it. On this 4-core
+host, contemporaneous 20-run isolated medians were 133 ms for the pinned
+pre-DIVE-2197 base (`1bde9dc`) and 145 ms here: **+12 ms**, inside the 30 ms
+acceptance envelope. The full migration had measured 517 ms.
 
 ## v0.19.0 — fix(heartbeat): surface a recurring instance that was never started (DIVE-2693)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,10 +90,16 @@ Two things the epoch had to learn, both of which reddened unrelated harnesses fi
   emits is `CREATE … IF NOT EXISTS`, so replaying it over an existing store is a
   no-op — a contract the migration driver and four other harnesses rely on, and a
   bare `INSERT` is the one statement that breaks it.
-- **The gate requires the seeded `ledger_started` marker, not only the right shape.**
-  The migration *seeds* as well as reshapes; skipping it dropped a self-heal that no
-  schema comparison can miss, because the store is shape-perfect and semantically
-  wrong.
+- **The gate requires the migration's seeded rows, not only the right shape.** The
+  migration *seeds* as well as reshapes; skipping it dropped self-heals that no schema
+  comparison can miss, because the store is shape-perfect and semantically wrong. Both
+  seeded prefs are covered — `ledger_started` (INST-4), which `trace` reads as a ledger
+  predating everything when absent, and `gate_history_coverage` (DIVE-2133), the
+  evidence boundary that lets a zero-row archive mean "no gates were displaced" rather
+  than "unknown". The first cut covered only the former and reddened
+  `tests/gate_history_unit.sh` in the nightly sweep. The gate's seed list is therefore
+  **derived from the migration's own source** and compared in both directions, the same
+  anti-drift rule the column list already follows.
 
 The epoch does **not** assert the canonical surface item for item. The curated
 migration was never a convergence engine and `CREATE TABLE IF NOT EXISTS` cannot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,18 +65,24 @@ branch does not exist on the remote. Fleet coverage on this host went **1 → 22
 23**; the remaining one is a worktree owned by a uid this session cannot assume, and
 its origin is a local path whose target is guarded.
 
-## v0.19.0 — fix(tasks-db): fresh and migrated schemas must converge (DIVE-2197)
+## v0.19.0 — fix(tasks-db): converge schemas without taxing every init (DIVE-2197, DIVE-2808)
 
-`tasks_db_init` now runs additive reconciliation for fresh stores as well as
-existing ones, then verifies the resulting `tasks` column set. This restores six
-columns that the canonical fresh schema omitted (`delivery_ref`, `delivered_at`,
-`parked_at`, `park_reason`, `escalated_at`, `escalated_by`) and turns a failed
-`ALTER TABLE` into a loud initialization failure instead of a healthy-looking
-partial schema.
+The canonical `tasks` CREATE now contains all 71 columns, including the eight that
+previously existed only in the additive migration list (`delivery_ref`,
+`delivered_at`, `delivery_ref_iteration`, `parked_at`, `park_reason`,
+`escalated_at`, `escalated_by`, and `human_evidence`). `tasks_db_init` checks the
+current column set once and skips the full migration when it is already complete.
+The gate uses pure Bash matching and derives its requirements from the exact array
+the migration loop consumes, so it cannot become a third drifting column list.
 
-The isolated restore harness asserts all six columns on a fresh `STATE_DIR` and
-injects a failure into the `delivery_ref` ALTER. Removing only the resulting-set
-assertion makes that arm red, proving the refusal is connected to the source path.
+DIVE-2197's loud resulting-set assertion remains on both the migrate and skip
+paths. The isolated restore harness proves all 71 columns exist on a fresh
+`STATE_DIR`, injects a failed `delivery_ref` ALTER, forces a lying skip-gate over
+the same one-column hole, and appends a test-only column to the migration array to
+show that the gate and ALTER path follow it. On this 4-core host, 20 isolated fresh
+initializations measured a 126 ms median, 22 ms over the 104 ms pre-DIVE-2197
+baseline and within the 30 ms acceptance envelope; the full migration had measured
+517 ms.
 
 ## v0.19.0 — fix(heartbeat): surface a recurring instance that was never started (DIVE-2693)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,21 +74,47 @@ previously existed only in the additive migration list (`delivery_ref`,
 current column set once and skips the full migration when it is already complete.
 The gate uses pure Bash matching and derives its task-column requirements from the
 exact array the migration loop consumes, so it cannot become a third drifting
-column list. A whole-schema epoch separately covers migrations outside `tasks`:
-fresh canonical stores stamp it in their original schema invocation; older stores
-run the full migration once, prove every canonical table/column/index is present,
-then stamp it. A tasks-current store with a stale `gate_history` therefore cannot
-skip the repair.
+column list.
+
+A **whole-schema epoch** covers the migrations that live outside `tasks`, which a
+tasks-column gate cannot see. It is a receipt that the curated migration generation
+named by `_TASKS_SCHEMA_EPOCH` has run to completion on this store — deliberately
+**not** a claim that the store matches the canonical schema item for item. A fresh
+store is stamped on the init path that just built the whole schema from nothing;
+an older store earns the stamp after the full migration runs. A tasks-current store
+with a stale `gate_history` therefore cannot skip the repair.
+
+Two things the epoch had to learn, both of which reddened unrelated harnesses first:
+
+- **The stamp does not live inside the canonical DDL.** Every statement that block
+  emits is `CREATE … IF NOT EXISTS`, so replaying it over an existing store is a
+  no-op — a contract the migration driver and four other harnesses rely on, and a
+  bare `INSERT` is the one statement that breaks it.
+- **The gate requires the seeded `ledger_started` marker, not only the right shape.**
+  The migration *seeds* as well as reshapes; skipping it dropped a self-heal that no
+  schema comparison can miss, because the store is shape-perfect and semantically
+  wrong.
+
+The epoch does **not** assert the canonical surface item for item. The curated
+migration was never a convergence engine and `CREATE TABLE IF NOT EXISTS` cannot
+widen an existing table, so that property holds on no code path — asserting it turned
+a slow init into a hard `fail` on every `5dive task` invocation against a
+legacy-shaped store. `tests/schema_sync_unit.sh` keeps the two copies of those
+`CREATE TABLE` statements from drifting; converging a genuinely short store needs
+per-table ALTERs and its own row.
 
 DIVE-2197's loud resulting-set assertion remains on both the migrate and skip
 paths. The isolated restore harness proves all 71 columns exist on a fresh
 `STATE_DIR`, injects a failed `delivery_ref` ALTER, forces a lying skip-gate over
 the same one-column hole, appends a test-only column to the migration array to show
-that the gate and ALTER path follow it, and removes a non-`tasks` migration column
-from a pre-epoch fixture to prove the full migration repairs it. On this 4-core
-host, contemporaneous 20-run isolated medians were 133 ms for the pinned
-pre-DIVE-2197 base (`1bde9dc`) and 145 ms here: **+12 ms**, inside the 30 ms
-acceptance envelope. The full migration had measured 517 ms.
+that the gate and ALTER path follow it, removes a non-`tasks` migration column from
+a pre-epoch fixture to prove the full migration repairs it, replays the canonical
+schema twice to hold the no-op contract, drives a legacy-shaped store through init
+to prove it completes and then settles, and deletes the ledger marker to prove it
+self-heals. On this 4-core control-plane host, 20 **interleaved** isolated fresh-init
+medians were 125 ms for the pinned pre-DIVE-2197 base (`1bde9dc`) and 127 ms here:
+**+2 ms**, inside the 30 ms acceptance envelope. The full migration had measured
+517 ms.
 
 ## v0.19.0 — fix(heartbeat): surface a recurring instance that was never started (DIVE-2693)
 

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -218,18 +218,15 @@ CREATE TABLE IF NOT EXISTS tasks (
   -- (`council`, `telegram`), so this is what makes a `--from` claim falsifiable
   -- after the fact rather than the only identity on file.
   --
-  -- MUST BE ADDED HERE **AND** in _tasks_db_migrate's array. A fresh store is built
-  -- from this schema and NEVER runs the migration (see tasks_db_init's if/else), so
-  -- a column added only to the array exists on every EXISTING board and on no NEW
-  -- one — and the failure lands on the first write to a brand-new store, which is
-  -- the one case a developer with a working board never exercises. Caught by
-  -- council_schedule_e2e, whose rig starts from an empty dir.
+  -- MUST BE ADDED HERE **AND** in _TASKS_ADDITIVE_COLUMNS. A fresh store is built
+  -- from this schema and DIVE-2808's gate skips the migration only when every
+  -- array column is already present. Keeping the two definitions complete makes
+  -- that fast path both safe and cheap; the convergence assertion is the backstop.
   derived_actor TEXT,
   -- DIVE-2615: why this gate has this tier — axis=pinned|type-default|secret-type
   -- |ask|title|title-fallback|none, plus ;term=<t> where a term is what fired.
-  -- Declared HERE as well as in _tasks_db_migrate: a fresh store takes this CREATE
-  -- and never runs the migration, so the array entry alone left the column missing
-  -- on exactly the boxes that have no history to migrate.
+  -- Declared HERE as well as in _TASKS_ADDITIVE_COLUMNS: a fresh store takes this
+  -- CREATE, and the migration gate must find this column before it may skip.
   floor_provenance TEXT,
   parent_id   INTEGER REFERENCES tasks(id) ON DELETE CASCADE,
   created_at  TEXT NOT NULL DEFAULT (datetime('now')),
@@ -281,6 +278,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   -- enforcement of "no valid sig ⇒ reject" is a later flip, not here.
   need_answered_uid INTEGER,
   need_answer_sig  TEXT,
+  escalated_at     TEXT,
+  escalated_by     TEXT,
   -- DIVE-916: per-gate HUMAN nonce that closes the sudo->--human forge. On a
   -- hard human gate (approval/secret/manual) `task need` mints a 16-byte nonce,
   -- stores ONLY its SHA-256 here, and embeds the RAW nonce solely in the trusted
@@ -291,6 +290,9 @@ CREATE TABLE IF NOT EXISTS tasks (
   -- (SUDO_UID=agent-*, no nonce) is rejected under enforcement. Hash-only at
   -- rest, so a group-readable db leak can't reconstruct the nonce.
   human_nonce_hash TEXT,
+  -- DIVE-1518: independently records which authenticated evidence form cleared
+  -- the current gate (tap nonce, sudo uid, channel session, or proof).
+  human_evidence   TEXT,
   -- Recurring task templates (DIVE step 1). kind='recurring' marks a row as a
   -- TEMPLATE, not work: it's excluded from the work board, the heartbeat TODO
   -- count + wake, and the human inbox, so it's never picked up directly.
@@ -320,6 +322,10 @@ CREATE TABLE IF NOT EXISTS tasks (
   -- working it regardless of the agent-level fresh setting.
   from_template_id INTEGER,
   fresh            INTEGER,
+  -- Parking is task state, not a separate table: these were historically
+  -- migration-only and therefore made a fresh canonical store incomplete.
+  parked_at        TEXT,
+  park_reason      TEXT,
   -- DIVE-476: loop-spec columns — make a task's verify loop declarative + durable
   -- so the (c) deterministic verify-runner (DIVE-475) reads its inputs off the row
   -- instead of every caller re-passing them. acceptance_criteria = the human-
@@ -466,6 +472,10 @@ CREATE TABLE IF NOT EXISTS tasks (
   -- boundary is unchanged for anything not explicitly routed. `secret` is never
   -- routed (stays hard-human), and a tier-2 gate is never routed.
   routed_reviewer     TEXT,
+  -- DIVE-1376/DIVE-2728: merge-gate binding and the loop iteration it belongs to.
+  delivery_ref           TEXT,
+  delivered_at           TEXT,
+  delivery_ref_iteration INTEGER,
   -- OSS-27 (OSS-19 re-plan cycle): provenance for a task ORIGINATED by an
   -- objective's planner cycle. originated_by_objective = objectives.id that
   -- filed it; originated_cycle = the objective_cycles.cycle_no it was filed in.
@@ -1056,98 +1066,102 @@ tasks_db_init() {
       chmod 0660 "$TASKS_DB" 2>/dev/null || true
     fi
   fi
-  # DIVE-2197: fresh and restored stores need the same additive reconciliation
-  # as an existing store. The canonical CREATE TABLE historically omitted six
-  # additive columns, and skipping this call made an isolated STATE_DIR report a
-  # healthy-but-partial schema. _tasks_db_migrate now verifies the result, so a
-  # failed ALTER is loud instead of being hidden by its idempotency guard.
-  _tasks_db_migrate
+  # DIVE-2808: the canonical schema is complete, so almost every invocation can
+  # skip the expensive reconciliation. The gate and the migration consume the
+  # SAME array below; pure-Bash membership avoids one grep process per column.
+  # Both arms retain DIVE-2197's resulting-set assertion.
+  if _tasks_db_migration_needed; then
+    _tasks_db_migrate
+  else
+    _tasks_db_assert_required_columns "$_TASKS_DB_GATE_COLUMNS"
+  fi
   # DIVE-1479: stamp the durable "this board exists" sentinel (idempotent). On a
   # pre-existing board this is the one-time backfill so a later wipe is caught.
   _tasks_mark_initialized
 }
 
-# Idempotent additive migrations for already-initialised stores. sqlite has
-# no `ADD COLUMN IF NOT EXISTS`, so we check pragma_table_info first. Each
-# migration is a one-shot check + ALTER; running it on every init is cheap
-# (single PRAGMA read). Add new column migrations to the array below.
+# One source of truth for both migration and its skip-gate. Each entry is
+# "<column> <type>"; existing rows backfill to NULL. Pure expand (no contract),
+# so old queries/rows remain readable after downgrade. project_key deliberately
+# omits REFERENCES here because sqlite rejects a non-NULL FK default on ADD.
+_TASKS_ADDITIVE_COLUMNS=(
+  'result TEXT' 'need_type TEXT' 'ask TEXT' 'need_options TEXT' 'recommend TEXT'
+  'need_answer TEXT' 'need_answered_at TEXT'
+  "kind TEXT NOT NULL DEFAULT 'standard'" 'schedule TEXT' 'last_fired_at TEXT'
+  'from_template_id INTEGER' 'fresh INTEGER'
+  'parked_at TEXT' 'park_reason TEXT' 'need_answered_by TEXT'
+  'need_answered_uid INTEGER' 'need_answer_sig TEXT'
+  'escalated_at TEXT' 'escalated_by TEXT'
+  "project_key TEXT NOT NULL DEFAULT 'dive'" 'issue_number INTEGER'
+  'acceptance_criteria TEXT' 'verify_command TEXT' 'max_iterations INTEGER' 'verifier TEXT'
+  'iteration INTEGER' 'maker_agent TEXT' 'handoff_ack_at TEXT' 'task_budget TEXT'
+  'handoff_delivered_at TEXT' 'handoff_stale_pinged_at TEXT' 'handoff_rejected_at TEXT'
+  'recurring_stall_pinged_at TEXT'
+  'tier INTEGER' 'need_asked_at TEXT' 'gate_pinged_at TEXT' 'wake_at TEXT'
+  'gate_filed_by TEXT'
+  'secret_key TEXT' 'connector TEXT' 'secret_oob TEXT' 'human_nonce_hash TEXT'
+  'ask_shape TEXT' 'precedent_ref INTEGER' 'precedent_kind TEXT'
+  'needs_capability TEXT'
+  'shipped_flag_at TEXT' 'routed_reviewer TEXT'
+  'delivery_ref TEXT' 'delivered_at TEXT' 'delivery_ref_iteration INTEGER'
+  'originated_by_objective INTEGER' 'originated_cycle INTEGER'
+  'verify_unavailable INTEGER' 'last_skipped_at TEXT'
+  'human_evidence TEXT' 'derived_actor TEXT' 'floor_provenance TEXT'
+)
+_TASKS_DB_GATE_COLUMNS=''
+
+# Exact newline membership without a subprocess. The newline frame prevents a
+# prefix (need_ty) from satisfying a full column name (need_type).
+_tasks_columns_have_all_additive() { # <newline-delimited pragma names>
+  local cols="${1:-}" c name framed
+  framed=$'\n'"$cols"$'\n'
+  for c in "${_TASKS_ADDITIVE_COLUMNS[@]}"; do
+    name="${c%% *}"
+    [[ "$framed" == *$'\n'"$name"$'\n'* ]] || return 1
+  done
+  return 0
+}
+
+_tasks_db_migration_needed() {
+  _TASKS_DB_GATE_COLUMNS=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
+    "SELECT name FROM pragma_table_info('tasks');" 2>/dev/null) || return 0
+  ! _tasks_columns_have_all_additive "$_TASKS_DB_GATE_COLUMNS"
+}
+
+# DIVE-2197's resulting-set assertion. It is called after a real migration and
+# on the skip path, so an ALTER failure and a lying gate are both loud.
+_tasks_db_assert_required_columns() {
+  local final_cols c name
+  local -a missing_columns=()
+  if (($#)); then
+    final_cols="$1"
+  else
+    final_cols=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
+                 "SELECT name FROM pragma_table_info('tasks');" 2>/dev/null)
+  fi
+  local framed=$'\n'"$final_cols"$'\n'
+  for c in "${_TASKS_ADDITIVE_COLUMNS[@]}"; do
+    name="${c%% *}"
+    [[ "$framed" == *$'\n'"$name"$'\n'* ]] || missing_columns+=("$name")
+  done
+  ((${#missing_columns[@]} == 0)) || fail "$E_GENERIC" \
+    "tasks db schema incomplete after migration — missing columns: ${missing_columns[*]} (DIVE-2197)"
+}
+
+# Idempotent additive migrations for stores that fail the gate above.
 _tasks_db_migrate() {
-  local cols
+  local cols c name framed
   cols=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
          "SELECT name FROM pragma_table_info('tasks');" 2>/dev/null)
-  local c
-  local -a required_columns=()
-  # Each entry: "<column> <type>". Add new additive columns here; existing
-  # rows backfill to NULL. Pure expand (no contract), so old queries/rows are
-  # untouched and a downgrade still reads/writes the table fine.
-  # NB project_key uses a constant DEFAULT (no REFERENCES) — sqlite forbids
-  # ADD COLUMN with a foreign key unless the default is NULL. The FK is declared
-  # in _tasks_schema for fresh boxes; on migrated stores the project_key→projects
-  # link is enforced at the app layer (project add/resolve), same as parent_id's
-  # behavior pre-FK. issue_number is the per-project sequence (DIVE-484).
-  for c in 'result TEXT' 'need_type TEXT' 'ask TEXT' 'need_options TEXT' 'recommend TEXT' 'need_answer TEXT' 'need_answered_at TEXT' \
-           "kind TEXT NOT NULL DEFAULT 'standard'" 'schedule TEXT' 'last_fired_at TEXT' \
-           'from_template_id INTEGER' 'fresh INTEGER' \
-           'parked_at TEXT' 'park_reason TEXT' 'need_answered_by TEXT' \
-           'need_answered_uid INTEGER' 'need_answer_sig TEXT' \
-           'escalated_at TEXT' 'escalated_by TEXT' \
-           "project_key TEXT NOT NULL DEFAULT 'dive'" 'issue_number INTEGER' \
-           'acceptance_criteria TEXT' 'verify_command TEXT' 'max_iterations INTEGER' 'verifier TEXT' \
-           'iteration INTEGER' 'maker_agent TEXT' 'handoff_ack_at TEXT' 'task_budget TEXT' \
-           'handoff_delivered_at TEXT' 'handoff_stale_pinged_at TEXT' \
-           'handoff_rejected_at TEXT' \
-           'recurring_stall_pinged_at TEXT' \
-           'tier INTEGER' 'need_asked_at TEXT' 'gate_pinged_at TEXT' 'wake_at TEXT' \
-           'gate_filed_by TEXT' \
-           'secret_key TEXT' 'connector TEXT' 'secret_oob TEXT' 'human_nonce_hash TEXT' \
-           'ask_shape TEXT' 'precedent_ref INTEGER' 'precedent_kind TEXT' \
-           'needs_capability TEXT' \
-           'shipped_flag_at TEXT' 'routed_reviewer TEXT' \
-           'delivery_ref TEXT' 'delivered_at TEXT' 'delivery_ref_iteration INTEGER' \
-           'originated_by_objective INTEGER' 'originated_cycle INTEGER' \
-           'verify_unavailable INTEGER' 'last_skipped_at TEXT' \
-           'human_evidence TEXT' \
-           'derived_actor TEXT' \
-           'floor_provenance TEXT'; do
-    required_columns+=("${c%% *}")
-    # DIVE-2418: herestring, NOT a pipe. `printf | grep -q` lets grep exit on its
-    # first match while printf is still writing, and printf then takes SIGPIPE and
-    # emits "write error: Broken pipe" on stderr. This runs from tasks_db_init on
-    # essentially every `5dive task` invocation, so the stray line can surface
-    # anywhere — it is not test-only. It reddened CI on 0efcd66 by landing INSIDE a
-    # harness's captured stream (loop_panel_unit T6 redirects 2>&1 into the file it
-    # then jq-parses), so the assertion failed while the subject under test had
-    # succeeded. A herestring has no pipe, so no SIGPIPE is possible.
-    #
-    # THE MECHANISM IS NOT ESTABLISHED AND THIS FIX DOES NOT DEPEND ON IT. olivia
-    # built the exact shape at the real payload size (~70 short strings, far under
-    # the 64KB pipe buffer) with the match on line one and got ZERO broken pipes in
-    # 400 runs, so the obvious early-exit story does not reproduce where it actually
-    # occurs; CI under load is the untested variable. Removing the pipe removes the
-    # class regardless of which race fires. Semantics verified equivalent over five
-    # probes including the prefix case `grep -x` must reject (need_ty vs need_type).
-    #
-    # If anyone adds `set -o pipefail` on this path, the SIGPIPE stops being
-    # cosmetic and becomes a hard failure in schema migration.
-    if ! grep -qx "${c%% *}" <<<"$cols"; then
+  framed=$'\n'"$cols"$'\n'
+  for c in "${_TASKS_ADDITIVE_COLUMNS[@]}"; do
+    name="${c%% *}"
+    if [[ "$framed" != *$'\n'"$name"$'\n'* ]]; then
       sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
         "ALTER TABLE tasks ADD COLUMN ${c};" >/dev/null 2>&1 || true
     fi
   done
-  # DIVE-2197: `|| true` above is necessary for duplicate-column races between
-  # concurrent initializers, but it must not turn every other ALTER failure into
-  # success. Re-read the schema after the attempts and assert the anchor: every
-  # additive column is present. This also grades a genuinely fresh store because
-  # tasks_db_init now sends that path through this reconciliation.
-  local final_cols
-  final_cols=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
-               "SELECT name FROM pragma_table_info('tasks');" 2>/dev/null)
-  local -a missing_columns=()
-  for c in "${required_columns[@]}"; do
-    grep -qx "$c" <<<"$final_cols" || missing_columns+=("$c")
-  done
-  ((${#missing_columns[@]} == 0)) || fail "$E_GENERIC" \
-    "tasks db schema incomplete after migration — missing columns: ${missing_columns[*]} (DIVE-2197)"
+  _tasks_db_assert_required_columns
 
   # OSS-11 precedent-lookup index (idempotent; harmless if the columns just
   # backfilled to NULL above — an all-NULL ask_shape simply never matches).

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -1050,15 +1050,18 @@ tasks_db_init() {
     # Only a genuinely fresh box (no sentinel, no snapshot) gets a new schema.
     if _tasks_board_existed; then
       _tasks_board_recover
-      _tasks_db_migrate            # bring the restored snapshot up to current schema
     else
       sqlite3 -cmd ".timeout 5000" "$TASKS_DB" < <(_tasks_schema) >/dev/null \
         || fail "$E_GENERIC" "failed to initialise tasks db at $TASKS_DB"
       chmod 0660 "$TASKS_DB" 2>/dev/null || true
     fi
-  else
-    _tasks_db_migrate
   fi
+  # DIVE-2197: fresh and restored stores need the same additive reconciliation
+  # as an existing store. The canonical CREATE TABLE historically omitted six
+  # additive columns, and skipping this call made an isolated STATE_DIR report a
+  # healthy-but-partial schema. _tasks_db_migrate now verifies the result, so a
+  # failed ALTER is loud instead of being hidden by its idempotency guard.
+  _tasks_db_migrate
   # DIVE-1479: stamp the durable "this board exists" sentinel (idempotent). On a
   # pre-existing board this is the one-time backfill so a later wipe is caught.
   _tasks_mark_initialized
@@ -1073,6 +1076,7 @@ _tasks_db_migrate() {
   cols=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
          "SELECT name FROM pragma_table_info('tasks');" 2>/dev/null)
   local c
+  local -a required_columns=()
   # Each entry: "<column> <type>". Add new additive columns here; existing
   # rows backfill to NULL. Pure expand (no contract), so old queries/rows are
   # untouched and a downgrade still reads/writes the table fine.
@@ -1105,6 +1109,7 @@ _tasks_db_migrate() {
            'human_evidence TEXT' \
            'derived_actor TEXT' \
            'floor_provenance TEXT'; do
+    required_columns+=("${c%% *}")
     # DIVE-2418: herestring, NOT a pipe. `printf | grep -q` lets grep exit on its
     # first match while printf is still writing, and printf then takes SIGPIPE and
     # emits "write error: Broken pipe" on stderr. This runs from tasks_db_init on
@@ -1129,6 +1134,21 @@ _tasks_db_migrate() {
         "ALTER TABLE tasks ADD COLUMN ${c};" >/dev/null 2>&1 || true
     fi
   done
+  # DIVE-2197: `|| true` above is necessary for duplicate-column races between
+  # concurrent initializers, but it must not turn every other ALTER failure into
+  # success. Re-read the schema after the attempts and assert the anchor: every
+  # additive column is present. This also grades a genuinely fresh store because
+  # tasks_db_init now sends that path through this reconciliation.
+  local final_cols
+  final_cols=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
+               "SELECT name FROM pragma_table_info('tasks');" 2>/dev/null)
+  local -a missing_columns=()
+  for c in "${required_columns[@]}"; do
+    grep -qx "$c" <<<"$final_cols" || missing_columns+=("$c")
+  done
+  ((${#missing_columns[@]} == 0)) || fail "$E_GENERIC" \
+    "tasks db schema incomplete after migration — missing columns: ${missing_columns[*]} (DIVE-2197)"
+
   # OSS-11 precedent-lookup index (idempotent; harmless if the columns just
   # backfilled to NULL above — an all-NULL ask_shape simply never matches).
   sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -885,11 +885,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS lifecycle_events_idem_idx ON lifecycle_events(
 CREATE INDEX IF NOT EXISTS lifecycle_events_ident_idx ON lifecycle_events(ident, id);
 CREATE INDEX IF NOT EXISTS lifecycle_events_ts_idx ON lifecycle_events(ts, kind);
 SQL
-  # DIVE-2808: a fresh store is born at the current whole-schema epoch in the
-  # SAME sqlite invocation. Existing stores earn this receipt only after the
-  # complete migration and canonical-surface assertion below.
-  printf "INSERT INTO task_prefs(key,value) VALUES ('schema_epoch',%s);\n" \
-    "$(sqlq "$_TASKS_SCHEMA_EPOCH")"
 }
 
 # -------- DIVE-1479: silent-recreate trap guard --------
@@ -1068,8 +1063,30 @@ tasks_db_init() {
       _tasks_board_recover
     else
       local fresh_payload row
+      # DIVE-2808: a fresh store is born at the current whole-schema epoch in the
+      # SAME sqlite invocation. Existing stores earn this receipt only after the
+      # complete migration and canonical-surface assertion below.
+      #
+      # The stamp lives HERE and not in _tasks_schema() on purpose. Every statement
+      # that block emits is `CREATE ... IF NOT EXISTS`, so replaying it over an
+      # existing store is a no-op — a contract the migration driver and several
+      # harnesses rely on, and a bare INSERT is the one statement that breaks it
+      # (UNIQUE constraint failed: task_prefs.key). Making the INSERT itself
+      # idempotent would be worse than leaving it out: an upsert would stamp the
+      # CURRENT epoch onto a store that a replay does not actually complete, since
+      # `CREATE TABLE IF NOT EXISTS tasks` adds no column to an existing tasks
+      # table. That is the lying-gate class this row exists to close. Only this
+      # arm has just proved it created the whole schema from nothing.
       fresh_payload=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" < <(
         _tasks_schema
+        printf "INSERT INTO task_prefs(key,value) VALUES ('schema_epoch',%s);\n" \
+          "$(sqlq "$_TASKS_SCHEMA_EPOCH")"
+        # DIVE-2808: the ledger start marker was seeded inside _tasks_db_migrate,
+        # which a fresh store no longer enters. Without this a brand-new board has
+        # no marker at all, and `trace` reads a ledger with nothing to say about
+        # anything as one that predates everything — absence read as evidence,
+        # which is the exact failure the marker exists to prevent.
+        printf "INSERT OR IGNORE INTO task_prefs(key,value) VALUES ('ledger_started',datetime('now'));\n"
         printf "SELECT 'column:'||name FROM pragma_table_info('tasks');\n"
       )) || fail "$E_GENERIC" "failed to initialise tasks db at $TASKS_DB"
       _TASKS_DB_GATE_COLUMNS=''
@@ -1130,6 +1147,7 @@ _TASKS_ADDITIVE_COLUMNS=(
 )
 _TASKS_DB_GATE_COLUMNS=''
 _TASKS_DB_GATE_EPOCH=''
+_TASKS_DB_GATE_LEDGER=''
 
 # Exact newline membership without a subprocess. The newline frame prevents a
 # prefix (need_ty) from satisfying a full column name (need_type).
@@ -1145,61 +1163,64 @@ _tasks_columns_have_all_additive() { # <newline-delimited pragma names>
 
 _tasks_db_migration_needed() {
   local payload row
+  # The ledger marker rides along in the SAME read as the epoch and the columns,
+  # so keeping its self-heal costs no extra process. See the note below.
   payload=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
     "SELECT 'epoch:'||COALESCE((SELECT value FROM task_prefs WHERE key='schema_epoch'),'')
+       UNION ALL
+     SELECT 'ledger:'||COALESCE((SELECT '1' FROM task_prefs WHERE key='ledger_started'),'')
        UNION ALL
      SELECT 'column:'||name FROM pragma_table_info('tasks');" 2>/dev/null) || return 0
   _TASKS_DB_GATE_COLUMNS=''
   _TASKS_DB_GATE_EPOCH=''
+  _TASKS_DB_GATE_LEDGER=''
   while IFS= read -r row; do
     case "$row" in
       epoch:*)  _TASKS_DB_GATE_EPOCH="${row#epoch:}" ;;
+      ledger:*) _TASKS_DB_GATE_LEDGER="${row#ledger:}" ;;
       column:*) _TASKS_DB_GATE_COLUMNS+="${row#column:}"$'\n' ;;
     esac
   done <<<"$payload"
   _TASKS_DB_GATE_COLUMNS="${_TASKS_DB_GATE_COLUMNS%$'\n'}"
   [[ "$_TASKS_DB_GATE_EPOCH" == "$_TASKS_SCHEMA_EPOCH" ]] || return 0
+  # DIVE-2808: the migration also SEEDS things, it does not only alter shape, and a
+  # gate that only reasons about shape silently drops those seeds. `ledger_started`
+  # is re-inserted (INSERT OR IGNORE) on every pass through _tasks_db_migrate, so
+  # before this gate existed a deleted marker healed itself on the next invocation.
+  # Skipping the migration removed that, and the loss is invisible in a schema
+  # comparison: the store is shape-perfect and semantically wrong. Missing marker
+  # therefore sends the store back through the migration once, which re-seeds it.
+  [[ -n "$_TASKS_DB_GATE_LEDGER" ]] || return 0
   ! _tasks_columns_have_all_additive "$_TASKS_DB_GATE_COLUMNS"
 }
 
-_tasks_db_schema_manifest_sql() {
-  printf '%s\n' "SELECT item FROM (
-    SELECT 'table:'||name AS item FROM sqlite_schema
-      WHERE type='table' AND name NOT LIKE 'sqlite_%'
-    UNION ALL
-    SELECT 'column:'||m.name||'.'||p.name AS item
-      FROM sqlite_schema AS m, pragma_table_info(m.name) AS p
-      WHERE m.type='table' AND m.name NOT LIKE 'sqlite_%' AND m.name!='tasks'
-    UNION ALL
-    SELECT 'index:'||name AS item FROM sqlite_schema
-      WHERE type='index' AND name NOT LIKE 'sqlite_%'
-  ) ORDER BY item;"
-}
-
-# The epoch is a receipt for the WHOLE migration, not only tasks columns. Before
-# stamping it, prove every canonical table, non-tasks column and named index
-# exists; tasks columns are proved by the dedicated assertion above. Extras are
-# allowed for forward compatibility and local extensions.
-_tasks_db_assert_canonical_surface() {
-  local manifest_sql canonical observed item framed
-  manifest_sql=$(_tasks_db_schema_manifest_sql)
-  canonical=$(
-    {
-      printf '.output /dev/null\n'
-      _tasks_schema
-      printf '.output stdout\n%s\n' "$manifest_sql"
-    } | sqlite3 -cmd ".timeout 5000" :memory:
-  ) || fail "$E_GENERIC" "could not build canonical tasks-db schema manifest (DIVE-2808)"
-  observed=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" "$manifest_sql" 2>/dev/null) \
-    || fail "$E_GENERIC" "could not read migrated tasks-db schema manifest (DIVE-2808)"
-  framed=$'\n'"$observed"$'\n'
-  while IFS= read -r item; do
-    [[ -n "$item" ]] || continue
-    [[ "$framed" == *$'\n'"$item"$'\n'* ]] || fail "$E_GENERIC" \
-      "tasks db canonical surface incomplete after migration — missing $item (DIVE-2808)"
-  done <<<"$canonical"
-}
-
+# DIVE-2808: the epoch is a receipt that the curated migration GENERATION named by
+# $_TASKS_SCHEMA_EPOCH has run to completion on this store. It is deliberately NOT
+# a claim that the store matches the canonical schema item for item.
+#
+# The first cut asserted exactly that — every canonical table, index and non-tasks
+# column after migrating — and `fail`ed tasks_db_init when it did not hold, which
+# is every `5dive task` invocation rather than merely a slow one. It cannot hold:
+# the migration is a curated set of one-shot blocks that was never a convergence
+# engine, and `CREATE TABLE IF NOT EXISTS` cannot widen a table that already
+# exists, so neither the migration nor a replay of the canonical DDL can add a
+# missing column to an existing table or an index over a column that is absent.
+# Asserting a property no code path can repair converts a slow migration into an
+# outage; four unrelated harnesses (ledger, policy_refusals, rollback_rate,
+# whoami_for_chain) went red on precisely that, on a store shaped like a legacy box.
+#
+# What still covers the axis the first cut was reaching for:
+#   - The EPOCH itself, which is what Case 13 of tests/tasks_db_restore_guard_unit.sh
+#     exercises: a stale/absent epoch sends a tasks-current store back through the
+#     whole migration, so a hole OUTSIDE tasks (gate_history.floor_provenance) is
+#     still repaired. That win belongs to the epoch, not to the manifest assertion.
+#   - tests/schema_sync_unit.sh, which fails CI if the migration's copies of those
+#     CREATE TABLE statements drift from the canonical ones — so a table built by
+#     EITHER path carries the same columns.
+#   - DIVE-2197's resulting-column assertion, retained on BOTH arms below.
+# A store that is genuinely short of a canonical table or column is not made worse
+# by the gate: the pre-DIVE-2808 code re-ran the migration on every invocation and
+# never created those either. Converging one needs per-table ALTERs — its own row.
 _tasks_db_stamp_schema_epoch() {
   sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
     "INSERT INTO task_prefs(key,value,updated_at)
@@ -1719,7 +1740,6 @@ MIG
         "ALTER TABLE objectives ADD COLUMN run_mode TEXT NOT NULL DEFAULT 'live';" >/dev/null 2>&1 || true
     fi
   fi
-  _tasks_db_assert_canonical_surface
   _tasks_db_stamp_schema_epoch
 }
 

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -1157,7 +1157,7 @@ _TASKS_ADDITIVE_COLUMNS=(
 )
 _TASKS_DB_GATE_COLUMNS=''
 _TASKS_DB_GATE_EPOCH=''
-_TASKS_DB_GATE_LEDGER=''
+_TASKS_DB_GATE_SEEDS=''
 
 # Exact newline membership without a subprocess. The newline frame prevents a
 # prefix (need_ty) from satisfying a full column name (need_type).
@@ -1171,37 +1171,67 @@ _tasks_columns_have_all_additive() { # <newline-delimited pragma names>
   return 0
 }
 
+# DIVE-2808: the migration also SEEDS, it does not only alter shape, and a gate that
+# reasons only about SHAPE silently drops every seed. Each key below is written by
+# `_tasks_db_migrate` with an INSERT OR IGNORE that re-runs on every pass, so before
+# this gate existed a deleted row healed itself on the next invocation. Skipping the
+# migration removes that, and the loss is invisible to any schema comparison: the
+# store is shape-perfect and semantically wrong. A missing seed therefore sends the
+# store back through the migration once, which re-seeds it.
+#
+# ONE SOURCE OF TRUTH. This array is the gate's model of what the migration seeds,
+# and it is the same drift hazard as the column list: a copy that falls behind the
+# migration reports *current* on a store that is not. tests/tasks_db_restore_guard_unit.sh
+# Case 16 DERIVES the seeded keys from `_tasks_db_migrate`'s own source and reds if
+# the two disagree in either direction, so adding a seed to the migration without
+# adding it here cannot pass quietly.
+#
+# `ledger_started` (INST-4) was the first found: `trace` reads a missing marker as a
+# ledger that predates everything. `gate_history_coverage` (DIVE-2133) was the second
+# and was missed by the first cut — the coverage boundary the gate_history reader
+# needs to tell "no gates were displaced" from "the archive was not yet writing", so
+# losing it downgrades a truthful complete zero to `unknown`. Two of two seeds in the
+# migration were self-healing, which is why the list is enumerated rather than the
+# exception hand-carved.
+_TASKS_SELFHEAL_PREFS=(ledger_started gate_history_coverage)
+
 _tasks_db_migration_needed() {
-  local payload row
-  # The ledger marker rides along in the SAME read as the epoch and the columns,
-  # so keeping its self-heal costs no extra process. See the note below.
+  local payload row k in_list=''
+  # The seed markers ride along in the SAME read as the epoch and the columns, so
+  # keeping their self-heal costs no extra process. See the note above.
+  for k in "${_TASKS_SELFHEAL_PREFS[@]}"; do in_list+="${in_list:+,}'${k//\'/\'\'}'"; done
   payload=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
     "SELECT 'epoch:'||COALESCE((SELECT value FROM task_prefs WHERE key='schema_epoch'),'')
        UNION ALL
-     SELECT 'ledger:'||COALESCE((SELECT '1' FROM task_prefs WHERE key='ledger_started'),'')
+     SELECT 'seed:'||key FROM task_prefs WHERE key IN ($in_list)
        UNION ALL
      SELECT 'column:'||name FROM pragma_table_info('tasks');" 2>/dev/null) || return 0
   _TASKS_DB_GATE_COLUMNS=''
   _TASKS_DB_GATE_EPOCH=''
-  _TASKS_DB_GATE_LEDGER=''
+  _TASKS_DB_GATE_SEEDS=''
   while IFS= read -r row; do
     case "$row" in
       epoch:*)  _TASKS_DB_GATE_EPOCH="${row#epoch:}" ;;
-      ledger:*) _TASKS_DB_GATE_LEDGER="${row#ledger:}" ;;
+      seed:*)   _TASKS_DB_GATE_SEEDS+="${row#seed:}"$'\n' ;;
       column:*) _TASKS_DB_GATE_COLUMNS+="${row#column:}"$'\n' ;;
     esac
   done <<<"$payload"
   _TASKS_DB_GATE_COLUMNS="${_TASKS_DB_GATE_COLUMNS%$'\n'}"
+  _TASKS_DB_GATE_SEEDS="${_TASKS_DB_GATE_SEEDS%$'\n'}"
   [[ "$_TASKS_DB_GATE_EPOCH" == "$_TASKS_SCHEMA_EPOCH" ]] || return 0
-  # DIVE-2808: the migration also SEEDS things, it does not only alter shape, and a
-  # gate that only reasons about shape silently drops those seeds. `ledger_started`
-  # is re-inserted (INSERT OR IGNORE) on every pass through _tasks_db_migrate, so
-  # before this gate existed a deleted marker healed itself on the next invocation.
-  # Skipping the migration removed that, and the loss is invisible in a schema
-  # comparison: the store is shape-perfect and semantically wrong. Missing marker
-  # therefore sends the store back through the migration once, which re-seeds it.
-  [[ -n "$_TASKS_DB_GATE_LEDGER" ]] || return 0
+  _tasks_prefs_have_all_seeds "$_TASKS_DB_GATE_SEEDS" || return 0
   ! _tasks_columns_have_all_additive "$_TASKS_DB_GATE_COLUMNS"
+}
+
+# Same newline-framed membership as the column check, and for the same reason: no
+# subprocess per key, and no prefix satisfying a longer name.
+_tasks_prefs_have_all_seeds() { # <newline-delimited present pref keys>
+  local present="${1:-}" k framed
+  framed=$'\n'"$present"$'\n'
+  for k in "${_TASKS_SELFHEAL_PREFS[@]}"; do
+    [[ "$framed" == *$'\n'"$k"$'\n'* ]] || return 1
+  done
+  return 0
 }
 
 # DIVE-2808: the epoch is a receipt that the curated migration GENERATION named by

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -165,6 +165,7 @@ require_sqlite() {
 # NOTE: projects/loop_runs/supervisor_events are ALSO defined inside gated
 # one-shot migration blocks in _tasks_db_migrate() below — edit both copies
 # together; tests/schema_sync_unit.sh fails CI if they diverge.
+_TASKS_SCHEMA_EPOCH='2808-1'
 _tasks_schema() {
   cat <<'SQL'
 PRAGMA journal_mode=WAL;
@@ -884,6 +885,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS lifecycle_events_idem_idx ON lifecycle_events(
 CREATE INDEX IF NOT EXISTS lifecycle_events_ident_idx ON lifecycle_events(ident, id);
 CREATE INDEX IF NOT EXISTS lifecycle_events_ts_idx ON lifecycle_events(ts, kind);
 SQL
+  # DIVE-2808: a fresh store is born at the current whole-schema epoch in the
+  # SAME sqlite invocation. Existing stores earn this receipt only after the
+  # complete migration and canonical-surface assertion below.
+  printf "INSERT INTO task_prefs(key,value) VALUES ('schema_epoch',%s);\n" \
+    "$(sqlq "$_TASKS_SCHEMA_EPOCH")"
 }
 
 # -------- DIVE-1479: silent-recreate trap guard --------
@@ -1051,7 +1057,7 @@ tasks_db_init() {
   # WAL read-lock, which never blocks writers. .timeout lets a genuine
   # first-run race serialise instead of erroring. stdout is discarded because
   # `PRAGMA journal_mode=WAL` echoes "wal".
-  local has
+  local has created_fresh=0
   has=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
         "SELECT 1 FROM sqlite_master WHERE type='table' AND name='tasks' LIMIT 1;" 2>/dev/null)
   if [[ "$has" != "1" ]]; then
@@ -1061,16 +1067,30 @@ tasks_db_init() {
     if _tasks_board_existed; then
       _tasks_board_recover
     else
-      sqlite3 -cmd ".timeout 5000" "$TASKS_DB" < <(_tasks_schema) >/dev/null \
-        || fail "$E_GENERIC" "failed to initialise tasks db at $TASKS_DB"
+      local fresh_payload row
+      fresh_payload=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" < <(
+        _tasks_schema
+        printf "SELECT 'column:'||name FROM pragma_table_info('tasks');\n"
+      )) || fail "$E_GENERIC" "failed to initialise tasks db at $TASKS_DB"
+      _TASKS_DB_GATE_COLUMNS=''
+      while IFS= read -r row; do
+        [[ "$row" == column:* ]] || continue  # ignores PRAGMA journal_mode's "wal"
+        _TASKS_DB_GATE_COLUMNS+="${row#column:}"$'\n'
+      done <<<"$fresh_payload"
+      _TASKS_DB_GATE_COLUMNS="${_TASKS_DB_GATE_COLUMNS%$'\n'}"
       chmod 0660 "$TASKS_DB" 2>/dev/null || true
+      created_fresh=1
     fi
   fi
   # DIVE-2808: the canonical schema is complete, so almost every invocation can
-  # skip the expensive reconciliation. The gate and the migration consume the
-  # SAME array below; pure-Bash membership avoids one grep process per column.
-  # Both arms retain DIVE-2197's resulting-set assertion.
-  if _tasks_db_migration_needed; then
+  # skip the expensive reconciliation. The gate requires the whole-schema epoch
+  # plus the SAME tasks-column array the migration consumes; pure-Bash membership
+  # avoids one grep process per column. Both arms retain DIVE-2197's assertion.
+  if ((created_fresh)); then
+    # The CREATE and epoch stamp succeeded in one sqlite invocation. Preserve DIVE-2197's
+    # independent resulting-set assertion without paying a redundant epoch read.
+    _tasks_db_assert_required_columns "$_TASKS_DB_GATE_COLUMNS"
+  elif _tasks_db_migration_needed; then
     _tasks_db_migrate
   else
     _tasks_db_assert_required_columns "$_TASKS_DB_GATE_COLUMNS"
@@ -1109,6 +1129,7 @@ _TASKS_ADDITIVE_COLUMNS=(
   'human_evidence TEXT' 'derived_actor TEXT' 'floor_provenance TEXT'
 )
 _TASKS_DB_GATE_COLUMNS=''
+_TASKS_DB_GATE_EPOCH=''
 
 # Exact newline membership without a subprocess. The newline frame prevents a
 # prefix (need_ty) from satisfying a full column name (need_type).
@@ -1123,9 +1144,68 @@ _tasks_columns_have_all_additive() { # <newline-delimited pragma names>
 }
 
 _tasks_db_migration_needed() {
-  _TASKS_DB_GATE_COLUMNS=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
-    "SELECT name FROM pragma_table_info('tasks');" 2>/dev/null) || return 0
+  local payload row
+  payload=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
+    "SELECT 'epoch:'||COALESCE((SELECT value FROM task_prefs WHERE key='schema_epoch'),'')
+       UNION ALL
+     SELECT 'column:'||name FROM pragma_table_info('tasks');" 2>/dev/null) || return 0
+  _TASKS_DB_GATE_COLUMNS=''
+  _TASKS_DB_GATE_EPOCH=''
+  while IFS= read -r row; do
+    case "$row" in
+      epoch:*)  _TASKS_DB_GATE_EPOCH="${row#epoch:}" ;;
+      column:*) _TASKS_DB_GATE_COLUMNS+="${row#column:}"$'\n' ;;
+    esac
+  done <<<"$payload"
+  _TASKS_DB_GATE_COLUMNS="${_TASKS_DB_GATE_COLUMNS%$'\n'}"
+  [[ "$_TASKS_DB_GATE_EPOCH" == "$_TASKS_SCHEMA_EPOCH" ]] || return 0
   ! _tasks_columns_have_all_additive "$_TASKS_DB_GATE_COLUMNS"
+}
+
+_tasks_db_schema_manifest_sql() {
+  printf '%s\n' "SELECT item FROM (
+    SELECT 'table:'||name AS item FROM sqlite_schema
+      WHERE type='table' AND name NOT LIKE 'sqlite_%'
+    UNION ALL
+    SELECT 'column:'||m.name||'.'||p.name AS item
+      FROM sqlite_schema AS m, pragma_table_info(m.name) AS p
+      WHERE m.type='table' AND m.name NOT LIKE 'sqlite_%' AND m.name!='tasks'
+    UNION ALL
+    SELECT 'index:'||name AS item FROM sqlite_schema
+      WHERE type='index' AND name NOT LIKE 'sqlite_%'
+  ) ORDER BY item;"
+}
+
+# The epoch is a receipt for the WHOLE migration, not only tasks columns. Before
+# stamping it, prove every canonical table, non-tasks column and named index
+# exists; tasks columns are proved by the dedicated assertion above. Extras are
+# allowed for forward compatibility and local extensions.
+_tasks_db_assert_canonical_surface() {
+  local manifest_sql canonical observed item framed
+  manifest_sql=$(_tasks_db_schema_manifest_sql)
+  canonical=$(
+    {
+      printf '.output /dev/null\n'
+      _tasks_schema
+      printf '.output stdout\n%s\n' "$manifest_sql"
+    } | sqlite3 -cmd ".timeout 5000" :memory:
+  ) || fail "$E_GENERIC" "could not build canonical tasks-db schema manifest (DIVE-2808)"
+  observed=$(sqlite3 -cmd ".timeout 5000" "$TASKS_DB" "$manifest_sql" 2>/dev/null) \
+    || fail "$E_GENERIC" "could not read migrated tasks-db schema manifest (DIVE-2808)"
+  framed=$'\n'"$observed"$'\n'
+  while IFS= read -r item; do
+    [[ -n "$item" ]] || continue
+    [[ "$framed" == *$'\n'"$item"$'\n'* ]] || fail "$E_GENERIC" \
+      "tasks db canonical surface incomplete after migration — missing $item (DIVE-2808)"
+  done <<<"$canonical"
+}
+
+_tasks_db_stamp_schema_epoch() {
+  sqlite3 -cmd ".timeout 5000" "$TASKS_DB" \
+    "INSERT INTO task_prefs(key,value,updated_at)
+       VALUES ('schema_epoch',$(sqlq "$_TASKS_SCHEMA_EPOCH"),datetime('now'))
+       ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=datetime('now');" \
+    >/dev/null 2>&1 || fail "$E_GENERIC" "failed to stamp tasks-db schema epoch (DIVE-2808)"
 }
 
 # DIVE-2197's resulting-set assertion. It is called after a real migration and
@@ -1639,6 +1719,8 @@ MIG
         "ALTER TABLE objectives ADD COLUMN run_mode TEXT NOT NULL DEFAULT 'live';" >/dev/null 2>&1 || true
     fi
   fi
+  _tasks_db_assert_canonical_surface
+  _tasks_db_stamp_schema_epoch
 }
 
 # Per-connection setup, passed via -cmd / .timeout so it produces NO output

--- a/tests/gate_floor_provenance_unit.sh
+++ b/tests/gate_floor_provenance_unit.sh
@@ -233,6 +233,10 @@ seed DIVE-9009 'ordinary title'
 OLD="$TMP/old"; mkdir -p "$OLD/tasks"
 ( STATE_DIR="$OLD"; TASKS_DIR="$OLD/tasks"; TASKS_DB="$OLD/tasks/tasks.db"; tasks_db_init >/dev/null 2>&1 )
 sqlite3 "$OLD/tasks/tasks.db" "DROP TABLE gate_history; CREATE TABLE gate_history (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id INTEGER NOT NULL, retired_by TEXT NOT NULL);" 2>/dev/null
+# This fixture represents a pre-DIVE-2808 store, so it cannot carry the
+# whole-schema receipt introduced by DIVE-2808. Leaving a current receipt after
+# deliberately rewinding one table would instead model post-stamp corruption.
+sqlite3 "$OLD/tasks/tasks.db" "DELETE FROM task_prefs WHERE key='schema_epoch';" 2>/dev/null
 before=$(sqlite3 "$OLD/tasks/tasks.db" "SELECT COUNT(*) FROM pragma_table_info('gate_history') WHERE name='floor_provenance';")
 [[ "$(sqlite3 "$OLD/tasks/tasks.db" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='tasks';")" == "1" ]] \
   && ok_t 'migration fixture: the store has a tasks table, so init takes the MIGRATE path (not fresh-create)' \

--- a/tests/tasks_db_restore_guard_unit.sh
+++ b/tests/tasks_db_restore_guard_unit.sh
@@ -171,23 +171,26 @@ out=$(TASKS_BACKUP_DIR="$paired_backups" tasks_db_init 2>&1); rc=$?
 [[ "$(row_count)" == "3" ]] && ok "paired: explicit TASKS_BACKUP_DIR still restores" \
   || bad "paired: rows=$(row_count) ($out)"
 
-# --- Case 9 (DIVE-2197): a fresh schema contains all six additive columns -----
-# These lived only in the migration list, while a genuinely fresh STATE_DIR
-# skipped migration. The result was a green init over a partial tasks table.
+# --- Case 9 (DIVE-2808): canonical schema is complete at birth ----------------
+# Eight columns lived only in the migration list. The completed CREATE must have
+# the full 71-column tasks surface before the skip-gate is allowed to save work.
 fresh_tree
 out=$(tasks_db_init 2>&1); rc=$?
-required='delivered_at delivery_ref escalated_at escalated_by park_reason parked_at'
+required='delivered_at delivery_ref delivery_ref_iteration escalated_at escalated_by human_evidence park_reason parked_at'
 actual=$(sqlite3 "$TASKS_DB" \
   "SELECT name FROM pragma_table_info('tasks')
-    WHERE name IN ('delivery_ref','delivered_at','parked_at','park_reason','escalated_at','escalated_by')
+    WHERE name IN ('delivery_ref','delivered_at','delivery_ref_iteration','parked_at','park_reason','escalated_at','escalated_by','human_evidence')
     ORDER BY name;" 2>/dev/null | tr '\n' ' ' | sed 's/ $//')
-[[ $rc -eq 0 && "$actual" == "$required" ]] \
-  && ok "fresh schema: all six additive columns are present" \
-  || bad "fresh schema: init returned a partial tasks table" "rc=$rc got=[$actual] want=[$required] out=$out"
+column_count=$(sqlite3 "$TASKS_DB" "SELECT count(*) FROM pragma_table_info('tasks');" 2>/dev/null)
+[[ $rc -eq 0 && "$actual" == "$required" && "$column_count" == "71" ]] \
+  && ok "fresh schema: all 71 columns, including the eight former holes, are present" \
+  || bad "fresh schema: init returned a partial tasks table" "rc=$rc count=$column_count got=[$actual] want=[$required] out=$out"
 
-# --- Case 10 (DIVE-2197): one ALTER fails -> init fails loudly ----------------
+# --- Case 10 (DIVE-2197): migrate arm still rejects a failed ALTER ------------
 fresh_tree
+tasks_db_init >/dev/null 2>&1
 real_sqlite=$(command -v sqlite3)
+"$real_sqlite" "$TASKS_DB" "ALTER TABLE tasks DROP COLUMN delivery_ref;"
 mkdir -p "$TMP/bin"
 cat > "$TMP/bin/sqlite3" <<'SQLITE_SHIM'
 #!/usr/bin/env bash
@@ -213,6 +216,48 @@ grep -q 'schema incomplete.*delivery_ref' <<<"$out" \
 [[ "$actual" == 'delivered_at escalated_at escalated_by park_reason parked_at' ]] \
   && ok "failed ALTER: mutation applied and only delivery_ref remains absent" \
   || bad "failed ALTER: mutation precondition/result is not the intended one-column hole" "got=[$actual]"
+
+# --- Case 11 (DIVE-2808): skip arm retains the resulting-set assertion --------
+# Force the gate to lie over a one-column hole. Removing the skip-arm assertion
+# makes this mutation green, so the test proves that path is connected too.
+fresh_tree
+tasks_db_init >/dev/null 2>&1
+sqlite3 "$TASKS_DB" "ALTER TABLE tasks DROP COLUMN delivery_ref;"
+out=$( ( _tasks_db_migration_needed() {
+           _TASKS_DB_GATE_COLUMNS=$(sqlite3 "$TASKS_DB" \
+             "SELECT name FROM pragma_table_info('tasks');" 2>/dev/null)
+           return 1
+         }
+         tasks_db_init ) 2>&1); rc=$?
+[[ $rc -ne 0 ]] \
+  && ok "skip assertion: a lying gate cannot accept a partial schema" \
+  || bad "skip assertion: partial schema was silently accepted" "rc=$rc out=$out"
+grep -q 'schema incomplete.*delivery_ref' <<<"$out" \
+  && ok "skip assertion: refusal names the missing column" \
+  || bad "skip assertion: refusal does not identify the hole" "out=$out"
+
+# --- Case 12 (DIVE-2808): gate derives its list from the migration array ------
+# Change the array alone. The gate must immediately follow that new requirement,
+# and the same array must drive the ALTER that satisfies it.
+fresh_tree
+tasks_db_init >/dev/null 2>&1
+if _tasks_db_migration_needed; then
+  bad "derived gate: complete canonical schema unexpectedly needs migration"
+else
+  ok "derived gate: complete canonical schema takes the skip path"
+fi
+_TASKS_ADDITIVE_COLUMNS+=('dive2808_probe TEXT')
+if _tasks_db_migration_needed; then
+  ok "derived gate: array-only column addition enters migration"
+else
+  bad "derived gate: array-only column addition was ignored"
+fi
+out=$(_tasks_db_migrate 2>&1); rc=$?
+probe=$(sqlite3 "$TASKS_DB" \
+  "SELECT count(*) FROM pragma_table_info('tasks') WHERE name='dive2808_probe';" 2>/dev/null)
+[[ $rc -eq 0 && "$probe" == "1" ]] \
+  && ok "derived gate: migration follows the same array and adds its column" \
+  || bad "derived gate: migration did not follow the array" "rc=$rc probe=$probe out=$out"
 
 echo
 echo "tasks-db restore guard: $PASS passed, $FAIL failed"

--- a/tests/tasks_db_restore_guard_unit.sh
+++ b/tests/tasks_db_restore_guard_unit.sh
@@ -352,36 +352,87 @@ ship=$(sqlite3 "$TASKS_DB" \
   || bad "legacy store: migration did not run" "ship=$ship"
 
 # --- Case 16 (DIVE-2808): the migration SEEDS, it does not only reshape ---------
-# `ledger_started` is re-inserted on every pass through _tasks_db_migrate, so before
-# the gate existed a deleted marker healed itself on the next invocation, and a
-# fresh store got one on the way in. A gate that reasons only about SHAPE drops both:
-# the store is shape-perfect and semantically wrong, which no schema comparison can
-# see. tests/whoami_for_chain_unit.sh caught the self-heal half as
-# "H/REACHABILITY: marker did not self-heal"; nothing was watching the fresh half.
+# `_tasks_db_migrate` re-inserts several task_prefs rows (INSERT OR IGNORE) on every
+# pass, so before the gate existed a deleted row healed itself on the next
+# invocation, and a fresh store got one on the way in. A gate that reasons only about
+# SHAPE drops both: the store is shape-perfect and semantically wrong, which no
+# schema comparison can see. tests/whoami_for_chain_unit.sh caught the
+# `ledger_started` self-heal half as "H/REACHABILITY: marker did not self-heal";
+# nothing was watching the fresh half.
+#
+# The first cut of this case hand-listed `ledger_started` and stopped there, so the
+# SECOND seeded pref — `gate_history_coverage` (DIVE-2133) — went out unguarded and
+# reddened tests/gate_history_unit.sh in the nightly sweep only, two cases deep in a
+# harness this branch never touched. Enumerating one member of a class is not
+# covering the class. So the key set is now DERIVED FROM THE MIGRATION'S OWN SOURCE
+# and compared with $_TASKS_SELFHEAL_PREFS in BOTH directions, exactly as Case 12
+# derives the column list from the additive array: a seed added to the migration
+# without being added to the gate's model reds HERE, at the source of the drift,
+# instead of somewhere downstream that happens to read the row.
 fresh_tree
 tasks_db_init >/dev/null 2>&1
-marker=$(sqlite3 "$TASKS_DB" "SELECT count(*) FROM task_prefs WHERE key='ledger_started';" 2>/dev/null)
-[[ "$marker" == "1" ]] \
-  && ok "ledger marker: a FRESH store is born with the start marker" \
-  || bad "ledger marker: fresh store has no ledger_started (trace would read absence as predating)" "marker=$marker"
-# Self-heal: delete it on an otherwise-current store. The gate must not skip.
-sqlite3 "$TASKS_DB" "DELETE FROM task_prefs WHERE key='ledger_started';"
-if _tasks_db_migration_needed; then
-  ok "ledger marker: a missing marker on a shape-perfect store still enters migration"
-else
-  bad "ledger marker: shape-only gate skipped a store that lost a seeded row"
-fi
-out=$(tasks_db_init 2>&1); rc=$?
-marker=$(sqlite3 "$TASKS_DB" "SELECT count(*) FROM task_prefs WHERE key='ledger_started';" 2>/dev/null)
-[[ $rc -eq 0 && "$marker" == "1" ]] \
-  && ok "ledger marker: the marker self-heals through tasks_db_init" \
-  || bad "ledger marker: no self-heal" "rc=$rc marker=$marker out=$out"
-# And the healed store settles: the next invocation takes the skip path again.
-if _tasks_db_migration_needed; then
-  bad "ledger marker: store never settles — every invocation re-migrates"
-else
-  ok "ledger marker: a healed store settles back onto the skip path"
-fi
+# Parse the seeded keys out of _tasks_db_migrate's body. Two spellings exist in the
+# migration (a VALUES tuple and a SELECT projection), so take the first single-quoted
+# literal within three lines of the INSERT. Scoped to the function body on purpose:
+# `schema_epoch` is stamped elsewhere and is already the gate's first arm.
+mapfile -t SEEDED_KEYS < <(
+  awk '
+    /^_tasks_db_migrate\(\)/      { inf = 1; next }
+    inf && /^}/                   { inf = 0 }
+    inf && /INSERT OR IGNORE INTO task_prefs/ { grab = 3 }
+    grab > 0 {
+      if (match($0, /'"'"'[A-Za-z_][A-Za-z0-9_]*'"'"'/)) {
+        print substr($0, RSTART + 1, RLENGTH - 2); grab = 0; next
+      }
+      grab--
+    }
+  ' "$SRC/lib/tasks_db.sh" | LC_ALL=C sort -u
+)
+printf '%s\n' ${SEEDED_KEYS[@]+"${SEEDED_KEYS[@]}"} | LC_ALL=C sort -u > "$TMP/seeded.txt"
+printf '%s\n' "${_TASKS_SELFHEAL_PREFS[@]}"      | LC_ALL=C sort -u > "$TMP/modelled.txt"
+# Liveness: a parse that finds nothing would make both comparisons below vacuous, and
+# a silently-empty derivation is the same failure mode as a gate that never fires.
+(( ${#SEEDED_KEYS[@]} >= 2 )) \
+  && ok "seed drift: the derivation really read seeds out of the migration (${#SEEDED_KEYS[@]})" \
+  || bad "seed drift: derived NO seeds — the parse broke, so the two arms below prove nothing" \
+         "keys=[${SEEDED_KEYS[*]-}]"
+unmodelled=$(LC_ALL=C comm -23 "$TMP/seeded.txt" "$TMP/modelled.txt" | tr '\n' ' ' | sed 's/ $//')
+phantom=$(LC_ALL=C comm -13 "$TMP/seeded.txt" "$TMP/modelled.txt" | tr '\n' ' ' | sed 's/ $//')
+[[ -z "$unmodelled" ]] \
+  && ok "seed drift: every pref the migration seeds is in the gate's model" \
+  || bad "seed drift: the migration seeds a pref the gate does not know about (it will be skipped away)" \
+         "unmodelled=[$unmodelled]"
+[[ -z "$phantom" ]] \
+  && ok "seed drift: the gate models no pref the migration cannot re-seed" \
+  || bad "seed drift: gate demands a pref the migration never writes (every invocation would re-migrate)" \
+         "phantom=[$phantom]"
+
+# Behaviour, per modelled key: born on a fresh store, self-heals when deleted from an
+# otherwise-current store, and the healed store settles back onto the skip path.
+for seed_key in "${_TASKS_SELFHEAL_PREFS[@]}"; do
+  fresh_tree
+  tasks_db_init >/dev/null 2>&1
+  marker=$(sqlite3 "$TASKS_DB" "SELECT count(*) FROM task_prefs WHERE key='$seed_key';" 2>/dev/null)
+  [[ "$marker" == "1" ]] \
+    && ok "seed $seed_key: a FRESH store is born with it" \
+    || bad "seed $seed_key: fresh store lacks it (the reader sees absence, not a stamped boundary)" "marker=$marker"
+  sqlite3 "$TASKS_DB" "DELETE FROM task_prefs WHERE key='$seed_key';"
+  if _tasks_db_migration_needed; then
+    ok "seed $seed_key: a missing row on a shape-perfect store still enters migration"
+  else
+    bad "seed $seed_key: shape-only gate skipped a store that lost a seeded row"
+  fi
+  out=$(tasks_db_init 2>&1); rc=$?
+  marker=$(sqlite3 "$TASKS_DB" "SELECT count(*) FROM task_prefs WHERE key='$seed_key';" 2>/dev/null)
+  [[ $rc -eq 0 && "$marker" == "1" ]] \
+    && ok "seed $seed_key: it self-heals through tasks_db_init" \
+    || bad "seed $seed_key: no self-heal" "rc=$rc marker=$marker out=$out"
+  if _tasks_db_migration_needed; then
+    bad "seed $seed_key: store never settles — every invocation re-migrates"
+  else
+    ok "seed $seed_key: a healed store settles back onto the skip path"
+  fi
+done
 
 # --- Case 17 (DIVE-2808): the canonical CREATE and the additive array PARTITION -
 # The row warned about a THIRD copy of the column list drifting. Merging main into

--- a/tests/tasks_db_restore_guard_unit.sh
+++ b/tests/tasks_db_restore_guard_unit.sh
@@ -258,6 +258,28 @@ probe=$(sqlite3 "$TASKS_DB" \
 [[ $rc -eq 0 && "$probe" == "1" ]] \
   && ok "derived gate: migration follows the same array and adds its column" \
   || bad "derived gate: migration did not follow the array" "rc=$rc probe=$probe out=$out"
+unset '_TASKS_ADDITIVE_COLUMNS[${#_TASKS_ADDITIVE_COLUMNS[@]}-1]'
+
+# --- Case 13 (DIVE-2808): epoch covers non-tasks migration surfaces -----------
+# A tasks-only gate would skip this store because all 71 tasks columns remain.
+# A pre-epoch store with a hole elsewhere must run the whole migration once and
+# earn the receipt only after the canonical surface is complete.
+fresh_tree
+tasks_db_init >/dev/null 2>&1
+sqlite3 "$TASKS_DB" "ALTER TABLE gate_history DROP COLUMN floor_provenance;
+                     DELETE FROM task_prefs WHERE key='schema_epoch';"
+if _tasks_db_migration_needed; then
+  ok "schema epoch: a non-tasks hole on a pre-epoch store enters migration"
+else
+  bad "schema epoch: tasks-only currency hid a non-tasks migration"
+fi
+out=$(tasks_db_init 2>&1); rc=$?
+gh_col=$(sqlite3 "$TASKS_DB" \
+  "SELECT count(*) FROM pragma_table_info('gate_history') WHERE name='floor_provenance';")
+epoch=$(sqlite3 "$TASKS_DB" "SELECT value FROM task_prefs WHERE key='schema_epoch';")
+[[ $rc -eq 0 && "$gh_col" == "1" && "$epoch" == "$_TASKS_SCHEMA_EPOCH" ]] \
+  && ok "schema epoch: full migration repairs the hole and stamps its receipt" \
+  || bad "schema epoch: repair/receipt incomplete" "rc=$rc column=$gh_col epoch=$epoch out=$out"
 
 echo
 echo "tasks-db restore guard: $PASS passed, $FAIL failed"

--- a/tests/tasks_db_restore_guard_unit.sh
+++ b/tests/tasks_db_restore_guard_unit.sh
@@ -281,6 +281,104 @@ epoch=$(sqlite3 "$TASKS_DB" "SELECT value FROM task_prefs WHERE key='schema_epoc
   && ok "schema epoch: full migration repairs the hole and stamps its receipt" \
   || bad "schema epoch: repair/receipt incomplete" "rc=$rc column=$gh_col epoch=$epoch out=$out"
 
+# --- Case 14 (DIVE-2808): _tasks_schema stays REPLAY-IDEMPOTENT ---------------
+# Every statement the canonical block emits is `CREATE ... IF NOT EXISTS`, so
+# applying it twice to one store must be a no-op. The migration driver and four
+# other harnesses (ledger, rollback_rate, whoami_for_chain, policy_refusals)
+# replay it, and they all failed CI at 6e48ee0 with a single bare INSERT in that
+# block: "UNIQUE constraint failed: task_prefs.key". Nothing in the tasks-db
+# suite was watching the contract, so the break surfaced as four unrelated reds.
+# This arm keeps the epoch stamp's call site honest: it belongs to the fresh-init
+# path, never to the replayable DDL.
+fresh_tree
+sqlite3 "$TASKS_DB" < <(_tasks_schema) >/dev/null 2>&1
+out=$(sqlite3 "$TASKS_DB" < <(_tasks_schema) 2>&1); rc=$?
+[[ $rc -eq 0 ]] \
+  && ok "schema replay: applying the canonical schema twice is a no-op" \
+  || bad "schema replay: canonical schema is not idempotent" "rc=$rc out=$out"
+# And the block must not carry the stamp, which is what made it non-idempotent.
+if _tasks_schema | grep -q "schema_epoch"; then
+  bad "schema replay: the epoch stamp is back inside the replayable DDL"
+else
+  ok "schema replay: the epoch stamp stays out of the replayable DDL"
+fi
+# Belt and braces: a fresh store must still be born stamped, so moving the
+# stamp out of the DDL cannot have quietly dropped it.
+fresh_tree
+tasks_db_init >/dev/null 2>&1
+epoch=$(sqlite3 "$TASKS_DB" "SELECT value FROM task_prefs WHERE key='schema_epoch';" 2>/dev/null)
+[[ "$epoch" == "$_TASKS_SCHEMA_EPOCH" ]] \
+  && ok "schema replay: a fresh store is still born at the current epoch" \
+  || bad "schema replay: fresh store lost its epoch stamp" "epoch=$epoch"
+
+# --- Case 15 (DIVE-2808): a legacy store must not be BRICKED by the receipt -----
+# The first cut of the epoch asserted every canonical table, index and non-tasks
+# column after migrating, and `fail`ed tasks_db_init when that did not hold. It
+# cannot hold — the curated migration was never a convergence engine, and
+# `CREATE TABLE IF NOT EXISTS` cannot widen an existing table nor index a column
+# that is absent — so the assertion took down every `5dive task` invocation on a
+# legacy-shaped store. Four unrelated harnesses (ledger, policy_refusals,
+# rollback_rate, whoami_for_chain) went red on exactly this fixture shape. This arm
+# is that store: init must COMPLETE, and the gate must not re-enter the migration
+# forever afterwards.
+fresh_tree
+sqlite3 "$TASKS_DB" "CREATE TABLE tasks (id INTEGER PRIMARY KEY, ident TEXT);
+                     CREATE TABLE supervisor_events (id INTEGER PRIMARY KEY, agent TEXT, classification TEXT);
+                     CREATE TABLE policy_refusals (id INTEGER PRIMARY KEY, policy TEXT);"
+: > "$STATE_DIR/tasks/.board-initialized"    # pre-existing board (DIVE-1479 guard)
+out=$(tasks_db_init 2>&1); rc=$?
+[[ $rc -eq 0 ]] \
+  && ok "legacy store: tasks_db_init completes rather than failing on an unrepairable surface" \
+  || bad "legacy store: init hard-failed on a legacy store" "rc=$rc out=$out"
+epoch=$(sqlite3 "$TASKS_DB" "SELECT value FROM task_prefs WHERE key='schema_epoch';" 2>/dev/null)
+[[ "$epoch" == "$_TASKS_SCHEMA_EPOCH" ]] \
+  && ok "legacy store: a completed migration earns the epoch receipt" \
+  || bad "legacy store: no receipt after a successful migration" "epoch=$epoch"
+# The receipt must also settle the store: a second init takes the skip path.
+if _tasks_db_migration_needed; then
+  bad "legacy store: gate still demands migration after a completed one"
+else
+  ok "legacy store: the receipt settles the gate on the next invocation"
+fi
+# And the migration must still have done its actual job on this store.
+ship=$(sqlite3 "$TASKS_DB" \
+  "SELECT count(*) FROM sqlite_schema WHERE type='table' AND name='ship_events';" 2>/dev/null)
+[[ "$ship" == "1" ]] \
+  && ok "legacy store: the curated migration still ran (ship_events created)" \
+  || bad "legacy store: migration did not run" "ship=$ship"
+
+# --- Case 16 (DIVE-2808): the migration SEEDS, it does not only reshape ---------
+# `ledger_started` is re-inserted on every pass through _tasks_db_migrate, so before
+# the gate existed a deleted marker healed itself on the next invocation, and a
+# fresh store got one on the way in. A gate that reasons only about SHAPE drops both:
+# the store is shape-perfect and semantically wrong, which no schema comparison can
+# see. tests/whoami_for_chain_unit.sh caught the self-heal half as
+# "H/REACHABILITY: marker did not self-heal"; nothing was watching the fresh half.
+fresh_tree
+tasks_db_init >/dev/null 2>&1
+marker=$(sqlite3 "$TASKS_DB" "SELECT count(*) FROM task_prefs WHERE key='ledger_started';" 2>/dev/null)
+[[ "$marker" == "1" ]] \
+  && ok "ledger marker: a FRESH store is born with the start marker" \
+  || bad "ledger marker: fresh store has no ledger_started (trace would read absence as predating)" "marker=$marker"
+# Self-heal: delete it on an otherwise-current store. The gate must not skip.
+sqlite3 "$TASKS_DB" "DELETE FROM task_prefs WHERE key='ledger_started';"
+if _tasks_db_migration_needed; then
+  ok "ledger marker: a missing marker on a shape-perfect store still enters migration"
+else
+  bad "ledger marker: shape-only gate skipped a store that lost a seeded row"
+fi
+out=$(tasks_db_init 2>&1); rc=$?
+marker=$(sqlite3 "$TASKS_DB" "SELECT count(*) FROM task_prefs WHERE key='ledger_started';" 2>/dev/null)
+[[ $rc -eq 0 && "$marker" == "1" ]] \
+  && ok "ledger marker: the marker self-heals through tasks_db_init" \
+  || bad "ledger marker: no self-heal" "rc=$rc marker=$marker out=$out"
+# And the healed store settles: the next invocation takes the skip path again.
+if _tasks_db_migration_needed; then
+  bad "ledger marker: store never settles — every invocation re-migrates"
+else
+  ok "ledger marker: a healed store settles back onto the skip path"
+fi
+
 echo
 echo "tasks-db restore guard: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]

--- a/tests/tasks_db_restore_guard_unit.sh
+++ b/tests/tasks_db_restore_guard_unit.sh
@@ -171,6 +171,49 @@ out=$(TASKS_BACKUP_DIR="$paired_backups" tasks_db_init 2>&1); rc=$?
 [[ "$(row_count)" == "3" ]] && ok "paired: explicit TASKS_BACKUP_DIR still restores" \
   || bad "paired: rows=$(row_count) ($out)"
 
+# --- Case 9 (DIVE-2197): a fresh schema contains all six additive columns -----
+# These lived only in the migration list, while a genuinely fresh STATE_DIR
+# skipped migration. The result was a green init over a partial tasks table.
+fresh_tree
+out=$(tasks_db_init 2>&1); rc=$?
+required='delivered_at delivery_ref escalated_at escalated_by park_reason parked_at'
+actual=$(sqlite3 "$TASKS_DB" \
+  "SELECT name FROM pragma_table_info('tasks')
+    WHERE name IN ('delivery_ref','delivered_at','parked_at','park_reason','escalated_at','escalated_by')
+    ORDER BY name;" 2>/dev/null | tr '\n' ' ' | sed 's/ $//')
+[[ $rc -eq 0 && "$actual" == "$required" ]] \
+  && ok "fresh schema: all six additive columns are present" \
+  || bad "fresh schema: init returned a partial tasks table" "rc=$rc got=[$actual] want=[$required] out=$out"
+
+# --- Case 10 (DIVE-2197): one ALTER fails -> init fails loudly ----------------
+fresh_tree
+real_sqlite=$(command -v sqlite3)
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/sqlite3" <<'SQLITE_SHIM'
+#!/usr/bin/env bash
+if [[ "${DIVE2197_FAIL_COLUMN:-}" == "delivery_ref" \
+      && "$*" == *"ALTER TABLE tasks ADD COLUMN delivery_ref"* ]]; then
+  exit 1
+fi
+exec "$DIVE2197_REAL_SQLITE" "$@"
+SQLITE_SHIM
+chmod +x "$TMP/bin/sqlite3"
+out=$(DIVE2197_FAIL_COLUMN=delivery_ref DIVE2197_REAL_SQLITE="$real_sqlite" \
+      PATH="$TMP/bin:$PATH" tasks_db_init 2>&1); rc=$?
+actual=$("$real_sqlite" "$TASKS_DB" \
+  "SELECT name FROM pragma_table_info('tasks')
+    WHERE name IN ('delivery_ref','delivered_at','parked_at','park_reason','escalated_at','escalated_by')
+    ORDER BY name;" 2>/dev/null | tr '\n' ' ' | sed 's/ $//')
+[[ $rc -ne 0 ]] \
+  && ok "failed ALTER: tasks_db_init fails instead of accepting a partial schema" \
+  || bad "failed ALTER: init silently returned success" "rc=$rc out=$out"
+grep -q 'schema incomplete.*delivery_ref' <<<"$out" \
+  && ok "failed ALTER: refusal names the missing column" \
+  || bad "failed ALTER: refusal does not identify the hole" "out=$out"
+[[ "$actual" == 'delivered_at escalated_at escalated_by park_reason parked_at' ]] \
+  && ok "failed ALTER: mutation applied and only delivery_ref remains absent" \
+  || bad "failed ALTER: mutation precondition/result is not the intended one-column hole" "got=[$actual]"
+
 echo
 echo "tasks-db restore guard: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Iteration 2 — the `full-pristine (3)` red is fixed

main2 rejected iteration 1: hosted CI at `90e4d51` had `full-pristine (3)` = FAILURE while all three
shards were green at the merge base `cd7ad4c`. Correct call, and it is this branch's.

**The failing harness is `tests/gate_history_unit.sh`, 2 of 32 cases.** Reproduced locally at
`90e4d51` (30 passed / 2 failed) and green at `cd7ad4c` (32/0), so attribution is clean in both
directions.

### What broke

It is defect 3 from the iteration-1 write-up, in the *second* of exactly two seeded prefs.
`_tasks_db_migrate` re-seeds two `task_prefs` rows with `INSERT OR IGNORE` on every pass, so both
self-heal when deleted. The skip-gate models shape, so once it starts winning, both stop being
re-planted. Iteration 1 found that with `ledger_started`, fixed **that key**, and stopped.

The other one is `gate_history_coverage` (DIVE-2133) — the evidence boundary that lets a zero-row
archive mean *"no gates were displaced"* rather than *"unknown"*. Skipping the migration stopped
re-stamping it, which silently downgrades a truthful complete zero to `unknown`:

```
FAIL - migration must use evidence, not a release-date guess
   earliest=2026-08-06 19:52:42 stamped=
FAIL - an inferred same-second task must not be overstated as covered
```

The iteration-1 write-up said *"enumerate a gated procedure's side effects"*. The patch did not — it
hard-coded the one side effect that had already reddened a harness. **The prose was general and the
patch was specific, and nothing in between noticed.** One grep of the gated function finds both.

### What changed

`$_TASKS_SELFHEAL_PREFS` is now the gate's single source for seeded rows, read in the same SQLite
round-trip as the epoch and the columns, matched with the same pure-Bash membership as the column
arm — no extra process.

The model is **derived, not transcribed.** `tasks_db_restore_guard_unit.sh` Case 16 parses the
seeded keys out of `_tasks_db_migrate`'s own source and compares them against the array **in both
directions**, the same anti-drift rule the column list already carries:

- a seed the migration writes that the gate does not model → gets skipped away (the bug above)
- a key the gate models that the migration never writes → *every* invocation re-migrates

The derivation asserts its own non-vacuity first, because a parse that silently finds nothing makes
both comparisons pass. Per-key behavioural arms then run for every modelled seed: born on a fresh
store, self-heals when deleted from a shape-perfect store, and settles back onto the skip path.

### Evidence

| check | result |
|---|---|
| `tests/gate_history_unit.sh` | **32 passed / 0 failed** — exactly the merge base |
| `tests/tasks_db_restore_guard_unit.sh` | **49 → 56 passed / 0 failed** |
| mutation: drop `gate_history_coverage` from the array | restore-guard reds on the derivation arm; `gate_history_unit` returns to 30/2 |
| mutation: add a key the migration never seeds | 8 red, incl. both settle arms and the reverse-direction drift arm |
| fresh-init, arms **interleaved**, n=20 | base `1bde9dc` 147 ms, head 155 ms — **+8 ms**, inside the ~30 ms envelope |
| `pii-scan` (diff + CHANGELOG) | clean |

Interleaved because the same base has read 104 / 125 / 133 / 147 ms across sittings against a 30 ms
envelope — a cross-sitting delta is drift, not signal. Both arms here are inflated by a concurrent
corpus run on the same box; the delta is the readable part, not the absolutes.

### On the `actor_claim_corroboration_unit.sh` T19 claim

main2 was right that iteration 1's "PRE-EXISTING ON MAIN" was unsupported by CI. Resolved:

- **It was never the shard-3 failure.** That harness runs in shard 3 and was `HARNESS-RC=0` there —
  the failure was `gate_history_unit.sh`.
- It fails on this control-plane host at **both** the branch and the merge base, and passes in CI on
  both. So it is host-local, not a main regression, and not this branch's. It owes its own row.
- **The first attempt to re-baseline it read green and was not.** A fresh base worktree with no built
  bundle reports `14 passed, 0 failed, 1 skipped` — the failing case is an e2e that skips itself when
  there is no binary. Building the base first reproduces the failure identically. Build the base
  before calling anything pre-existing.

### Scope of local verification

Ran the **full** tier locally this time, not just `core`. That is the point of the miss: the maker's
254-harness core tier was green and the branch was wrong, because `gate_history_unit.sh` is nightly.
A change whose whole purpose is to stop doing work is graded by the harnesses that notice missing
work, and those sit in subjects the diff never names.

Hosted CI is the binding evidence and has not yet run at this head.

### Knowledge compiled

`community/wiki/a-gate-is-a-model-of-the-work-it-skips.md` (new §1b: enumerating one member of a
class is not covering the class; derive the model from the procedure) and
`community/wiki/a-skip-gate-only-pays-if-the-thing-it-guards-is-complete-at-birth.md` (iteration-2
evidence section), both with updated index lines.
