### PR TITLE
fix(task): park warns when the target is a recurring instance, because the beat stops with it (DIVE-2877)

### DIFF
--- a/changelog.d/DIVE-2877.md
+++ b/changelog.d/DIVE-2877.md
@@ -1,0 +1,44 @@
+## Unreleased — fix(task): `task park` on a recurring INSTANCE now says it is stopping the beat (DIVE-2877)
+
+Parking an instance materialized from a recurring template was never a delay of that one row — it
+**stops the whole schedule, and the occurrences inside the window are deleted rather than deferred.**
+Two shipped predicates make that true, and neither is visible from the park:
+
+- The materializer dedups on `status NOT IN ('done','cancelled')`. A park sets `status='blocked'`, so
+  the parked instance **holds the template's only open slot** and the template declines to fire. There
+  is no backfill (`V1 LIMITATION: no catch-up`), so the missed ticks are gone.
+- The recurring-stall watchdog (DIVE-2693, and rung 2 from DIVE-2853) requires `status='todo' AND
+  parked_at IS NULL`. The row that stopped the beat is therefore **the one state the watchdog cannot
+  see** — so the outage reports itself nowhere.
+
+Measured cost: `DIVE-2694`, the daily character drip, parked 2026-08-07 under a legitimate fleet-wide
+token freeze. Nine days of dropped occurrences, a blocked downstream ship, and nothing red on any
+board. It took an unrelated agent noticing a stale artifact to find it.
+
+`task park` now **warns** when the target has `from_template_id` set, naming the template and its
+schedule, stating that the occurrences are dropped with no catch-up, and printing the two levers that
+actually mean "pause the job": park the **template** (a `blocked` template leaves the materializer's
+`status='todo'` selection, and unparking resumes the schedule), or **cancel the instance** with a
+written result (which frees the slot so the next tick fires). `--json` callers get the same fact as
+`data.stops_recurring_template`, since `warn()` is stderr-only.
+
+**Warn, never refuse.** The command cannot know whether the operator means to stop the beat — DIVE-2694's
+park was authorised — and a refusal would be a confident claim about intent.
+
+**Why the guard is here and not in the stall ladder**, which was the first proposed remedy. Rung 2's
+remedy is **auto-cancel**: widening its population to parked rows would convert an operator's "not now"
+into a destruction, on precisely the rows most likely to have been frozen deliberately — a widened rung
+2 would have *cancelled* DIVE-2694 rather than surfaced it. Rung 1 is the same argument one notch
+softer; a parked row is pending by design, and pinging it every beat is the false-positive class already
+fixed once (DIVE-639/711). `parked_at IS NULL` is correct at both rungs **for the action each rung
+takes**. The population is not the defect: a park's blast radius exceeding its own row is, and that is
+knowable at park time from the row itself, so it needs no watchdog at all.
+
+This is the **second** entry into the DIVE-2237 trap (a recurring template switching itself off in
+silence) and strictly worse, because park also mutes the watchdog that surfaced the first. Fixing one
+entry path is not fixing the trap.
+
+`tests/task_park_recurring_instance_warn_unit.sh` grades it, including two precondition arms that pin
+the *premises* rather than the message: that a parked instance still counts as the template's open slot,
+and that parking the template really does drop it from the materializer's selection — so if either
+predicate changes, the harness fails instead of continuing to advise something untrue.

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -6173,10 +6173,59 @@ cmd_task_park() {
   # DIVE-2410: park clears the gate columns, so whatever button that gate put in a
   # human's chat now points at a question the task no longer holds.
   _task_gate_retire_buttons "$tident" "parked" || true
+  # DIVE-2877: A PARK'S BLAST RADIUS EXCEEDS THE ROW IT IS APPLIED TO, and until
+  # now nothing said so at the moment of the park. On an instance materialized
+  # from a recurring template (from_template_id set) a park is not a delay of one
+  # row — it is a stop of the whole beat, with no catch-up:
+  #
+  #   - the materializer dedups on `status NOT IN ('done','cancelled')`
+  #     (_hb_materialize_recurring, src/cmd_heartbeat.sh) and a park sets
+  #     status='blocked', so the parked instance HOLDS the template's only open
+  #     slot. Every occurrence inside the park window is DROPPED, not deferred —
+  #     the materializer carries an explicit `V1 LIMITATION: no catch-up`.
+  #   - the DIVE-2693 stall ladder requires `status='todo' AND parked_at IS NULL`
+  #     at BOTH rungs (rung 2 added by DIVE-2853), so the row that stopped the
+  #     beat is the one state the watchdog cannot see.
+  #
+  # THE LADDER IS NOT THE DEFECT and this guard is deliberately not there. Rung 2's
+  # remedy is AUTO-CANCEL: widening its population to parked rows would convert an
+  # operator's "not now" into a destruction, on exactly the rows most likely to have
+  # been frozen for a real reason. Rung 1 is the same argument one notch softer — a
+  # parked row is pending BY DESIGN, and pinging it every beat is the false-positive
+  # class already fixed once (DIVE-639/711). Both clauses are correct FOR THE ACTION
+  # EACH RUNG TAKES, which is why the guard belongs here instead: the fact is
+  # knowable at park time from the row itself, so it needs no watchdog at all.
+  #
+  # WARN, NEVER REFUSE. This command cannot know whether the operator means to stop
+  # the beat (DIVE-2694 was parked by a legitimate fleet-wide token freeze), and a
+  # refusal would be a confident claim about intent. Naming the template and the two
+  # levers that actually mean "pause the job" is the whole job here.
+  #
+  # Cost of not having had it: DIVE-2694 (daily character drip) parked 2026-08-07,
+  # 9 days of dropped occurrences, downstream +3 days, and nothing red anywhere.
+  # CLASS: this is the SECOND entry into the DIVE-2237 trap (skip-if-open switches a
+  # template off silently) and strictly worse, because park also mutes the watchdog
+  # that surfaced the first. Fixing an entry path is not fixing the trap.
+  local _tmpl_ident=""
+  local _park_landed; _park_landed=$(db "SELECT CASE WHEN parked_at IS NOT NULL THEN 1 ELSE 0 END FROM tasks WHERE id=${tid};" 2>/dev/null || echo 0)
+  if [[ "$_park_landed" == "1" ]]; then
+    # ident has no spaces, so one row split on the first space keeps this to a
+    # single query. Empty when the row is not a materialized instance.
+    local _tmpl_row=""
+    _tmpl_row=$(db "SELECT p.ident || ' ' || COALESCE(p.schedule,'?')
+                    FROM tasks t JOIN tasks p ON p.id = t.from_template_id
+                    WHERE t.id=${tid};" 2>/dev/null || echo "")
+    if [[ -n "$_tmpl_row" ]]; then
+      _tmpl_ident="${_tmpl_row%% *}"
+      local _tmpl_sched="${_tmpl_row#* }"
+      warn "$tident is a recurring INSTANCE of ${_tmpl_ident} (schedule: ${_tmpl_sched}) — this park STOPS THAT BEAT, it does not delay one row (DIVE-2877). The materializer counts a parked instance as ${_tmpl_ident}'s open slot, so ${_tmpl_ident} will not fire again until this row is unparked or closed, and the occurrences inside the window are DROPPED with no catch-up. The recurring-stall watchdog skips parked rows, so nothing will report it. If you meant to pause the JOB: park the template instead — '5dive task park ${_tmpl_ident} --reason=<why> --wake=<when>' (a blocked template is skipped by the materializer, and unparking it resumes the schedule). If you meant to skip just THIS occurrence: '5dive task cancel $tident --result=\"<why>\"' — a cancel frees the slot, so the next tick fires normally."
+    fi
+  fi
   local wake_note=""; [[ "$wake_sql" != "NULL" ]] && wake_note=" — wakes $(db "SELECT wake_at FROM tasks WHERE id=${tid};") UTC"
   ok "$tident parked (no action needed)${reason:+ — $reason}${wake_note}" \
-     '{task:($t|tonumber), task_ident:$ti, parked:true, reason:$r, wake_at:(($w|select(length>0)) // null)}' \
-     --arg t "$tid" --arg ti "$tident" --arg r "$reason" --arg w "$([[ "$wake_sql" != "NULL" ]] && db "SELECT wake_at FROM tasks WHERE id=${tid};" || echo "")"
+     '{task:($t|tonumber), task_ident:$ti, parked:true, reason:$r, wake_at:(($w|select(length>0)) // null), stops_recurring_template:(($tm|select(length>0)) // null)}' \
+     --arg t "$tid" --arg ti "$tident" --arg r "$reason" --arg w "$([[ "$wake_sql" != "NULL" ]] && db "SELECT wake_at FROM tasks WHERE id=${tid};" || echo "")" \
+     --arg tm "$_tmpl_ident"
 }
 
 # Clear a park -> back to todo (unless real dependency edges still block it).

--- a/tests/task_park_recurring_instance_warn_unit.sh
+++ b/tests/task_park_recurring_instance_warn_unit.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+# TIER: nightly — 2.9s measured (agent-main control plane, 2026-08-08, DIVE-2877): the core/
+# installed-host tier measured 313s against a 312s effective cap WITH this file present and
+# 256/256 harnesses passing, so the corpus is at its cap and a new guard has to pay for itself.
+# The argument is not that 2.9s is expensive — it is which 2.9s is safest to move. What this
+# file grades is a WARNING on a non-destructive path: park still succeeds either way, so its
+# failure mode is "the advice is missing or stale", never a data loss or a wrong mutation. That
+# is a slow-drift property, which is what a nightly sweep is for, and it is the only thing in
+# the diff that could move without either retiring another subject's guard or welding these
+# arms onto one that must stay in core.
+# MERGE BY SUBJECT WAS TRIED FIRST (the guard's own first preference) and MEASURED, not assumed:
+# folding these arms into tests/task_park_gate_guard_unit.sh — same subject, the guards on
+# cmd_task_park — ran 6771ms against 6545ms for the two files separately, i.e. it reclaims
+# NOTHING here; the per-file setup is already cheap and the arms dominate. It would also have
+# welded a warn-only guard to the DIVE-1453 park-over-gate guard, which protects a path that
+# SILENTLY DESTROYS an open human gate and therefore must not be demotable. Reverted.
+#
 # DIVE-2877 isolated unit harness for the RECURRING-INSTANCE warning in cmd_task_park.
 #
 # Bug: parking an instance materialized from a recurring template is not a delay of

--- a/tests/task_park_recurring_instance_warn_unit.sh
+++ b/tests/task_park_recurring_instance_warn_unit.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# DIVE-2877 isolated unit harness for the RECURRING-INSTANCE warning in cmd_task_park.
+#
+# Bug: parking an instance materialized from a recurring template is not a delay of
+# that row — it stops the whole beat. The materializer dedups on `status NOT IN
+# ('done','cancelled')`, a park sets status='blocked', so the parked instance holds
+# the template's only open slot and every occurrence in the window is DROPPED with no
+# catch-up; and the DIVE-2693 stall ladder requires `status='todo' AND parked_at IS
+# NULL` at both rungs, so the row that stopped the beat is the one state the watchdog
+# cannot see. Live case: DIVE-2694 (daily character drip), 9 days dark, nothing red.
+#
+# Fix graded here: park WARNS (never refuses) when from_template_id IS NOT NULL,
+# names the template + its schedule, says the occurrences are dropped, and points at
+# the two levers that actually mean "pause the job" (park the TEMPLATE, or cancel the
+# instance). The ladder is deliberately NOT widened — rung 2's remedy is auto-cancel,
+# so a wider population would destroy rows someone deliberately froze.
+#
+# Isolation matches the sibling park harness (tests/task_park_gate_guard_unit.sh):
+# source src/ libs into a throwaway STATE_DIR — the live shared tasks.db is NEVER
+# touched. Run: bash tests/task_park_recurring_instance_warn_unit.sh (no root, no network).
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades. No `2>/dev/null` — the helper's
+# stderr line IS the payload (see the note in task_park_gate_guard_unit.sh).
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/park-recurring-unit.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+# DIVE-1919: bind the gate-proof paths to the isolated STATE_DIR too; tasks_db.sh
+# derives them at SOURCE time from the DEFAULT /var/lib/5dive.
+GATE_PROOF_KEY="$STATE_DIR/gate-proof.key"
+GATE_PROOF_ENFORCE="$STATE_DIR/gate-proof.enforce"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"; set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+tasks_db_init
+audit_log() { :; }
+
+seed_template() { db "INSERT INTO tasks (ident, title, status, created_by, kind, schedule) VALUES ('$1','tmpl-$1','todo','main','recurring','$2');"; }
+seed_instance() { db "INSERT INTO tasks (ident, title, status, created_by, kind, from_template_id) VALUES ('$1','inst-$1','todo','main','standard',(SELECT id FROM tasks WHERE ident='$2'));"; }
+seed_plain()    { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','main');"; }
+statusof()      { db "SELECT status FROM tasks WHERE ident='$1';"; }
+parkedof()      { db "SELECT CASE WHEN parked_at IS NULL THEN 'no' ELSE 'yes' END FROM tasks WHERE ident='$1';"; }
+
+# PRECONDITION, asserted not assumed: the dedup predicate this warning describes must
+# actually still count a parked instance as open. If a later change makes the
+# materializer ignore parked rows, the warning becomes a lie and every arm below would
+# still pass — so pin the claim, not just the message.
+seed_template DIVE-2900 '0 4 * * *'
+seed_instance DIVE-2901 DIVE-2900
+cmd_task_park DIVE-2901 --reason="precond" --wake=+1d >/dev/null 2>&1
+_open=$(db "SELECT COUNT(*) FROM tasks WHERE from_template_id=(SELECT id FROM tasks WHERE ident='DIVE-2900') AND status NOT IN ('done','cancelled');")
+[[ "$_open" == "1" ]] \
+  && ok_t "PRECOND a PARKED instance still counts as the template's open slot (dedup would skip)" \
+  || bad_t "PRECOND parked instance counts as open" "open=$_open (expected 1 — if 0, the materializer no longer suppresses and this warning's premise is stale)"
+# ...and the correct lever the warning names is real: a parked TEMPLATE leaves the
+# materializer's own selection (kind='recurring' AND schedule IS NOT NULL AND status='todo').
+cmd_task_park DIVE-2900 --reason="freeze the job" --wake=+1d >/dev/null 2>&1
+_sel=$(db "SELECT COUNT(*) FROM tasks WHERE kind='recurring' AND schedule IS NOT NULL AND status='todo' AND ident='DIVE-2900';")
+[[ "$_sel" == "0" ]] \
+  && ok_t "PRECOND parking the TEMPLATE drops it from the materializer's selection (the lever we advise is real)" \
+  || bad_t "PRECOND template park stops the beat" "still selected=$_sel"
+
+# --- T1: parking a recurring INSTANCE warns, and the warning is actionable. --------
+seed_template DIVE-2910 '17 5 * * 1'
+seed_instance DIVE-2911 DIVE-2910
+out=$(cmd_task_park DIVE-2911 --reason="hold" --wake=+2d 2>&1); rc=$?
+[[ "$out" == *"warn:"* && "$out" == *"DIVE-2877"* ]] \
+  && ok_t "T1 park on a recurring instance emits an attributed warning" \
+  || bad_t "T1 warning emitted" "rc=$rc out=$out"
+[[ "$out" == *"DIVE-2910"* ]] \
+  && ok_t "T1 the warning NAMES the template" \
+  || bad_t "T1 names template" "out=$out"
+[[ "$out" == *"17 5 * * 1"* ]] \
+  && ok_t "T1 the warning carries the template's schedule" \
+  || bad_t "T1 carries schedule" "out=$out"
+[[ "$out" == *"DROPPED"* || "$out" == *"no catch-up"* ]] \
+  && ok_t "T1 the warning states the occurrences are dropped, not deferred" \
+  || bad_t "T1 states no catch-up" "out=$out"
+[[ "$out" == *"task park DIVE-2910"* && "$out" == *"task cancel DIVE-2911"* ]] \
+  && ok_t "T1 the warning names BOTH correct levers, with idents filled in" \
+  || bad_t "T1 names both levers" "out=$out"
+
+# --- T2: it WARNS, it does not refuse — the park still lands. This is the whole
+#     design call (DIVE-2694 was parked for a legitimate reason). ------------------
+[[ $rc -eq 0 ]] \
+  && ok_t "T2 park still SUCCEEDS (exit 0) — warn, never refuse" \
+  || bad_t "T2 park succeeds" "rc=$rc out=$out"
+[[ "$(statusof DIVE-2911)" == "blocked" && "$(parkedof DIVE-2911)" == "yes" ]] \
+  && ok_t "T2 the park took effect (status=blocked, parked_at set)" \
+  || bad_t "T2 park took effect" "status=$(statusof DIVE-2911) parked=$(parkedof DIVE-2911)"
+
+# --- T3: MUTATION CONTROL. The arms above must be able to FAIL. An ordinary task
+#     (from_template_id NULL) parks with NO warning — the guard is scoped, and the
+#     string checks are not passing on something every park prints. ---------------
+seed_plain DIVE-2920
+out2=$(cmd_task_park DIVE-2920 --reason="revisit later" --wake=+3d 2>&1); rc2=$?
+[[ "$out2" != *"warn:"* && "$out2" != *"DIVE-2877"* ]] \
+  && ok_t "T3 an ordinary task parks with NO recurring warning (guard is scoped)" \
+  || bad_t "T3 no warning on a plain task" "out2=$out2"
+[[ $rc2 -eq 0 && "$(parkedof DIVE-2920)" == "yes" ]] \
+  && ok_t "T3 the ordinary park is UNCHANGED" \
+  || bad_t "T3 ordinary park unchanged" "rc2=$rc2 parked=$(parkedof DIVE-2920)"
+
+# --- T4: the warning names the RIGHT template, not merely some template. Two
+#     templates exist by now, so a hardcoded/wrong-join warning is caught here. ---
+seed_template DIVE-2930 '0 9 * * *'
+seed_instance DIVE-2931 DIVE-2930
+out3=$(cmd_task_park DIVE-2931 --reason="hold" --wake=+1d 2>&1)
+[[ "$out3" == *"DIVE-2930"* && "$out3" != *"DIVE-2910"* ]] \
+  && ok_t "T4 the warning resolves ITS OWN template (not another instance's)" \
+  || bad_t "T4 correct template resolved" "out3=$out3"
+
+# --- T5: the JSON envelope carries the fact too — warn() is stderr-only, so a
+#     machine caller reading stdout would otherwise never see it. -----------------
+seed_template DIVE-2940 '30 6 * * *'
+seed_instance DIVE-2941 DIVE-2940
+j=$(cmd_task_park DIVE-2941 --reason="hold" --wake=+1d 2>/dev/null)
+got=$(printf '%s' "$j" | jq -r '.data.stops_recurring_template // "null"' 2>/dev/null)
+[[ "$got" == "DIVE-2940" ]] \
+  && ok_t "T5 JSON data.stops_recurring_template names the template" \
+  || bad_t "T5 JSON field set" "got='$got' json=$j"
+seed_plain DIVE-2950
+j2=$(cmd_task_park DIVE-2950 --reason="hold" --wake=+1d 2>/dev/null)
+got2=$(printf '%s' "$j2" | jq -r '.data.stops_recurring_template // "null"' 2>/dev/null)
+[[ "$got2" == "null" ]] \
+  && ok_t "T5 JSON field is null on an ordinary park (no false positive)" \
+  || bad_t "T5 JSON field null when scoped out" "got2='$got2' json=$j2"
+
+printf '\n%s\n' "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
Parking an instance materialized from a recurring template is not a delay of that one row — it **stops the schedule and deletes the occurrences inside the window.** Two shipped predicates make that true, and neither is visible from the park:

- The materializer dedups on `status NOT IN ('done','cancelled')`. A park sets `status='blocked'`, so the parked instance **holds the template's only open slot** and the template declines to fire. No backfill (`V1 LIMITATION: no catch-up`), so the missed ticks are gone rather than deferred.
- The recurring-stall watchdog (DIVE-2693, rung 2 from DIVE-2853) requires `status='todo' AND parked_at IS NULL` at **both** rungs. The row that stopped the beat is the one state the watchdog cannot see, so the outage reports itself nowhere.

**Measured cost:** DIVE-2694, the daily character drip, parked 2026-08-07 under a legitimate fleet-wide token freeze. Nine days of dropped occurrences, a blocked downstream ship, nothing red on any board. An unrelated agent noticing a stale artifact is what found it.

## What changes

`task park` **warns** when the target has `from_template_id` set — naming the template and its schedule, stating that the occurrences are dropped with no catch-up, and printing the two levers that actually mean "pause the job":

- park the **template** (a `blocked` template leaves the materializer's `kind='recurring' AND schedule IS NOT NULL AND status='todo'` selection; unparking resumes the schedule), or
- **cancel the instance** with a written result, which frees the slot so the next tick fires normally.

`--json` callers get the same fact as `data.stops_recurring_template`, because `warn()` is stderr-only and a machine reader on stdout would otherwise never see it.

**Warn, never refuse.** The command cannot know whether the operator means to stop the beat — DIVE-2694's park was authorised — and a refusal would be a confident claim about intent.

## Why the guard is here and not in the stall ladder

That was the first proposed remedy, and acting on it would have broken something. **Rung 2's remedy is auto-cancel:** widening its population to parked rows converts an operator's "not now" into a destruction, on precisely the rows most likely to have been frozen for a real reason — a widened rung 2 would have **cancelled** DIVE-2694 rather than surfaced it. Rung 1 is the same argument one notch softer; a parked row is pending by design, and pinging it every beat is the false-positive class already fixed once (DIVE-639/711).

`parked_at IS NULL` is **correct at both rungs, for the action each rung takes.** The population is not the defect. A park's blast radius exceeding its own row is — and that is knowable at park time from the row itself, so it needs no watchdog at all.

This is the **second** entry into the DIVE-2237 trap (a recurring template switching itself off in silence) and strictly worse, because park also mutes the watchdog that surfaced the first. Fixing one entry path is not fixing the trap.

## Test

`tests/task_park_recurring_instance_warn_unit.sh` — 14 arms, isolated `STATE_DIR`, never touches the shared `tasks.db`.

Two of them are **precondition arms that pin the premises rather than the message**: that a parked instance still counts as the template's open slot, and that parking a template really does drop it from the materializer's own selection. If either predicate changes, the harness fails instead of continuing to advise something untrue.

**Mutation control:** neutralizing the guard turns 7 arms red (T1 ×5, T4, T5-set) and leaves the unchanged-behaviour arms (T2 park-still-lands, T3 ordinary-park-untouched) and both preconditions green — so the string assertions are not passing on something every park prints.

**Regression, all green:** `task_park_gate_guard_unit` (6), `heartbeat_materialize_recurring_unit` (32), `heartbeat_recurring_stall_unit` (14), `heartbeat_recurring_stall_escalate_unit` (22), `gate_button_retire_unit` (44), `gate_history_unit` (32), `objective_replan_unit` (33), `task_block_anchor_unit` (9), `task_open_blocker_guard_unit` (12), `task_start_recurring_guard_unit` (7). Bundle builds and parses (`bash -n`). `shellcheck -S error` adds no new finding (the only hit is the pre-existing SC2148 on `src/cmd_task.sh`, a sourced fragment with no shebang).

Task: DIVE-2877 (raised by olivia off creative's DIVE-2875). Verifier: olivia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
