### PR TITLE
fix(heartbeat): the recurring-stall ladder's second rung changes hands, not volume (DIVE-2853)

### DIFF
--- a/changelog.d/DIVE-2853.md
+++ b/changelog.d/DIVE-2853.md
@@ -1,0 +1,35 @@
+## Unreleased — fix(heartbeat): the recurring-stall ladder's second rung changes hands instead of raising volume (DIVE-2853)
+
+The DIVE-2693 watchdog detects a never-started recurring instance correctly and says
+it exactly once — and then there was no second act. Its one notice is addressed to
+the row's assignee, i.e. to the party whose non-pickup *is* the observed fault.
+Measured on DIVE-2694: flagged on time (`recurring_stall_pinged_at 2026-08-05
+04:00:08`, once, right row), then unstarted a further 28h. The cause was not a lost
+message — dev had it and replied. dev was mid-delivery under a single-task goal and
+therefore **structurally barred** from starting a second row. A fence outlives every
+re-ping, so a louder notice to that same addressee is a guaranteed no-op.
+
+A second rung now fires on an instance still `todo` with `started_at IS NULL` a full
+window after its flag (`HEARTBEAT_RECURRING_ESCALATE_HOURS`, default 24). It **changes
+hands** rather than raising volume:
+
+- **reassign** to an agent the board can already see is free — heartbeat enabled in
+  the registry, no `in_progress` standard row — preferring the template's creator,
+  who owns the beat's inputs and unstuck it by hand both previous times;
+- **cancel with a written reason** when nobody is free, so the schedule re-fires. Not
+  a `blocked` park: skip-if-open counts every instance that is not `done`/`cancelled`,
+  so parking renames the outage instead of ending it. The old assignee and the
+  coordinator are told in the same breath, and the reason is written into the row.
+
+`recurring_stall_escalated_at` latches the rung to once per instance, so a
+reassignment cannot thrash a row around the fleet; if the new hands do not start it
+either, the next window's rung is the cancel that actually restores the beat.
+
+Fail-closed on an unreadable fleet: `registry_read()` collapses "no file",
+"unreadable" and "empty fleet" onto `{"agents":{}}`, and here an empty free list is
+the input that reaches the *cancel* rung — so the picker uses
+`registry_read_checked` and a tick that cannot read the registry escalates nothing.
+
+The first rung now also names whether its addressee could act at all — an assignee
+already holding an `in_progress` row is reported as occupied, rather than leaving
+"misaddressed" to be inferred from another day of silence.

--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -100,6 +100,13 @@ _HB_VERIFY_STALE_MIN="${HEARTBEAT_VERIFY_STALE_MIN:-60}"
 # outlived its own cadence and started suppressing the NEXT slot.
 _HB_RECURRING_STALL_HOURS="${HEARTBEAT_RECURRING_STALL_HOURS:-24}"
 [[ "$_HB_RECURRING_STALL_HOURS" =~ ^[0-9]+$ ]] || _HB_RECURRING_STALL_HOURS=24
+# DIVE-2853: how long AFTER that one-shot notice an instance may still sit
+# todo-and-never-started before the ladder CHANGES HANDS. Same default window as
+# the first rung, so a daily beat gets one full extra cadence with its original
+# assignee before the row moves. Detection bounds how long an outage is invisible;
+# only this rung bounds the outage.
+_HB_RECURRING_ESCALATE_HOURS="${HEARTBEAT_RECURRING_ESCALATE_HOURS:-24}"
+[[ "$_HB_RECURRING_ESCALATE_HOURS" =~ ^[0-9]+$ ]] || _HB_RECURRING_ESCALATE_HOURS=24
 _HB_STALL_MIN_MINUTES="${HEARTBEAT_STALL_MIN_MINUTES:-30}"
 [[ "$_HB_STALL_MIN_MINUTES" =~ ^[0-9]+$ ]] || _HB_STALL_MIN_MINUTES=30
 # Orphan reclaim. An in_progress task whose claiming claude session is GONE — the
@@ -2278,6 +2285,41 @@ _hb_fleet_activity_probe() {
   return 0
 }
 
+# _hb_free_agents — the agents the BOARD can already see are free, one per line.
+#
+# "Free" is two facts we hold, not an inference from silence: the registry says the
+# agent has heartbeat config and it is ENABLED, and the task store says it holds no
+# in_progress standard row. Deterministically ordered (LC_ALL=C sort) so the
+# reassignment target a stalled row gets is reproducible and gradeable rather than
+# whatever jq happened to emit first.
+#
+# FAIL-CLOSED ON AN UNREADABLE REGISTRY, and that is the whole reason this is a
+# function with an exit code instead of an inline jq. registry_read() collapses "no
+# registry file", "unreadable (perms/IO)" and "genuinely empty fleet" onto
+# {"agents":{}} — indistinguishable. An empty list is NOT a harmless no-op for the
+# only caller: it is precisely the input that sends the escalation ladder to its
+# CANCEL rung. So this uses registry_read_checked and propagates its non-zero, and
+# the caller skips the tick entirely rather than closing a live row on evidence it
+# never actually had.
+_hb_free_agents() {
+  local reg name busy
+  reg=$(registry_read_checked 2>/dev/null) || return $?
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    busy=$(db "SELECT COUNT(*) FROM tasks
+               WHERE kind='standard' AND status='in_progress'
+                 AND assignee=$(sqlq "$name");" 2>/dev/null || echo 1)
+    # A failed/garbled count reads as BUSY, never as free — the cost of wrongly
+    # calling an agent busy is that this row waits one more tick; the cost of
+    # wrongly calling one free is handing it work it cannot take.
+    [[ "$busy" =~ ^[0-9]+$ ]] || busy=1
+    (( busy == 0 )) && printf '%s\n' "$name"
+  done < <(jq -r '.agents | to_entries[]
+                  | select(.value.heartbeat != null and ((.value.heartbeat.enabled // false) == true))
+                  | .key' <<<"$reg" 2>/dev/null | LC_ALL=C sort)
+  return 0
+}
+
 _hb_stall_sweep() {
   # (a) GAP#2 — surface stale maker->verifier deliveries.
   #
@@ -2347,8 +2389,20 @@ _hb_stall_sweep() {
       ( cmd_send "$rasg" --from="task-engine" \
           --message="⏳ ${rident} is a RECURRING instance you have never started — ${rhours}h old. While it sits open the schedule's next slot is SUPPRESSED (skip-if-open), so the beat is not late, it is not happening. Work it or close it: \`5dive task start ${rident}\`, or \`5dive task cancel ${rident} --result=...\` to let the schedule re-fire." ) >/dev/null 2>&1 || true
     fi
+    # DIVE-2853: NAME whether the addressee could even act, instead of leaving it to
+    # be inferred from another day of silence. An assignee already holding an
+    # in_progress row is the shape that produced the 28h non-response on DIVE-2694:
+    # under a single-task goal, taking this row would break an explicit instruction,
+    # so the notice is misaddressed at SEND time and no re-ping can fix it. Reported
+    # here (not acted on) because the remedy is the ladder's second rung below —
+    # holding a row's original assignee for one window is deliberate, and 'busy now'
+    # is not yet evidence of a stall that needs hands changed.
+    local rbusy
+    rbusy=$(db "SELECT COALESCE(ident,'DIVE-'||id) FROM tasks
+                WHERE kind='standard' AND status='in_progress'
+                  AND assignee=$(sqlq "${rasg:-}") ORDER BY id LIMIT 1;" 2>/dev/null || echo "")
     ( cmd_send "main" --from="task-engine" \
-        --message="⏳ Recurring beat stalled: ${rident} (from template ${rtmpl}) has sat todo and never-started for ${rhours}h, assignee '${rasg:-unassigned}' — every slot since is suppressed by skip-if-open (DIVE-2693)." ) >/dev/null 2>&1 || true
+        --message="⏳ Recurring beat stalled: ${rident} (from template ${rtmpl}) has sat todo and never-started for ${rhours}h, assignee '${rasg:-unassigned}'${rbusy:+ — who is OCCUPIED on ${rbusy}, so this notice may be undeliverable-in-effect (a goal-fenced assignee cannot take a second row)} — every slot since is suppressed by skip-if-open (DIVE-2693). If it is still unstarted in ${_HB_RECURRING_ESCALATE_HOURS}h the ladder reassigns or cancels it (DIVE-2853)." ) >/dev/null 2>&1 || true
     db "UPDATE tasks SET recurring_stall_pinged_at=datetime('now') WHERE id=${rid};"
     _hb_log "[recurring-stall] ${rident} never-started ${rhours}h (template ${rtmpl}) -> surfaced"
   done < <(db "SELECT t.id||x'1f'||COALESCE(t.ident,'DIVE-'||t.id)||x'1f'||COALESCE(t.assignee,'')||x'1f'||t.created_at||x'1f'||COALESCE(p.ident,'DIVE-'||t.from_template_id)
@@ -2359,6 +2413,104 @@ _hb_stall_sweep() {
                  AND NOT (t.need_type IS NOT NULL AND t.need_answered_at IS NULL)
                  AND t.parked_at IS NULL
                  AND t.created_at <= datetime('now','-${_HB_RECURRING_STALL_HOURS} hours');")
+
+  # (a3) DIVE-2853 — the SECOND RUNG, on a row (a2) already surfaced and that is
+  # still todo-and-never-started a full window later.
+  #
+  # WHY A LOUDER OR REPEATED NOTICE CANNOT BE THIS RUNG. (a2)'s single notice is
+  # addressed to the row's assignee — i.e. to the one party whose not picking the
+  # row up IS the observed fault. Measured on DIVE-2694: flagged on time
+  # (recurring_stall_pinged_at 2026-08-05 04:00:08, exactly once, correctly), then
+  # sat unstarted another 28h. The cause was NOT a missed message. dev had the
+  # message, replied to it, and was mid-delivery on DIVE-2801 under a single-task
+  # goal — STRUCTURALLY BARRED from starting a second row. A fence outlives every
+  # re-ping, so volume at that same addressee is a guaranteed no-op and the row
+  # stays dark for as long as the other goal runs.
+  #
+  # SO THIS RUNG CHANGES HANDS INSTEAD OF RAISING VOLUME:
+  #   1. reassign to an agent the board can see is FREE (_hb_free_agents), the
+  #      template's creator first when they are free — that is who owns the beat's
+  #      inputs and who unstuck it by hand both previous times;
+  #   2. if nobody is free, CANCEL with a written reason so the template re-fires.
+  #
+  # WHY CANCEL IS THE FALLBACK AND NOT A 'blocked' PARK, which is the posture used
+  # for a reaped in_progress row a few hundred lines up: skip-if-open counts EVERY
+  # instance with status NOT IN ('done','cancelled'), so 'blocked' would keep
+  # suppressing later slots — it renames the outage instead of ending it. Cancel is
+  # also the documented manual unstick (main did exactly this on the DIVE-2237 sweep
+  # and on DIVE-2403), and it never runs with an empty result: the reason is written
+  # into the row, and the old assignee is told in the same breath, so a cancel here
+  # is never indistinguishable from the beat having never fired.
+  #
+  # ONCE PER INSTANCE (recurring_stall_escalated_at), so a reassignment cannot
+  # thrash a row around a fleet — and if the NEW hands do not start it either, the
+  # next window's rung is the cancel, which is what actually restores the beat.
+  local erow eid eident easg etmpl etcreator ehours ecand etarget
+  local efree="" efree_read=0 efree_ok=0 ecancel_reason emsg
+  while IFS= read -r erow; do
+    [[ -n "$erow" ]] || continue
+    IFS=$'\x1f' read -r eid eident easg etmpl etcreator ehours <<<"$erow"
+    [[ -n "$eid" ]] || continue
+    if (( efree_read == 0 )); then
+      efree_read=1
+      if efree=$(_hb_free_agents); then
+        efree_ok=1
+      else
+        _hb_log "[recurring-escalate] registry unreadable — escalation SKIPPED this tick; no row was reassigned or cancelled on an unread fleet"
+      fi
+    fi
+    (( efree_ok )) || break
+
+    etarget=""
+    while IFS= read -r ecand; do
+      [[ -n "$ecand" ]] || continue
+      # The current assignee is not a target: handing the row back to the addressee
+      # that already had a full window with it is the no-op this rung exists to stop.
+      [[ -n "$easg" && "$ecand" == "$easg" ]] && continue
+      if [[ -n "$etcreator" && "$ecand" == "$etcreator" ]]; then etarget="$ecand"; break; fi
+      [[ -z "$etarget" ]] && etarget="$ecand"
+    done <<<"$efree"
+
+    if [[ -n "$etarget" ]]; then
+      db "UPDATE tasks SET assignee=$(sqlq "$etarget"), recurring_stall_escalated_at=datetime('now'),
+                           updated_at=datetime('now')
+          WHERE id=${eid} AND status='todo' AND started_at IS NULL;" 2>/dev/null || true
+      ( cmd_send "$etarget" --from="task-engine" \
+          --message="🔁 ${eident} (recurring beat from template ${etmpl}) has been REASSIGNED to you: it sat never-started for ${ehours}h with '${easg:-unassigned}', who was surfaced once and could not take it. While it sits open the schedule's next slot is SUPPRESSED (skip-if-open), so nothing is late — the beat is not happening. \`5dive task start ${eident}\`, or \`5dive task cancel ${eident} --result=...\` if it is genuinely not workable, which lets the schedule re-fire." ) >/dev/null 2>&1 || true
+      if [[ -n "$easg" ]]; then
+        ( cmd_send "$easg" --from="task-engine" \
+            --message="🔁 ${eident} has been moved OFF you to '${etarget}' — it was never started ${ehours}h after being flagged, and the beat's later slots are suppressed while it sits. Nothing for you to do; if you were about to start it, say so to ${etarget} rather than both starting it." ) >/dev/null 2>&1 || true
+      fi
+      ( cmd_send "main" --from="task-engine" \
+          --message="🔁 Recurring-stall ESCALATED: ${eident} (template ${etmpl}) reassigned '${easg:-unassigned}' -> '${etarget}' after ${ehours}h unstarted past its flag — a re-ping to the original assignee cannot clear a goal-fenced one, so the ladder changes hands (DIVE-2853)." ) >/dev/null 2>&1 || true
+      ledger_emit "task.recurring_stall_escalated" ident="$eident" task_id="$eid" \
+        actor="task-engine" authority="heartbeat" \
+        detail="reassigned ${easg:-unassigned}->${etarget} after ${ehours}h never-started (template ${etmpl})" || true
+      _hb_log "[recurring-escalate] ${eident} ${ehours}h unstarted -> reassigned ${easg:-unassigned} -> ${etarget}"
+    else
+      ecancel_reason="auto-cancelled by the recurring-stall ladder (DIVE-2853): materialized from template ${etmpl}, never started, surfaced once to '${easg:-unassigned}' and still unstarted ${ehours}h later, and no free agent was available to take it. Cancelled rather than left open BECAUSE skip-if-open counts every non-closed instance, so this row was suppressing every later slot of the beat — the schedule re-fires on its next slot. Not a judgement that the work is unwanted."
+      db "UPDATE tasks SET status='cancelled', done_at=datetime('now'), updated_at=datetime('now'),
+                           result=$(sqlq "$ecancel_reason"), recurring_stall_escalated_at=datetime('now')
+          WHERE id=${eid} AND status='todo' AND started_at IS NULL;" 2>/dev/null || true
+      emsg="🗑 ${eident} (recurring beat from template ${etmpl}) was AUTO-CANCELLED after sitting never-started ${ehours}h past its stall flag, with no free agent to hand it to. The reason is written into the row's result; the template re-fires on its next slot, which is the only way the beat restarts (skip-if-open counts an open instance)."
+      if [[ -n "$easg" ]]; then
+        ( cmd_send "$easg" --from="task-engine" --message="$emsg If you still want this instance, the next materialization is yours to start on time — or reply to say the row should not be assigned to you." ) >/dev/null 2>&1 || true
+      fi
+      ( cmd_send "main" --from="task-engine" --message="$emsg No free agent existed at escalation time, so reassignment had nowhere to go (DIVE-2853)." ) >/dev/null 2>&1 || true
+      ledger_emit "task.recurring_stall_escalated" ident="$eident" task_id="$eid" \
+        actor="task-engine" authority="heartbeat" \
+        detail="auto-cancelled after ${ehours}h never-started, no free agent (template ${etmpl})" || true
+      _hb_log "[recurring-escalate] ${eident} ${ehours}h unstarted, no free agent -> auto-cancelled so template ${etmpl} re-fires"
+    fi
+  done < <(db "SELECT t.id||x'1f'||COALESCE(t.ident,'DIVE-'||t.id)||x'1f'||COALESCE(t.assignee,'')||x'1f'||COALESCE(p.ident,'DIVE-'||t.from_template_id)||x'1f'||COALESCE(p.created_by,'')||x'1f'||CAST((julianday('now')-julianday(t.created_at))*24 AS INTEGER)
+               FROM tasks t LEFT JOIN tasks p ON p.id=t.from_template_id
+               WHERE t.kind='standard' AND t.from_template_id IS NOT NULL
+                 AND t.status='todo' AND t.started_at IS NULL
+                 AND t.recurring_stall_pinged_at IS NOT NULL
+                 AND t.recurring_stall_escalated_at IS NULL
+                 AND NOT (t.need_type IS NOT NULL AND t.need_answered_at IS NULL)
+                 AND t.parked_at IS NULL
+                 AND t.recurring_stall_pinged_at <= datetime('now','-${_HB_RECURRING_ESCALATE_HOURS} hours');")
 
   # (b) GAP#3 core — fleet-idle-while-actionable-work-is-open, persisting.
   local in_prog running_loops stranded_todo open_gates total_stranded

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -386,6 +386,16 @@ CREATE TABLE IF NOT EXISTS tasks (
   -- DIVE-2403 ate 07-31..08-04. Both recovered cleanly downstream, which is exactly
   -- what kept the fault quiet.
   recurring_stall_pinged_at TEXT,
+  -- DIVE-2853: recurring_stall_escalated_at throttles the SECOND rung — the one
+  -- that changes hands — to once per instance. The first rung's notice goes to the
+  -- row's assignee, i.e. to the party whose non-pickup IS the fault, so repeating it
+  -- cannot clear the state: measured on DIVE-2694, which was flagged exactly on time
+  -- and then sat unstarted another 28h because dev was mid-delivery under a
+  -- single-task goal and structurally could not take a second row. A fence outlives
+  -- every re-ping. So the second rung reassigns to a free agent, or cancels with a
+  -- written reason so the template re-fires, and this column is what stops a
+  -- reassignment from thrashing the row around the fleet tick after tick.
+  recurring_stall_escalated_at TEXT,
   -- DIVE-891: risk-tiered gates (adopted design DIVE-861). tier is set when the
   -- gate is filed: 0 = auto-clear (rec applies immediately, digest line only),
   -- 1 = agent-clearable + 48h TTL auto-applies the recommendation, 2 = hard
@@ -1092,7 +1102,7 @@ _tasks_db_migrate() {
            'iteration INTEGER' 'maker_agent TEXT' 'handoff_ack_at TEXT' 'task_budget TEXT' \
            'handoff_delivered_at TEXT' 'handoff_stale_pinged_at TEXT' \
            'handoff_rejected_at TEXT' \
-           'recurring_stall_pinged_at TEXT' \
+           'recurring_stall_pinged_at TEXT' 'recurring_stall_escalated_at TEXT' \
            'tier INTEGER' 'need_asked_at TEXT' 'gate_pinged_at TEXT' 'wake_at TEXT' \
            'gate_filed_by TEXT' \
            'secret_key TEXT' 'connector TEXT' 'secret_oob TEXT' 'human_nonce_hash TEXT' \

--- a/tests/heartbeat_recurring_stall_escalate_unit.sh
+++ b/tests/heartbeat_recurring_stall_escalate_unit.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# TIER: core
+#
+# DIVE-2853 — the recurring-stall ladder's SECOND RUNG: the one that CHANGES HANDS.
+#
+# WHY THIS IS A BEHAVIOURAL HARNESS AND NOT A PREDICATE ONE (its sibling
+# heartbeat_recurring_stall_unit.sh grades the first rung's SELECT and explains why
+# a predicate test is right there): here the SELECT is the cheap half. What can be
+# wrong in a way nobody notices is the ACTION — who the row lands on, and whether a
+# tick that cannot read the fleet closes a live row anyway. An escalation that
+# reassigns to the same fenced assignee, or that auto-cancels because a registry
+# read failed, passes any predicate test and is worse than no escalation at all.
+#
+# The rung exists because volume cannot be rung 2. Measured on DIVE-2694: flagged on
+# time, exactly once, correctly — then unstarted another 28h, because its assignee
+# was mid-delivery under a single-task goal and structurally could not take a second
+# row. Every arm below is one way that fix could be wrong.
+set -euo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: one trap, every exit path.
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+cd "$(dirname "$0")/.."
+SRC=src
+command -v sqlite3 >/dev/null 2>&1 || { echo "SKIP: sqlite3 not present"; exit 0; }
+command -v jq      >/dev/null 2>&1 || { echo "SKIP: jq not present"; exit 0; }
+TMP=$(mktemp -d /tmp/rec-stall-esc.XXXXXX)
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_agent.sh cmd_heartbeat.sh; do
+  source "$SRC/$f"
+done
+set +e
+STATE_DIR="$TMP"; TASKS_DIR="$TMP/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+mkdir -p "$TASKS_DIR"
+tasks_db_init; _tasks_db_migrate
+
+# The rail is REAL in this harness (cmd_agent.sh is sourced), so stub it or a unit
+# test injects into live tmux panes. Same posture as heartbeat_gate_renag_unit.sh.
+AGENT_SEND_LOG="$TMP/agent_sends"; : >"$AGENT_SEND_LOG"
+cmd_send() {
+  local to="$1" a msg=""; shift
+  for a in "$@"; do [[ "$a" == --message=* ]] && msg="${a#--message=}"; done
+  printf '%s\t%s\n' "$to" "$msg" >>"$AGENT_SEND_LOG"
+  return 0
+}
+_hb_log() { :; }
+audit_log() { :; }
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+REGISTRY="$TMP/registry.json"
+# Every agent here has heartbeat ENABLED; who is free is decided by the task store,
+# which is the point — "free" must be a fact the board holds, not a name list.
+write_registry() {
+  cat >"$REGISTRY" <<'JSON'
+{"agents":{
+  "main":     {"heartbeat":{"enabled":true,"everyMin":15}},
+  "dev":      {"heartbeat":{"enabled":true,"everyMin":15}},
+  "creative": {"heartbeat":{"enabled":true,"everyMin":15}},
+  "anton":    {"heartbeat":{"enabled":true,"everyMin":15}},
+  "asleep":   {"heartbeat":{"enabled":false,"everyMin":15}}
+}}
+JSON
+}
+write_registry
+
+# ---------------------------------------------------------------------------
+# Fixture builders. One template (created_by=creative, who owns the beat's inputs
+# and unstuck it by hand both previous times) plus instances that differ from the
+# ESCALATED row in exactly one column each.
+# ---------------------------------------------------------------------------
+mk_fixture() {
+  db "DELETE FROM tasks; DELETE FROM lifecycle_events;"
+  : >"$AGENT_SEND_LOG"
+  db "INSERT INTO tasks (id,ident,title,status,kind,schedule,assignee,created_by,created_at)
+      VALUES (100,'DIVE-1237','openagent drip','todo','recurring','0 4 * * *','dev','creative',datetime('now','-30 days'));"
+  # ESCALATE: pinged 25h ago, never started, still todo.
+  db "INSERT INTO tasks (id,ident,title,status,kind,assignee,created_by,created_at,from_template_id,recurring_stall_pinged_at)
+      VALUES (1,'DIVE-2694','drip slot','todo','standard','dev','task-engine',datetime('now','-3 days'),100,datetime('now','-25 hours'));"
+  # never flagged by rung 1 -> rung 2 must not run ahead of it
+  db "INSERT INTO tasks (id,ident,title,status,kind,assignee,created_at,from_template_id)
+      VALUES (2,'DIVE-2695','drip slot','todo','standard','dev',datetime('now','-3 days'),100);"
+  # flagged only 1h ago -> inside the window
+  db "INSERT INTO tasks (id,ident,title,status,kind,assignee,created_at,from_template_id,recurring_stall_pinged_at)
+      VALUES (3,'DIVE-2696','drip slot','todo','standard','dev',datetime('now','-3 days'),100,datetime('now','-1 hours'));"
+  # started -> being worked, not stalled
+  db "INSERT INTO tasks (id,ident,title,status,kind,assignee,created_at,started_at,from_template_id,recurring_stall_pinged_at)
+      VALUES (4,'DIVE-2697','drip slot','todo','standard','dev',datetime('now','-3 days'),datetime('now','-2 days'),100,datetime('now','-25 hours'));"
+  # parked with a wake date -> deliberately asleep
+  db "INSERT INTO tasks (id,ident,title,status,kind,assignee,created_at,from_template_id,recurring_stall_pinged_at,parked_at)
+      VALUES (5,'DIVE-2698','drip slot','todo','standard','dev',datetime('now','-3 days'),100,datetime('now','-25 hours'),datetime('now','-2 days'));"
+  # unanswered human gate -> the wait is on a person, never auto-moved or cancelled
+  db "INSERT INTO tasks (id,ident,title,status,kind,assignee,created_at,from_template_id,recurring_stall_pinged_at,need_type)
+      VALUES (6,'DIVE-2699','drip slot','todo','standard','dev',datetime('now','-3 days'),100,datetime('now','-25 hours'),'decision');"
+  # not from a template -> no beat to restore
+  db "INSERT INTO tasks (id,ident,title,status,kind,assignee,created_at,recurring_stall_pinged_at)
+      VALUES (7,'DIVE-2700','one-off','todo','standard','dev',datetime('now','-3 days'),datetime('now','-25 hours'));"
+}
+# dev is OCCUPIED: this is the DIVE-2694 shape — the flagged row's assignee holds an
+# in_progress row, so a re-ping to them is undeliverable-in-effect. It also keeps
+# gap#3's fleet-idle branch (and its tmux probe) out of this harness.
+busy() { db "INSERT INTO tasks (ident,title,status,kind,assignee,created_at)
+             VALUES ($(sqlq "DIVE-28-busy-$1"),'other work','in_progress','standard',$(sqlq "$1"),datetime('now','-2 hours'));"; }
+
+col()   { db "SELECT COALESCE($2,'NULL') FROM tasks WHERE id=$1;"; }
+sent()  { cut -f1 "$AGENT_SEND_LOG" | sort -u | tr '\n' ' '; }
+msgto() { awk -F'\t' -v w="$1" '$1==w{print $2}' "$AGENT_SEND_LOG"; }
+
+# ---------------------------------------------------------------------------
+# 1. REASSIGN to a free agent, template creator preferred.
+# ---------------------------------------------------------------------------
+mk_fixture; busy dev
+_hb_stall_sweep >/dev/null 2>&1
+got_asg=$(col 1 assignee); got_esc=$(col 1 recurring_stall_escalated_at); got_st=$(col 1 status)
+[[ "$got_asg" == "creative" ]] \
+  && ok_t "reassigns the stalled instance to the TEMPLATE CREATOR when they are free" \
+  || bad_t "reassigns the stalled instance to the TEMPLATE CREATOR when they are free" "assignee=[$got_asg] want creative (free agents: anton, creative, main)"
+[[ "$got_st" == "todo" && "$got_esc" != "NULL" ]] \
+  && ok_t "the row stays open and is stamped escalated (once-per-instance latch)" \
+  || bad_t "the row stays open and is stamped escalated" "status=[$got_st] escalated_at=[$got_esc]"
+case " $(sent) " in
+  *" creative "*) ok_t "the NEW hands are told (they are the only party who can act)" ;;
+  *)              bad_t "the NEW hands are told" "sends went to: [$(sent)]" ;;
+esac
+case " $(sent) " in
+  *" dev "*) ok_t "the OLD assignee is told in the same breath (never a silent move)" ;;
+  *)         bad_t "the OLD assignee is told in the same breath" "sends went to: [$(sent)]" ;;
+esac
+case " $(sent) " in
+  *" main "*) ok_t "the coordinator is told" ;;
+  *)          bad_t "the coordinator is told" "sends went to: [$(sent)]" ;;
+esac
+[[ -n "$(db "SELECT 1 FROM lifecycle_events WHERE kind='task.recurring_stall_escalated' AND ident='DIVE-2694' LIMIT 1;")" ]] \
+  && ok_t "the escalation is on the append-only ledger, not only in a chat message" \
+  || bad_t "the escalation is on the append-only ledger" "no task.recurring_stall_escalated row for DIVE-2694"
+
+# Exclusions, asserted BY NAME so a future predicate that drops one arm reds the arm
+# that owns it. Each of these rows differs from DIVE-2694 in exactly one column.
+for spec in "2:never flagged by rung 1" \
+            "3:flagged inside the escalation window" \
+            "4:already started" \
+            "5:parked with a wake date" \
+            "6:blocked on an unanswered human gate" \
+            "7:not materialized from a template"; do
+  rid="${spec%%:*}"; why="${spec#*:}"
+  a=$(col "$rid" assignee); s=$(col "$rid" status); e=$(col "$rid" recurring_stall_escalated_at)
+  [[ "$a" == "dev" && "$s" == "todo" && "$e" == "NULL" ]] \
+    && ok_t "leaves row $rid alone — $why" \
+    || bad_t "leaves row $rid alone — $why" "assignee=[$a] status=[$s] escalated_at=[$e]"
+done
+
+# ---------------------------------------------------------------------------
+# 2. ONCE PER INSTANCE. A second tick must not thrash the row onward.
+# ---------------------------------------------------------------------------
+: >"$AGENT_SEND_LOG"
+_hb_stall_sweep >/dev/null 2>&1
+[[ "$(col 1 assignee)" == "creative" && -z "$(sent | tr -d ' ')" ]] \
+  && ok_t "a second tick neither re-sends nor moves the row again (escalated_at latch holds)" \
+  || bad_t "a second tick neither re-sends nor moves the row again" "assignee=[$(col 1 assignee)] sends=[$(sent)]"
+
+# ---------------------------------------------------------------------------
+# 3. NO FREE AGENT -> cancel WITH a written reason, so the template re-fires.
+#    'blocked' would not do: skip-if-open counts every non-closed instance, so a
+#    park renames the outage instead of ending it.
+# ---------------------------------------------------------------------------
+mk_fixture
+for a in dev creative anton main; do busy "$a"; done
+_hb_stall_sweep >/dev/null 2>&1
+st=$(col 1 status); res=$(col 1 result)
+[[ "$st" == "cancelled" ]] \
+  && ok_t "with no free agent, the instance is CANCELLED so the schedule can re-fire" \
+  || bad_t "with no free agent, the instance is CANCELLED" "status=[$st] — a row left open keeps suppressing every later slot"
+[[ "$res" != "NULL" && ${#res} -gt 40 && "$res" == *"template"* ]] \
+  && ok_t "the cancel carries a written reason naming the template (never an empty result)" \
+  || bad_t "the cancel carries a written reason naming the template" "result=[$res]"
+# Asserted on the TEXT, not just the recipient: dev is also the recipient of the
+# reassign message, so a recipient-only check would pass on the wrong branch.
+case "$(msgto dev)" in
+  *AUTO-CANCELLED*) ok_t "the assignee whose row was cancelled is told THAT it was cancelled" ;;
+  *)                bad_t "the assignee whose row was cancelled is told THAT it was cancelled" "text to dev: [$(msgto dev)]" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 4. FAIL-CLOSED ON AN UNREADABLE REGISTRY. This is the arm that matters most: an
+#    unreadable fleet reads as "nobody is free", which is exactly the input that
+#    reaches the cancel rung. A tick that cannot see the fleet must do NOTHING.
+# ---------------------------------------------------------------------------
+mk_fixture; busy dev
+REGISTRY="$TMP/does-not-exist.json"
+_hb_stall_sweep >/dev/null 2>&1
+st=$(col 1 status); a=$(col 1 assignee); e=$(col 1 recurring_stall_escalated_at)
+[[ "$st" == "todo" && "$a" == "dev" && "$e" == "NULL" ]] \
+  && ok_t "an unreadable registry escalates NOTHING — no reassign, and above all no cancel" \
+  || bad_t "an unreadable registry escalates NOTHING" "status=[$st] assignee=[$a] escalated_at=[$e] — a failed fleet read must never close a live row"
+REGISTRY="$TMP/registry.json"
+
+# ---------------------------------------------------------------------------
+# 5. NON-VACUITY + MUTATION. Arms 1-4 all pass on a sweep whose (a3) block does
+#    nothing at all except arm 1, so arm 1 IS the anchor — assert it moved the row
+#    from its fixture value, then break the latch and prove the latch is what stops
+#    the second tick, rather than something else silently doing so.
+# ---------------------------------------------------------------------------
+mk_fixture; busy dev
+before=$(col 1 assignee)
+_hb_stall_sweep >/dev/null 2>&1
+after=$(col 1 assignee)
+[[ "$before" == "dev" && "$after" != "dev" ]] \
+  && ok_t "ANCHOR: the sweep demonstrably MUTATES the fixture (dev -> $after), so the exclusion arms are not vacuous" \
+  || bad_t "ANCHOR: the sweep demonstrably mutates the fixture" "before=[$before] after=[$after] — every 'leaves row alone' arm above is passing for free"
+db "UPDATE tasks SET recurring_stall_escalated_at=NULL, assignee='dev' WHERE id=1;"
+: >"$AGENT_SEND_LOG"
+_hb_stall_sweep >/dev/null 2>&1
+[[ "$(col 1 assignee)" != "dev" ]] \
+  && ok_t "MUTATION: clearing recurring_stall_escalated_at makes the row eligible again (the latch is load-bearing, not incidental)" \
+  || bad_t "MUTATION: clearing recurring_stall_escalated_at makes the row eligible again" "assignee=[$(col 1 assignee)] — the second tick's no-op in arm 2 was NOT caused by the latch, so its cause is unknown"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/heartbeat_recurring_stall_unit.sh
+++ b/tests/heartbeat_recurring_stall_unit.sh
@@ -43,13 +43,25 @@ DB="$TMP/t.db"
 # 1. EXTRACT the live predicate. If this fails the test fails loudly rather than
 #    falling back to a hand-copy — a fallback here would silently grade nothing.
 # ---------------------------------------------------------------------------
-QUERY=$(awk '/SELECT t\.id\|\|x.1f.\|\|COALESCE\(t\.ident/,/hours.\);"\)/' "$SRC" \
+# STOPS AT THE FIRST RANGE, and then proves which range it got. DIVE-2853 added a
+# SECOND sweep query in the same function whose first line is character-identical to
+# this one (same SELECT list prefix), and an awk /start/,/end/ range RE-TRIGGERS on
+# it — the extraction silently returned both queries concatenated, which is not
+# valid SQL and reds an unrelated arm. The `exit` bounds it to one block; the
+# identity assertions below name WHICH block, so a future reordering of the two
+# fails loudly here instead of grading rung 2 while claiming to grade rung 1.
+QUERY=$(awk '/SELECT t\.id\|\|x.1f.\|\|COALESCE\(t\.ident/{c=1} c{print} c && /hours.\);"\)/{exit}' "$SRC" \
         | sed -e 's/^ *//' -e '1s/^.*db "//' -e 's/;")$/;/')
 if [[ -z "$QUERY" || "$QUERY" != *"from_template_id"* ]]; then
   bad_t "extract the live predicate from $SRC" "awk matched nothing, or the match does not mention from_template_id — the sweep query moved or was renamed; this test is now blind and must be re-anchored, NOT deleted"
   printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"; exit 1
 fi
+if [[ "$QUERY" != *"recurring_stall_pinged_at IS NULL"* || "$QUERY" == *"recurring_stall_escalated_at"* ]]; then
+  bad_t "the extracted block is rung 1 (DIVE-2693), not rung 2 (DIVE-2853)" "extracted: $QUERY"
+  printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"; exit 1
+fi
 ok_t "the sweep's SELECT is extracted from cmd_heartbeat.sh, not retyped here"
+ok_t "the extracted block is IDENTIFIED as rung 1 (pinged_at IS NULL, no escalated_at conjunct)"
 
 # The threshold is interpolated by the shell in the real caller; bind the default.
 QUERY="${QUERY//\$\{_HB_RECURRING_STALL_HOURS\}/24}"


### PR DESCRIPTION
## The gap

DIVE-2693's recurring-stall watchdog works: right row, right time, exactly once. It has no second act.

Its one notice is addressed to the row's **assignee** — the party whose non-pickup *is* the observed fault. Measured on DIVE-2694: `recurring_stall_pinged_at = 2026-08-05 04:00:08`, stamped once, correctly. The row then sat `todo` / `started_at NULL` for another **28h**.

The cause was not a lost message. dev received it, replied, and was mid-delivery on DIVE-2801 under a single-task goal — **structurally barred** from starting a second row. A fence outlives every re-ping, so escalating *volume* to that same addressee is a guaranteed no-op. That is why rung 2 had to change hands, not get louder.

Why it matters beyond one late row: the materializer is skip-if-open, so an unworked instance does not delay the beat, it **deletes every later slot while it sits**. Detection bounds how long the outage is invisible; only the ladder bounds the outage. Fourth consecutive period as of today (creative + marketing, 08-06): `index.json` on origin/main is still 19 packs ending at fixer.

## The rung

Fires on an instance still `todo` with `started_at IS NULL` a full window after its flag (`HEARTBEAT_RECURRING_ESCALATE_HOURS`, default 24 — one extra cadence with the original assignee):

1. **Reassign** to an agent the board can already see is free — heartbeat enabled in the registry **and** no `in_progress` standard row — preferring the **template's creator**, who owns the beat's inputs and unstuck it by hand both previous times (DIVE-2237 sweep, DIVE-2403).
2. **Cancel with a written reason** when nobody is free, so the template re-fires.

Not a `blocked` park, which is the posture used for a reaped `in_progress` row: skip-if-open counts every instance not in (`done`,`cancelled`), so parking **renames** the outage instead of ending it. Cancel is also the documented manual unstick — and it never runs blank: the reason goes into `result`, and the old assignee is told in the same breath, so it is never indistinguishable from the beat having never fired.

`recurring_stall_escalated_at` latches the rung to once per instance, so a reassignment cannot thrash a row around the fleet. If the new hands do not start it either, the next window's rung is the cancel, which is what actually restores the beat.

## Fail-closed on an unreadable fleet

`registry_read()` collapses "no registry file", "unreadable (perms/IO)" and "genuinely empty fleet" onto `{"agents":{}}` — indistinguishable. Here an empty free list is **not** a harmless no-op: it is exactly the input that reaches the *cancel* rung. So `_hb_free_agents` uses `registry_read_checked` and propagates its non-zero, and a tick that cannot read the registry escalates **nothing**. A garbled busy-count reads as busy, never as free, for the same reason.

## Rung 1 also stops inferring deliverability from silence

An assignee already holding an `in_progress` row is now **named as occupied** in the first notice, with the escalation window stated. Reported, not acted on: holding a row with its original assignee for one window is deliberate, and "busy now" is not yet evidence of a stall that needs hands changed.

## Grading

`tests/heartbeat_recurring_stall_escalate_unit.sh` — 19 arms, behavioural (real DB + real sweep, rail stubbed), because here the SELECT is the cheap half and the **action** is what can be wrong invisibly:

- reassign lands on the template creator when free; row stays open; latch stamped; new hands, old assignee and coordinator all told; ledger row written
- six exclusions asserted **by name**, each differing in exactly one column (never flagged, inside window, started, parked, unanswered gate, not from a template)
- second tick neither re-sends nor moves the row again
- no free agent ⇒ cancelled, with a reason naming the template, and dev's message asserted on its **text** (dev also receives the reassign message, so a recipient-only check would pass on the wrong branch)
- **unreadable registry ⇒ nothing happens** — no reassign, and above all no cancel
- non-vacuity anchor (the sweep demonstrably mutates the fixture) + mutation arm (clearing the latch makes the row eligible again, proving the latch is what stopped the second tick)

Sibling harness `heartbeat_recurring_stall_unit.sh` **re-anchored, not deleted**: this change adds a second query in the same function whose first line is character-identical, and awk `/start/,/end/` re-triggered on it — the extraction silently returned both queries concatenated. It now stops at the first block and asserts *which* block it got (`pinged_at IS NULL` present, no `escalated_at`), so a future reordering fails loudly instead of grading rung 2 while claiming rung 1.

Full local run: heartbeat + schema-sensitive suites, 22 harnesses, all green (incl. `heartbeat_stall_sweep_unit.sh` 34/34, `heartbeat_materialize_recurring_unit.sh` 32/32). No release cut — the batch freeze stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
