### PR TITLE
feat(task): compare a close's stated version against the INSTALLED artifact (DIVE-2835)

### DIFF
--- a/changelog.d/DIVE-2835.md
+++ b/changelog.d/DIVE-2835.md
@@ -1,0 +1,43 @@
+## Unreleased — feat(task): a close that NAMES a version is compared against the INSTALLED artifact (DIVE-2835)
+
+`task done` and `task verify` now read the version a result claims it verified on and compare it to
+the version the box's own `/usr/local/bin/5dive` reports. The durable half of DIVE-2819, which
+rolled out a fix but built no machinery.
+
+**What it is for.** DIVE-2762 closed *"verified on v0.19.2"* onto a control plane running 0.19.1.
+The board read fixed; the defect stayed live for a day and ate maker text twice, with a verifier's
+signature on the row. DIVE-2819's pass then turned on a human **remembering** to grep the installed
+artifact. This runs that comparison at the only moment the closer can act on it.
+
+- **It keys on the ARTIFACT, not the string.** `_gate_installed_cli` resolves `/usr/local/bin/5dive`
+  — the path cron and every agent execute — and asks that file what it reports, rather than trusting
+  `$FIVE_VERSION` of whatever bundle is executing, which on a maker's worktree is not what the
+  control plane runs. Every message points at the file, because the whole lesson of DIVE-2819 is
+  that a version string was never the evidence.
+- **Direction is graded, not just difference.** Installed OLDER than claimed is the DIVE-2762 shape
+  and gets the loud line; installed NEWER gets a note (it shipped, and more shipped after); equal
+  emits a `step` so the record shows the comparison RAN. A dev build (`0.0.0-dev`, which is what
+  `main` permanently reads since DIVE-2247) refuses to be ordered against a release instead of
+  false-REDing every worktree, and an unreadable artifact says **NOT CHECKED** out loud rather than
+  passing silently.
+- **It warns, it never refuses — deliberately.** The guard cannot know WHICH artifact a version
+  names: `v2.1.0` may be a plugin, the api, or a dependency. A refusal would be a confident claim
+  about something this code did not identify.
+- **A result that makes no claim is met with complete silence.** The enabling half must cost a
+  non-adopter nothing.
+
+**The fence is looser than `graded-sha`'s, and that is the design, not an inconsistency.**
+`_gate_graded_sha` matches only a labelled declaration because it drives a REFUSAL, where a false
+positive blocks a close. This one can only warn, so its false positive costs one line and its false
+NEGATIVE costs what DIVE-2762 cost. A tidy label-only fence (`verified-on:`) would have matched
+**nothing** in the incident that motivates it, because the claim was ordinary prose. So it matches a
+verification VERB and a full `x.y.z` on the same line, verb first — and the gap between them
+excludes `;` and `,` so it cannot cross into the next clause, which is where an unrelated version
+lives. Write-up: `community/wiki/a-fences-tightness-belongs-to-the-consequence-it-drives.md`.
+
+`tests/task_version_vs_installed_unit.sh`, 22 arms, extracting the three functions from the shipped
+`src/cmd_task.sh` rather than re-typing them — with anchor-uniqueness arms and an empty-extraction
+arm so the extraction cannot silently grade the wrong block or read as a vacuous green. Graded by
+four mutations of the shipped file: widening the gap class to the naive `[^0-9]*` reds the
+cross-clause arm, collapsing the direction split reds the NEWER arm, removing the path from the
+mismatch sentence reds the OLDER arm, and making the no-claim case speak reds the silence arm.

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -2876,6 +2876,112 @@ _gate_graded_sha() {
   printf '%s' "${sha,,}"
 }
 
+# DIVE-2835: _gate_version_claim <text> — the version a close STATES it verified on.
+#
+# Sibling of `_gate_graded_sha` above, and deliberately a LOOSER fence, for one
+# reason worth stating because it looks like an inconsistency: THE TIGHTNESS OF A
+# FENCE BELONGS TO THE CONSEQUENCE IT DRIVES. `graded-sha` drives a REFUSAL, so a
+# false positive blocks a close and the fence must be a labelled declaration only.
+# This one can never do more than WARN, so its false positive costs one line of
+# output while its false NEGATIVE costs what DIVE-2762 cost: a result reading
+# "VERIFIED ON v0.19.2" while this host ran 0.19.1, the board reading fixed for a
+# full day, and the live defect eating maker text twice with a verifier signature
+# on the row. A label-only fence (`verified-on:`) would be tidy and would have
+# matched NOTHING in the incident that motivates this, because the claim was
+# ordinary prose. A guard that cannot fire on its own founding case is decoration.
+#
+# So: a verification VERB and a full x.y.z version on the SAME line, verb first.
+# Requiring all three parts is what keeps it from matching the versions a result
+# routinely names without claiming to have verified against them — "fixed in
+# v0.19.2, rollout tracked in DIVE-2816", a version in a quoted log line, a
+# changelog citation. LAST occurrence wins, same as graded-sha: `--append-result`
+# prepends the earlier close's text, so the later statement is the current one.
+#
+# Prints the bare version (no leading v), or EMPTY when the result makes no such
+# claim. Empty is "nothing was claimed", never "it matched".
+_gate_version_claim() {
+  local txt="${1:-}" line ver=""
+  # One regex, and the ORDER inside it is the fence: the verb, then a gap, then the
+  # version. The gap class `[^0-9;,]*` is doing the real work and it is worth being
+  # precise about why, because the obvious `[^0-9]*` is NOT enough: "verified the
+  # retirement; separately, the box runs 0.19.1" has no digits between the verb and
+  # the version, so a digit-only gap matches it and attributes a claim to a sentence
+  # that never made one. Excluding `;` and `,` means the gap cannot cross into the
+  # next clause, which is where an unrelated version lives. Measured both ways.
+  # The pattern lives in a VARIABLE, not inline: an unquoted `;` inside `[[ =~ ]]`
+  # terminates the command and bash reports a syntax error at parse time, so the
+  # class that makes this fence work cannot be written inline at all.
+  local _re='(VERIFIED|Verified|verified|TESTED|Tested|tested|CONFIRMED|Confirmed|confirmed|VALIDATED|Validated|validated|SMOKED|Smoked|smoked|REPRODUCED|Reproduced|reproduced)[^0-9;,]*[vV]?([0-9]+\.[0-9]+\.[0-9]+)'
+  while IFS= read -r line; do
+    [[ "$line" =~ $_re ]] && ver="${BASH_REMATCH[2]}"
+  done <<<"$txt"
+  printf '%s' "$ver"
+}
+
+# DIVE-2835: _gate_installed_cli — the DEPLOYED artifact, as `<path>|<version>`.
+#
+# The point of the whole check is that a version STRING is not evidence (DIVE-2819),
+# so this resolves a FILE and asks that file what it reports, rather than trusting
+# `$FIVE_VERSION` of whatever bundle happens to be executing — which on a maker's
+# worktree is not what the control plane runs. `/usr/local/bin/5dive` first because
+# that is the path cron and every agent execute (the same path
+# `_gate_merged_not_deployed` names); `command -v` only as a fallback for a box that
+# installed elsewhere. Empty means the artifact could not be read, which the caller
+# must report as NOT CHECKED rather than as agreement.
+_gate_installed_cli() {
+  local p v
+  for p in /usr/local/bin/5dive "$(command -v 5dive 2>/dev/null)"; do
+    [[ -n "$p" && -f "$p" && -x "$p" ]] || continue
+    v=$("$p" --version 2>/dev/null | head -1 | awk '{print $2}')
+    [[ -n "$v" ]] || continue
+    printf '%s|%s' "$p" "$v"; return 0
+  done
+  return 1
+}
+
+# DIVE-2835: _gate_version_vs_installed <ident> <verb> <result-text>
+#
+# Converts a discipline into machinery. DIVE-2762 closed "verified on v0.19.2" onto a
+# host running 0.19.1; DIVE-2819's pass then turned on a human REMEMBERING to grep the
+# installed artifact. This runs that comparison at the only moment the closer can act
+# on it, and it always points at the FILE.
+#
+# WARN, never refuse, and that is not timidity: the guard cannot know WHICH artifact a
+# version names. "verified on v2.1.0" may be a plugin, the api, or a dependency, and a
+# refusal would be a confident claim about something this code did not identify. So it
+# reports the comparison and names its own scope, which is the honest shape for a check
+# whose subject is inferred rather than declared.
+#
+# Direction matters and is reported separately. Installed OLDER than claimed is the
+# DIVE-2762 shape — the artifact carrying the fix is not the artifact running here, and
+# the board is about to read fixed. Installed NEWER is ordinarily fine (it shipped, and
+# more shipped after), so it gets a note rather than the loud line.
+_gate_version_vs_installed() {
+  local ident="${1:-}" verb="${2:-}" txt="${3:-}"
+  local claimed; claimed=$(_gate_version_claim "$txt")
+  [[ -n "$claimed" ]] || return 0
+  local inst ipath iver
+  if ! inst=$(_gate_installed_cli); then
+    warn "$ident: this $verb states it verified on v$claimed, but the INSTALLED 5dive artifact could not be read (tried /usr/local/bin/5dive and \$PATH) — the deployed-vs-claimed comparison did NOT run (DIVE-2835). That is 'not checked', not 'agreed'."
+    return 0
+  fi
+  ipath="${inst%%|*}"; iver="${inst##*|}"
+  if [[ "$iver" == 0.0.0* || "$iver" == *-dev* ]]; then
+    warn "$ident: this $verb states it verified on v$claimed; $ipath reports '$iver', a dev build whose ordering against a release is meaningless, so no comparison was made (DIVE-2835). Grep the artifact for the change itself — the version string was never the evidence."
+    return 0
+  fi
+  if [[ "$iver" == "$claimed" ]]; then
+    step "$ident: verified-on v$claimed matches the installed artifact ($ipath reports $iver) — the claim describes what this host actually runs (DIVE-2835)."
+    return 0
+  fi
+  local older; older=$(printf '%s\n%s\n' "$claimed" "$iver" | sort -V | head -1)
+  if [[ "$older" == "$iver" ]]; then
+    warn "$ident: DEPLOYED-VS-CLAIMED MISMATCH — this $verb states it verified on v$claimed, but $ipath reports $iver, which is OLDER (DIVE-2835). The board is about to read this as fixed while the artifact every agent and cron actually executes does not carry it: that is exactly DIVE-2762, which stayed live for a day under a verifier's signature. Confirm against the FILE, not the version string — grep $ipath for the change — and if the rollout has not happened, this row is a rollout row, not a done one."
+  else
+    warn "$ident: this $verb states it verified on v$claimed; $ipath reports $iver, which is NEWER (DIVE-2835). Usually fine — it shipped and more shipped after — but the claim describes an artifact nobody is running now, so grep $ipath if the behaviour still matters."
+  fi
+}
+
 # DIVE-2656 PART 1: _gate_pr_shas <ref> <tok> — the two shas a merged PR can be
 # legitimately said to carry, as `<headRefOid>|<mergeCommit.oid>`.
 #
@@ -3493,6 +3599,12 @@ _task_status_cmd() {
     _task_guard_result_over_closed "$id" "$ident" "$verb" "$result" "$append_result" "$force_result"
     result="$_TASK_GUARDED_RESULT"
   fi
+  # DIVE-2835: a result that NAMES a version is making a claim about a DEPLOYED
+  # artifact — compare it to the one this host runs. Placed BEFORE the DIVE-477
+  # routing below on purpose: a maker's `task done` that delivers rather than
+  # closes carries exactly the same claim, and the moment to check it is the
+  # moment it is written, not the moment someone later re-reads it.
+  [[ "$verb" == "done" ]] && _gate_version_vs_installed "$ident" done "$result"
   # DIVE-477: maker→verifier routing. A `task done` on a task that carries a
   # `verifier` distinct from its current assignee is NOT a close — it's a handoff.
   # The maker is claiming the work is ready; the verifier must grade it before the
@@ -5746,6 +5858,13 @@ cmd_task_verify() {
   # append below, and running both would append twice. This is keyed on status at
   # the CALL SITE — which is fine and is not the defect this ticket is about — to
   # avoid two preservation mechanisms overlapping on one write.
+  # DIVE-2835: run the deployed-vs-claimed comparison on THIS close's own text,
+  # deliberately before the guard below prepends the prior result. After that
+  # prepend the cell also carries the MAKER's words, and warning "this verify
+  # states it verified on vX" about a sentence the verifier did not write would be
+  # a true finding attributed to the wrong author — the same misattribution
+  # DIVE-2725 spent two iterations removing from a probe verdict.
+  _gate_version_vs_installed "$ident" verify "$result_txt"
   local _v_guard_st
   _v_guard_st=$(db "SELECT COALESCE(status,'') FROM tasks WHERE id=${id};")
   if [[ "$_v_guard_st" != "done" && "$_v_guard_st" != "cancelled" ]]; then

--- a/tests/task_version_vs_installed_unit.sh
+++ b/tests/task_version_vs_installed_unit.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# DIVE-2835 — grade the close-time deployed-vs-claimed comparison.
+#
+# A result that NAMES a version is making a claim about a DEPLOYED artifact.
+# DIVE-2762 closed "verified on v0.19.2" onto a host running 0.19.1 and the board
+# read fixed for a day. This harness grades the guard that converts the human
+# discipline (remember to grep the installed file) into machinery.
+#
+# It EXTRACTS the three functions from the shipped src/cmd_task.sh rather than
+# re-typing them, so it cannot drift into grading a copy — same design as
+# tests/roundtrip_openrouter_verdict.sh, and the same obligation that comes with
+# it: prove the extraction anchor is unique and that an empty extraction REDS
+# rather than reading as all-arms-pass.
+#
+# Run: bash tests/task_version_vs_installed_unit.sh   (no root, no network, no db).
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC="${1:-src/cmd_task.sh}"
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# --- extraction, and its own non-vacuity ------------------------------------
+xtract() { awk -v fn="^$1\\\\(\\\\)" '$0 ~ fn {f=1} f{print} f&&/^}/{exit}' "$SRC"; }
+for fn in _gate_version_claim _gate_installed_cli _gate_version_vs_installed; do
+  n=$(grep -c "^${fn}()" "$SRC")
+  [[ "$n" == 1 ]] && ok_t "extraction anchor for $fn occurs exactly once (got $n)" \
+                  || bad_t "anchor for $fn is not unique" "grep -c = $n; an extracting harness can silently grade the wrong block"
+  b=$(xtract "$fn")
+  [[ -n "$b" ]] && eval "$b" || bad_t "could not extract $fn from $SRC"
+done
+
+# warn/step are the CLI's real emitters; here they only need to be capturable.
+WARNED=""; STEPPED=""
+warn(){ WARNED="$WARNED$*"$'\n'; }
+step(){ STEPPED="$STEPPED$*"$'\n'; }
+
+# --- ARM 1: the fence. What IS a claim ---------------------------------------
+claim(){ _gate_version_claim "$1"; }
+for pair in \
+  "VERIFIED ON v0.19.2|0.19.2" \
+  "verified on 0.19.2 by main2|0.19.2" \
+  "smoked v1.2.3 on a fresh box|1.2.3" \
+  "all three acceptance items confirmed against v0.19.3|0.19.3" \
+  "tested v2.0.10|2.0.10"; do
+  txt="${pair%%|*}"; want="${pair##*|}"; got=$(claim "$txt")
+  [[ "$got" == "$want" ]] && ok_t "claim recognised: '${txt:0:44}' -> $got" \
+                          || bad_t "claim missed: '$txt'" "got '$got' want '$want'"
+done
+
+# --- ARM 2: the fence. What is NOT a claim, and the load-bearing one ----------
+# A result routinely names versions it is not claiming to have verified against.
+# The last case here is the one a naive `[^0-9]*` gap matches: verb and version in
+# DIFFERENT clauses. It is the reason the gap class excludes ; and , and it is the
+# arm that reds if someone "simplifies" the regex.
+for txt in \
+  "fixed in v0.19.2, rollout tracked in DIVE-2816" \
+  "the host runs 0.19.1 and the board says fixed" \
+  "verified the retirement; separately, the box runs 0.19.1" \
+  "graded-sha: d46c0e158f4c1dd09d3709568cb6be764e37b331" \
+  "verified on main" \
+  "verified against v0.19"; do
+  got=$(claim "$txt")
+  [[ -z "$got" ]] && ok_t "not a claim: '${txt:0:52}'" \
+                  || bad_t "false claim from '$txt'" "extracted '$got' — a version NAMED is not a version VERIFIED ON"
+done
+got=$(claim $'verified on v0.1.0\nlater: verified on v9.9.9')
+[[ "$got" == "9.9.9" ]] && ok_t "LAST occurrence wins (--append-result prepends the older text)" \
+                        || bad_t "last-wins" "got '$got' want 9.9.9"
+
+# --- ARM 3: the comparison, by direction --------------------------------------
+run_cmp(){ WARNED=""; STEPPED=""
+  eval "_gate_installed_cli(){ printf '%s' '$1'; ${2:-return 0}; }"
+  _gate_version_vs_installed DIVE-TEST done "$3"; }
+
+run_cmp "/usr/local/bin/5dive|0.19.2" "" "VERIFIED ON v0.19.2"
+{ [[ "$STEPPED" == *"matches the installed artifact"* && -z "$WARNED" ]]; } \
+  && ok_t "equal: reports that the comparison RAN and agreed, and does not warn" \
+  || bad_t "equal case" "step='$STEPPED' warn='$WARNED'"
+
+run_cmp "/usr/local/bin/5dive|0.19.1" "" "VERIFIED ON v0.19.2"
+# The path assertion is deliberately POSITIONAL — "/usr/local/bin/5dive reports
+# 0.19.1", not just "the path appears somewhere". Measured: a mutation that
+# removed the path from the mismatch sentence still passed a loose contains-check,
+# because the closing "grep $ipath" sentence supplies the same substring. An arm
+# that can be satisfied by a different occurrence is not grading what it names.
+{ [[ "$WARNED" == *"DEPLOYED-VS-CLAIMED MISMATCH"* && "$WARNED" == *OLDER* \
+    && "$WARNED" == *"/usr/local/bin/5dive reports 0.19.1"* && "$WARNED" == *DIVE-2762* ]]; } \
+  && ok_t "installed OLDER than claimed: the DIVE-2762 shape, named, and the mismatch sentence itself names the FILE" \
+  || bad_t "older case" "$WARNED"
+
+run_cmp "/usr/local/bin/5dive|0.19.3" "" "VERIFIED ON v0.19.2"
+{ [[ "$WARNED" == *NEWER* && "$WARNED" != *"DEPLOYED-VS-CLAIMED MISMATCH"* ]]; } \
+  && ok_t "installed NEWER: a note, NOT the mismatch banner (direction is graded, not just difference)" \
+  || bad_t "newer case" "$WARNED"
+
+# --- ARM 4: the three honest non-answers --------------------------------------
+run_cmp "" "return 1" "VERIFIED ON v0.19.2"
+{ [[ "$WARNED" == *"did NOT run"* && "$WARNED" == *"not checked"* ]]; } \
+  && ok_t "artifact unreadable: says NOT CHECKED out loud, never silence and never 'agreed'" \
+  || bad_t "unreadable case" "$WARNED"
+
+run_cmp "/usr/local/bin/5dive|0.0.0-dev" "" "VERIFIED ON v0.19.2"
+{ [[ "$WARNED" == *"dev build"* && "$WARNED" != *OLDER* ]]; } \
+  && ok_t "dev build: refuses to order a dev version against a release instead of false-REDing every worktree" \
+  || bad_t "dev case" "$WARNED"
+
+run_cmp "/usr/local/bin/5dive|0.19.3" "" "landed the fix, rollout tracked in DIVE-2816"
+{ [[ -z "$WARNED" && -z "$STEPPED" ]]; } \
+  && ok_t "no claim -> completely SILENT (the enabling half must cost a non-adopter nothing)" \
+  || bad_t "no-claim case is noisy" "warn='$WARNED' step='$STEPPED'"
+
+# --- ARM 5: empty extraction must RED, not read as all-arms-pass --------------
+# The re-invocation needs a BASE CASE: without the fence the nested run reaches
+# this arm too and re-invokes itself forever. Found by hanging the harness twice,
+# which is the cheap way to learn that a self-invoking arm is a recursion.
+if [[ -z "${DIVE2835_NESTED:-}" ]]; then
+  : > "/tmp/dive2835-noblock.$$"
+  out=$(DIVE2835_NESTED=1 timeout 30 bash "$0" "/tmp/dive2835-noblock.$$" 2>&1); rc=$?
+  rm -f "/tmp/dive2835-noblock.$$"
+  { [[ $rc -ne 0 && "$out" == *"is not unique"* ]]; } \
+    && ok_t "pointed at a file with no block: reds (rc=$rc), never a vacuous green" \
+    || bad_t "empty extraction did not red" "rc=$rc out=${out:0:200}"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
The durable half DIVE-2819 rolled out but did not build (DIVE-2835).

`task done` and `task verify` now read the version a result claims it verified on and compare it to the version this box's own `/usr/local/bin/5dive` reports.

**Why it is worth machinery.** DIVE-2762 closed *"verified on v0.19.2"* onto a control plane running 0.19.1. The board read fixed; the defect stayed live for a day and ate maker text twice, with a verifier's signature on the row. DIVE-2819's pass then turned on a human **remembering** to grep the installed artifact.

## Design

- **Keys on the ARTIFACT, not the string** — resolves `/usr/local/bin/5dive`, the path cron and every agent execute, and asks that file what it reports rather than trusting `$FIVE_VERSION` of whatever bundle is executing (on a maker's worktree that is not what the control plane runs). Every message points at the file.
- **Grades the DIRECTION, not just the difference** — installed older than claimed is the DIVE-2762 shape and gets the loud line; newer gets a note; equal emits a `step` so the record shows the comparison RAN.
- **Three non-answers stay distinct** — unreadable artifact says **NOT CHECKED** (DIVE-2318's rule one level down); a `0.0.0-dev` build refuses to be ordered against a release rather than false-REDing every worktree; a result with no claim is met with **complete silence**, so the enabling half costs a non-adopter nothing.
- **Warns, never refuses** — the guard cannot know WHICH artifact a version names (`v2.1.0` may be a plugin, the api, a dependency), so a refusal would be a confident claim about something this code did not identify.

## The fence is looser than `_gate_graded_sha`'s, on purpose

That guard matches only a labelled declaration because it drives a **refusal**, where a false positive blocks a close. This one can only **warn**: a false positive costs one line, and a false negative costs what DIVE-2762 cost. A tidy `verified-on:` label would have matched **nothing** in the founding incident, because the claim was ordinary prose — and a guard that cannot fire on its own founding case is decoration that looks like coverage.

So: a verification verb, a gap, and a full `x.y.z`, on one line, verb first. The gap class excludes `;` and `,` so it cannot cross into the next clause — `[^0-9]*` matches *"verified the retirement; separately, the box runs 0.19.1"*, because no digits intervene.

## How it was checked

`tests/task_version_vs_installed_unit.sh` — **22 arms, 0 failed**. It extracts the three functions from the shipped `src/cmd_task.sh` rather than re-typing them, and carries the two obligations that come with an extracting harness: anchor-uniqueness arms, and an empty-extraction arm proving a missing block **reds** instead of reading as all-arms-pass.

**Four mutations of the shipped file**, each asserted to a single site, each reverted after:

| mutation | result |
|---|---|
| widen the gap class to the naive `[^0-9]*` | cross-clause arm red |
| collapse the direction split (NEWER gets the mismatch banner) | NEWER arm red |
| drop the path from the mismatch sentence | OLDER arm red *(after the arm was fixed — see below)* |
| make the no-claim case speak | silence arm red |

The third one **survived the first pass**: the arm asserted `warn contains "/usr/local/bin/5dive"` and the message's closing "grep `$ipath`" sentence still supplied that substring. When a message repeats a token, a `contains` assertion grades the message, not the sentence — fixed by anchoring it positionally to `"/usr/local/bin/5dive reports 0.19.1"`, after which the mutation reds.

Neighbouring close-path harnesses, all green on this tree: `task_core_unit` 51/0, `task_close_needs_a_reason_unit` 19/0, `task_deliver_merge_gate_unit` 43/0, `task_done_delivered_guard_unit` 20/0, `task_close_preserves_done_at_unit` 16/0, `task_deliver_over_closed_result_unit` 23/0, `task_done_ack_before_merge_gate_unit` 11/0, `task_result_loss_open_row_unit` 30/0.

Write-up: `community/wiki/a-fences-tightness-belongs-to-the-consequence-it-drives.md` + index line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
