### PR TITLE
fix(auth): auth set refuses to revert a custom endpoint instead of re-deriving it (DIVE-2809)

### DIFF
--- a/changelog.d/DIVE-2809.md
+++ b/changelog.d/DIVE-2809.md
@@ -1,0 +1,35 @@
+## Unreleased — fix(auth): `auth set` refuses to revert a custom endpoint instead of silently re-deriving it (DIVE-2809)
+
+`agent create --base-url=<url>` (DIVE-2757) pins a claude agent to an Anthropic-compatible
+endpoint that is not in the provider catalog — a self-hosted server, a corporate gateway, a
+vendor host we ship no row for. `agent auth set claude --provider=<vendor> --auth-profile=<p>`
+did not know that flag existed: it re-derived `ANTHROPIC_BASE_URL` from
+`CLAUDE_PROVIDER_BASEURL` and wrote the catalog's url over the operator's.
+
+**The defect is the silence, not the breakage.** The agent does not refuse afterwards. The value
+it gets is a real vendor URL, so nothing downstream looks wrong, and a self-hosted agent quietly
+resumes sending its traffic *and its key* to a vendor the operator deliberately moved off. A key
+rotation is the routine reason to run `auth set`, so the revert arrives attached to an unrelated
+intention.
+
+Now, applying a catalog provider to a profile whose stored `ANTHROPIC_BASE_URL` no catalog row
+serves is **refused**, and the refusal names both doors with the same flag:
+
+- `--base-url=<the custom url>` — keep the endpoint, rotate the key.
+- `--base-url=<the catalog url>` — move this profile onto the vendor, deliberately.
+
+`auth set` learned `--base-url` and `--model` to make those exits real; a refusal with no door is
+a wall. Both are claude-only and both require `--provider`, refused rather than accepted-and-ignored
+(`pi` and `opencode` also take `--provider` but return from their own branches above the BYO block,
+so a flag they do not read would have been dropped there).
+
+**Preserving silently would not have been enough.** An operator who genuinely wants this profile
+back on a catalog vendor has to have a path that says so, and one that a reader of the shell
+history can see was taken on purpose.
+
+The guard keys on *catalog membership*, not on difference: re-pointing a profile from one catalog
+vendor to another was named on the command line by `--provider` and is not silent, so that switch
+still applies. The harness reads the systemd `EnvironmentFile` off disk before and after and
+asserts it is byte-identical across the refusal, and its mutation arm cuts the guard out of the
+live source — anchor-counted first, so a range that matched nothing could not pass as a mutation —
+and shows the endpoint reverting without it.

--- a/src/cmd_agent_create.sh
+++ b/src/cmd_agent_create.sh
@@ -871,6 +871,34 @@ _apply_byo_claude() {
   fi
   [[ -n "$base_url" ]] \
     || fail "$E_VALIDATION" "claude does not support provider '$canonical' (${BYO_PROVIDER_LABEL[$canonical]:-unknown}: no Anthropic-compatible endpoint). Pass --base-url=<url> to point at one yourself."
+  # DIVE-2809 GUARD BEGIN — do not let a catalog re-derivation silently revert
+  # an operator's endpoint.
+  #
+  # Everything above this point resolves ANTHROPIC_BASE_URL from argv or the
+  # catalog and then WRITES it. That is correct on a first apply and wrong on a
+  # re-apply: `agent auth set claude --provider=<vendor> --auth-profile=<p>`
+  # (a routine key rotation) reaches here with url_override EMPTY, so the
+  # catalog's url wins and a profile created with --base-url loses its endpoint.
+  #
+  # The failure is not that the agent breaks — it is that it does not. The value
+  # written is a real vendor URL, so nothing downstream looks wrong, and a
+  # self-hosted agent quietly resumes sending its traffic AND ITS KEY to a vendor
+  # the operator deliberately moved off. Silence is the whole defect.
+  #
+  # Preserving silently is not the fix either: an operator who genuinely wants
+  # this profile back on a catalog vendor has to have a path that says so. So
+  # REFUSE, and name both exits with the same flag — keep, or move, but state
+  # which. The predicate is "the stored url is not in the catalog", not "the
+  # stored url differs": a profile already on vendor A that is re-pointed at
+  # vendor B was named on the command line by --provider and is not silent.
+  if [[ -z "$url_override" ]]; then
+    local stored_url
+    stored_url=$(profile_env_value "$profile" ANTHROPIC_BASE_URL)
+    if [[ -n "$stored_url" && -z "$(claude_baseurl_catalog_provider "$stored_url")" ]]; then
+      fail "$E_VALIDATION" "auth profile '$profile' is pinned to a custom endpoint (${stored_url}) that no provider catalog row serves; applying provider '$canonical' here would replace it with ${base_url}. Pass --base-url=${stored_url} to keep the custom endpoint, or --base-url=${base_url} to move this profile onto '$canonical' deliberately."
+    fi
+  fi
+  # DIVE-2809 GUARD END
   step "Configuring claude BYO provider '$canonical' → ${base_url} (profile=$profile)"
   printf '%s' "$base_url"  | profile_set_var "$profile" ANTHROPIC_BASE_URL
   printf '%s' "$api_key"   | profile_set_var "$profile" ANTHROPIC_AUTH_TOKEN

--- a/src/cmd_auth.sh
+++ b/src/cmd_auth.sh
@@ -1214,19 +1214,44 @@ pi_apply_model_default() {
 # The "-" sentinel reads the key from stdin — use that from the API layer
 # so the key never touches process argv (and thus never shows up in `ps`).
 cmd_auth_set() {
-  local type="" api_key="" profile="" byo_provider=""
+  local type="" api_key="" profile="" byo_provider="" base_url="" byo_model=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --api-key=*)       api_key="${1#--api-key=}" ;;
       --auth-profile=*)  profile="${1#--auth-profile=}" ;;
       --provider=*)      byo_provider="${1#--provider=}" ;;
+      # DIVE-2809: the create path's --base-url/--model reach auth set too, so a
+      # key rotation on a custom-endpoint profile has a way to RESTATE the
+      # endpoint instead of losing it to the catalog. Without these two flags the
+      # guard in _apply_byo_claude would be a wall with no door.
+      --base-url=*)      base_url="${1#--base-url=}" ;;
+      --model=*)         byo_model="${1#--model=}" ;;
       -*)                fail "$E_USAGE" "unknown flag: $1" ;;
       *)                 [[ -z "$type" ]] && type="$1" || fail "$E_USAGE" "extra arg: $1" ;;
     esac
     shift
   done
-  [[ -n "$type" ]] || fail "$E_USAGE" "usage: 5dive agent auth set <type> --api-key=<key> [--auth-profile=<name>] [--provider=<id>]"
+  [[ -n "$type" ]] || fail "$E_USAGE" "usage: 5dive agent auth set <type> --api-key=<key> [--auth-profile=<name>] [--provider=<id>] [--base-url=<url>] [--model=<slug>]"
   is_known_type "$type" || fail "$E_NOT_FOUND" "unknown type: $type"
+  # DIVE-2809: both new flags only mean anything on the BYO branch below, which
+  # is entered by --provider. Refuse rather than accept-and-ignore: an operator
+  # who passes --base-url without --provider is asking for exactly the endpoint
+  # pin this row exists to protect, and silently dropping it is the same class
+  # of bug. `pi` and `opencode` also take --provider but return from their own
+  # branches ABOVE the BYO block, so a flag they do not read would be accepted
+  # and dropped there — hence the type check as well as the --provider one.
+  if [[ -n "$base_url" ]]; then
+    [[ -n "$byo_provider" ]] \
+      || fail "$E_USAGE" "--base-url requires --provider=<id> (it configures a claude BYO endpoint; see 'agent create --base-url')"
+    [[ "$type" == "claude" ]] \
+      || fail "$E_VALIDATION" "--base-url is only supported for claude (got: $type — hermes/openclaw carry their own provider URL tables)"
+  fi
+  if [[ -n "$byo_model" ]]; then
+    [[ -n "$byo_provider" ]] \
+      || fail "$E_USAGE" "--model requires --provider=<id> (per-tier model ids are BYO-provider state)"
+    [[ "$type" == "claude" || "$type" == "hermes" || "$type" == "openclaw" ]] \
+      || fail "$E_VALIDATION" "--model is only supported for claude/hermes/openclaw (got: $type)"
+  fi
   [[ -n "$api_key" ]] || fail "$E_USAGE" "--api-key=<key> required (use --api-key=- to read from stdin)"
 
   if [[ "$api_key" == "-" ]]; then
@@ -1298,7 +1323,7 @@ cmd_auth_set() {
       # override env vars directly in combined.env, so skip that step for it.
       [[ "$type" == "claude" ]] || profile_type_dir "$profile" "$type" >/dev/null
     fi
-    apply_byo_provider "$type" "$byo_provider" "$api_key" "$profile"
+    apply_byo_provider "$type" "$byo_provider" "$api_key" "$profile" "$byo_model" "$base_url"
 
     # Restart any running agents that consume this credential so the new
     # provider takes effect immediately. Without this, hermes/openclaw

--- a/src/header.sh
+++ b/src/header.sh
@@ -974,6 +974,38 @@ declare -A CLAUDE_PROVIDER_HAIKU_MODEL=(
   [zai]="glm-4.5-air"
 )
 
+# claude_baseurl_catalog_provider <url> — reverse the CLAUDE_PROVIDER_BASEURL
+# catalog: echo the canonical vendor id that serves <url>, or nothing when no
+# row does. Empty output is the load-bearing answer: it means the url came from
+# somewhere other than this table — i.e. an operator's --base-url (DIVE-2757) —
+# which is the one value a re-derivation from the catalog must not silently
+# overwrite (DIVE-2809). Exit status is not the signal; read stdout.
+claude_baseurl_catalog_provider() {
+  local url="$1" cand
+  [[ -n "$url" ]] || return 0
+  for cand in "${!CLAUDE_PROVIDER_BASEURL[@]}"; do
+    if [[ "${CLAUDE_PROVIDER_BASEURL[$cand]}" == "$url" ]]; then
+      echo "$cand"; return 0
+    fi
+  done
+  return 0
+}
+
+# profile_env_value <profile> <VAR> — read one KEY=VALUE out of an auth
+# profile's combined.env without creating anything (the writer's counterpart is
+# profile_set_var in cmd_auth.sh, which is root-only and DOES create). Empty
+# output for an absent file, an absent profile or an unset var — a caller that
+# needs to tell those apart must check the file itself. Lives in header.sh
+# rather than next to the writer because the create path reads it in contexts
+# that do not source cmd_auth.sh.
+profile_env_value() {
+  local profile="$1" var="$2" file="${AUTH_PROFILES_DIR}/${1}/combined.env" v
+  [[ -n "$profile" && -r "$file" ]] || return 0
+  v=$(grep -E "^${var}=" "$file" 2>/dev/null | tail -1 | cut -d= -f2-) || v=""
+  v="${v%\"}"; v="${v#\"}"
+  printf '%s' "$v"
+}
+
 # Resolve a canonical UI id to the agent CLI's native provider id. Empty
 # result means the type doesn't support that vendor and the caller should
 # fail with a clear error.

--- a/src/main.sh
+++ b/src/main.sh
@@ -194,8 +194,12 @@ Auth (lower-level; the dashboard uses these — prefer 'account' for human-drive
   5dive agent auth status [--probe] [--type=<type>]    # real --print probe reveals stale creds
   5dive agent auth login <type>                        # interactive TTY (hands off this process)
   5dive agent auth set <type> --api-key=<key|-> [--auth-profile=<name>] [--provider=<id>]
+                              [--base-url=<url>] [--model=<slug>]
                                                        # --provider=<id> required for hermes/openclaw;
                                                        # id is one of: ${!BYO_PROVIDER_LABEL[*]}
+                                                       # --base-url (claude only) restates a custom
+                                                       # endpoint; without it a profile pinned off the
+                                                       # catalog is refused, not reverted (DIVE-2809)
   5dive agent auth start <type> [--auth-profile=<name>]      # non-TTY device-code: returns session id
   5dive agent auth poll <session_id>                         # {state, url, error}
   5dive agent auth submit <session_id> --code=<callback>     # paste the claude callback code

--- a/tests/claude_custom_base_url_unit.sh
+++ b/tests/claude_custom_base_url_unit.sh
@@ -219,6 +219,204 @@ else
 fi
 rm -rf "$_ap_root"
 
+
+# ============================================================================
+# DIVE-2809 — the same endpoint, one command later.
+#
+# Folded into this file rather than shipped as its own harness because it is the
+# same subject (a claude BYO endpoint that is NOT in the catalog) and the core
+# tier is at its cap: a separate file pays a second bash start and a second
+# source of six libraries to re-reach the state arm 5 already builds. Merging by
+# subject is the budget runner's own first remedy and it drops no assertion.
+#
+# `agent auth set claude --provider=<vendor> --auth-profile=<p>` re-derived
+# ANTHROPIC_BASE_URL from CLAUDE_PROVIDER_BASEURL and wrote the catalog's url
+# over the one --base-url pinned above. The agent did not break afterwards —
+# that is the defect. The value is a real vendor URL, so nothing downstream
+# looks wrong while a self-hosted agent resumes sending its traffic AND ITS KEY
+# to a vendor the operator deliberately moved off.
+#
+# Everything below drives the REAL writer against a REAL EnvironmentFile in a
+# mktemp dir and reads it off disk before and after; only root-owned side
+# effects are stubbed.
+# ============================================================================
+root=$(mktemp -d)
+AUTH_PROFILES_DIR="$root/auth-profiles"
+
+# Root-owned side effects only. profile_set_var itself is the shipped writer.
+step() { :; }
+warn() { :; }
+require_root() { :; }
+chown() { :; }
+chmod() { :; }
+ensure_profile_dir() { local d="$AUTH_PROFILES_DIR/$1"; mkdir -p "$d"; : >>"$d/combined.env"; printf '%s' "$d"; }
+# fail() EXITS in production; a stub that merely returns would let a refused
+# call run on and write the profile anyway. Keep the exit, run refusals in a
+# SUBSHELL.
+fail() { printf 'FAIL[%s] %s\n' "$1" "$2" >&2; exit "$1"; }
+
+CUSTOM_URL="https://weights.example.com/v1"
+ZAI_URL="${CLAUDE_PROVIDER_BASEURL[zai]}"
+
+# Stand up the profile the way `agent create --base-url=<custom> --model=<slug>`
+# leaves it: a custom endpoint plus all three pinned tiers.
+seed_custom_profile() {
+  local p="$1" url="${2:-$CUSTOM_URL}"
+  rm -rf "${AUTH_PROFILES_DIR:?}/$p"
+  ensure_profile_dir "$p" >/dev/null
+  printf '%s' "$url"           | profile_set_var "$p" ANTHROPIC_BASE_URL
+  printf '%s' "sk-selfhost-12" | profile_set_var "$p" ANTHROPIC_AUTH_TOKEN
+  printf '%s' "qwen3.8-max"    | profile_set_var "$p" ANTHROPIC_DEFAULT_OPUS_MODEL
+  printf '%s' "qwen3.8-max"    | profile_set_var "$p" ANTHROPIC_DEFAULT_SONNET_MODEL
+  printf '%s' "qwen3.8-max"    | profile_set_var "$p" ANTHROPIC_DEFAULT_HAIKU_MODEL
+}
+env_of() { printf '%s' "$AUTH_PROFILES_DIR/$1/combined.env"; }
+url_in()  { grep -E '^ANTHROPIC_BASE_URL=' "$(env_of "$1")" | tail -1 | cut -d= -f2-; }
+
+# --- 1. the silent revert is refused, and the file is untouched -------------
+echo "auth set on a custom-endpoint profile: refuse, do not revert"
+seed_custom_profile p1
+before=$(cat "$(env_of p1)")
+before_sum=$(sha256sum < "$(env_of p1)")
+rc=0
+( _apply_byo_claude zai sk-zai-rotate-12 p1 "" "" ) >/dev/null 2>&1 || rc=$?
+if (( rc == E_VALIDATION )); then ok "catalog re-derivation over a custom endpoint is refused (exit $rc)"
+else bad "expected exit $E_VALIDATION, got $rc — the custom endpoint was reverted"; fi
+after_sum=$(sha256sum < "$(env_of p1)")
+if [[ "$before_sum" == "$after_sum" ]]; then ok "EnvironmentFile is byte-identical after the refusal"
+else bad "EnvironmentFile CHANGED across a refusal:"$'\n'"--- before ---"$'\n'"$before"$'\n'"--- after ---"$'\n'"$(cat "$(env_of p1)")"; fi
+# The refusal has to NAME the endpoint it is protecting and the flag that
+# resolves it, or the operator is told "no" with nowhere to go.
+msg=$( ( _apply_byo_claude zai sk-zai-rotate-12 p1 "" "" ) 2>&1 || true )
+for want in "$CUSTOM_URL" "--base-url" "p1"; do
+  case "$msg" in *"$want"*) ok "refusal names: $want" ;;
+                 *) bad "refusal does not name '$want': $msg" ;; esac
+done
+
+# --- 1b. the same thing through the COMMAND an operator actually types ------
+# Arm 1 drives the applier. This drives `agent auth set` itself, because the
+# row's acceptance is about that command and because a guard reachable only
+# from an internal function is a guard the CLI does not have. Everything the
+# refusal path touches before it exits is stubbed above; it never reaches the
+# registry or systemctl.
+echo "cmd_auth_set claude --provider=<vendor> on a custom-endpoint profile"
+seed_custom_profile p6
+before_sum=$(sha256sum < "$(env_of p6)")
+rc=0
+( cmd_auth_set claude --api-key=sk-zai-rotate-12 --provider=zai --auth-profile=p6 ) >/dev/null 2>&1 || rc=$?
+if (( rc == E_VALIDATION )); then ok "the command refuses (exit $rc)"
+else bad "expected exit $E_VALIDATION from cmd_auth_set, got $rc"; fi
+if [[ "$before_sum" == "$(sha256sum < "$(env_of p6)")" ]]; then
+  ok "EnvironmentFile byte-identical after the command refused"
+else
+  bad "cmd_auth_set modified the EnvironmentFile despite refusing"
+fi
+# ...and the same command WITH the flag goes all the way through, so the arm
+# above is attributable to the pin and not to cmd_auth_set being unrunnable here.
+registry_read() { printf '{"agents":{}}'; }
+seed_custom_profile p7
+if ( cmd_auth_set claude --api-key=sk-zai-rotate-12 --provider=zai --auth-profile=p7 \
+       --base-url="$CUSTOM_URL" --model=qwen3.8-max ) >/dev/null 2>&1 \
+   && [[ "$(url_in p7)" == "$CUSTOM_URL" ]]; then
+  ok "positive control: the same command WITH --base-url completes and keeps the endpoint"
+else
+  bad "positive control: cmd_auth_set could not complete even with --base-url (url=$(url_in p7))"
+fi
+
+# --- 2. both doors the refusal offers actually open -------------------------
+echo "the two exits the refusal names"
+# 2a. KEEP: restate the same custom url.
+seed_custom_profile p2
+if ( _apply_byo_claude zai sk-zai-rotate-12 p2 "qwen3.8-max" "$CUSTOM_URL" ) >/dev/null 2>&1; then
+  [[ "$(url_in p2)" == "$CUSTOM_URL" ]] \
+    && ok "--base-url=<same> rotates the key and KEEPS the custom endpoint" \
+    || bad "--base-url=<same> accepted but the url is now $(url_in p2)"
+else
+  bad "--base-url=<same> was refused — the 'keep' exit does not open"
+fi
+# ...and the rotation actually landed, so 2a is not passing on a no-op.
+grep -q '^ANTHROPIC_AUTH_TOKEN=sk-zai-rotate-12$' "$(env_of p2)" \
+  && ok "positive control: the new key reached the profile" \
+  || bad "positive control: the key was NOT written — 2a proves nothing"
+# 2b. MOVE: name the catalog url explicitly.
+seed_custom_profile p3
+if ( _apply_byo_claude zai sk-zai-rotate-12 p3 "" "$ZAI_URL" ) >/dev/null 2>&1; then
+  [[ "$(url_in p3)" == "$ZAI_URL" ]] \
+    && ok "--base-url=<catalog url> MOVES the profile onto the vendor deliberately" \
+    || bad "--base-url=<catalog url> left the url at $(url_in p3)"
+else
+  bad "--base-url=<catalog url> was refused — there is no way back to a vendor"
+fi
+
+# --- 3. a catalog-pinned profile is NOT refused -----------------------------
+# The guard keys on catalog membership, not on difference. Re-pointing a profile
+# from one catalog vendor to another was named by --provider and is not silent,
+# so refusing it would break an ordinary vendor switch.
+echo "a profile already on a catalog url still switches vendors"
+seed_custom_profile p4 "$ZAI_URL"
+if ( _apply_byo_claude openrouter sk-or-rotate-12 p4 "" "" ) >/dev/null 2>&1; then
+  [[ "$(url_in p4)" == "${CLAUDE_PROVIDER_BASEURL[openrouter]}" ]] \
+    && ok "catalog->catalog vendor switch still applies" \
+    || bad "vendor switch left the url at $(url_in p4)"
+else
+  bad "catalog->catalog vendor switch was REFUSED (guard is over-broad)"
+fi
+
+# --- 4. cmd_auth_set parses and forwards the flags --------------------------
+echo "cmd_auth_set: --base-url / --model"
+disp=$(declare -f cmd_auth_set)
+grep -q -- '--base-url=\*)' <<<"$disp" \
+  && ok "cmd_auth_set parses --base-url" || bad "cmd_auth_set does not parse --base-url"
+grep -q -- '--model=\*)' <<<"$disp" \
+  && ok "cmd_auth_set parses --model" || bad "cmd_auth_set does not parse --model"
+grep -q 'apply_byo_provider "$type" "$byo_provider" "$api_key" "$profile" "$byo_model" "$base_url"' <<<"$disp" \
+  && ok "cmd_auth_set forwards both to apply_byo_provider" \
+  || bad "cmd_auth_set does not forward --model/--base-url (the parser would drop them)"
+rc=0; ( cmd_auth_set claude --api-key=sk-test-123456 --base-url="$CUSTOM_URL" ) >/dev/null 2>&1 || rc=$?
+(( rc == E_USAGE )) && ok "--base-url without --provider is refused (exit $rc)" \
+                    || bad "expected $E_USAGE for --base-url with no --provider, got $rc"
+rc=0; ( cmd_auth_set codex --api-key=sk-test-123456 --provider=zai --base-url="$CUSTOM_URL" ) >/dev/null 2>&1 || rc=$?
+(( rc == E_VALIDATION )) && ok "--base-url on a non-claude type is refused (exit $rc)" \
+                         || bad "expected $E_VALIDATION for --base-url on codex, got $rc"
+
+# --- 5. MUTATION: cut the guard, arm 1 must go red --------------------------
+# Cut from the LIVE file, so the mutant tracks the shipped source. Count the
+# anchors BEFORE cutting: a range that matches nothing yields a mutant identical
+# to the original, and this arm would then pass while grading nothing.
+echo "mutation: remove the guard and the refusal must disappear"
+src=src/cmd_agent_create.sh
+mutant="$root/mutant_cmd_agent_create.sh"
+n_begin=$(grep -c '^  # DIVE-2809 GUARD BEGIN' "$src" || true)
+n_end=$(grep -c '^  # DIVE-2809 GUARD END' "$src" || true)
+if [[ "$n_begin" == "1" && "$n_end" == "1" ]]; then
+  ok "mutation anchors are present exactly once each (BEGIN=$n_begin END=$n_end)"
+else
+  bad "mutation anchors are not 1/1 (BEGIN=$n_begin END=$n_end) — the cut below would be a no-op"
+fi
+sed '/^  # DIVE-2809 GUARD BEGIN/,/^  # DIVE-2809 GUARD END/d' "$src" >"$mutant"
+cut_lines=$(( $(wc -l <"$src") - $(wc -l <"$mutant") ))
+if (( cut_lines > 0 )); then ok "the cut removed $cut_lines lines"
+else bad "the cut removed NOTHING — the mutant is the original"; fi
+if grep -q 'is pinned to a custom endpoint' "$mutant"; then
+  bad "the guard's refusal survived the cut — the mutant still carries it"
+else
+  ok "the mutant no longer carries the guard's refusal"
+fi
+
+seed_custom_profile p5
+rc=0
+(
+  # shellcheck disable=SC1090
+  source "$mutant"
+  _apply_byo_claude zai sk-zai-rotate-12 p5 "" ""
+) >/dev/null 2>&1 || rc=$?
+if (( rc == 0 )) && [[ "$(url_in p5)" == "$ZAI_URL" ]]; then
+  ok "without the guard the custom endpoint IS silently reverted to $ZAI_URL — arm 1 is attributable"
+else
+  bad "the mutant did not reproduce the bug (rc=$rc url=$(url_in p5)) — arm 1 proves nothing"
+fi
+rm -rf "$root"
+
 echo
 if (( fails )); then echo "$fails failed"; exit 1; fi
 echo "all assertions passed"

--- a/tests/hermes_openclaw_byo_model_unit.sh
+++ b/tests/hermes_openclaw_byo_model_unit.sh
@@ -59,9 +59,13 @@ grep -q 'override_model:-\${OPENCLAW_PROVIDER_MODEL' <<<"$o" \
 
 # Backward-compat: a 4-arg call (auth re-login path) still resolves to the
 # catalog default (override_model defaults to empty).
-grep -q 'apply_byo_provider "$type" "$byo_provider" "$api_key" "$profile"$' src/cmd_auth.sh \
-  && ok_t "auth re-login 4-arg call still valid (override defaults empty)" \
-  || ok_t "auth re-login call shape changed (acceptable if still <=5 args)"
+# DIVE-2809 gave `auth set` its own --model/--base-url, so the call is now 6-arg
+# and forwards both. Anchor on that shape: the arm exists to catch the forward
+# being DROPPED, and a fallback that ok_t's either way cannot (it did not).
+grep -q 'apply_byo_provider "$type" "$byo_provider" "$api_key" "$profile" "$byo_model" "$base_url"$' src/cmd_auth.sh \
+  && ok_t "auth set forwards \$model (and \$base_url) to apply_byo_provider" \
+  || bad_t "auth set no longer forwards \$model to apply_byo_provider" \
+           "$(grep -n 'apply_byo_provider "\$type"' src/cmd_auth.sh)"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 (( FAIL == 0 ))


### PR DESCRIPTION
## The footgun

`agent create --base-url=<url>` (DIVE-2757) pins a claude agent to an Anthropic-compatible endpoint the provider catalog does not serve — a self-hosted server, a corporate gateway, a vendor host we ship no row for.

`agent auth set claude --provider=<vendor> --auth-profile=<p>` did not know that flag existed. It re-derived `ANTHROPIC_BASE_URL` from the `CLAUDE_PROVIDER_BASEURL` catalog and wrote the catalog's url over the operator's.

**The defect is the silence, not the breakage.** The agent does not refuse afterwards. The value it gets is a real vendor URL, so nothing downstream looks wrong, and a self-hosted agent quietly resumes sending its traffic *and its key* to a vendor the operator deliberately moved off. A key rotation is the routine reason to run `auth set`, so the revert arrives attached to an unrelated intention.

## What changed

`_apply_byo_claude` refuses when the profile's stored `ANTHROPIC_BASE_URL` is one no catalog row serves and no `--base-url` was passed. The refusal names both doors with the same flag:

- `--base-url=<the custom url>` — keep the endpoint, rotate the key.
- `--base-url=<the catalog url>` — move this profile onto the vendor, deliberately.

Preserving silently would not have been enough on its own: an operator who genuinely wants the vendor back needs a path that says so, and one a reader of the shell history can see was taken on purpose.

`auth set` learned `--base-url` and `--model` to make those exits real — a refusal with no door is a wall. Both are claude-only and both require `--provider`, **refused rather than accepted-and-ignored**: `pi` and `opencode` also take `--provider` but return from their own branches above the BYO block, so a flag they do not read would have been dropped there.

The guard keys on catalog **membership**, not on difference. Re-pointing a profile from one catalog vendor to another was named on the command line by `--provider` and is not silent, so that switch still applies.

## Evidence

**`tests/claude_custom_base_url_unit.sh` — +198 lines, 19 added `ok` assertions, all green.**

> **Corrected 2026-08-09 (was wrong in the original body, caught by olivia on review).** This section
> previously named `tests/claude_auth_set_baseurl_revert_unit.sh` — "21 assertions". **No such file
> exists on this branch or on main.** The arms were FOLDED into the existing
> `tests/claude_custom_base_url_unit.sh` and the real added-assertion count is **19**, not 21.
>
> **Why folded rather than a new harness, stated as a decision rather than left in a task result:**
> same subject (custom `ANTHROPIC_BASE_URL`), and the core tier is running at **96–98% of its 300s
> budget cap** (DIVE-2867), so a new file would have bought a duplicate setup cost against a budget
> with no headroom. Folding reclaims that setup and drops no assertion.
>
> **THE DEAD POINTER IS FROZEN IN MAIN'S HISTORY. It is permanent and this body cannot undo it.**
> Commit **`89a5abb`** — the branch commit this PR merged — names
> `tests/claude_auth_set_baseurl_revert_unit.sh` in its own commit message, and `89a5abb` is an
> ancestor of `origin/main`. Merging with `--merge` rather than `--squash` did **not** avoid this:
> it *preserved* that message instead of replacing it with this body. A commit message is
> uneditable after the fact, so the PR body you are reading is the **only** layer that could be
> corrected, and it has been.
>
> **If you arrived here from `git log --grep=claude_auth_set_baseurl_revert_unit`:** that file has
> never existed. The harness is `tests/claude_custom_base_url_unit.sh`, above. `89a5abb`'s message
> is wrong and cannot be fixed; this note is the correction of record.
>
> An earlier revision of this note claimed the opposite — that the pointer "did not freeze into
> main's history" because the PR landed as a merge commit. That was false, and it was false for a
> reason worth naming: the check behind it ran `git log -3` from the merge tip, which walks
> `6c4e8c8 -> 41124a8 -> 476ba90` — three MERGE commits — and never reaches the work commit a merge
> brings in. A bounded log from a merge tip cannot answer "is this string anywhere in history";
> only an unbounded `git log --grep` can.

The 19 arms:

- reads the systemd `EnvironmentFile` **off disk before and after** and asserts it is byte-identical across the refusal (the row asked for this explicitly, not a unit test alone);
- drives the real `cmd_auth_set`, not only the internal applier — a guard reachable only from an internal function is a guard the CLI does not have;
- positive controls on both refusal arms: the same command **with** `--base-url` completes and keeps the endpoint, and the rotated key actually lands, so the refusals are attributable;
- the catalog→catalog vendor switch still applies (the guard is not over-broad);
- **mutation arm**: cuts the guard out of the live source and shows the endpoint reverting to `https://api.z.ai/api/anthropic` without it. The cut is **anchor-counted first** (BEGIN=1, END=1, 28 lines removed, refusal string absent from the mutant) — a sed range that matched nothing would yield a mutant identical to the original and the arm would pass while grading nothing.

Adjacent harnesses re-run green: `byo_model_create_unit`, `claude_qwen_byo_unit`, `hermes_openclaw_byo_model_unit`, `dive1762_regression_unit`, `hermes_zai_baseurl_unit`, `openclaw_zai_baseurl_unit`, `opencode_init_provider_unit`.

`hermes_openclaw_byo_model_unit.sh` carried the one anchor on the call shape that changed. It had a fallback that `ok_t`'d in **both** branches — so it could not have caught the forward being dropped. Re-anchored on the 6-arg call and given a real `bad_t`.

Bundle builds; `shellcheck -x` clean on every changed file (header.sh's `SC2034`s are pre-existing and untouched).

Closes DIVE-2809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


