### PR TITLE
feat(auth): qwen becomes the fifth claude BYO tile, smoked with a live key (DIVE-2756)

### DIFF
--- a/changelog.d/DIVE-2756.md
+++ b/changelog.d/DIVE-2756.md
@@ -1,0 +1,30 @@
+## Unreleased — feat(auth): qwen becomes the fifth claude BYO tile, smoked with a live key before it shipped (DIVE-2756)
+
+The claude BYO catalog had four vendors (deepseek, moonshot, openrouter, zai).
+`qwen` is the fifth:
+
+```sh
+sudo 5dive agent auth set claude --provider=qwen --api-key=<key> --auth-profile=<name>
+```
+
+`agent create --type=claude --provider=qwen` and the init wizard's custom-provider
+picker take the same tile. The endpoint and all three tier model ids come from
+`CLAUDE_PROVIDER_*` in one shot, exactly like the other four.
+
+**This tile shipped smoked, not documented.** The row sat blocked two days on "no
+key", because a tile that 403s for every customer is worse than no tile. When a
+live Token Plan key arrived, the check was run for real: a `/v1/messages` POST to
+the endpoint returned 200 with a completion, and a claude-type agent ran
+qwen3.8-max through this exact env shape for hours the same day.
+
+**The key-space split is the trap, and the comment in `src/header.sh` now owns
+it.** Alibaba serves two credential families that do not interchange: Token Plan
+(subscription) keys auth only on `token-plan.<region>.maas.aliyuncs.com`, while
+pay-as-you-go Model Studio keys auth on `dashscope[-intl|-us].aliyuncs.com`.
+Measured with one key against all three hosts: 200 on token-plan, "invalid
+api-key" on both dashscope hosts. The tile ships the endpoint it was smoked on;
+a pay-as-you-go key reaches its own host through `--base-url` (DIVE-2757) rather
+than an unsmoked catalog default.
+
+No context-cap var is set: the harness has no per-provider context knob, and a
+wrong value would silently truncate rather than error.

--- a/src/cmd_compose.sh
+++ b/src/cmd_compose.sh
@@ -20,7 +20,7 @@
 #       defer_auth:     true               # create without auth gate
 #       isolation:      admin|standard|sandboxed
 #       auth_profile:   <named-account>
-#       provider:       <byo-id>           # hermes/openclaw (any), claude (anthropic-skin: deepseek moonshot openrouter zai)
+#       provider:       <byo-id>           # hermes/openclaw (any), claude (anthropic-skin: deepseek moonshot openrouter qwen zai)
 #       api_key:        "<key>"            # paired with provider; claude also needs auth_profile
 #       pack:           <slug>             # import a character pack instead of a
 #                                          # bare create — supplies persona+skills

--- a/src/cmd_init.sh
+++ b/src/cmd_init.sh
@@ -340,7 +340,8 @@ USAGE
               "openrouter|OpenRouter|Broad model catalog · recommended" \
               "zai|z.ai|GLM models over Anthropic-compatible API" \
               "deepseek|DeepSeek|DeepSeek models over Anthropic-compatible API" \
-              "moonshot|Moonshot|Kimi models over Anthropic-compatible API"
+              "moonshot|Moonshot|Kimi models over Anthropic-compatible API" \
+              "qwen|Qwen|Qwen models over Anthropic-compatible API (Token Plan key)"
             [[ -n "${CLAUDE_PROVIDER_BASEURL[$byo_provider]:-}" ]] \
               || fail "$E_VALIDATION" "unknown provider '$byo_provider'"
             _init_secret byo_key "${byo_provider} API key"

--- a/src/header.sh
+++ b/src/header.sh
@@ -918,28 +918,53 @@ valid_base_url() {
 # there is no claude-haiku-5 on OpenRouter, 4.5 is the current haiku. NOTE the opus
 # slot was the only stale entry — its sibling sonnet was already at 5, so one tier had
 # been bumped and the other had not.
+# Qwen / Alibaba Model Studio (DIVE-2756): verified LIVE with a real Token Plan key
+# 2026-08-07 — not doc-and-probe-only like the pre-ship research. A full /v1/messages
+# POST to token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic returned 200 with
+# a real completion, and a claude-type agent ran qwen3.8-max through this exact env
+# shape for hours the same day. BEWARE THE KEY-SPACE SPLIT: Alibaba serves TWO
+# credential families that do NOT interchange. Token Plan (subscription) keys auth
+# ONLY on token-plan.<region>.maas.aliyuncs.com; pay-as-you-go Model Studio keys auth
+# on dashscope[-intl|-us].aliyuncs.com. Measured 2026-08-07 with the same key across
+# all three hosts: 200 on token-plan, `403 {"message":"invalid api-key"}` on both
+# dashscope hosts — a discriminating auth layer rejecting a FOREIGN key, which is what
+# makes the split real rather than a route difference. The tile ships the endpoint it
+# was SMOKED on (token-plan); a pay-as-you-go key points at its own host through the
+# generic `agent create --base-url` (DIVE-2757) instead of an unsmoked catalog default
+# — a tile that 403s for every customer is worse than no tile. Region is part of the
+# host (ap-southeast-1); operators on another region override via --base-url the same
+# way. Auth rides ANTHROPIC_AUTH_TOKEN (Bearer) with ANTHROPIC_API_KEY empty — both
+# already handled by _apply_byo_claude, same shape as openrouter. Model ids verified
+# live the same day: qwen3.8-max answers on opus+sonnet tiers, qwen3.6-flash on the
+# haiku tier. No context-cap var is set deliberately: the harness has no per-provider
+# context knob, and a wrong one would silently TRUNCATE rather than error (the row's
+# open question, resolved as "don't guess").
 declare -A CLAUDE_PROVIDER_BASEURL=(
   [deepseek]="https://api.deepseek.com/anthropic"
   [moonshot]="https://api.moonshot.ai/anthropic"
   [openrouter]="https://openrouter.ai/api"
+  [qwen]="https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic"
   [zai]="https://api.z.ai/api/anthropic"
 )
 declare -A CLAUDE_PROVIDER_OPUS_MODEL=(
   [deepseek]="deepseek-v4-pro"
   [moonshot]="kimi-k2.5"
   [openrouter]="anthropic/claude-opus-5"
+  [qwen]="qwen3.8-max"
   [zai]="glm-5.2"
 )
 declare -A CLAUDE_PROVIDER_SONNET_MODEL=(
   [deepseek]="deepseek-v4-pro"
   [moonshot]="kimi-k2.5"
   [openrouter]="anthropic/claude-sonnet-5"
+  [qwen]="qwen3.8-max"
   [zai]="glm-5-turbo"
 )
 declare -A CLAUDE_PROVIDER_HAIKU_MODEL=(
   [deepseek]="deepseek-v4-flash"
   [moonshot]="kimi-k2.5"
   [openrouter]="anthropic/claude-haiku-4.5"
+  [qwen]="qwen3.6-flash"
   [zai]="glm-4.5-air"
 )
 

--- a/tests/claude_qwen_byo_unit.sh
+++ b/tests/claude_qwen_byo_unit.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# DIVE-2756: the fifth claude BYO tile — Qwen / Alibaba Token Plan. The tile was
+# blocked for two days on "no key to smoke with"; a live Token Plan key then made
+# the endpoint + model ids VERIFIED (200 with a real completion, plus hours of real
+# agent turns), so this harness pins the catalog values and the full
+# _apply_byo_claude write path against them. No root, network, credentials, users,
+# or runtime state are touched.
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source.
+# NOTE the absence of `2>/dev/null`. The obvious hardening -- redirect the
+# source's stderr so bash's "No such file" does not litter the log -- also
+# swallows the helper's own stderr line, which IS the payload. That silenced all
+# 210 harnesses at once while every other check in this change stayed green.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh lib/agent_setup.sh cmd_agent_create.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f" 2>/dev/null || { echo "source FAIL: $f"; exit 7; }
+done
+set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# 1. The four catalog maps all carry qwen, pinned at the values verified live
+#    2026-08-07 with a real Token Plan key.
+[[ "${CLAUDE_PROVIDER_BASEURL[qwen]:-}" == "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic" ]] \
+  && ok_t "CLAUDE_PROVIDER_BASEURL[qwen] = smoked token-plan endpoint" \
+  || bad_t "qwen base url wrong/missing" "got: '${CLAUDE_PROVIDER_BASEURL[qwen]:-}'"
+[[ "${CLAUDE_PROVIDER_OPUS_MODEL[qwen]:-}" == "qwen3.8-max" ]] \
+  && ok_t "CLAUDE_PROVIDER_OPUS_MODEL[qwen] = qwen3.8-max" \
+  || bad_t "qwen opus model wrong/missing" "got: '${CLAUDE_PROVIDER_OPUS_MODEL[qwen]:-}'"
+[[ "${CLAUDE_PROVIDER_SONNET_MODEL[qwen]:-}" == "qwen3.8-max" ]] \
+  && ok_t "CLAUDE_PROVIDER_SONNET_MODEL[qwen] = qwen3.8-max" \
+  || bad_t "qwen sonnet model wrong/missing" "got: '${CLAUDE_PROVIDER_SONNET_MODEL[qwen]:-}'"
+[[ "${CLAUDE_PROVIDER_HAIKU_MODEL[qwen]:-}" == "qwen3.6-flash" ]] \
+  && ok_t "CLAUDE_PROVIDER_HAIKU_MODEL[qwen] = qwen3.6-flash" \
+  || bad_t "qwen haiku model wrong/missing" "got: '${CLAUDE_PROVIDER_HAIKU_MODEL[qwen]:-}'"
+
+# 2. The endpoint is https:// — the DIVE-2757 invariant for any URL that carries
+#    an API key on every request.
+[[ "${CLAUDE_PROVIDER_BASEURL[qwen]:-}" == https://* ]] \
+  && ok_t "qwen endpoint is https://" \
+  || bad_t "qwen endpoint is not https" "got: '${CLAUDE_PROVIDER_BASEURL[qwen]:-}'"
+
+# 3. The wiring that was MISSING before this change: qwen passes the BYO label
+#    gate AND resolves as a native claude provider. Without the catalog rows,
+#    resolve_native_provider returned empty and `auth set claude --provider=qwen`
+#    failed with "claude does not support provider 'qwen'".
+valid_byo_provider qwen \
+  && ok_t "valid_byo_provider qwen passes" \
+  || bad_t "qwen missing from BYO_PROVIDER_LABEL"
+[[ "$(resolve_native_provider claude qwen)" == "qwen" ]] \
+  && ok_t "resolve_native_provider claude qwen -> qwen" \
+  || bad_t "claude does not resolve qwen natively" "got: '$(resolve_native_provider claude qwen)'"
+
+# 4. Behavioral: _apply_byo_claude writes the exact env shape the live smoke
+#    proved. Stub the writer (as byo_model_create_unit.sh does) and read back.
+capture=$(mktemp)
+trap 'rm -f "$capture"' EXIT
+step() { :; }
+profile_set_var() {
+  local profile="$1" var="$2" value
+  value=$(cat)
+  printf '%s %s=%s\n' "$profile" "$var" "$value" >>"$capture"
+}
+_apply_byo_claude qwen sk-sp-test-123456 qa-qwen ""
+for want in \
+  "qa-qwen ANTHROPIC_BASE_URL=https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic" \
+  "qa-qwen ANTHROPIC_AUTH_TOKEN=sk-sp-test-123456" \
+  "qa-qwen ANTHROPIC_DEFAULT_OPUS_MODEL=qwen3.8-max" \
+  "qa-qwen ANTHROPIC_DEFAULT_SONNET_MODEL=qwen3.8-max" \
+  "qa-qwen ANTHROPIC_DEFAULT_HAIKU_MODEL=qwen3.6-flash" \
+  "qa-qwen API_TIMEOUT_MS=3000000" \
+  "qa-qwen CLAUDE_CODE_OAUTH_TOKEN=" \
+  "qa-qwen ANTHROPIC_API_KEY=" \
+; do
+  grep -qxF "$want" "$capture" \
+    && ok_t "_apply_byo_claude writes: $want" \
+    || bad_t "_apply_byo_claude did not write" "$want"
+done
+# The empty ANTHROPIC_API_KEY is load-bearing: a NON-empty value makes the claude
+# harness treat the profile as a custom-API-key login and block headless on a
+# yes/no prompt (measured live 2026-08-07 — the agent goes silent). Guard the
+# emptiness explicitly, not just the line's presence.
+grep -qxF "qa-qwen ANTHROPIC_API_KEY=" "$capture" && ! grep -qE "^qa-qwen ANTHROPIC_API_KEY=.+" "$capture" \
+  && ok_t "ANTHROPIC_API_KEY is written EMPTY (Bearer-token shape)" \
+  || bad_t "ANTHROPIC_API_KEY must be empty for the token-plan shape" "$(grep ANTHROPIC_API_KEY "$capture")"
+
+# 5. The init wizard offers the tile in the claude custom-provider picker.
+grep -q '"qwen|Qwen|' "$SRC/cmd_init.sh" \
+  && ok_t "cmd_init.sh claude custom picker offers qwen" \
+  || bad_t "init wizard does not offer qwen for claude"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+(( FAIL == 0 ))

--- a/tests/claude_qwen_byo_unit.sh
+++ b/tests/claude_qwen_byo_unit.sh
@@ -6,6 +6,7 @@
 # _apply_byo_claude write path against them. No root, network, credentials, users,
 # or runtime state are touched.
 set -uo pipefail
+trap 'rc=$?; rm -f "${capture:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry
@@ -64,7 +65,6 @@ valid_byo_provider qwen \
 # 4. Behavioral: _apply_byo_claude writes the exact env shape the live smoke
 #    proved. Stub the writer (as byo_model_create_unit.sh does) and read back.
 capture=$(mktemp)
-trap 'rm -f "$capture"' EXIT
 step() { :; }
 profile_set_var() {
   local profile="$1" var="$2" value


### PR DESCRIPTION
## What

`qwen` becomes the fifth claude BYO provider tile: `CLAUDE_PROVIDER_BASEURL` +
the three per-tier model maps gain a qwen entry, and the init wizard's claude
custom-provider picker plus the compose provider comment offer it.

```
sudo 5dive agent auth set claude --provider=qwen --api-key=<key> --auth-profile=<name>
sudo 5dive agent create qwen-box --type=claude --provider=qwen --api-key=<key> --auth-profile=qwen-box
```

## Why smoked, not just documented

DIVE-2756 sat blocked two days on "no key to smoke with" — a tile that 403s for
every customer is worse than no tile. A live Token Plan key arrived 2026-08-07
and the check ran for real:

- POST /v1/messages to the endpoint -> 200 with a real completion (qwen3.6-flash).
- A claude-type agent ran qwen3.8-max through this exact env shape for hours
  the same day (live headless turns, incl. tool use).

## The key-space split (the trap)

Alibaba serves two credential families that do NOT interchange. Measured with
one key against all three hosts:

- token-plan.ap-southeast-1.maas.aliyuncs.com -> 200
- dashscope-intl.aliyuncs.com -> 403 "invalid api-key"
- dashscope.aliyuncs.com -> 403 "invalid api-key"

So the tile ships the endpoint it was SMOKED on (token-plan). Pay-as-you-go
Model Studio keys reach their own host through `agent create --base-url`
(DIVE-2757) instead of an unsmoked catalog default. The picker label names the
key type. The header comment owns the full measurement.

## Verification

- tests/claude_qwen_byo_unit.sh — 17 assertions: catalog values, https shape,
  valid_byo_provider + resolve_native_provider wiring (the exact gate that
  rejected qwen before), the full _apply_byo_claude write path including the
  empty-ANTHROPIC_API_KEY Bearer shape, and the picker line.
- All existing CLAUDE_PROVIDER-touching harnesses re-run green
  (claude_custom_base_url, hermes_zai_baseurl, openclaw_zai_baseurl,
  model_aliases) plus the init_* and compose_* unit tiers.
