### PR TITLE
fix(task): an explicit reassign restarts the recurring-stall ladder instead of being yanked next tick (DIVE-2853)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -1576,8 +1576,22 @@ cmd_task_assign() {
   # OLD assignee. Without this, an inherited in_progress task keeps the prior
   # owner's started_at, and the heartbeat stale-reaper (_hb_reap_stale) can
   # cancel it on the new owner's very first tick before they touch it.
+  # DIVE-2853, and the SAME hazard the paragraph above fixes for the stale-reaper,
+  # one layer over: the recurring-stall ladder escalates on how long ago the row was
+  # FLAGGED, so a row flagged two days ago that someone deliberately reassigns by
+  # hand is eligible for rung 2 on the new owner's very first tick — the machine
+  # would yank a routing decision seconds after a person or agent made it, having
+  # measured nothing about the new hands. Clearing both stamps when the assignee
+  # actually CHANGES restarts the ladder at detection: the new owner gets a full
+  # rung-1 window, and is re-flagged on their own clock if they also sit on it.
+  # Only an explicit `task assign` resets it — the ladder writes assignee directly
+  # and keeps its own latch, so the machine's own move still cannot repeat.
   db "UPDATE tasks SET
         handoff_ack_at=CASE WHEN assignee IS NOT $(sqlq "$who") THEN NULL ELSE handoff_ack_at END,
+        recurring_stall_pinged_at=CASE WHEN assignee IS NOT $(sqlq "$who")
+                                       THEN NULL ELSE recurring_stall_pinged_at END,
+        recurring_stall_escalated_at=CASE WHEN assignee IS NOT $(sqlq "$who")
+                                          THEN NULL ELSE recurring_stall_escalated_at END,
         assignee=$(sqlq "$who"),
         started_at=CASE WHEN status='in_progress' AND assignee IS NOT $(sqlq "$who")
                         THEN datetime('now') ELSE started_at END

--- a/tests/heartbeat_recurring_stall_escalate_unit.sh
+++ b/tests/heartbeat_recurring_stall_escalate_unit.sh
@@ -220,5 +220,31 @@ _hb_stall_sweep >/dev/null 2>&1
   && ok_t "MUTATION: clearing recurring_stall_escalated_at makes the row eligible again (the latch is load-bearing, not incidental)" \
   || bad_t "MUTATION: clearing recurring_stall_escalated_at makes the row eligible again" "assignee=[$(col 1 assignee)] — the second tick's no-op in arm 2 was NOT caused by the latch, so its cause is unknown"
 
+# ---------------------------------------------------------------------------
+# 6. A HAND REASSIGN RESTARTS THE LADDER, it does not hand the new owner a row the
+#    machine yanks back on its first tick. The clock is time-since-FLAG, so without
+#    this a row flagged two days ago is eligible the instant a person reassigns it —
+#    the ladder would overrule a routing decision seconds after it was made, having
+#    measured nothing about the new hands. Same hazard cmd_task_assign already
+#    guards for the stale-reaper (started_at), one layer over. Live case: creative
+#    hand-moved DIVE-2694 hours before this code would first run.
+# ---------------------------------------------------------------------------
+mk_fixture; busy dev
+cmd_task_assign 1 anton >/dev/null 2>&1
+[[ "$(col 1 recurring_stall_pinged_at)" == "NULL" && "$(col 1 recurring_stall_escalated_at)" == "NULL" ]] \
+  && ok_t "an explicit reassign CLEARS both stall stamps (the ladder restarts at detection)" \
+  || bad_t "an explicit reassign clears both stall stamps" "pinged=[$(col 1 recurring_stall_pinged_at)] escalated=[$(col 1 recurring_stall_escalated_at)]"
+: >"$AGENT_SEND_LOG"
+_hb_stall_sweep >/dev/null 2>&1
+[[ "$(col 1 assignee)" == "anton" && "$(col 1 status)" == "todo" ]] \
+  && ok_t "the very next tick does NOT move or cancel the freshly reassigned row" \
+  || bad_t "the very next tick does NOT move or cancel the freshly reassigned row" "assignee=[$(col 1 assignee)] status=[$(col 1 status)] — the machine overruled a hand routing decision"
+# ...and it is not immune forever: re-flag it, age the flag, and rung 2 applies again.
+db "UPDATE tasks SET recurring_stall_pinged_at=datetime('now','-25 hours') WHERE id=1;"
+_hb_stall_sweep >/dev/null 2>&1
+[[ "$(col 1 assignee)" != "anton" || "$(col 1 status)" == "cancelled" ]] \
+  && ok_t "MUTATION: re-flagging the reassigned row makes rung 2 apply again (the reset delays, it does not exempt)" \
+  || bad_t "MUTATION: re-flagging the reassigned row makes rung 2 apply again" "assignee=[$(col 1 assignee)] status=[$(col 1 status)] — the reset is a permanent exemption, which would hide the next stall"
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Found by creative's own action, before the code was live anywhere

Rung 2 escalates on **time since the row was FLAGGED**. DIVE-2694's flag is `2026-08-05 04:00:08`. creative hand-moved that row off `dev3` to `dev` today — so on the first tick after this code reaches a box, the ladder would have **yanked it straight back off dev**, seconds after a deliberate routing decision, having measured nothing about the new hands.

Same hazard `cmd_task_assign` already guards for the stale-reaper (its `started_at` CASE, and the comment above it says exactly this: the reaper "can cancel it on the new owner's very first tick before they touch it"). One layer over, same fix.

## Fix

When the assignee actually **changes**, `task assign` clears `recurring_stall_pinged_at` and `recurring_stall_escalated_at`. The ladder restarts at **detection**: the new owner gets a full rung-1 window and is re-flagged on their own clock if they also sit on it.

Only an *explicit* `task assign` resets it. The ladder writes `assignee` directly in SQL and keeps its own latch, so the machine's own move still cannot repeat — a person's decision restarts the clock, the machine's does not.

## Grading

`tests/heartbeat_recurring_stall_escalate_unit.sh` — 22 arms, 0 failed. Three new:

- an explicit reassign clears **both** stamps
- the very next tick moves or cancels **nothing**
- **re-flagging** the reassigned row makes rung 2 apply again — the reset is a delay, not a permanent exemption that would hide the next stall

Regression: `release_cut_assign_unit` 23/23, `task_verifier_rail_unit` 35/35, `heartbeat_stall_sweep_unit` 34/34, `heartbeat_recurring_stall_unit` 14/14, `heartbeat_dispatcher_claim_unit` 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
