### PR TITLE
test(actor): ground T19's created_by readback in sqlite, not padded task-show text (DIVE-2898)

### DIFF
--- a/tests/actor_claim_corroboration_unit.sh
+++ b/tests/actor_claim_corroboration_unit.sh
@@ -310,10 +310,16 @@ else
   # on the actor derived from the caller's uid, and under sudo that derivation
   # correctly answers `root`, which would grade nothing about this change.
   # `sudo -n` — never prompt. No sudo means SKIP, and a skip is not a pass.
+  # DIVE-2898: ANNOUNCE the gating. Without sudo the scratch store is never
+  # initialised, so this seat grades a DIFFERENT arm set (T19-T21 skip on the
+  # isolation fence, T25/T26 go red on "tasks store not initialised") — and it
+  # did so silently, which reads as "the same suite, and it happened to skip".
   if sudo -n true 2>/dev/null; then
     sudo -n env STATE_DIR="$SBOX" TASKS_DIR="$SBOX/tasks" TASKS_DB="$SBOX/tasks/tasks.db" \
       "$BIN" task init >/dev/null 2>&1 || true
     sudo -n chown -R "$(id -u):$(id -g)" "$SBOX" 2>/dev/null || true
+  else
+    skip "e2e passwordless sudo unavailable: the scratch store was NOT initialised, so T19-T21 will skip and T25/T26 grade a store-less path — this seat runs a different arm set from CI's"
   fi
 
   # PROVE THE ISOLATION BEFORE WRITING ANYTHING, and SKIP rather than write if it
@@ -382,11 +388,24 @@ else
     # exactly as specified. Ground truth is the registry FILE, read directly, not
     # `actor_registry_agent` — that is the function under test.
     tid2=$(e2e task add "DIVE-2518 claimed row" --project=dive --from="$FORGE_BOARD" 2>&1 | grep -oE 'DIVE-[0-9]+' | head -1)
-    cb=$(e2e task show "$tid2" | awk -F' = ' '/^created_by /{print $2; exit}')
+    # DIVE-2898: read the STORE, exactly as T19b/T19c do — not `task show`'s text.
+    # This arm parsed that text with `/^created_by /`, but `task show` RIGHT-ALIGNS
+    # its field names ("  created_by = x"), so the ^anchor never matched and cb was
+    # '' on EVERY seat that got this far, reporting a relay loss that did not exist.
+    # CI never saw it: the isolation fence skips T19-T21 on a pristine runner whose
+    # default board lists 0 rows, so only a lived-in seat with sudo reached the arm.
+    # The display is a rendering of the column; the column is the claim.
+    cb=$(sqlite3 "$SBOX/tasks/tasks.db" \
+      "SELECT COALESCE(created_by,'<null>') FROM tasks WHERE ident='$tid2';" 2>/dev/null)
     # created_by keeps the CLAIM — for a uid-less relay principal that is the only
     # true answer — and `derived_actor` carries the uid that ran it. T19b is the half
     # that makes the claim falsifiable; neither arm means anything without the other.
-    if [[ "$cb" == "$FORGE_BOARD" ]]; then
+    if [[ -z "$cb" ]]; then
+      # COALESCE means a NULL column still returns '<null>', so EMPTY here can only
+      # be the instrument (no sqlite3 / unreadable store / no such row) — never a
+      # verdict about the claim. Grading it red would be the same false-red again.
+      skip "T19 sqlite3 unavailable, store unreadable, or row '$tid2' absent; created_by not graded"
+    elif [[ "$cb" == "$FORGE_BOARD" ]]; then
       ok "T19 e2e: --from=$FORGE_BOARD stamped created_by=$FORGE_BOARD (relay attribution preserved)"
     else
       no "T19 e2e: created_by='$cb', expected the claim '$FORGE_BOARD' (relay would be lost)"


### PR DESCRIPTION
## What

`tests/actor_claim_corroboration_unit.sh` T19 parsed `task show` TEXT with
`awk -F' = ' '/^created_by /'`. `task show` **right-aligns** its field names
(`  created_by = x`), so the `^` anchor never matched: `cb` read `''` on every
seat that reached the arm, reporting a relay loss that does not exist.

CI stayed green because the arm's own isolation fence skips T19-T21 on a
pristine runner whose default store lists 0 rows — only a lived-in board with
passwordless sudo ever reaches it.

## Change

- T19 reads `created_by` from the store (sqlite), exactly as T19b/T19c already do.
- An empty read **skips** instead of grading red: `COALESCE` returns `'<null>'`
  for a NULL column, so empty can only be the instrument, never a verdict.
- The e2e block's silent `sudo -n` gating now announces itself — a sudo-less seat
  grades a different arm set (T19-T21 skip, T26 red on "tasks store not
  initialised") and said nothing about it.

## Grading (agent-olivia: uid 1002, passwordless sudo, lived-in board)

| run | result |
|---|---|
| pre-fix | `NOT OK T19 created_by=''` — 23 passed, 1 failed |
| post-fix | `ok T19 created_by=notoliviax` — 24 passed, 0 failed, 0 skipped |
| mutation: `creator="$ACTOR_BOARD"` at `src/cmd_task.sh:1194` (the row's write site) | `NOT OK T19 created_by='olivia'` — 20 passed, 4 failed; restored + **rebuilt** green |
| mutation: sqlite path -> `NOPE.db` | `skip`, not a false red |
| mutation: `if sudo -n true` -> `if false` | announcement fires |

First mutation attempt (`actor_claim ""` inside `task_actor_claim`) was a **no-op**
— it is not the write path — and is reported here rather than counted as coverage.

Fixes DIVE-2898. Attribution measured on DIVE-2784.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
