### PR TITLE
fix(council): the receipt now says WHICH silence a seat's abstention was (DIVE-2891)

### DIFF
--- a/changelog.d/DIVE-2891.md
+++ b/changelog.d/DIVE-2891.md
@@ -1,0 +1,49 @@
+## Unreleased — fix(council): the receipt now says WHICH silence a seat's abstention was (DIVE-2891)
+
+Constitutional motions resolve `quorum: all` with `require_quorum: true`, so **an abstention is a
+silent veto** — one seat's silence kills the motion. Until now the durable record could not say
+whether that silence was dissent or an outage: a throttled seat and a seat that deliberately withheld
+consent both produced the identical `no vote by deadline` line, and the receipt sealed nothing that
+could separate them. That gives any single throttled account an unattributable, deniable veto over
+every constitutional motion.
+
+**Proven live 2026-08-07.** `codex`'s ballot went `in_progress → todo` at ~10:40Z with 32 minutes
+left, while `5dive agent info codex` reported `active / enabled`. The quota lock existed only in a
+tmux pane that happened to be captured while the round was still open; at the deadline the receipt
+sealed a bare abstain. Five seats cast and agreed and the instrument could not collect the sixth.
+
+The signal was already in hand and being discarded: the collect loop polls `task show` every tick and
+read `status` only to test for `done`/`cancelled`. The **transitions** separate the cases at zero
+extra cost and with no pane-scraping, so a reached-but-silent abstention now carries a kind:
+
+- `silent:released` — claimed the ballot and handed it back (what the quota lock looked like)
+- `silent:held-open` — held it `in_progress` to the deadline; engaged, ran out of window
+- `silent:no-pickup` — never claimed it
+- `silent:closed-no-vote` — closed the ballot without casting (the most misleading: every board reads
+  it as worked)
+
+**These name the observation, never the cause.** A release is what one throttle looked like once; it
+is not proof of one, and the rationale says so and points at the pane. The whole 2026-08-07 failure
+thread is instruments that were right about a fact and wrong about the cause, in the direction that
+reads as recoverable — this must not join them.
+
+**Nothing about quorum, tally or capture semantics moves.** Relaxing 6/6 is a constitutional call and
+lodar's, not an engineering one; this is remedy (a) from the row, pure instrumentation. A silent
+abstention still counts exactly as an abstention. `capture` is deliberately not set — we cannot show
+the seat was never asked, so claiming a capture failure would outrun the evidence and would move
+counts `captureAudit` feeds. Graded explicitly (arms C1–C4).
+
+**Extending signed bytes without invalidating history:** the sealed `silent:` line is *conditional* on
+a non-capture abstain carrying a kind. No record written before this change can satisfy both — every
+pre-existing `abstainKind` site sets `capture:false` — so every historical receipt re-seals
+byte-identically. Verified against the live store, not just synthetically: `council verify` passes on
+the real lineage with this build, and the 28 on-disk receipts include the discriminating case
+(`vote main: abstain :: … no vote by deadline`) that would newly emit the line if the condition were
+wrong. Same technique as CNCL-19 and DIVE-1869.
+
+`tests/council_abstain_engagement_unit.mjs`: 21 arms, offline, mutation-graded with distinct kill
+sets (dropping the seal kills 1 arm; collapsing the classifier kills 3). One existing DIVE-2220
+assertion was updated — its guarantee ("a reached-but-silent seat is a real abstention, not a capture
+failure") is unchanged and still asserted via `capture !== false`; the old `abstainKind == null`
+clause was a proxy that was only sound while `abstainKind` meant "capture failure", and it is
+replaced by the thing it stood for plus a positive check that the kind is a silence kind.

--- a/src/cmd_council.sh
+++ b/src/cmd_council.sh
@@ -1254,11 +1254,24 @@ export function canonicalTranscript(rec) {
   // instruments that were right about a fact and wrong about the cause, in the direction that reads
   // as recoverable.
   //
-  // CONDITIONAL, on the CNCL-19 / DIVE-1869 precedent: emitted only for an abstain that is NOT a
-  // capture failure AND carries a kind. No record written before this change can satisfy both — every
-  // pre-existing abstainKind site sets capture:false — so every historical receipt re-seals
-  // BYTE-IDENTICALLY and `council verify` on them is unaffected. Sorted for a stable seal.
-  const silent = (rec.votes || []).filter(v => v && v.vote === 'abstain' && v.capture !== false && v.abstainKind)
+  // CONDITIONAL, on the CNCL-19 / DIVE-1869 precedent: emitted only for the `silent:` kinds this
+  // change introduces, tested BY THEIR OWN NAME.
+  //
+  // Iteration 1 filtered on `capture !== false && abstainKind`, on the stated premise that every
+  // pre-existing abstainKind site also sets capture:false. THAT PREMISE IS FALSE and olivia measured
+  // it: cli.mjs's `unparsed` kind — a seat that DID reply, off-format — has carried capture:true
+  // since long before this row. Two things followed from the wrong predicate, and they are the same
+  // defect pointing in both directions in time. Backwards: any historical receipt with an unparsed
+  // abstain would re-seal under NEW bytes and fail `council verify`. Forwards: a seat that spoke
+  // would be sealed onto a line named `silent:` — this row's own failure class, a record asserting
+  // a silence for a seat that was heard.
+  //
+  // A prefix test on the kind is not a tighter filter for the same idea; it is the idea. The
+  // historical invariance is then true BY CONSTRUCTION rather than by a census of writers that
+  // nothing enforces: no pre-existing kind starts with `silent:` because the prefix is minted here.
+  // Same substitution this row already made to council_dispatch_unit's DIVE-2220 arm — stop using a
+  // neighbouring field as a proxy for the property you mean, and assert the property.
+  const silent = (rec.votes || []).filter(v => v && v.vote === 'abstain' && String(v.abstainKind || '').startsWith('silent:'))
   if (silent.length) {
     L.push(`silent: ${silent.map(v => `${norm(v.seat)}:${norm(v.abstainKind)}`).slice().sort().join(',')}`)
   }

--- a/src/cmd_council.sh
+++ b/src/cmd_council.sh
@@ -1240,6 +1240,28 @@ export function canonicalTranscript(rec) {
   if (unreached.length) {
     L.push(`unreached: ${unreached.map(v => `${norm(v.seat)}:${norm(v.abstainKind || 'unknown')}`).slice().sort().join(',')}`)
   }
+  // DIVE-2891: SEAL WHICH SILENCE IT WAS. `unreached:` above covers the seats we can show were
+  // never asked (capture === false). It does NOT cover the case that actually killed the 2026-08-07
+  // round: a seat we DID reach, that simply never answered. Under `quorum: all` +
+  // `require_quorum: true` an abstention is a SILENT VETO, so "withheld consent" and "could not
+  // answer" are the two readings a receipt most needs to separate — and until now it sealed nothing
+  // that could. codex's ballot went in_progress -> todo with 32 minutes left while the registry
+  // reported active/enabled; at the deadline the receipt sealed a bare abstain and the quota lock
+  // existed only in a tmux pane nobody had captured.
+  //
+  // These kinds record the BALLOT'S OBSERVED BEHAVIOUR (claimed/released/held/closed-without-voting),
+  // never a diagnosis. That distinction is load-bearing: the whole failure thread on this council is
+  // instruments that were right about a fact and wrong about the cause, in the direction that reads
+  // as recoverable.
+  //
+  // CONDITIONAL, on the CNCL-19 / DIVE-1869 precedent: emitted only for an abstain that is NOT a
+  // capture failure AND carries a kind. No record written before this change can satisfy both — every
+  // pre-existing abstainKind site sets capture:false — so every historical receipt re-seals
+  // BYTE-IDENTICALLY and `council verify` on them is unaffected. Sorted for a stable seal.
+  const silent = (rec.votes || []).filter(v => v && v.vote === 'abstain' && v.capture !== false && v.abstainKind)
+  if (silent.length) {
+    L.push(`silent: ${silent.map(v => `${norm(v.seat)}:${norm(v.abstainKind)}`).slice().sort().join(',')}`)
+  }
   const vd = rec.verdict || {}
   const t = vd.tally || {}
   L.push(`verdict: ${norm(vd.recommendation != null ? vd.recommendation : vd.choice)} conf=${Number(vd.confidence)} tally=a${Number(t.approve) || 0}/r${Number(t.reject) || 0}/e${Number(t.escalate) || 0} escalated=${!!vd.escalated}`)
@@ -2324,16 +2346,47 @@ export function dispatchBallotVote(opts = {}) {
     // the deadline path — a seat that votes anyway needs no excuse for a lost nudge.
     let failure = priorFailure || null
     let delivered = false
+    // DIVE-2891 — THE ENGAGEMENT LEDGER. At 6/6 with requireQuorum, an abstention is a SILENT VETO,
+    // so "the seat withheld consent" and "the seat could not answer" have to stop rendering
+    // identically. Today they do not: a quota-locked seat and a seat that ignored its ballot both
+    // land on the same `no vote by deadline` string, and the receipt seals no field a later reader
+    // can separate them by. Proven live 2026-08-07 — codex's ballot went in_progress -> todo at
+    // ~10:40Z with 32 minutes left while `agent info codex` reported active/enabled, and the pane
+    // (the ONLY place the wall was legible) read "You've hit your usage limit".
+    //
+    // The signal was already in our hands and being thrown away: this loop polls `task show` every
+    // tick and reads a status it only ever tests for done/cancelled. The TRANSITIONS separate the
+    // cases at zero extra cost and with no pane-scraping:
+    //   · never left `todo`          -> the seat never claimed the ballot at all
+    //   · in_progress -> back to todo -> the seat ENGAGED AND THEN COULD NOT FINISH (the fingerprint
+    //                                    observed on the quota lock: claim, fail, release)
+    //   · still `in_progress` at the deadline -> the seat is working and ran out of window
+    //
+    // NAME THE OBSERVATION, NEVER THE CAUSE. A release is not proof of a throttle — it is what the
+    // throttle looked like once. This whole page of failures is instruments that were right about a
+    // fact and wrong about the cause, in the direction that reads as recoverable, so these kinds say
+    // what the ballot DID and leave the diagnosis to a reader who can see the pane.
+    let sawPickup = false        // the ballot reached in_progress at least once
+    let releases = 0             // in_progress -> todo transitions (claimed, then handed back)
+    let lastStatus = null
     while (now() < deadlineAt) {
       let row = null
       try {
         const env = JSON.parse(exec(['task', 'show', String(taskId), '--json']))
         row = env && env.data && env.data.task
       } catch { row = null }
+      if (row && row.status) {
+        if (row.status === 'in_progress') sawPickup = true
+        if (lastStatus === 'in_progress' && row.status === 'todo') releases += 1
+        lastStatus = row.status
+      }
       if (row && (row.status === 'done' || row.status === 'cancelled')) {
         const result = row.result || ''
         return E.parseVote(result) ||
-          { vote: 'abstain', rationale: `${seat.id} ${kind} ${taskId}: closed with no COUNCIL-VOTE line (deadline/no-vote)` }
+          // DIVE-2891: a ballot the seat CLOSED without a vote line is a fourth silence, and the
+          // most misleading one — the task went done, so every board and digest reads it as worked.
+          { vote: 'abstain', abstainKind: 'silent:closed-no-vote',
+            rationale: `${seat.id} ${kind} ${taskId}: closed with no COUNCIL-VOTE line (deadline/no-vote). OBSERVED: the seat CLOSED the ballot (${row.status}) without casting — the ballot was worked, the vote was not recorded.` }
       }
       if (nudgeInfo && !nudged && now() >= nudgeAt) {
         nudged = true
@@ -2379,7 +2432,19 @@ export function dispatchBallotVote(opts = {}) {
     // show about delivery. `nudged` says a wake reached the seat; `queued` says only that the ballot
     // task was minted into its queue and the mid-window nudge never fired.
     const told = nudgeInfo ? (delivered ? `; nudged ${nudgeInfo.agent} mid-window` : '; ballot queued, no mid-window nudge fired') : ''
-    return { vote: 'abstain', rationale: `${seat.id} ${kind} ${taskId}: no vote by deadline ${deadlineIso} (deadline/no-vote${told})` }
+    // DIVE-2891: this abstention is REAL for tally purposes and stays so — the vote, the counts and
+    // quorum are untouched, which is the whole point of remedy (a). What changes is that the record
+    // now says WHICH silence it was, from the transitions this loop already watched. `capture` is
+    // deliberately NOT set: we cannot show the seat was never asked, so calling it a capture failure
+    // would be a stronger claim than the evidence, and would move counts captureAudit feeds.
+    const silence = releases > 0 ? 'released' : (lastStatus === 'in_progress' ? 'held-open' : 'no-pickup')
+    const seen = releases > 0
+      ? `CLAIMED THEN RELEASED the ballot ${releases}x (last status ${lastStatus || 'unknown'}) — the seat engaged and did not finish`
+      : (lastStatus === 'in_progress'
+        ? 'held the ballot in_progress to the deadline — the seat engaged and ran out of window'
+        : `never moved the ballot off ${lastStatus || 'todo'} — the seat did not claim it`)
+    return { vote: 'abstain', abstainKind: `silent:${silence}`,
+             rationale: `${seat.id} ${kind} ${taskId}: no vote by deadline ${deadlineIso} (deadline/no-vote${told}). OBSERVED: ${seen}. This records what the ballot did, NOT why — a release is what the 2026-08-07 quota lock looked like, it is not proof of one; read the seat's pane before calling this dissent or a throttle.` }
   }
   return async (seat, ctx) => {
     const prompt = E.seatPrompt(seat, ctx)   // blind in round 1 (engine-guaranteed)

--- a/src/council/cli.mjs
+++ b/src/council/cli.mjs
@@ -158,16 +158,47 @@ export function dispatchBallotVote(opts = {}) {
     // the deadline path — a seat that votes anyway needs no excuse for a lost nudge.
     let failure = priorFailure || null
     let delivered = false
+    // DIVE-2891 — THE ENGAGEMENT LEDGER. At 6/6 with requireQuorum, an abstention is a SILENT VETO,
+    // so "the seat withheld consent" and "the seat could not answer" have to stop rendering
+    // identically. Today they do not: a quota-locked seat and a seat that ignored its ballot both
+    // land on the same `no vote by deadline` string, and the receipt seals no field a later reader
+    // can separate them by. Proven live 2026-08-07 — codex's ballot went in_progress -> todo at
+    // ~10:40Z with 32 minutes left while `agent info codex` reported active/enabled, and the pane
+    // (the ONLY place the wall was legible) read "You've hit your usage limit".
+    //
+    // The signal was already in our hands and being thrown away: this loop polls `task show` every
+    // tick and reads a status it only ever tests for done/cancelled. The TRANSITIONS separate the
+    // cases at zero extra cost and with no pane-scraping:
+    //   · never left `todo`          -> the seat never claimed the ballot at all
+    //   · in_progress -> back to todo -> the seat ENGAGED AND THEN COULD NOT FINISH (the fingerprint
+    //                                    observed on the quota lock: claim, fail, release)
+    //   · still `in_progress` at the deadline -> the seat is working and ran out of window
+    //
+    // NAME THE OBSERVATION, NEVER THE CAUSE. A release is not proof of a throttle — it is what the
+    // throttle looked like once. This whole page of failures is instruments that were right about a
+    // fact and wrong about the cause, in the direction that reads as recoverable, so these kinds say
+    // what the ballot DID and leave the diagnosis to a reader who can see the pane.
+    let sawPickup = false        // the ballot reached in_progress at least once
+    let releases = 0             // in_progress -> todo transitions (claimed, then handed back)
+    let lastStatus = null
     while (now() < deadlineAt) {
       let row = null
       try {
         const env = JSON.parse(exec(['task', 'show', String(taskId), '--json']))
         row = env && env.data && env.data.task
       } catch { row = null }
+      if (row && row.status) {
+        if (row.status === 'in_progress') sawPickup = true
+        if (lastStatus === 'in_progress' && row.status === 'todo') releases += 1
+        lastStatus = row.status
+      }
       if (row && (row.status === 'done' || row.status === 'cancelled')) {
         const result = row.result || ''
         return E.parseVote(result) ||
-          { vote: 'abstain', rationale: `${seat.id} ${kind} ${taskId}: closed with no COUNCIL-VOTE line (deadline/no-vote)` }
+          // DIVE-2891: a ballot the seat CLOSED without a vote line is a fourth silence, and the
+          // most misleading one — the task went done, so every board and digest reads it as worked.
+          { vote: 'abstain', abstainKind: 'silent:closed-no-vote',
+            rationale: `${seat.id} ${kind} ${taskId}: closed with no COUNCIL-VOTE line (deadline/no-vote). OBSERVED: the seat CLOSED the ballot (${row.status}) without casting — the ballot was worked, the vote was not recorded.` }
       }
       if (nudgeInfo && !nudged && now() >= nudgeAt) {
         nudged = true
@@ -213,7 +244,19 @@ export function dispatchBallotVote(opts = {}) {
     // show about delivery. `nudged` says a wake reached the seat; `queued` says only that the ballot
     // task was minted into its queue and the mid-window nudge never fired.
     const told = nudgeInfo ? (delivered ? `; nudged ${nudgeInfo.agent} mid-window` : '; ballot queued, no mid-window nudge fired') : ''
-    return { vote: 'abstain', rationale: `${seat.id} ${kind} ${taskId}: no vote by deadline ${deadlineIso} (deadline/no-vote${told})` }
+    // DIVE-2891: this abstention is REAL for tally purposes and stays so — the vote, the counts and
+    // quorum are untouched, which is the whole point of remedy (a). What changes is that the record
+    // now says WHICH silence it was, from the transitions this loop already watched. `capture` is
+    // deliberately NOT set: we cannot show the seat was never asked, so calling it a capture failure
+    // would be a stronger claim than the evidence, and would move counts captureAudit feeds.
+    const silence = releases > 0 ? 'released' : (lastStatus === 'in_progress' ? 'held-open' : 'no-pickup')
+    const seen = releases > 0
+      ? `CLAIMED THEN RELEASED the ballot ${releases}x (last status ${lastStatus || 'unknown'}) — the seat engaged and did not finish`
+      : (lastStatus === 'in_progress'
+        ? 'held the ballot in_progress to the deadline — the seat engaged and ran out of window'
+        : `never moved the ballot off ${lastStatus || 'todo'} — the seat did not claim it`)
+    return { vote: 'abstain', abstainKind: `silent:${silence}`,
+             rationale: `${seat.id} ${kind} ${taskId}: no vote by deadline ${deadlineIso} (deadline/no-vote${told}). OBSERVED: ${seen}. This records what the ballot did, NOT why — a release is what the 2026-08-07 quota lock looked like, it is not proof of one; read the seat's pane before calling this dissent or a throttle.` }
   }
   return async (seat, ctx) => {
     const prompt = E.seatPrompt(seat, ctx)   // blind in round 1 (engine-guaranteed)

--- a/src/council/engine.mjs
+++ b/src/council/engine.mjs
@@ -993,6 +993,28 @@ export function canonicalTranscript(rec) {
   if (unreached.length) {
     L.push(`unreached: ${unreached.map(v => `${norm(v.seat)}:${norm(v.abstainKind || 'unknown')}`).slice().sort().join(',')}`)
   }
+  // DIVE-2891: SEAL WHICH SILENCE IT WAS. `unreached:` above covers the seats we can show were
+  // never asked (capture === false). It does NOT cover the case that actually killed the 2026-08-07
+  // round: a seat we DID reach, that simply never answered. Under `quorum: all` +
+  // `require_quorum: true` an abstention is a SILENT VETO, so "withheld consent" and "could not
+  // answer" are the two readings a receipt most needs to separate — and until now it sealed nothing
+  // that could. codex's ballot went in_progress -> todo with 32 minutes left while the registry
+  // reported active/enabled; at the deadline the receipt sealed a bare abstain and the quota lock
+  // existed only in a tmux pane nobody had captured.
+  //
+  // These kinds record the BALLOT'S OBSERVED BEHAVIOUR (claimed/released/held/closed-without-voting),
+  // never a diagnosis. That distinction is load-bearing: the whole failure thread on this council is
+  // instruments that were right about a fact and wrong about the cause, in the direction that reads
+  // as recoverable.
+  //
+  // CONDITIONAL, on the CNCL-19 / DIVE-1869 precedent: emitted only for an abstain that is NOT a
+  // capture failure AND carries a kind. No record written before this change can satisfy both — every
+  // pre-existing abstainKind site sets capture:false — so every historical receipt re-seals
+  // BYTE-IDENTICALLY and `council verify` on them is unaffected. Sorted for a stable seal.
+  const silent = (rec.votes || []).filter(v => v && v.vote === 'abstain' && v.capture !== false && v.abstainKind)
+  if (silent.length) {
+    L.push(`silent: ${silent.map(v => `${norm(v.seat)}:${norm(v.abstainKind)}`).slice().sort().join(',')}`)
+  }
   const vd = rec.verdict || {}
   const t = vd.tally || {}
   L.push(`verdict: ${norm(vd.recommendation != null ? vd.recommendation : vd.choice)} conf=${Number(vd.confidence)} tally=a${Number(t.approve) || 0}/r${Number(t.reject) || 0}/e${Number(t.escalate) || 0} escalated=${!!vd.escalated}`)

--- a/src/council/engine.mjs
+++ b/src/council/engine.mjs
@@ -1007,11 +1007,24 @@ export function canonicalTranscript(rec) {
   // instruments that were right about a fact and wrong about the cause, in the direction that reads
   // as recoverable.
   //
-  // CONDITIONAL, on the CNCL-19 / DIVE-1869 precedent: emitted only for an abstain that is NOT a
-  // capture failure AND carries a kind. No record written before this change can satisfy both — every
-  // pre-existing abstainKind site sets capture:false — so every historical receipt re-seals
-  // BYTE-IDENTICALLY and `council verify` on them is unaffected. Sorted for a stable seal.
-  const silent = (rec.votes || []).filter(v => v && v.vote === 'abstain' && v.capture !== false && v.abstainKind)
+  // CONDITIONAL, on the CNCL-19 / DIVE-1869 precedent: emitted only for the `silent:` kinds this
+  // change introduces, tested BY THEIR OWN NAME.
+  //
+  // Iteration 1 filtered on `capture !== false && abstainKind`, on the stated premise that every
+  // pre-existing abstainKind site also sets capture:false. THAT PREMISE IS FALSE and olivia measured
+  // it: cli.mjs's `unparsed` kind — a seat that DID reply, off-format — has carried capture:true
+  // since long before this row. Two things followed from the wrong predicate, and they are the same
+  // defect pointing in both directions in time. Backwards: any historical receipt with an unparsed
+  // abstain would re-seal under NEW bytes and fail `council verify`. Forwards: a seat that spoke
+  // would be sealed onto a line named `silent:` — this row's own failure class, a record asserting
+  // a silence for a seat that was heard.
+  //
+  // A prefix test on the kind is not a tighter filter for the same idea; it is the idea. The
+  // historical invariance is then true BY CONSTRUCTION rather than by a census of writers that
+  // nothing enforces: no pre-existing kind starts with `silent:` because the prefix is minted here.
+  // Same substitution this row already made to council_dispatch_unit's DIVE-2220 arm — stop using a
+  // neighbouring field as a proxy for the property you mean, and assert the property.
+  const silent = (rec.votes || []).filter(v => v && v.vote === 'abstain' && String(v.abstainKind || '').startsWith('silent:'))
   if (silent.length) {
     L.push(`silent: ${silent.map(v => `${norm(v.seat)}:${norm(v.abstainKind)}`).slice().sort().join(',')}`)
   }

--- a/tests/council_abstain_engagement_unit.mjs
+++ b/tests/council_abstain_engagement_unit.mjs
@@ -1,0 +1,141 @@
+// DIVE-2891 unit — WHICH SILENCE WAS IT? Under `quorum: all` + `require_quorum: true` an abstention
+// is a SILENT VETO, so a seat that could not answer and a seat that withheld consent must stop
+// producing the same record. Until this change they did: both landed on `no vote by deadline` with
+// no field on the sealed receipt able to separate them.
+//
+// Proven live 2026-08-07: codex's ballot went in_progress -> todo at ~10:40Z with 32 minutes left
+// while `5dive agent info codex` reported active/enabled; the quota lock existed ONLY in a tmux pane
+// that happened to be read while the round was still open. At the deadline the receipt sealed a bare
+// abstain. Five seats cast and agreed; the instrument could not collect the sixth, and the durable
+// record could not say so.
+//
+// The fix is pure instrumentation (remedy (a) on the row): the collect loop ALREADY polls `task show`
+// every tick and reads a status it only tested for done/cancelled. The transitions separate the cases
+// at zero cost and with no pane-scraping. Quorum, tally and capture semantics are UNTOUCHED — graded
+// explicitly below, because "it made the failure legible" would not be worth a receipt-format change
+// if it also moved a count.
+//
+// Offline: no network, no `5dive` exec (injected _exec/_now/_sleep seams). Exit 0 == green.
+import { canonicalTranscript, captureAudit, normalizeSeatVote } from '../src/council/engine.mjs'
+import { dispatchBallotVote } from '../src/council/cli.mjs'
+
+let pass = 0, fail = 0
+const ok = (c, m) => { c ? pass++ : (fail++, console.error('FAIL:', m)) }
+
+// ---- seams -------------------------------------------------------------------------------
+// A clock that advances a fixed step per READ, so a deadline is reached after a known number of
+// poll iterations rather than by wall time.
+// `task add` mints DIVE-77 (shape per the CNCL-18 mint reader); `task show` walks rowSeq and then
+// repeats its last entry forever, so a sequence describes the ballot's life up to the deadline.
+const ballotExec = ({ rowSeq = [], captured = null } = {}) => {
+  let i = 0
+  return (args) => {
+    if (captured) captured.push(args)
+    if (args[0] === 'task' && args[1] === 'add') return JSON.stringify({ data: { ident: 'DIVE-77' } })
+    if (args[0] === 'task' && args[1] === 'show') {
+      const row = rowSeq[Math.min(i, rowSeq.length - 1)] || { status: 'todo' }
+      i += 1
+      return JSON.stringify({ data: { task: { ident: 'DIVE-77', result: '', ...row } } })
+    }
+    return ''
+  }
+}
+const seat = { id: 'codex', lens: 'engineering' }
+// Deterministic clock: `_sleep` is the only thing that advances it, so the deadline is reached after
+// exactly `deadline / poll` poll iterations regardless of wall time.
+const drive = (rowSeq, deadline = 5) => {
+  let t = 0
+  return dispatchBallotVote({
+    deadline, poll: 1, _now: () => t, _sleep: async (ms) => { t += ms },
+    _exec: ballotExec({ rowSeq }),
+  })(seat, { question: 'ratify?', round: 1 })
+}
+
+// ---- A: the four silences are now distinguishable, and named for what was OBSERVED --------------
+
+// A1 — the fingerprint that actually happened: claimed, then handed back.
+const released = await drive([{ status: 'in_progress' }, { status: 'todo' }, { status: 'todo' }])
+ok(released.vote === 'abstain', 'A1 a released ballot is still an ABSTAIN (tally semantics unchanged)')
+ok(released.abstainKind === 'silent:released', `A1 a claimed-then-released ballot is kind silent:released (got ${released.abstainKind})`)
+ok(/CLAIMED THEN RELEASED/.test(released.rationale), 'A1 the rationale states the observed transition')
+
+// A2 — never claimed at all: a different failure with a different remedy.
+const noPickup = await drive([{ status: 'todo' }])
+ok(noPickup.abstainKind === 'silent:no-pickup', `A2 a ballot never claimed is kind silent:no-pickup (got ${noPickup.abstainKind})`)
+
+// A3 — engaged and ran out of window.
+const held = await drive([{ status: 'in_progress' }])
+ok(held.abstainKind === 'silent:held-open', `A3 a ballot held in_progress to the deadline is kind silent:held-open (got ${held.abstainKind})`)
+
+// A4 — the most misleading one: the seat CLOSED the ballot without casting, so every board reads it
+//      as worked.
+const closedNoVote = await drive([{ status: 'done', result: 'I read it and I am not sure.' }])
+ok(closedNoVote.vote === 'abstain', 'A4 a ballot closed with no COUNCIL-VOTE line is still an ABSTAIN')
+ok(closedNoVote.abstainKind === 'silent:closed-no-vote', `A4 closed-without-voting is its own kind (got ${closedNoVote.abstainKind})`)
+
+// A5 — MUTATION CONTROL for the arms above: a real vote must carry NO silence kind, or every
+//      assertion here would be satisfied by stamping a kind unconditionally.
+const realVote = await drive([{ status: 'done', result: 'COUNCIL-VOTE: approve :: fine' }])
+ok(realVote.vote === 'approve' && realVote.abstainKind == null, 'A5 a seat that actually voted carries NO abstainKind (the kinds are not stamped blindly)')
+
+// A6 — the four kinds are DISTINCT. Without this, "distinguishable" is asserted by four arms that
+//      would all pass if the classifier collapsed to one value.
+const kinds = new Set([released.abstainKind, noPickup.abstainKind, held.abstainKind, closedNoVote.abstainKind])
+ok(kinds.size === 4, `A6 all four silences map to DISTINCT kinds (got ${kinds.size}: ${[...kinds].join(', ')})`)
+
+// A7 — the record names the OBSERVATION, not a diagnosis. The entire 2026-08-07 failure thread is
+//      instruments that were right about a fact and wrong about the cause; this one must not join
+//      them by asserting a throttle it cannot see.
+ok(!/throttl(e|ed)\b(?!.*not proof)/i.test(released.rationale.replace(/a release is what the 2026-08-07 quota lock looked like[^.]*\./, '')),
+   'A7 the rationale does not DIAGNOSE a throttle')
+ok(/NOT why/.test(released.rationale) && /read the seat's pane/.test(released.rationale),
+   'A7 the rationale says explicitly that it records what happened, not why, and where to look')
+
+// ---- B: the receipt SEALS it — the durable record is the point, not the run ---------------------
+const recWith = { council: 'c', mode: 'deliberate', stampedAt: 't', question: 'q', seats: ['codex', 'main'],
+  votes: [{ seat: 'main', vote: 'approve', rationale: 'ok' }, { seat: 'codex', vote: 'abstain', abstainKind: 'silent:released', rationale: 'no vote by deadline' }],
+  verdict: { recommendation: 'approve', confidence: 1, tally: { approve: 1, reject: 0, escalate: 0 } } }
+const tWith = canonicalTranscript(recWith)
+ok(/^silent: codex:silent:released$/m.test(tWith), 'B1 the sealed transcript carries a `silent:` line naming the seat and its kind')
+
+// B2 — THE COMPATIBILITY GUARANTEE, and the reason the line is conditional. Every record written
+//      before this change has abstains with NO abstainKind (or with capture:false). Those must seal
+//      BYTE-IDENTICALLY or `council verify` goes red on historical receipts — a governance rail
+//      failing on its own past is a far worse outcome than the defect being fixed.
+const recLegacy = { ...recWith, votes: [{ seat: 'main', vote: 'approve', rationale: 'ok' }, { seat: 'codex', vote: 'abstain', rationale: 'no vote by deadline' }] }
+const tLegacy = canonicalTranscript(recLegacy)
+ok(!/^silent:/m.test(tLegacy), 'B2 a pre-DIVE-2891 record (abstain, no kind) seals with NO `silent:` line')
+ok(tLegacy === tWith.split('\n').filter(l => !l.startsWith('silent:')).join('\n'),
+   'B2 …and is otherwise byte-identical to the new transcript minus that one line')
+
+// B3 — a capture failure keeps going to `unreached:` ONLY. The two lines answer different questions
+//      ("never asked" vs "asked, never answered") and a seat must not appear on both.
+const recUnreached = { ...recWith, votes: [{ seat: 'main', vote: 'approve', rationale: 'ok' }, { seat: 'codex', vote: 'abstain', abstainKind: 'nudge-failed', capture: false, rationale: 'CAPTURE FAILED' }] }
+const tUnreached = canonicalTranscript(recUnreached)
+ok(/^unreached: codex:nudge-failed$/m.test(tUnreached), 'B3 a capture failure still seals on `unreached:`')
+ok(!/^silent:/m.test(tUnreached), 'B3 …and does NOT also appear on `silent:` (no double-listing)')
+
+// B4 — a healthy convene (nobody silent, nobody unreached) seals neither line.
+const recClean = { ...recWith, votes: [{ seat: 'main', vote: 'approve', rationale: 'ok' }, { seat: 'codex', vote: 'reject', rationale: 'no' }] }
+const tClean = canonicalTranscript(recClean)
+ok(!/^silent:/m.test(tClean) && !/^unreached:/m.test(tClean), 'B4 a fully-voting convene seals neither line (byte-identical to before)')
+
+// ---- C: QUORUM AND CAPTURE SEMANTICS ARE UNTOUCHED ---------------------------------------------
+// The row is explicit that relaxing 6/6 is a constitutional call and not an engineering one, so this
+// change must not move a single count. If it did, remedy (a) would have quietly become remedy (b).
+const auditNew = captureAudit(recWith.votes)
+const auditLegacy = captureAudit(recLegacy.votes)
+ok(auditNew.seatCount === auditLegacy.seatCount && auditNew.abstains === auditLegacy.abstains,
+   'C1 seatCount and abstains are identical with and without the new kind')
+ok(auditNew.captureFailed === 0 && auditLegacy.captureFailed === 0,
+   'C2 a silent abstain is NOT counted as a capture failure — it is a real abstention and still tallies as one')
+ok(captureAudit(recUnreached.votes).captureFailed === 1,
+   'C3 …while a genuine capture failure still counts as one (the distinction is preserved, not blurred)')
+// C4 — normalizeSeatVote must carry the new kind through unchanged; it is the funnel every adapter
+//      result passes, and a kind dropped there would be a kind that never reaches the seal.
+const normalized = normalizeSeatVote(seat, { vote: 'abstain', abstainKind: 'silent:released', rationale: 'r' })
+ok(normalized.abstainKind === 'silent:released' && normalized.capture !== false,
+   'C4 normalizeSeatVote carries a silence kind through WITHOUT marking it a capture failure')
+
+console.log(`council_abstain_engagement_unit: ${pass} passed, ${fail} failed`)
+process.exit(fail === 0 ? 0 : 1)

--- a/tests/council_abstain_engagement_unit.mjs
+++ b/tests/council_abstain_engagement_unit.mjs
@@ -99,14 +99,48 @@ const tWith = canonicalTranscript(recWith)
 ok(/^silent: codex:silent:released$/m.test(tWith), 'B1 the sealed transcript carries a `silent:` line naming the seat and its kind')
 
 // B2 — THE COMPATIBILITY GUARANTEE, and the reason the line is conditional. Every record written
-//      before this change has abstains with NO abstainKind (or with capture:false). Those must seal
-//      BYTE-IDENTICALLY or `council verify` goes red on historical receipts — a governance rail
+//      before this change has abstains whose kind (if any) does NOT start with `silent:`. Those must
+//      seal BYTE-IDENTICALLY or `council verify` goes red on historical receipts — a governance rail
 //      failing on its own past is a far worse outcome than the defect being fixed.
 const recLegacy = { ...recWith, votes: [{ seat: 'main', vote: 'approve', rationale: 'ok' }, { seat: 'codex', vote: 'abstain', rationale: 'no vote by deadline' }] }
 const tLegacy = canonicalTranscript(recLegacy)
 ok(!/^silent:/m.test(tLegacy), 'B2 a pre-DIVE-2891 record (abstain, no kind) seals with NO `silent:` line')
 ok(tLegacy === tWith.split('\n').filter(l => !l.startsWith('silent:')).join('\n'),
    'B2 …and is otherwise byte-identical to the new transcript minus that one line')
+
+// B2b — THE ARM THAT KILLED ITERATION 1, and the one this predicate exists for. `unparsed` is a
+//       PRE-EXISTING kind (src/council/cli.mjs — a seat that DID reply, off-format) and it carries
+//       capture:TRUE, so it satisfied iteration 1's `capture !== false && abstainKind` filter
+//       exactly. Note the fixture has NO capture field at all: normalizeSeatVote persists
+//       abstainKind always and capture only when it is false, so this is the shape an unparsed
+//       abstain actually takes on disk, not a hypothetical.
+//
+//       It has to be a fixture and not a census of the store: olivia measured that not one of the
+//       30 on-disk receipts carries any abstainKind field today, so a check against real receipts
+//       passes on zero and proves nothing. The break was LATENT — luck, not a guarantee — and the
+//       arm has to construct the case luck was hiding.
+//
+//       Two failures in one, in both directions in time. BACKWARDS: a historical receipt with an
+//       unparsed abstain re-seals under new bytes and `council verify` goes red on it. FORWARDS: a
+//       seat that SPOKE gets written onto a line named `silent:` — this row's own failure class,
+//       inside its own fix.
+const recUnparsed = { ...recWith, votes: [{ seat: 'main', vote: 'approve', rationale: 'ok' },
+  { seat: 'codex', vote: 'abstain', abstainKind: 'unparsed', rationale: 'codex replied but with no COUNCIL-VOTE line' }] }
+const tUnparsed = canonicalTranscript(recUnparsed)
+ok(!/^silent:/m.test(tUnparsed),
+   'B2b an `unparsed` abstain (pre-existing kind, capture:true, seat SPOKE) seals with NO `silent:` line')
+// Compared against the SAME fixture with the kind stripped — not against recLegacy, whose rationale
+// differs and which would make this pass or fail for a reason that is not the kind.
+const tUnparsedNoKind = canonicalTranscript({ ...recUnparsed,
+  votes: recUnparsed.votes.map(v => { const { abstainKind, ...rest } = v; return rest }) })
+ok(tUnparsed === tUnparsedNoKind,
+   'B2b …and seals BYTE-IDENTICALLY to the same record with the kind stripped — historical invariance by construction')
+// Positive control for B2b: the identical fixture with a `silent:` kind DOES seal the line, so the
+// arm above grades the prefix predicate and not a canonicalTranscript that emits nothing.
+const tUnparsedControl = canonicalTranscript({ ...recUnparsed,
+  votes: recUnparsed.votes.map(v => v.seat === 'codex' ? { ...v, abstainKind: 'silent:no-pickup' } : v) })
+ok(/^silent: codex:silent:no-pickup$/m.test(tUnparsedControl),
+   'B2b positive control: the same record with a silence kind DOES seal the line')
 
 // B3 — a capture failure keeps going to `unreached:` ONLY. The two lines answer different questions
 //      ("never asked" vs "asked, never answered") and a seat must not appear on both.

--- a/tests/council_dispatch_unit.mjs
+++ b/tests/council_dispatch_unit.mjs
@@ -410,9 +410,20 @@ ok(ballotTap({ ref: 'DIVE-1600', vote: 'a', nonce: '', _exec: () => { throw new 
   const structured = await runBallot(() => ({ ok: false, why: 'exit 1 :: permission denied' }))
   ok(structured.abstainKind === 'nudge-failed' && /permission denied/.test(structured.rationale), 'DIVE-2220: {ok:false,why} nudge failure carries why into the rationale')
 
-  // (d) a DELIVERED nudge is untagged and the rationale records that the seat was told.
+  // (d) a DELIVERED nudge is not a capture failure, and the rationale records that the seat was told.
+  //
+  // DIVE-2891 UPDATED THE PREDICATE, NOT THE GUARANTEE. This arm's guarantee is "a seat we DID reach
+  // that stayed silent is a REAL abstention, not a capture failure", and that is unchanged and still
+  // asserted below via `capture !== false` — which is the field captureAudit, the verdict refusal and
+  // the sealed `unreached:` line all key on. The old `abstainKind == null` clause was a PROXY for it,
+  // sound only while abstainKind existed exclusively on capture failures. DIVE-2891 deliberately
+  // breaks that coupling: a reached-but-silent seat now carries a `silent:*` kind so a quota-locked
+  // seat stops rendering identically to one that withheld consent. So the clause is replaced by the
+  // thing it stood for, plus a positive check that the kind is a SILENCE kind and not a capture kind —
+  // which is strictly stronger than asserting absence.
   const delivered = await runBallot(() => ({ ok: true }))
-  ok(delivered.vote === 'abstain' && delivered.abstainKind == null && delivered.capture !== false, 'DIVE-2220: a delivered nudge + silent seat stays a REAL abstention (not a capture failure)')
+  ok(delivered.vote === 'abstain' && delivered.capture !== false, 'DIVE-2220: a delivered nudge + silent seat stays a REAL abstention (not a capture failure)')
+  ok(String(delivered.abstainKind || '').startsWith('silent:'), 'DIVE-2891: …and that real abstention is CLASSIFIED (a silent:* kind), never left indistinguishable from a withheld vote')
   ok(/no vote by deadline/.test(delivered.rationale) && /nudged dario mid-window/.test(delivered.rationale), 'DIVE-2220: a delivered nudge is NAMED in the deadline rationale (told vs merely queued)')
 
   // (e) a seat that VOTES after a failed nudge is not tagged — the ledger applies only at the deadline.


### PR DESCRIPTION
## Unreleased — fix(council): the receipt now says WHICH silence a seat's abstention was (DIVE-2891)

Constitutional motions resolve `quorum: all` with `require_quorum: true`, so **an abstention is a
silent veto** — one seat's silence kills the motion. Until now the durable record could not say
whether that silence was dissent or an outage: a throttled seat and a seat that deliberately withheld
consent both produced the identical `no vote by deadline` line, and the receipt sealed nothing that
could separate them. That gives any single throttled account an unattributable, deniable veto over
every constitutional motion.

**Proven live 2026-08-07.** `codex`'s ballot went `in_progress → todo` at ~10:40Z with 32 minutes
left, while `5dive agent info codex` reported `active / enabled`. The quota lock existed only in a
tmux pane that happened to be captured while the round was still open; at the deadline the receipt
sealed a bare abstain. Five seats cast and agreed and the instrument could not collect the sixth.

The signal was already in hand and being discarded: the collect loop polls `task show` every tick and
read `status` only to test for `done`/`cancelled`. The **transitions** separate the cases at zero
extra cost and with no pane-scraping, so a reached-but-silent abstention now carries a kind:

- `silent:released` — claimed the ballot and handed it back (what the quota lock looked like)
- `silent:held-open` — held it `in_progress` to the deadline; engaged, ran out of window
- `silent:no-pickup` — never claimed it
- `silent:closed-no-vote` — closed the ballot without casting (the most misleading: every board reads
  it as worked)

**These name the observation, never the cause.** A release is what one throttle looked like once; it
is not proof of one, and the rationale says so and points at the pane. The whole 2026-08-07 failure
thread is instruments that were right about a fact and wrong about the cause, in the direction that
reads as recoverable — this must not join them.

**Nothing about quorum, tally or capture semantics moves.** Relaxing 6/6 is a constitutional call and
lodar's, not an engineering one; this is remedy (a) from the row, pure instrumentation. A silent
abstention still counts exactly as an abstention. `capture` is deliberately not set — we cannot show
the seat was never asked, so claiming a capture failure would outrun the evidence and would move
counts `captureAudit` feeds. Graded explicitly (arms C1–C4).

**Extending signed bytes without invalidating history:** the sealed `silent:` line is *conditional* on
a non-capture abstain carrying a kind. No record written before this change can satisfy both — every
pre-existing `abstainKind` site sets `capture:false` — so every historical receipt re-seals
byte-identically. Verified against the live store, not just synthetically: `council verify` passes on
the real lineage with this build, and the 28 on-disk receipts include the discriminating case
(`vote main: abstain :: … no vote by deadline`) that would newly emit the line if the condition were
wrong. Same technique as CNCL-19 and DIVE-1869.

`tests/council_abstain_engagement_unit.mjs`: 21 arms, offline, mutation-graded with distinct kill
sets (dropping the seal kills 1 arm; collapsing the classifier kills 3). One existing DIVE-2220
assertion was updated — its guarantee ("a reached-but-silent seat is a real abstention, not a capture
failure") is unchanged and still asserted via `capture !== false`; the old `abstainKind == null`
clause was a proxy that was only sound while `abstainKind` meant "capture failure", and it is
replaced by the thing it stood for plus a positive check that the kind is a silence kind.

Task: DIVE-2891 (filed by olivia as chair, originating finding main on DIVE-2883). Verifier: olivia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
