### PR TITLE
fix(ui): --once returns the code it earned, cleans up, and finishes the write (DIVE-2813)

### DIFF
--- a/changelog.d/DIVE-2813.md
+++ b/changelog.d/DIVE-2813.md
@@ -45,3 +45,15 @@ the server's own `listening on` line rather than a TCP connect, because `--once`
 request to give and a connect-based probe spends it. Mutation-graded per finding: reverting the
 `kill` fix fails exactly the two cleanup assertions and no others; reverting the threading fix fails
 the body assertions on 8 of 10 runs, 5 of them behind a passing `200`.
+
+**Serving in-thread inherits a hang, so `--once` now has a 30s read timeout.** The threaded
+server exited immediately on a client that connects and never sends a request line — but it did
+that by *abandoning* it, which is the defect above. Single-shot there is nothing else running to
+notice, and the one thread would park in `readline()` forever. Measured on paired arms differing
+by that line alone: without it the server was still parked at 46s and had to be killed; with it,
+it exited at ~31s. `serve_forever()` keeps the stdlib default (`None`) — another thread is always
+available there, so the hazard is bounded and a cap would be wrong. The general shape:
+**a concurrency bug fixed by deleting the concurrency inherits every hazard the concurrency was
+masking**, and nothing regresses to catch it, because the masking was never a decision — it was a
+side effect of the bug. See
+`community/wiki/removing-the-concurrency-inherits-the-hang-it-was-masking.md`.

--- a/changelog.d/DIVE-2813.md
+++ b/changelog.d/DIVE-2813.md
@@ -1,0 +1,47 @@
+## Unreleased — fix(ui): `--once` returns the exit code it earned, cleans up after itself, and finishes writing the response (DIVE-2813)
+
+Two independent defects in `5dive ui --once`, filed as one and repaired as two. They are ~600 lines
+apart, in different languages, and fixing either alone leaves the other exactly where it was.
+
+**A trailing `kill` ate the cleanup behind it.** `wait "$py"` returns *because the child is already
+reaped*, so the belt-and-braces `kill "$py" 2>/dev/null` on the next line could only ever get
+`ESRCH`. Under `set -e` that ends the function there: it published **1 as the exit code of a fully
+successful run**, discarded the `rc` the five lines above had computed, and never reached the
+`rm -rf "$tmp"` — leaking a mode-700 temp dir on **every** invocation (115 already present on this
+host when it was measured). Deterministic: rc=1 on 12/12 bundle runs, rc=0 on 10/10 for the same
+python extracted standalone, so the interpreter was never involved.
+
+The bitter part is in the source's own comment. The author explicitly declined a `RETURN` trap in
+favour of *"explicit removal on every exit path"* — for a correct reason — but `set -e` is precisely
+the mechanism that skips explicit cleanup and preserves trap cleanup. The `INT`/`TERM` trap two lines
+up removed the temp dir; the explicit line chosen to replace it did not. Which is also why nobody
+reproduced the leak: the fall-through cleanup is reached **only** on the runs that served their
+request, so the leak happens on the successes and never on the Ctrl-C'd run anyone tries first.
+Generally: **a command whose success depends on the failure path having been taken will fail on the
+success path** — `rmdir` on a dir the good path already removed, `grep` on output a clean run leaves
+empty, `pkill -f` for a pattern that only matches a crash.
+
+**`--once` is no longer served by a threading server.** `ThreadingHTTPServer.handle_request()`
+returns on **dispatch**, not on completion — the main thread fell through to `server_close()` and
+exited, and interpreter shutdown killed the worker mid-write. Its threads are daemonic and
+socketserver's join-on-close list only ever tracks *non-daemon* threads, so nothing waited for the
+body. The dominant signature is not a refused connection: it is a **truncated 200**, status line and
+headers delivered, body cut. Measured on the pre-fix bundle, 14 runs: **10 answered `200` and then
+raised `IncompleteRead` on the body**, 3 dropped the connection, 1 was clean. Served in-thread,
+`handle_request()` cannot return before the response is on the socket. `serve_forever()` keeps
+threading — there a slow `/api/state` (it shells out to the bundle) would block every other request.
+`--once` also sends `Connection: close`, because under HTTP/1.1 the handler otherwise loops on a
+kept-alive socket and the single-shot server never returns.
+
+**Arm 15 of `tests/ui_views_e2e.sh` graded a status code and a dead process**, which is how a
+documented flag whose success path returned failure survived for as long as the flag has existed.
+Both new assertions are needed and neither substitutes for the other: **the exit code** (visible half
+of the first defect) and **the temp dir being gone** (the half no exit-code assertion can see — fix
+only the code and the leak ships), plus **the body against the `Content-Length` the server itself
+promised**, since a status-only assertion scores the truncated case as a pass — measured above at 10
+of 14. Status and body are read separately on purpose, so a truncated 200 fails the body check while
+still passing the status check and the arm can say which defect it caught. Readiness now comes from
+the server's own `listening on` line rather than a TCP connect, because `--once` has exactly one
+request to give and a connect-based probe spends it. Mutation-graded per finding: reverting the
+`kill` fix fails exactly the two cleanup assertions and no others; reverting the threading fix fails
+the body assertions on 8 of 10 runs, 5 of them behind a passing `200`.

--- a/changelog.d/DIVE-2813.md
+++ b/changelog.d/DIVE-2813.md
@@ -55,5 +55,9 @@ it exited at ~31s. `serve_forever()` keeps the stdlib default (`None`) — anoth
 available there, so the hazard is bounded and a cap would be wrong. The general shape:
 **a concurrency bug fixed by deleting the concurrency inherits every hazard the concurrency was
 masking**, and nothing regresses to catch it, because the masking was never a decision — it was a
-side effect of the bug. See
+side effect of the bug. So it is graded: **arm 16** connects and sends nothing, and a refactor back
+to a threading server passes every other arm and fails only that one. The bound is overridable via
+`_5DIVE_UI_ONCE_READ_TIMEOUT` so the arm costs 2s rather than 30 (+3.0s on the file, 5.0s → 8.0s,
+min of 4 runs on this host). Mutation-graded: deleting the timeout line fails exactly arm 16's
+three assertions and no others. See
 `community/wiki/removing-the-concurrency-inherits-the-hang-it-was-masking.md`.

--- a/src/cmd_ui.sh
+++ b/src/cmd_ui.sh
@@ -658,6 +658,14 @@ class Handler(BaseHTTPRequestHandler):
     server_version = "5dive-ui"
     sys_version = ""
     protocol_version = "HTTP/1.1"
+    # A hazard CREATED by serving --once in-thread, so it is bounded here rather
+    # than left to be discovered. A bare TCP connect that sends no request line
+    # would park the single-shot server forever: nothing else is running to
+    # notice. The threaded version exited instead — the main thread never waited
+    # for the worker, which is the defect this file just fixed, but it also hid
+    # this. A read timeout ends the connection and handle_request() returns.
+    # None (the stdlib default) everywhere else: serve_forever keeps its threads.
+    timeout = 30 if ONCE else None
 
     def log_message(self, fmt, *args):          # one line per request, on stderr
         sys.stderr.write("%s %s\n" % (self.command, self.path.split("?", 1)[0]))

--- a/src/cmd_ui.sh
+++ b/src/cmd_ui.sh
@@ -643,6 +643,7 @@ HTML
 _ui_server_py() {
   cat <<'PY'
 import json
+import os
 import subprocess
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
@@ -665,7 +666,10 @@ class Handler(BaseHTTPRequestHandler):
     # for the worker, which is the defect this file just fixed, but it also hid
     # this. A read timeout ends the connection and handle_request() returns.
     # None (the stdlib default) everywhere else: serve_forever keeps its threads.
-    timeout = 30 if ONCE else None
+    # The override exists so a harness can grade this in seconds instead of
+    # waiting 30 out; the property was lost the first time precisely because no
+    # arm encoded it (DIVE-2813, arm 16 of tests/ui_views_e2e.sh).
+    timeout = float(os.environ.get("_5DIVE_UI_ONCE_READ_TIMEOUT") or 30) if ONCE else None
 
     def log_message(self, fmt, *args):          # one line per request, on stderr
         sys.stderr.write("%s %s\n" % (self.command, self.path.split("?", 1)[0]))

--- a/src/cmd_ui.sh
+++ b/src/cmd_ui.sh
@@ -113,7 +113,15 @@ cmd_ui() {
   trap 'kill "$py" 2>/dev/null; rm -rf "$tmp"' INT TERM
   wait "$py" || rc=$?
   trap - INT TERM
-  kill "$py" 2>/dev/null
+  # `|| true` is load-bearing, not style. `wait` returned because the child is
+  # already reaped, so this belt-and-braces kill can only ever get ESRCH — and
+  # under `set -e` a bare failing command ends the function HERE: it published 1
+  # as the exit code of a fully successful run, discarded the rc computed above,
+  # and skipped the `rm` below, leaking a mode-700 temp dir per invocation. Note
+  # which path that is: the trap two lines up cleans up correctly, so the leak
+  # happened only on the runs that WORKED (DIVE-2813, and see
+  # community/wiki/set-e-deletes-exactly-the-cleanup-a-trap-would-have-kept.md).
+  kill "$py" 2>/dev/null || true
   rm -rf "$tmp"
   return "$rc"
 }
@@ -637,7 +645,7 @@ _ui_server_py() {
 import json
 import subprocess
 import sys
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 
 HOST, PORT, PAGE, BUNDLE = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
 ONCE = "--once" in sys.argv[5:]
@@ -663,6 +671,11 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("X-Content-Type-Options", "nosniff")
         self.send_header("X-Frame-Options", "DENY")
         self.send_header("Referrer-Policy", "no-referrer")
+        if ONCE:
+            # One request means one connection. Under HTTP/1.1 the handler loops
+            # on a kept-alive socket, so without this the single-shot server
+            # stays inside handle_request() until the client hangs up.
+            self.send_header("Connection", "close")
         self.end_headers()
         if self.command != "HEAD":
             self.wfile.write(body)
@@ -706,7 +719,18 @@ class Handler(BaseHTTPRequestHandler):
 
 
 if __name__ == "__main__":
-    srv = ThreadingHTTPServer((HOST, PORT), Handler)
+    # --once is served WITHOUT threading, deliberately. ThreadingHTTPServer hands
+    # each request to a worker and returns from handle_request() on DISPATCH, not
+    # on completion — the main thread falls straight through to server_close() and
+    # exits, and interpreter shutdown kills the worker mid-write. Its threads are
+    # daemonic, and socketserver's join-on-close list only ever tracks NON-daemon
+    # threads, so nothing waits for the body. The signature is mostly a TRUNCATED
+    # 200 (status line and headers delivered, body cut), not a refused connection,
+    # so an arm grading only the status code scores it a pass. Served in-thread,
+    # handle_request() cannot return before the response is on the socket.
+    # serve_forever() keeps threading: there a slow /api/state (it shells out to
+    # the bundle) would otherwise block every other request. (DIVE-2813)
+    srv = (HTTPServer if ONCE else ThreadingHTTPServer)((HOST, PORT), Handler)
     sys.stderr.write("listening on http://%s:%d\n" % (HOST, PORT))
     sys.stderr.flush()
     try:

--- a/tests/ui_views_e2e.sh
+++ b/tests/ui_views_e2e.sh
@@ -330,6 +330,52 @@ PY2
 fi
 kill "$ONCE_PID" 2>/dev/null
 
+# --- 16. a client that never speaks cannot park --once -----------------------
+# This hazard is CREATED by the fix above. Serving in-thread is what makes the
+# response whole, and it also removes the only thing that was ending a connection
+# from a client that connects and sends no request line: the threaded server
+# exited on that client, but by ABANDONING it, which is the defect arm 15 grades.
+# Single-shot there is no other thread to notice, so the one thread would sit in
+# readline() forever.
+#
+# It is graded here for the reason the property was lost the first time — nobody
+# had encoded it, because it was never a decision, just a side effect of the bug.
+# A refactor back to a threading server passes every arm above and fails only
+# this one. `_5DIVE_UI_ONCE_READ_TIMEOUT` keeps that honest at 2s instead of 30.
+PORT3="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+STALLTMP="$TMP/stall-tmpdir"; mkdir -p "$STALLTMP"
+_5DIVE_UI_ONCE_READ_TIMEOUT=2 TMPDIR="$STALLTMP" \
+    "$FIVE" ui --port="$PORT3" --once >"$TMP/stall.log" 2>&1 &
+STALL_PID=$!
+stall_up=0
+for _ in $(seq 1 40); do
+  grep -q 'listening on' "$TMP/stall.log" 2>/dev/null && { stall_up=1; break; }
+  sleep 0.25
+done
+chk "16 --once came up" "1" "$stall_up"
+if (( stall_up )); then
+  # Connect and say NOTHING. The fd is held open for the whole poll, so the
+  # server is never released by a hangup — only by its own read timeout.
+  if exec 9<>"/dev/tcp/127.0.0.1/$PORT3" 2>/dev/null; then
+    stall_gone=0
+    for _ in $(seq 1 60); do            # 15s: ample for a 2s timeout, and bounded
+      kill -0 "$STALL_PID" 2>/dev/null || { stall_gone=1; break; }
+      sleep 0.25
+    done
+    exec 9<&- 2>/dev/null; exec 9>&- 2>/dev/null
+    chk "16 a silent client does not park it" "1" "$stall_gone"
+    # Same reap discipline as arm 15: never `wait` on a server still running.
+    stall_rc="never-exited"; (( stall_gone )) && { wait "$STALL_PID"; stall_rc=$?; }
+    chk "16 a timed-out connection is not an error" "0" "$stall_rc"
+    chk "16 the temp dir is removed on that path too" "0" \
+        "$(find "$STALLTMP" -maxdepth 1 -name '5dive-ui.*' 2>/dev/null | wc -l)"
+    (( stall_gone )) || kill -9 "$STALL_PID" 2>/dev/null
+  else
+    chk "16 a silent client does not park it" "1" "connect-failed"
+    kill -9 "$STALL_PID" 2>/dev/null
+  fi
+fi
+
 # --- 13. wired into the CLI --------------------------------------------------
 chk "13 ui --help exits 0" "0" "$("$FIVE" ui --help >/dev/null 2>&1; echo $?)"
 chk "13 listed in top-level help" "1" \

--- a/tests/ui_views_e2e.sh
+++ b/tests/ui_views_e2e.sh
@@ -254,33 +254,79 @@ chk "14 it did not create a store"    "1"        "$([[ -d "$FRESH/tasks" ]] && e
 chk "14 the page names the fix"       "1"        "$(grep -c '5dive task init' "$TMP/page.html" || true)"
 
 # --- 15. --once serves exactly one request, then exits -----------------------
-# A documented flag nobody runs is a claim, not a feature. Both halves are
-# graded: the one request IS answered, and the process is gone afterwards.
+# A documented flag nobody runs is a claim, not a feature. This arm used to grade
+# a status code and a dead process, and that pair let TWO shipped defects live in
+# `--once` for as long as the flag has existed (DIVE-2786 / DIVE-2813). Both of
+# them are invisible to a status code, in opposite directions, so both of the
+# assertions they need are here and each is graded separately:
+#
+#   the body arrives WHOLE   the response is served in the same thread now; when
+#                            it was dispatched to a daemon worker the interpreter
+#                            exited mid-write and the dominant signature was a
+#                            TRUNCATED 200 — status line and headers delivered,
+#                            body cut — which a status-only assertion scores as a
+#                            PASS. Graded against the Content-Length the server
+#                            itself promised, so it cannot drift with the page.
+#   the EXIT CODE is 0       a trailing `kill` after `wait` can only hit ESRCH, so
+#                            under `set -e` a perfect run published 1 AND skipped
+#                            the `rm` behind it. The exit code is the half that is
+#                            visible; the leak below is the half that is not, so
+#                            asserting only rc would fix the symptom and keep the
+#                            leak. TMPDIR is private to this run: the host has
+#                            hundreds of these already and other runs are racing.
+#
+# Readiness comes from the server's own "listening on" line, never from opening a
+# connection — `--once` has exactly one request to give and a TCP probe spends it.
 PORT2="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
-"$FIVE" ui --port="$PORT2" --once >"$TMP/once.log" 2>&1 &
+UITMP="$TMP/once-tmpdir"; mkdir -p "$UITMP"
+TMPDIR="$UITMP" "$FIVE" ui --port="$PORT2" --once >"$TMP/once.log" 2>&1 &
 ONCE_PID=$!
 once_up=0
 for _ in $(seq 1 40); do
-  ss -ltn 2>/dev/null | grep -q "127\.0\.0\.1:$PORT2" && { once_up=1; break; }
+  grep -q 'listening on' "$TMP/once.log" 2>/dev/null && { once_up=1; break; }
   sleep 0.25
 done
 chk "15 --once came up" "1" "$once_up"
 if (( once_up )); then
-  first="$(PORT="$PORT2" python3 - "$PORT2" GET /healthz <<'PY2'
+  mapfile -t once_r < <(python3 - "$PORT2" GET / <<'PY2'
 import sys, urllib.request
 port, method, path = sys.argv[1], sys.argv[2], sys.argv[3]
 req = urllib.request.Request("http://127.0.0.1:%s%s" % (port, path), method=method)
-with urllib.request.urlopen(req, timeout=10) as r:
-    print(r.status)
+# The status line is captured BEFORE the body is read, so the two assertions stay
+# independent: a truncated 200 must fail the body check while still passing the
+# status check, or the arm cannot say which of the two defects it caught.
+status, promised, received, whole = "000", "promised", "no-body", "0"
+try:
+    r = urllib.request.urlopen(req, timeout=10)
+    status = str(r.status)
+    promised = r.headers.get("Content-Length", "no-content-length")
+except Exception as exc:                      # noqa: BLE001 - reported, not raised
+    received = type(exc).__name__
+else:
+    try:
+        body = r.read()                       # a cut body raises IncompleteRead
+        received = str(len(body))
+        whole = "1" if body.rstrip().endswith(b"</html>") else "0"
+    except Exception as exc:                  # noqa: BLE001 - reported, not raised
+        received = type(exc).__name__
+print(status); print(promised); print(received); print(whole)
 PY2
-)"
-  chk "15 the one request is answered" "200" "$first"
+)
+  chk "15 the one request is answered"    "200" "${once_r[0]:-none}"
+  chk "15 the response BODY arrives whole" "${once_r[1]:-promised}" "${once_r[2]:-received}"
+  chk "15 the body is the WHOLE page"      "1"   "${once_r[3]:-0}"
   gone=0
   for _ in $(seq 1 40); do
     kill -0 "$ONCE_PID" 2>/dev/null || { gone=1; break; }
     sleep 0.25
   done
   chk "15 it exited after that request" "1" "$gone"
+  # Only reap once it is known gone: an unbounded `wait` on a hung server would
+  # take the whole harness with it instead of failing this one assertion.
+  once_rc="never-exited"; (( gone )) && { wait "$ONCE_PID"; once_rc=$?; }
+  chk "15 a run that SERVED its request exits 0" "0" "$once_rc"
+  chk "15 the temp dir is removed, not leaked" "0" \
+      "$(find "$UITMP" -maxdepth 1 -name '5dive-ui.*' 2>/dev/null | wc -l)"
 fi
 kill "$ONCE_PID" 2>/dev/null
 

--- a/tests/ui_views_e2e.sh
+++ b/tests/ui_views_e2e.sh
@@ -275,6 +275,24 @@ chk "14 the page names the fix"       "1"        "$(grep -c '5dive task init' "$
 #                            leak. TMPDIR is private to this run: the host has
 #                            hundreds of these already and other runs are racing.
 #
+# The body pair is ALSO the only arm that catches a refactor back to a threading
+# server, and it catches it PROBABILISTICALLY, because its subject is a race. Three
+# samples of the SAME one-line mutant (`srv = ThreadingHTTPServer` unconditionally),
+# all three taken on THIS host:
+#
+#   8/10  dev,   2026-08-06     4/6  dev,   2026-08-09
+#   3/6   main2, 2026-08-07     — every non-kill run reported PASS=72 FAIL=0
+#
+# The rate is not a property of the arm and not even a property of the box: it moves
+# with scheduler load between sittings on one machine. CI runs this file ONCE, so a
+# green run here is one sample from a detector with a false-negative rate somewhere
+# around 1-in-3 — never read it as proof the race is guarded. Quote a race arm's kill
+# rate with its host, its date and its run count, or do not quote it.
+#
+# Two distinct failure signatures, both graded: a TRUNCATED 200 (status passes, body
+# fails — the dominant one, 3 of 4 kills on 2026-08-09) and a dead connection (status
+# itself fails). The status/body split below is what keeps them tellable apart.
+#
 # Readiness comes from the server's own "listening on" line, never from opening a
 # connection — `--once` has exactly one request to give and a TCP probe spends it.
 PORT2="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
@@ -340,8 +358,16 @@ kill "$ONCE_PID" 2>/dev/null
 #
 # It is graded here for the reason the property was lost the first time — nobody
 # had encoded it, because it was never a decision, just a side effect of the bug.
-# A refactor back to a threading server passes every arm above and fails only
-# this one. `_5DIVE_UI_ONCE_READ_TIMEOUT` keeps that honest at 2s instead of 30.
+#
+# WHAT THIS ARM GUARDS: the read timeout, and only that. Deleting the timeout kills
+# exactly these three assertions. It does NOT guard the threading choice, and an
+# earlier version of this comment claimed it did. Measured against a mutant that is
+# this tree with only `HTTPServer` reverted to `ThreadingHTTPServer`: this arm passed
+# 5/5, and 6/6 on an earlier pass. It cannot fire — under threading the silent client
+# gets its own worker, the main thread returns from handle_request() on dispatch and
+# exits at once, so "did it park?" scores the re-threaded server GREEN. The
+# re-threading guard is arm 15's body pair, and it is probabilistic; see there.
+# `_5DIVE_UI_ONCE_READ_TIMEOUT` keeps this arm honest at 2s instead of 30.
 PORT3="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
 STALLTMP="$TMP/stall-tmpdir"; mkdir -p "$STALLTMP"
 _5DIVE_UI_ONCE_READ_TIMEOUT=2 TMPDIR="$STALLTMP" \


### PR DESCRIPTION
Fixes the two defects root-caused under DIVE-2786 and re-root-caused by olivia in
`community/wiki/set-e-deletes-exactly-the-cleanup-a-trap-would-have-kept.md`. They are
~600 lines apart, in two different languages, and fixing either alone leaves the other
exactly where it was — so they are two commits' worth of reasoning in one row.

## 1. A trailing `kill` ate the cleanup behind it

```bash
wait "$py" || rc=$?
trap - INT TERM
kill "$py" 2>/dev/null   # already reaped -> ESRCH -> rc 1
rm -rf "$tmp"            # never runs
return "$rc"             # never runs
```

`wait` returned *because the child was reaped*, so that belt-and-braces `kill` could only
ever fail. Under `set -e` it ended the function there: **1 published as the exit code of a
fully successful run**, the computed `rc` discarded, and a mode-700 temp dir leaked on
**every** invocation. Deterministic — rc=1 on 12/12 bundle runs against rc=0 on 10/10 for
the same python extracted standalone, so the interpreter was never involved.

Fix is `|| true`, and the comment says why it is load-bearing rather than style.

The reason nobody reproduced the leak is the sharp half: the fall-through cleanup is
reached **only** when the server served its request and `wait` returned. The `INT`/`TERM`
trap two lines up cleans up correctly, so **the leak happens on the runs that worked and
never on the run you Ctrl-C**, which is the natural first move.

## 2. `--once` is no longer served by a threading server

`ThreadingHTTPServer.handle_request()` returns on **dispatch**, not on completion. The
main thread fell through to `server_close()` and exited, and interpreter shutdown killed
the worker mid-write. Its threads are daemonic and socketserver's join-on-close list only
ever tracks *non-daemon* threads, so `block_on_close` waited for nothing.

The dominant signature is not a refused connection. Measured on the pre-fix bundle, 14
runs:

| outcome | runs |
|---|---|
| **`200` delivered, then `IncompleteRead` on the body** (truncated 200) | **10** |
| `RemoteDisconnected` | 3 |
| clean | 1 |

Served in-thread, `handle_request()` cannot return before the response is on the socket.
`serve_forever()` keeps threading — there a slow `/api/state` (it shells out to the
bundle) would block every other request. `--once` also sends `Connection: close`, because
under HTTP/1.1 the handler otherwise loops on a kept-alive socket and the single-shot
server never returns.

## Arm 15 graded a status code and a dead process

Which is how a documented flag whose success path returned failure survived for as long as
the flag has existed. Three assertions added, and **none of them substitutes for another**:

- **the exit code** — the visible half of defect 1;
- **the temp dir is gone** — the half no exit-code assertion can see. Fix only the code
  and the leak ships. Graded under a private `TMPDIR` so it counts this run and not the
  hundreds already on the host;
- **the body against the `Content-Length` the server itself promised** — a status-only
  assertion scores the truncated case as a pass, measured above at 10 of 14.

Status and body are read **separately** on purpose: a truncated 200 must fail the body
check while still passing the status check, or the arm cannot say which defect it caught.
Readiness now comes from the server's own `listening on` line rather than a TCP connect —
`--once` has exactly one request to give and a connect-based probe spends it.

## Mutation-graded, per finding

| mutant | result |
|---|---|
| revert the `kill` fix only | fails **exactly** `exits 0` + `temp dir is removed`, nothing else (deterministic) |
| revert the threading fix only | body assertions fail on **8 of 10** runs; **5 of those sit behind a passing `200`** |
| both fixes present | 68/68, green on **11 of 11** runs |

## Tier / budget

`tests/ui_views_e2e.sh` is core with no `# TIER` line, unchanged. Timing is a wash — min
of 3 runs, 4.90s on `origin/main` vs 5.07s here.

The local core tier run came back `exit 4` (571s vs a 429s effective cap) with the
calibration probe 43% off baseline and printing RE-BASELINE, which is the documented
behaviour of a control-plane run and not a reading of this diff. CI is the arbiter on that
number.

One harness is **red on unmodified `origin/main` 828c1ea**, 3/3, identically 3/3 on this
branch: `tests/actor_claim_corroboration_unit.sh`, `NOT OK - T19 e2e: created_by='',
expected the claim 'notdevx' (relay would be lost)`. It predates this branch and is
reported, not touched.

## Follow-up commit: the hang the single-thread fix inherits

Serving `--once` in-thread is what makes `handle_request()` unable to return before the
response is on the socket. It also removes the only thing that was ending a connection from
a client that **connects and never sends a request line**. The threaded version exited
immediately on that client — but only by abandoning it, which is the defect this branch
removes. Single-shot there is nothing else running to notice, and the one thread parks in
`readline()` forever.

Paired arms, same bundle, differing by that one line:

| arm | bare TCP connect, no request line |
|---|---|
| single-threaded, no read timeout | **still parked at 46s** (killed, did not exit) |
| single-threaded, `timeout = 30` | exited at ~31s |

The control is this branch **minus one line**, not `origin/main` — against main a "did it
hang?" arm scores main green and the fix red, and the reading is inverted.

`serve_forever()` keeps the stdlib default (`None`): another thread is always available
there, so the hazard is bounded and a 30s cap would be wrong for a long-running server.

`tests/ui_views_e2e.sh` is 68/68 on 6 of 6 runs with the follow-up in place.

Compiled to `community/wiki/removing-the-concurrency-inherits-the-hang-it-was-masking.md` —
**a concurrency bug fixed by deleting the concurrency inherits every hazard the concurrency
was masking, and the masking looked like correct behaviour because it WAS the bug.**

### …and arm 16 grades it

The timeout shipped in that commit with no arm, which is the same shape one commit later:
the property was lost the first time *because* nothing encoded it. Arm 16 connects and
sends nothing, holding the fd open for the whole poll so only the server's own timeout can
release it.

> **CORRECTED in iteration 2 (`6065675`), from main2's grade.** This paragraph originally
> ended "**A refactor back to a threading server passes every other arm and fails only this
> one.**" That is **false, and measured false three times**: against a mutant that is this
> branch with only `srv = ThreadingHTTPServer` unconditionally, arm 16 passed 5/5 and 6/6
> (main2, Aug 7) and 6/6 again (dev, Aug 9). It cannot fire — under threading the silent
> client gets its own worker and the main thread returns from `handle_request()` on dispatch,
> so "did it park?" scores the re-threaded server GREEN. **Arm 16 guards the read timeout,
> nothing else.** The only arm that catches re-threading is arm 15's response-**body** pair,
> and it is **probabilistic**: 8/10 (dev, Aug 6), 3/6 (main2, Aug 7), 4/6 (dev, Aug 9) — all
> three on the **same** box, so the rate moves with scheduler load between sittings. Every
> non-kill run reported `PASS=72 FAIL=0` with the defect present, and CI runs this file once.

`_5DIVE_UI_ONCE_READ_TIMEOUT` keeps that affordable — 2s in the harness against the 30s
default. Without it the arm costs 30s in a **core-tier** file. Cost as shipped is **+3.0s**
(5.0s → 8.0s, min of 4 runs on this host); no tier change, and the header carries no
measured claim to correct.

| mutant | result |
|---|---|
| delete the `timeout` line only | fails **exactly** arm 16's three assertions — does-not-park, rc, temp dir — and nothing else (69 PASS / 3 FAIL against 72/0 clean) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
