### PR TITLE
fix(council): the amendment ballot carries the candidate, and refuses to mint when it cannot (DIVE-2889)

### DIFF
--- a/changelog.d/DIVE-2889.md
+++ b/changelog.d/DIVE-2889.md
@@ -1,0 +1,41 @@
+## Unreleased — fix(council): an amendment ballot now carries the candidate it is about, and refuses to mint when it cannot (DIVE-2889)
+
+The `eng_approval_lead` constitutional amendment was balloted **twice** on digest `6498adcb…`, which
+resolves to **no file anywhere on disk**. Both approving rationales said *"I verified the on-disk
+content directly"* — true statements about `8ee23dff…`, the **live** constitution, which is not what
+was balloted. Two seats ran a verification that silently resolved to the live file and got a
+**confirmation instead of a finding**. `codex` rejected both rounds on exactly this ground and was
+right both times; the council overrode the only seat whose process held, and the inquorate failure is
+the sole reason an unreviewed policy did not seal.
+
+The ballot could not express the difference, because it named neither the path nor the full digest:
+**"the candidate is unavailable" and "the candidate is available and fine" are the same sentence one
+digest apart.** The precedent block cannot separate them either — it propagates a prior verdict and
+its prose, but not the digest that verdict was *about*.
+
+Two guards, at mint:
+
+- **The digest balloted must BE the digest of the candidate's bytes.** `amend-plan` already holds the
+  text it just parsed, so it re-derives the sha256 and refuses on mismatch, naming both digests. This
+  is what makes the `6498adcb…` shape structurally unable to reach a seat. `council amend` also
+  resolves the file to an absolute readable path and re-digests through *that* path, refusing if the
+  two reads disagree. A truncated digest and a missing path are refused for the same reason: a prefix
+  is not a binding.
+- **The ballot carries path + FULL digest + diff-vs-live**, with the exact one-command binding
+  (`sha256sum <path>`) and an explicit warning off the verification that returned a confirmation
+  twice. Both seats that went looking (DIVE-2882, DIVE-2886) had to locate the candidate
+  independently; that it worked is not the same as it being delivered, and a seat with no sibling row
+  to read had no route to the bytes at all.
+
+**The diff is capped (40 lines / 1600 chars) and the binding is not.** This question becomes the
+ballot body for human seats, delivered inside one Telegram message — an uncapped diff would turn a
+governance change into a capture failure, which is the same fail-open in a new coat. Truncation is
+loud and names the command that yields the whole diff; the path and full digest are never clipped,
+because they are the part a seat cannot reconstruct.
+
+`tests/council_amend_ballot_binding_unit.sh` grades the mint offline (17 arms, no root/network),
+including a precondition arm that the fixture is a *valid* constitution — without it every refusal
+arm would pass on the parse gate rather than the binding gate. Mutation-graded with distinct kill
+sets: dropping the digest-match guard kills exactly the 3 refusal arms, dropping the binding block
+kills the 8 delivery arms. The existing `tests/council_amend_e2e.sh` (17 arms, real `council
+{init,amend,convene,verify}`) passes unchanged.

--- a/src/cmd_council.sh
+++ b/src/cmd_council.sh
@@ -3282,9 +3282,70 @@ function cmdDriftCheck() {
   process.exit(res.drifted ? 7 : 0)
 }
 
+// DIVE-2889 — THE BALLOT MUST CARRY THE CANDIDATE, NOT A 12-CHAR PREFIX OF ITS DIGEST.
+//
+// MEASURED (olivia as chair, from dev's finding on DIVE-2887, re-measured before filing): the
+// eng_approval_lead amendment was balloted TWICE on digest 6498adcb…, which RESOLVES TO NO FILE
+// ANYWHERE ON DISK. Both approving rationales claimed a direct read of the on-disk content — and
+// both statements were true about 8ee23dff… (the LIVE constitution), which is not what was
+// balloted. Two seats ran a verification that silently resolved to the live file and got a
+// CONFIRMATION instead of a finding. codex rejected both rounds on exactly this ground and was
+// right both times; the inquorate failure is the only thing that stopped an unreviewed policy
+// from sealing.
+//
+// THE SHARP DISTINCTION, and the reason no amount of seat diligence fixes this: "the candidate is
+// unavailable" and "the candidate is available and fine" are THE SAME SENTENCE ONE DIGEST APART.
+// A seat reading the ballot could not tell them apart, because the ballot named neither the path
+// nor the full digest — and the precedent block propagates a prior VERDICT and its prose but NOT
+// the digest that verdict was about, so case law cannot separate them either.
+//
+// TWO GUARDS, and the first is the one that matters:
+//
+//   1. THE DIGEST MUST BE THE DIGEST OF THE BYTES WE ARE BALLOTING. We already hold the candidate
+//      text here (we just parsed it), so re-derive its sha256 and REFUSE on mismatch. This is what
+//      makes 6498adcb… structurally unreachable: a digest that no longer corresponds to the bytes
+//      at the named path cannot reach a seat at all. Fail closed at mint, per the row — "a motion
+//      whose bytes cannot be located should not reach seats at all".
+//   2. THE BALLOT CARRIES path + FULL digest + diff-vs-live. Not so a stale objection stops
+//      recurring (that was the earlier, wrong framing, corrected on the wiki page) but so a seat's
+//      `verify` CANNOT silently resolve to the live file: with the full digest in the row,
+//      `sha256sum <path>` is a one-command binding rather than an eyeball comparison against a
+//      truncated prefix, and a seat with no sibling row to read still has a route to the bytes.
+//      Before this, both seats that went looking (DIVE-2882, DIVE-2886) had to locate the
+//      candidate independently, and that it worked is not the same as it being delivered.
+//
+// WHY THE DIFF IS CAPPED: this question becomes the ballot BODY for human seats too, delivered as
+// a Telegram message with a hard length limit — an uncapped diff would turn a governance change
+// into a capture failure, which is the same fail-open in a new coat. So the cap is deliberate and
+// the ballot always names the exact command for the full diff; the binding (path + full digest) is
+// never truncated, because that is the part a seat cannot reconstruct.
+// Sized against the transport, not against taste. The human-seat ballot body is
+// `${question}` + a ~250-char tap suffix, and a PRECEDENT block (one line per prior decision) can
+// precede the ask — all of it inside one Telegram message. Measured with a 400-line diff: 40
+// lines / 1600 chars puts the whole question near ~1.9k, leaving ~2k of headroom. The binding
+// itself is never counted against this cap; only the diff is clipped.
+const AMEND_DIFF_MAX_LINES = 40
+const AMEND_DIFF_MAX_CHARS = 1600
+
+// Cap the diff for the ballot body while making the truncation LOUD and self-repairing — a seat
+// that sees the marker knows it is reading a prefix and is told the command that yields the whole.
+function clipAmendDiff(diff, cmd) {
+  const raw = String(diff == null ? '' : diff).replace(/\s+$/, '')
+  if (!raw) return `(no textual diff — the candidate's bytes differ from live only in ways \`diff -u\` does not show, or live is absent; bind with the digest above, NOT with this block)`
+  const lines = raw.split('\n')
+  let clipped = lines.slice(0, AMEND_DIFF_MAX_LINES).join('\n')
+  if (clipped.length > AMEND_DIFF_MAX_CHARS) clipped = clipped.slice(0, AMEND_DIFF_MAX_CHARS)
+  if (clipped.length < raw.length) {
+    return `${clipped}\n… TRUNCATED (${lines.length} diff lines total; this ballot shows the first ${Math.min(lines.length, AMEND_DIFF_MAX_LINES)}). `
+      + `THIS IS A PREFIX, NOT THE DIFF — read the whole of it before voting: ${cmd}`
+  }
+  return clipped
+}
+
 // `amend-plan` — validate the PROPOSED constitution (must parse+normalize), then emit the
 // constitutional-class deliberation question over the full current roster (no recusal, full
-// quorum + 2/3 + founder veto follow from the constitutional class). Fails closed on a bad file.
+// quorum + 2/3 + founder veto follow from the constitutional class). Fails closed on a bad file,
+// and (DIVE-2889) on a candidate whose bytes it cannot bind to the digest it is about to ballot.
 function cmdAmendPlan() {
   const roster = readJsonFlag('seats-json')
   if (!Array.isArray(roster) || !roster.length) die('amend-plan needs the current roster --seats-json (fail-closed)', 3)
@@ -3294,11 +3355,54 @@ function cmdAmendPlan() {
   try { E.normalizeConstitution(E.parseConstitutionFrontmatter(text)) }
   catch (e) { die(`the proposed constitution.yaml is not a valid constitution — refusing to convene an amendment on it: ${String(e && e.message || e)}`, 4) }
   const digest = flag('constitution-digest') === true || flag('constitution-digest') == null ? '' : String(flag('constitution-digest'))
+  const candPath = flag('constitution-path') === true || flag('constitution-path') == null ? '' : String(flag('constitution-path'))
+
+  // DIVE-2889 guard 1 — fail closed unless the digest we are about to ballot IS the digest of the
+  // bytes we just read. A prefix is not a binding and an unbindable motion does not reach seats.
+  if (!/^[0-9a-f]{64}$/i.test(digest)) {
+    die(`amend-plan needs the FULL 64-hex --constitution-digest of the candidate (got ${digest ? `"${digest}"` : 'nothing'}) — `
+      + `a ballot that carries only a truncated digest cannot be bound to a file by any seat (fail-closed, DIVE-2889)`, 4)
+  }
+  const actual = E.digestConstitution(text)
+  if (actual.toLowerCase() !== digest.toLowerCase()) {
+    die(`REFUSING TO MINT THIS BALLOT (DIVE-2889): the digest to be balloted (${digest}) is NOT the digest of the candidate's bytes `
+      + `(${actual}). This is the exact shape that put 6498adcb… in front of two rounds of seats while every "I verified the on-disk `
+      + `content" rationale was in fact describing the LIVE constitution. Re-digest the candidate and convene again.`, 4)
+  }
+  if (!candPath) {
+    die(`amend-plan needs --constitution-path=<path the seats can resolve> (fail-closed, DIVE-2889) — the ballot must name where the `
+      + `candidate's bytes live, or a seat's verification silently resolves to the live constitution and returns a confirmation`, 4)
+  }
+
+  const diffCmd = `diff -u ${flag('live-path') && flag('live-path') !== true ? String(flag('live-path')) : '<live constitution.yaml>'} ${candPath}`
+  const livePath = flag('live-path') === true || flag('live-path') == null ? '' : String(flag('live-path'))
+  const liveDigest = flag('live-digest') === true || flag('live-digest') == null ? '' : String(flag('live-digest'))
+  const diffRaw = flag('diff') === true || flag('diff') == null ? '' : String(flag('diff'))
+  const diffText = diffRaw.startsWith('@') ? (() => { try { return fs.readFileSync(diffRaw.slice(1), 'utf-8') } catch { return '' } })() : diffRaw
+
+  // The binding block. Deliberately BEFORE the ask, and deliberately naming what each field is for
+  // — a seat that reads only this block still has everything it needs to bind, and a seat that
+  // skips it has no honest way to claim it verified anything.
+  const binding = `\nCANDIDATE BINDING — the bytes this motion is about (DIVE-2889; verify before you vote):
+  path        ${candPath}
+  sha256      ${digest}
+  live        ${livePath || '(unknown)'}${liveDigest ? ` sha256 ${liveDigest}` : ''}
+  bind it     sha256sum ${candPath}     <- must print the sha256 above, exactly
+DO NOT verify by reading the live constitution: it will agree with itself and return a confirmation
+instead of a finding. That is what happened in both dead rounds of the eng_approval_lead amendment.
+If \`sha256sum\` does not reproduce the digest above, the ballot and the file have diverged — REJECT
+and say so; do not vote on bytes you could not bind.
+
+DIFF vs the live constitution (${diffCmd}):
+${clipAmendDiff(diffText, diffCmd)}
+`
+
   const question = `Constitution amendment motion (constitutional): should the Council RATIFY the proposed constitution.yaml `
-    + `(digest ${digest ? digest.slice(0, 12) + '…' : '?'})? This is the hardest bar — a 2/3 supermajority of ALL `
+    + `(sha256 ${digest})?${binding}This is the hardest bar — a 2/3 supermajority of ALL `
     + `${roster.length} seat(s) with full quorum, founder-veto-able. On a pass the new constitution is sealed into the `
     + `hash-chain and becomes the enforced governance policy. Approve to ratify, reject to keep the current constitution, escalate only if it genuinely needs a human.`
-  out({ class: 'constitutional', recuse: [], subject: null, votingSeats: roster, votingSeatSpec: seatsToSpec(roster), question, constitutionDigest: digest })
+  out({ class: 'constitutional', recuse: [], subject: null, votingSeats: roster, votingSeatSpec: seatsToSpec(roster), question,
+        constitutionDigest: digest, candidatePath: candPath, livePath: livePath || null, liveDigest: liveDigest || null })
 }
 
 // `amend-apply` — on a PASS only: build the hash-chained constitutional motion record carrying the
@@ -4843,6 +4947,31 @@ _council_amend() {
   local new_digest; new_digest="$(sha256sum < "$file" 2>/dev/null | awk '{print $1}')"
   [[ -n "$new_digest" ]] || fail "$E_GENERIC" "could not digest the proposed constitution $file"
 
+  # DIVE-2889 — RESOLVE THE CANDIDATE TO A REAL, ABSOLUTE PATH BEFORE ANY SEAT SEES A BALLOT.
+  # The eng_approval_lead amendment was balloted twice on a digest that resolves to no file
+  # anywhere on disk, while both approving rationales described the LIVE constitution. A seat
+  # cannot bind bytes it cannot name, so the ballot has to carry the name — and a relative path
+  # is not a name once the ballot leaves this process and lands in another agent's task body.
+  local cand_abs; cand_abs="$(readlink -f -- "$file" 2>/dev/null || true)"
+  [[ -n "$cand_abs" && -r "$cand_abs" ]] \
+    || fail "$E_NOT_FOUND" "could not resolve the proposed constitution '$file' to a readable absolute path — a motion whose bytes cannot be located must not reach seats (fail-closed, DIVE-2889)"
+  # Re-digest through the RESOLVED path, not the argument. If the two disagree the file moved or
+  # changed under us between the two reads, and the ballot would name bytes that no longer exist.
+  local cand_recheck; cand_recheck="$(sha256sum < "$cand_abs" 2>/dev/null | awk '{print $1}')"
+  [[ "$cand_recheck" == "$new_digest" ]] \
+    || fail "$E_CONFLICT" "the proposed constitution changed between reads ($new_digest -> ${cand_recheck:-unreadable}) — refusing to ballot a digest that no longer names the file (fail-closed, DIVE-2889)"
+
+  # Live side of the binding: seats are told what the candidate is being compared AGAINST, so
+  # "verified the on-disk content" can no longer be true of the wrong file without the ballot
+  # contradicting it. An absent live file is a legitimate state (pre-genesis), not a failure.
+  local live_path live_digest cand_diff diff_tmp
+  live_path="$(_council_constitution_path)"
+  live_digest="$(sha256sum < "$live_path" 2>/dev/null | awk '{print $1}')" || live_digest=""
+  diff_tmp="$(mktemp)"
+  # `diff` exits 1 when the files differ, which is the ORDINARY case here — never let that kill
+  # the amend under `set -e`, and never let it read as an error.
+  diff -u "$live_path" "$cand_abs" > "$diff_tmp" 2>/dev/null || true
+
   # Current roster + hash-chain head from the SEALED lineage tail.
   local head head_seats prev_digest last_seq seq
   head="$(tail -n1 "$COUNCIL_LINEAGE" 2>/dev/null)"
@@ -4851,8 +4980,11 @@ _council_amend() {
   prev_digest="$(printf '%s' "$head" | jq -r '.digest // ""')"
   last_seq="$(printf '%s' "$head" | jq -r '.seq // -1')"; [[ "$last_seq" =~ ^[0-9]+$ ]] && seq=$((last_seq+1)) || seq=0
 
-  local plan question
-  plan="$(node "$dir/cli.mjs" amend-plan --seats-json="$head_seats" --constitution="@$file" --constitution-digest="$new_digest")" || return $?
+  local plan question _amend_rc
+  plan="$(node "$dir/cli.mjs" amend-plan --seats-json="$head_seats" --constitution="@$cand_abs" --constitution-digest="$new_digest" \
+    --constitution-path="$cand_abs" --live-path="$live_path" --live-digest="$live_digest" --diff="@$diff_tmp")" \
+    || { _amend_rc=$?; rm -f "$diff_tmp"; return $_amend_rc; }   # preserve amend-plan's exit code — its fail-closed refusals are distinguishable by code
+  rm -f "$diff_tmp"
   question="$(printf '%s' "$plan" | jq -r '.question')"
 
   if (( dry )); then

--- a/src/council/cli.mjs
+++ b/src/council/cli.mjs
@@ -1116,9 +1116,70 @@ function cmdDriftCheck() {
   process.exit(res.drifted ? 7 : 0)
 }
 
+// DIVE-2889 — THE BALLOT MUST CARRY THE CANDIDATE, NOT A 12-CHAR PREFIX OF ITS DIGEST.
+//
+// MEASURED (olivia as chair, from dev's finding on DIVE-2887, re-measured before filing): the
+// eng_approval_lead amendment was balloted TWICE on digest 6498adcb…, which RESOLVES TO NO FILE
+// ANYWHERE ON DISK. Both approving rationales claimed a direct read of the on-disk content — and
+// both statements were true about 8ee23dff… (the LIVE constitution), which is not what was
+// balloted. Two seats ran a verification that silently resolved to the live file and got a
+// CONFIRMATION instead of a finding. codex rejected both rounds on exactly this ground and was
+// right both times; the inquorate failure is the only thing that stopped an unreviewed policy
+// from sealing.
+//
+// THE SHARP DISTINCTION, and the reason no amount of seat diligence fixes this: "the candidate is
+// unavailable" and "the candidate is available and fine" are THE SAME SENTENCE ONE DIGEST APART.
+// A seat reading the ballot could not tell them apart, because the ballot named neither the path
+// nor the full digest — and the precedent block propagates a prior VERDICT and its prose but NOT
+// the digest that verdict was about, so case law cannot separate them either.
+//
+// TWO GUARDS, and the first is the one that matters:
+//
+//   1. THE DIGEST MUST BE THE DIGEST OF THE BYTES WE ARE BALLOTING. We already hold the candidate
+//      text here (we just parsed it), so re-derive its sha256 and REFUSE on mismatch. This is what
+//      makes 6498adcb… structurally unreachable: a digest that no longer corresponds to the bytes
+//      at the named path cannot reach a seat at all. Fail closed at mint, per the row — "a motion
+//      whose bytes cannot be located should not reach seats at all".
+//   2. THE BALLOT CARRIES path + FULL digest + diff-vs-live. Not so a stale objection stops
+//      recurring (that was the earlier, wrong framing, corrected on the wiki page) but so a seat's
+//      `verify` CANNOT silently resolve to the live file: with the full digest in the row,
+//      `sha256sum <path>` is a one-command binding rather than an eyeball comparison against a
+//      truncated prefix, and a seat with no sibling row to read still has a route to the bytes.
+//      Before this, both seats that went looking (DIVE-2882, DIVE-2886) had to locate the
+//      candidate independently, and that it worked is not the same as it being delivered.
+//
+// WHY THE DIFF IS CAPPED: this question becomes the ballot BODY for human seats too, delivered as
+// a Telegram message with a hard length limit — an uncapped diff would turn a governance change
+// into a capture failure, which is the same fail-open in a new coat. So the cap is deliberate and
+// the ballot always names the exact command for the full diff; the binding (path + full digest) is
+// never truncated, because that is the part a seat cannot reconstruct.
+// Sized against the transport, not against taste. The human-seat ballot body is
+// `${question}` + a ~250-char tap suffix, and a PRECEDENT block (one line per prior decision) can
+// precede the ask — all of it inside one Telegram message. Measured with a 400-line diff: 40
+// lines / 1600 chars puts the whole question near ~1.9k, leaving ~2k of headroom. The binding
+// itself is never counted against this cap; only the diff is clipped.
+const AMEND_DIFF_MAX_LINES = 40
+const AMEND_DIFF_MAX_CHARS = 1600
+
+// Cap the diff for the ballot body while making the truncation LOUD and self-repairing — a seat
+// that sees the marker knows it is reading a prefix and is told the command that yields the whole.
+function clipAmendDiff(diff, cmd) {
+  const raw = String(diff == null ? '' : diff).replace(/\s+$/, '')
+  if (!raw) return `(no textual diff — the candidate's bytes differ from live only in ways \`diff -u\` does not show, or live is absent; bind with the digest above, NOT with this block)`
+  const lines = raw.split('\n')
+  let clipped = lines.slice(0, AMEND_DIFF_MAX_LINES).join('\n')
+  if (clipped.length > AMEND_DIFF_MAX_CHARS) clipped = clipped.slice(0, AMEND_DIFF_MAX_CHARS)
+  if (clipped.length < raw.length) {
+    return `${clipped}\n… TRUNCATED (${lines.length} diff lines total; this ballot shows the first ${Math.min(lines.length, AMEND_DIFF_MAX_LINES)}). `
+      + `THIS IS A PREFIX, NOT THE DIFF — read the whole of it before voting: ${cmd}`
+  }
+  return clipped
+}
+
 // `amend-plan` — validate the PROPOSED constitution (must parse+normalize), then emit the
 // constitutional-class deliberation question over the full current roster (no recusal, full
-// quorum + 2/3 + founder veto follow from the constitutional class). Fails closed on a bad file.
+// quorum + 2/3 + founder veto follow from the constitutional class). Fails closed on a bad file,
+// and (DIVE-2889) on a candidate whose bytes it cannot bind to the digest it is about to ballot.
 function cmdAmendPlan() {
   const roster = readJsonFlag('seats-json')
   if (!Array.isArray(roster) || !roster.length) die('amend-plan needs the current roster --seats-json (fail-closed)', 3)
@@ -1128,11 +1189,54 @@ function cmdAmendPlan() {
   try { E.normalizeConstitution(E.parseConstitutionFrontmatter(text)) }
   catch (e) { die(`the proposed constitution.yaml is not a valid constitution — refusing to convene an amendment on it: ${String(e && e.message || e)}`, 4) }
   const digest = flag('constitution-digest') === true || flag('constitution-digest') == null ? '' : String(flag('constitution-digest'))
+  const candPath = flag('constitution-path') === true || flag('constitution-path') == null ? '' : String(flag('constitution-path'))
+
+  // DIVE-2889 guard 1 — fail closed unless the digest we are about to ballot IS the digest of the
+  // bytes we just read. A prefix is not a binding and an unbindable motion does not reach seats.
+  if (!/^[0-9a-f]{64}$/i.test(digest)) {
+    die(`amend-plan needs the FULL 64-hex --constitution-digest of the candidate (got ${digest ? `"${digest}"` : 'nothing'}) — `
+      + `a ballot that carries only a truncated digest cannot be bound to a file by any seat (fail-closed, DIVE-2889)`, 4)
+  }
+  const actual = E.digestConstitution(text)
+  if (actual.toLowerCase() !== digest.toLowerCase()) {
+    die(`REFUSING TO MINT THIS BALLOT (DIVE-2889): the digest to be balloted (${digest}) is NOT the digest of the candidate's bytes `
+      + `(${actual}). This is the exact shape that put 6498adcb… in front of two rounds of seats while every "I verified the on-disk `
+      + `content" rationale was in fact describing the LIVE constitution. Re-digest the candidate and convene again.`, 4)
+  }
+  if (!candPath) {
+    die(`amend-plan needs --constitution-path=<path the seats can resolve> (fail-closed, DIVE-2889) — the ballot must name where the `
+      + `candidate's bytes live, or a seat's verification silently resolves to the live constitution and returns a confirmation`, 4)
+  }
+
+  const diffCmd = `diff -u ${flag('live-path') && flag('live-path') !== true ? String(flag('live-path')) : '<live constitution.yaml>'} ${candPath}`
+  const livePath = flag('live-path') === true || flag('live-path') == null ? '' : String(flag('live-path'))
+  const liveDigest = flag('live-digest') === true || flag('live-digest') == null ? '' : String(flag('live-digest'))
+  const diffRaw = flag('diff') === true || flag('diff') == null ? '' : String(flag('diff'))
+  const diffText = diffRaw.startsWith('@') ? (() => { try { return fs.readFileSync(diffRaw.slice(1), 'utf-8') } catch { return '' } })() : diffRaw
+
+  // The binding block. Deliberately BEFORE the ask, and deliberately naming what each field is for
+  // — a seat that reads only this block still has everything it needs to bind, and a seat that
+  // skips it has no honest way to claim it verified anything.
+  const binding = `\nCANDIDATE BINDING — the bytes this motion is about (DIVE-2889; verify before you vote):
+  path        ${candPath}
+  sha256      ${digest}
+  live        ${livePath || '(unknown)'}${liveDigest ? ` sha256 ${liveDigest}` : ''}
+  bind it     sha256sum ${candPath}     <- must print the sha256 above, exactly
+DO NOT verify by reading the live constitution: it will agree with itself and return a confirmation
+instead of a finding. That is what happened in both dead rounds of the eng_approval_lead amendment.
+If \`sha256sum\` does not reproduce the digest above, the ballot and the file have diverged — REJECT
+and say so; do not vote on bytes you could not bind.
+
+DIFF vs the live constitution (${diffCmd}):
+${clipAmendDiff(diffText, diffCmd)}
+`
+
   const question = `Constitution amendment motion (constitutional): should the Council RATIFY the proposed constitution.yaml `
-    + `(digest ${digest ? digest.slice(0, 12) + '…' : '?'})? This is the hardest bar — a 2/3 supermajority of ALL `
+    + `(sha256 ${digest})?${binding}This is the hardest bar — a 2/3 supermajority of ALL `
     + `${roster.length} seat(s) with full quorum, founder-veto-able. On a pass the new constitution is sealed into the `
     + `hash-chain and becomes the enforced governance policy. Approve to ratify, reject to keep the current constitution, escalate only if it genuinely needs a human.`
-  out({ class: 'constitutional', recuse: [], subject: null, votingSeats: roster, votingSeatSpec: seatsToSpec(roster), question, constitutionDigest: digest })
+  out({ class: 'constitutional', recuse: [], subject: null, votingSeats: roster, votingSeatSpec: seatsToSpec(roster), question,
+        constitutionDigest: digest, candidatePath: candPath, livePath: livePath || null, liveDigest: liveDigest || null })
 }
 
 // `amend-apply` — on a PASS only: build the hash-chained constitutional motion record carrying the

--- a/src/council/cmd_council.template.sh
+++ b/src/council/cmd_council.template.sh
@@ -1447,6 +1447,31 @@ _council_amend() {
   local new_digest; new_digest="$(sha256sum < "$file" 2>/dev/null | awk '{print $1}')"
   [[ -n "$new_digest" ]] || fail "$E_GENERIC" "could not digest the proposed constitution $file"
 
+  # DIVE-2889 — RESOLVE THE CANDIDATE TO A REAL, ABSOLUTE PATH BEFORE ANY SEAT SEES A BALLOT.
+  # The eng_approval_lead amendment was balloted twice on a digest that resolves to no file
+  # anywhere on disk, while both approving rationales described the LIVE constitution. A seat
+  # cannot bind bytes it cannot name, so the ballot has to carry the name — and a relative path
+  # is not a name once the ballot leaves this process and lands in another agent's task body.
+  local cand_abs; cand_abs="$(readlink -f -- "$file" 2>/dev/null || true)"
+  [[ -n "$cand_abs" && -r "$cand_abs" ]] \
+    || fail "$E_NOT_FOUND" "could not resolve the proposed constitution '$file' to a readable absolute path — a motion whose bytes cannot be located must not reach seats (fail-closed, DIVE-2889)"
+  # Re-digest through the RESOLVED path, not the argument. If the two disagree the file moved or
+  # changed under us between the two reads, and the ballot would name bytes that no longer exist.
+  local cand_recheck; cand_recheck="$(sha256sum < "$cand_abs" 2>/dev/null | awk '{print $1}')"
+  [[ "$cand_recheck" == "$new_digest" ]] \
+    || fail "$E_CONFLICT" "the proposed constitution changed between reads ($new_digest -> ${cand_recheck:-unreadable}) — refusing to ballot a digest that no longer names the file (fail-closed, DIVE-2889)"
+
+  # Live side of the binding: seats are told what the candidate is being compared AGAINST, so
+  # "verified the on-disk content" can no longer be true of the wrong file without the ballot
+  # contradicting it. An absent live file is a legitimate state (pre-genesis), not a failure.
+  local live_path live_digest cand_diff diff_tmp
+  live_path="$(_council_constitution_path)"
+  live_digest="$(sha256sum < "$live_path" 2>/dev/null | awk '{print $1}')" || live_digest=""
+  diff_tmp="$(mktemp)"
+  # `diff` exits 1 when the files differ, which is the ORDINARY case here — never let that kill
+  # the amend under `set -e`, and never let it read as an error.
+  diff -u "$live_path" "$cand_abs" > "$diff_tmp" 2>/dev/null || true
+
   # Current roster + hash-chain head from the SEALED lineage tail.
   local head head_seats prev_digest last_seq seq
   head="$(tail -n1 "$COUNCIL_LINEAGE" 2>/dev/null)"
@@ -1455,8 +1480,11 @@ _council_amend() {
   prev_digest="$(printf '%s' "$head" | jq -r '.digest // ""')"
   last_seq="$(printf '%s' "$head" | jq -r '.seq // -1')"; [[ "$last_seq" =~ ^[0-9]+$ ]] && seq=$((last_seq+1)) || seq=0
 
-  local plan question
-  plan="$(node "$dir/cli.mjs" amend-plan --seats-json="$head_seats" --constitution="@$file" --constitution-digest="$new_digest")" || return $?
+  local plan question _amend_rc
+  plan="$(node "$dir/cli.mjs" amend-plan --seats-json="$head_seats" --constitution="@$cand_abs" --constitution-digest="$new_digest" \
+    --constitution-path="$cand_abs" --live-path="$live_path" --live-digest="$live_digest" --diff="@$diff_tmp")" \
+    || { _amend_rc=$?; rm -f "$diff_tmp"; return $_amend_rc; }   # preserve amend-plan's exit code — its fail-closed refusals are distinguishable by code
+  rm -f "$diff_tmp"
   question="$(printf '%s' "$plan" | jq -r '.question')"
 
   if (( dry )); then

--- a/tests/council_amend_ballot_binding_unit.sh
+++ b/tests/council_amend_ballot_binding_unit.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# DIVE-2889 — the amend BALLOT MINT must refuse a motion it cannot bind, and must carry the
+# candidate's path + FULL digest + diff-vs-live into the ballot body.
+#
+# Incident: the eng_approval_lead amendment was balloted TWICE on digest 6498adcb…, which resolves
+# to no file anywhere on disk, while both approving rationales claimed "I verified the on-disk
+# content directly" — true statements about the LIVE constitution (8ee23dff…), which is not what
+# was balloted. Two seats ran a verification that silently resolved to the live file and got a
+# CONFIRMATION instead of a finding. codex rejected on exactly this ground both times and was right;
+# only the inquorate failure stopped an unreviewed policy from sealing.
+#
+# The distinction the old ballot could not express: "the candidate is unavailable" and "the
+# candidate is available and fine" are THE SAME SENTENCE ONE DIGEST APART — the ballot named neither
+# path nor full digest, and the precedent block propagates a verdict's prose but not the digest it
+# was about.
+#
+# Graded here, at the mint, offline (node + cli.mjs only — no council, no root, no network):
+#   A. the digest balloted must BE the digest of the candidate's bytes (the 6498adcb shape)
+#   B. a truncated digest is refused (a prefix is not a binding)
+#   C. a candidate with no resolvable path is refused
+#   D. the happy path carries path + FULL 64-hex digest + the one-command bind + the diff
+#   E. an oversized diff is capped LOUDLY and still names the command for the whole of it
+# Run: bash tests/council_amend_ballot_binding_unit.sh  (no root, no network).
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh). No `2>/dev/null` —
+# the helper's stderr line IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
+command -v node >/dev/null 2>&1 || { echo "SKIP: node not on PATH"; exit 0; }
+CLI="$ROOT/src/council/cli.mjs"
+[[ -f "$CLI" ]] || { echo "SKIP: $CLI not found"; exit 0; }
+TMP="$(mktemp -d /tmp/amend-binding-unit.XXXXXX)"
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+SEATS='[{"id":"a","lens":"a"},{"id":"b","lens":"b"},{"id":"c","lens":"c"}]'
+
+cat > "$TMP/candidate.yaml" <<'YAML'
+council:
+  bench: security
+quorum: none
+thresholds:
+  ordinary: 1
+  promote: majority
+  demote: 3/4
+  constitutional:
+    rule: fraction
+    value: 0.75
+    quorum: all
+    require_quorum: true
+veto:
+  principals: [human:main, human:owner]
+  hold_secs: 0
+  posthoc_secs: 86400
+hard_gates:
+  money: 'spend|billing'
+  comms: 'brand|press'
+ship:
+  require_ci: true
+comms:
+  public_requires_human: true
+YAML
+cp "$TMP/candidate.yaml" "$TMP/live.yaml"
+# The amendment under test: purely additive, and inside a field the schema actually accepts —
+# an unknown top-level key is refused by the PARSE gate, which would make every binding arm below
+# pass for the wrong reason. (Found by the precondition arm, which is what it is for.)
+printf "  eng_approval_lead: 'deploy|release'\n" >> "$TMP/candidate.yaml"
+
+CAND="$TMP/candidate.yaml"; LIVE="$TMP/live.yaml"
+CAND_SHA="$(sha256sum < "$CAND" | awk '{print $1}')"
+LIVE_SHA="$(sha256sum < "$LIVE" | awk '{print $1}')"
+diff -u "$LIVE" "$CAND" > "$TMP/diff.txt" 2>/dev/null || true
+
+# PRECONDITION, asserted not assumed: the fixture must actually be a VALID constitution, or every
+# refusal arm below would pass for the wrong reason (the parse gate, not the binding gate) and the
+# happy-path arm would be the only thing that could ever fail.
+if node "$CLI" amend-plan --seats-json="$SEATS" --constitution="@$CAND" \
+     --constitution-digest="$CAND_SHA" --constitution-path="$CAND" \
+     --live-path="$LIVE" --live-digest="$LIVE_SHA" --diff="@$TMP/diff.txt" >"$TMP/ok.json" 2>"$TMP/ok.err"; then
+  ok_t "PRECOND the fixture is a valid constitution and a correctly-bound mint SUCCEEDS"
+else
+  bad_t "PRECOND valid fixture mints" "rc=$? err=$(cat "$TMP/ok.err")"
+fi
+
+# --- A: THE CORE GUARD. A digest that is not the digest of the candidate's bytes is REFUSED.
+#     This is the 6498adcb shape, and it is what makes that motion structurally unable to reach a
+#     seat: the mint holds the bytes, so it can always answer "is this digest about them?" --------
+WRONG_SHA="6498adcb$(printf '%056d' 0)"
+out=$(node "$CLI" amend-plan --seats-json="$SEATS" --constitution="@$CAND" \
+        --constitution-digest="$WRONG_SHA" --constitution-path="$CAND" \
+        --live-path="$LIVE" --live-digest="$LIVE_SHA" --diff="@$TMP/diff.txt" 2>&1); rc=$?
+[[ $rc -ne 0 ]] \
+  && ok_t "A a digest that does not match the candidate's bytes is REFUSED (non-zero exit)" \
+  || bad_t "A wrong digest refused" "rc=$rc out=$out"
+[[ "$out" == *"DIVE-2889"* && "$out" == *"$WRONG_SHA"* && "$out" == *"$CAND_SHA"* ]] \
+  && ok_t "A the refusal names BOTH digests — the one balloted and the one the bytes actually have" \
+  || bad_t "A refusal names both digests" "out=$out"
+[[ "$out" != *"CANDIDATE BINDING"* ]] \
+  && ok_t "A no ballot text is emitted on the refusal (the motion does not reach seats at all)" \
+  || bad_t "A no ballot on refusal" "out=$out"
+
+# --- B: a truncated digest is not a binding. The old ballot printed exactly this — 12 chars and an
+#     ellipsis — which is why seats compared by eye against a file located by guesswork. ----------
+out=$(node "$CLI" amend-plan --seats-json="$SEATS" --constitution="@$CAND" \
+        --constitution-digest="${CAND_SHA:0:12}" --constitution-path="$CAND" 2>&1); rc=$?
+[[ $rc -ne 0 && "$out" == *"DIVE-2889"* ]] \
+  && ok_t "B a TRUNCATED digest is refused — a prefix is not a binding" \
+  || bad_t "B truncated digest refused" "rc=$rc out=$out"
+
+# --- C: no path means no route to the bytes. A seat with no sibling row to read has nothing to
+#     bind to, which is presumably how the first two rounds went. -----------------------------
+out=$(node "$CLI" amend-plan --seats-json="$SEATS" --constitution="@$CAND" \
+        --constitution-digest="$CAND_SHA" 2>&1); rc=$?
+[[ $rc -ne 0 && "$out" == *"DIVE-2889"* ]] \
+  && ok_t "C a candidate with no --constitution-path is refused" \
+  || bad_t "C missing path refused" "rc=$rc out=$out"
+
+# --- D: THE HAPPY PATH DELIVERS THE BINDING. Everything a seat needs to bind must be IN the
+#     ballot body, because "it worked when a seat went looking" is not the same as delivery. ----
+q=$(jq -r '.question' < "$TMP/ok.json" 2>/dev/null)
+[[ "$q" == *"$CAND_SHA"* ]] \
+  && ok_t "D the ballot carries the FULL 64-hex digest" \
+  || bad_t "D full digest in ballot" "q=$q"
+[[ "$q" == *"$CAND"* ]] \
+  && ok_t "D the ballot names the candidate's PATH" \
+  || bad_t "D path in ballot" "q=$q"
+[[ "$q" == *"sha256sum $CAND"* ]] \
+  && ok_t "D the ballot spells the ONE-COMMAND binding a seat should run" \
+  || bad_t "D bind command in ballot" "q=$q"
+[[ "$q" == *"eng_approval_lead"* ]] \
+  && ok_t "D the ballot carries the DIFF vs live (the amendment's actual content)" \
+  || bad_t "D diff in ballot" "q=$q"
+[[ "$q" == *"$LIVE_SHA"* && "$q" == *"$LIVE"* ]] \
+  && ok_t "D the ballot names what the candidate is being compared AGAINST (live path + digest)" \
+  || bad_t "D live side named" "q=$q"
+[[ "$q" == *"DO NOT verify by reading the live constitution"* ]] \
+  && ok_t "D the ballot warns off the exact verification that returned a confirmation twice" \
+  || bad_t "D anti-confirmation warning" "q=$q"
+# The JSON envelope carries it too, for anything reading the plan rather than the prose.
+[[ "$(jq -r '.candidatePath' < "$TMP/ok.json")" == "$CAND" \
+   && "$(jq -r '.constitutionDigest' < "$TMP/ok.json")" == "$CAND_SHA" ]] \
+  && ok_t "D the plan JSON carries candidatePath + the full constitutionDigest" \
+  || bad_t "D plan JSON binding" "$(cat "$TMP/ok.json")"
+
+# --- E: an oversized diff is CAPPED — this question becomes a Telegram ballot body for human
+#     seats, and an uncapped diff turns a governance change into a capture failure, which is the
+#     same fail-open wearing a new coat. The truncation must be LOUD and name the full command. --
+cp "$TMP/live.yaml" "$TMP/big.yaml"
+for i in $(seq 1 400); do printf "  gate_%03d: 'pattern_%03d'\n" "$i" "$i" >> "$TMP/big.yaml"; done
+BIG_SHA="$(sha256sum < "$TMP/big.yaml" | awk '{print $1}')"
+diff -u "$LIVE" "$TMP/big.yaml" > "$TMP/bigdiff.txt" 2>/dev/null || true
+node "$CLI" amend-plan --seats-json="$SEATS" --constitution="@$TMP/big.yaml" \
+  --constitution-digest="$BIG_SHA" --constitution-path="$TMP/big.yaml" \
+  --live-path="$LIVE" --live-digest="$LIVE_SHA" --diff="@$TMP/bigdiff.txt" >"$TMP/big.json" 2>"$TMP/big.err"
+bq=$(jq -r '.question' < "$TMP/big.json" 2>/dev/null)
+[[ -n "$bq" && "$bq" == *"TRUNCATED"* && "$bq" == *"THIS IS A PREFIX"* ]] \
+  && ok_t "E an oversized diff is capped with a LOUD truncation marker" \
+  || bad_t "E diff capped" "len=${#bq} err=$(cat "$TMP/big.err")"
+[[ "$bq" == *"diff -u $LIVE $TMP/big.yaml"* ]] \
+  && ok_t "E the truncated ballot still names the command that yields the WHOLE diff" \
+  || bad_t "E truncation names the command" "bq=$bq"
+[[ "$bq" == *"$BIG_SHA"* ]] \
+  && ok_t "E the BINDING is never truncated even when the diff is (it is the part a seat cannot rebuild)" \
+  || bad_t "E binding survives truncation" "bq=$bq"
+# Bounded enough to survive the human-ballot transport it will be embedded in.
+# NON-EMPTY is half the assertion: a mint that DIED produces a 0-length body, which sails through
+# a bare `< 4000` and reports the bound as proven. Measured — this arm passed green on an empty
+# string while every sibling arm was red.
+[[ -n "$bq" && ${#bq} -lt 4000 ]] \
+  && ok_t "E the capped ballot body is non-empty AND under the human-tap transport limit (${#bq} chars)" \
+  || bad_t "E ballot body bounded" "len=${#bq}"
+
+printf '\n%s\n' "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
The `eng_approval_lead` constitutional amendment was balloted **twice** on digest `6498adcb…`, which resolves to **no file anywhere on disk**. Both approving rationales said *"I verified the on-disk content directly"* — true statements about `8ee23dff…`, the **live** constitution, which is not what was balloted. Two seats ran a real verification that silently resolved to the live file and got a **confirmation instead of a finding**. `codex` rejected both rounds on exactly this ground and was the only seat whose process held; the council overrode it, and the inquorate failure is the only reason an unreviewed policy did not seal.

The ballot named neither the path nor the full digest, so:

> **"the candidate is unavailable" and "the candidate is available and fine" are the same sentence one digest apart.**

The precedent block cannot separate them either — it propagates a prior verdict and its prose, but not the digest that verdict was *about*.

## Two guards, both at mint

**1. The digest balloted must BE the digest of the candidate's bytes.** `amend-plan` already holds the text it just parsed, so it re-derives the sha256 and refuses on mismatch, naming both digests. That is what makes the `6498adcb…` shape structurally unable to reach a seat. `council amend` additionally resolves the file to an **absolute readable path** and re-digests through *that* path, refusing if the two reads disagree. A truncated digest and a missing path are refused on the same ground: **a prefix is not a binding.**

**2. The ballot carries path + FULL digest + diff-vs-live**, with the filled-in one-command binding (`sha256sum <path>`) and an explicit warning off reading the live file — the verification that returned a confirmation twice. Both seats that went looking (DIVE-2882, DIVE-2886) had to locate the candidate independently; that it worked is not the same as it being delivered, and a seat with no sibling row to read had no route to the bytes at all.

**The diff is capped (40 lines / 1600 chars); the binding never is.** This question becomes the ballot body for human seats, delivered inside one Telegram message — an uncapped diff would turn a governance change into a capture failure, the same fail-open in a new coat. Truncation is loud and names the command for the whole diff; path and full digest are never clipped, because they are the part a seat cannot reconstruct. Measured with a 400-line diff: whole question 2804 chars.

## Codegen

`src/cmd_council.sh` is **generated**. Canonical edits are in `src/council/cli.mjs` and `src/council/cmd_council.template.sh`, regenerated with `node src/council/gen_cmd.mjs`; `tests/council_cli_contract.mjs` is green, so there is no drift between the embedded copy and the sources.

## Test

`tests/council_amend_ballot_binding_unit.sh` — 17 arms, offline (node + `cli.mjs`, no root, no network, 377ms).

Includes a **precondition arm that the fixture is a valid constitution.** Without it every refusal arm passes on the *parse* gate rather than the *binding* gate — which is exactly how the harness behaved on first run, and the precondition arm is what caught it.

**Mutation-graded with distinct kill sets:** dropping the digest-match guard kills exactly the 3 refusal arms (A); dropping the binding block kills the 8 delivery arms (D/E). It also exposed a vacuous assertion in my own harness — `[[ ${#body} -lt 4000 ]]` passed green on a **0-length** body when the mint had died, so it now asserts non-empty as well.

**Regression:** `council_amend_e2e.sh` (17 arms, real `council {init,amend,convene,verify}` incl. a carried amendment and drift detection) passes unchanged; `council_cli_contract`, `council_engine_unit`, `council_constitution_unit`, `council_dispatch_unit`, `council_cosign_unit` all pass.

## Known, and not fixed here

The precedent block still carries a verdict and its prose **without** the digest that verdict was about, so case law carried into a *future* round still cannot tell "unavailable" from "fine". This fixes the round being voted on, not the memory of earlier ones.

Task: DIVE-2889 (filed by olivia as chair, from dev's finding on DIVE-2887). Verifier: olivia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
