### PR TITLE
fix(council): a test seam defaulting to a LIVE rail was messaging a real seat (DIVE-2914)

### DIFF
--- a/changelog.d/DIVE-2914.md
+++ b/changelog.d/DIVE-2914.md
@@ -1,0 +1,32 @@
+## Unreleased — fix(council): a test seam that defaulted to a LIVE rail was messaging a real seat (DIVE-2914)
+
+`dispatchBallotVote` takes three injectable seams. Two of them (`_exec`, `_emitBallot`) are inert by
+default in a test; the third, `_nudge`, defaults to **a live rail** — `nudgeSeatAgent()`, which shells
+`5dive agent send <seat> …` into a real agent's pane. Stubbing the collect loop therefore did **not**
+make a harness offline, and nothing said so.
+
+`tests/council_abstain_engagement_unit.mjs` injected `_exec` alone and set its fixture seat to the
+literal id `codex` — a live seat. Every run of the council suite sent **three** real notices to that
+agent, asking it to close ballot `DIVE-77`: a stub ident that exists on no board, carrying the
+deadline `1970-01-01T00:00:05.000Z` (`--ballot-deadline=5` against a zeroed mock clock). `codex`
+escalated twice, correctly, and spent turns voting on ballots that were never minted — while it was
+the quota-locked seat, i.e. the scarcest account on the fleet.
+
+**Captured, not inferred.** Re-running the suite against a logging stand-in for the fleet binary
+recorded the three sends byte-identical to what the seat received; the same run against the fixed
+tree records zero. No ballot task was ever minted against live seats — the task store contains no
+`DIVE-77`, which is exactly why the notices were unanswerable.
+
+Two changes:
+
+- **The harness is offline for real.** It injects `_nudge` and `_emitBallot`, and its seat id is now
+  the reserved fake `seat-under-test`. Per the repo's fixture convention, a fixture is precisely the
+  place where a real-looking value never needs to be real.
+- **The seam fails closed.** In both `dispatchBallotVote` and `preflightLiveness`, a caller that
+  stubbed the *other* exec rail (`_exec` / `_health`) has declared itself offline; the wake rail now
+  defaults to a no-op that **records why** instead of shelling out. The recorded non-delivery is also
+  the honest ledger entry — nothing was sent. Production injects no seams at all, so its behaviour is
+  byte-for-byte unchanged.
+
+The class of defect is the fail-open default: forgetting a seam sent mail to a colleague, and the
+only signal was the colleague noticing. Forgetting it now costs a logged non-delivery.

--- a/src/cmd_council.sh
+++ b/src/cmd_council.sh
@@ -2342,7 +2342,18 @@ export function dispatchBallotVote(opts = {}) {
   // on its queued ballot until the deadline abstains it out. Halfway through the window we send ONE
   // best-effort wake nudge into the seat agent's pane. Injectable + never-throws; a nudge that can't
   // land just means the seat isn't roused early — the deadline/abstain path is unchanged either way.
-  const nudge = opts._nudge || ((agent, msg) => nudgeSeatAgent(agent, msg))
+  // DIVE-2914: this seam FAILS CLOSED when the caller has already declared itself offline. `_nudge`
+  // defaults to a LIVE rail (nudgeSeatAgent -> `5dive agent send <seat> …`) that is NOT part of the
+  // collect loop, so a harness that stubs `_exec` and forgets this one does not become offline — it
+  // becomes a test that messages a real seat. Not hypothetical: council_abstain_engagement_unit.mjs
+  // injected `_exec` alone and addressed three `agent send codex …` notices PER RUN to a live,
+  // quota-locked seat, about a stub ident (DIVE-77) that exists on no board.
+  // A caller that stubbed `_exec` has declared the CLI rail unavailable; the only coherent default for
+  // the OTHER exec rail is then a no-op that RECORDS why, which is also the honest ledger entry —
+  // nothing was sent. Production (seatVoteFor) injects NO seams at all, so this branch cannot reach it.
+  const nudge = opts._nudge || (opts._exec
+    ? () => ({ ok: false, why: 'nudge suppressed: _exec stubbed without _nudge (offline test context, DIVE-2914)' })
+    : ((agent, msg) => nudgeSeatAgent(agent, msg)))
   const nudgeFrac = Number(opts.nudgeFrac) > 0 && Number(opts.nudgeFrac) < 1 ? Number(opts.nudgeFrac) : 0.5
   // (d) COLLECT (shared by the agent + human branches): poll task show until the ballot task closes
   // with a result, or the deadline elapses. The collection-loop deadline is AUTHORITATIVE regardless
@@ -2784,7 +2795,12 @@ export function preflightLiveness(seats, opts = {}) {
   if (health === null) {
     die('council liveness pre-flight FAILED: could not read seat health (`agent list --json`) — refusing to dispatch a full-quorum motion rather than gamble it into a structural inquorate.', 6)
   }
-  const nudge = opts._nudge || nudgeSeatAgent
+  // DIVE-2914: same fail-closed rule as dispatchBallotVote's seam. A caller that injected `_health`
+  // has declared itself offline (no real `agent list`); defaulting the WAKE rail to a live
+  // `agent send` there would message real seats from a test that believes it is isolated.
+  const nudge = opts._nudge || (opts._health
+    ? () => ({ ok: false, why: 'nudge suppressed: _health stubbed without _nudge (offline test context, DIVE-2914)' })
+    : nudgeSeatAgent)
   const unreachable = []
   for (const s of seats) {
     if (E.seatIsHuman(s)) continue

--- a/src/council/cli.mjs
+++ b/src/council/cli.mjs
@@ -141,7 +141,18 @@ export function dispatchBallotVote(opts = {}) {
   // on its queued ballot until the deadline abstains it out. Halfway through the window we send ONE
   // best-effort wake nudge into the seat agent's pane. Injectable + never-throws; a nudge that can't
   // land just means the seat isn't roused early — the deadline/abstain path is unchanged either way.
-  const nudge = opts._nudge || ((agent, msg) => nudgeSeatAgent(agent, msg))
+  // DIVE-2914: this seam FAILS CLOSED when the caller has already declared itself offline. `_nudge`
+  // defaults to a LIVE rail (nudgeSeatAgent -> `5dive agent send <seat> …`) that is NOT part of the
+  // collect loop, so a harness that stubs `_exec` and forgets this one does not become offline — it
+  // becomes a test that messages a real seat. Not hypothetical: council_abstain_engagement_unit.mjs
+  // injected `_exec` alone and addressed three `agent send codex …` notices PER RUN to a live,
+  // quota-locked seat, about a stub ident (DIVE-77) that exists on no board.
+  // A caller that stubbed `_exec` has declared the CLI rail unavailable; the only coherent default for
+  // the OTHER exec rail is then a no-op that RECORDS why, which is also the honest ledger entry —
+  // nothing was sent. Production (seatVoteFor) injects NO seams at all, so this branch cannot reach it.
+  const nudge = opts._nudge || (opts._exec
+    ? () => ({ ok: false, why: 'nudge suppressed: _exec stubbed without _nudge (offline test context, DIVE-2914)' })
+    : ((agent, msg) => nudgeSeatAgent(agent, msg)))
   const nudgeFrac = Number(opts.nudgeFrac) > 0 && Number(opts.nudgeFrac) < 1 ? Number(opts.nudgeFrac) : 0.5
   // (d) COLLECT (shared by the agent + human branches): poll task show until the ballot task closes
   // with a result, or the deadline elapses. The collection-loop deadline is AUTHORITATIVE regardless
@@ -583,7 +594,12 @@ export function preflightLiveness(seats, opts = {}) {
   if (health === null) {
     die('council liveness pre-flight FAILED: could not read seat health (`agent list --json`) — refusing to dispatch a full-quorum motion rather than gamble it into a structural inquorate.', 6)
   }
-  const nudge = opts._nudge || nudgeSeatAgent
+  // DIVE-2914: same fail-closed rule as dispatchBallotVote's seam. A caller that injected `_health`
+  // has declared itself offline (no real `agent list`); defaulting the WAKE rail to a live
+  // `agent send` there would message real seats from a test that believes it is isolated.
+  const nudge = opts._nudge || (opts._health
+    ? () => ({ ok: false, why: 'nudge suppressed: _health stubbed without _nudge (offline test context, DIVE-2914)' })
+    : nudgeSeatAgent)
   const unreachable = []
   for (const s of seats) {
     if (E.seatIsHuman(s)) continue

--- a/tests/council_abstain_engagement_unit.mjs
+++ b/tests/council_abstain_engagement_unit.mjs
@@ -40,7 +40,12 @@ const ballotExec = ({ rowSeq = [], captured = null } = {}) => {
     return ''
   }
 }
-const seat = { id: 'codex', lens: 'engineering' }
+// DIVE-2914: a RESERVED-FAKE seat id, never a real fleet agent. This fixture used to say `codex`,
+// and `codex` is a live seat — combined with the un-injected `_nudge` below it addressed three real
+// `5dive agent send codex ...` notices per run at a seat that was quota-locked, asking it to close
+// DIVE-77 (a stub ident that exists on no board). Per CLAUDE.md: a fixture is precisely the place
+// where a real-looking value never needs to be real.
+const seat = { id: 'seat-under-test', lens: 'engineering' }
 // Deterministic clock: `_sleep` is the only thing that advances it, so the deadline is reached after
 // exactly `deadline / poll` poll iterations regardless of wall time.
 const drive = (rowSeq, deadline = 5) => {
@@ -48,6 +53,12 @@ const drive = (rowSeq, deadline = 5) => {
   return dispatchBallotVote({
     deadline, poll: 1, _now: () => t, _sleep: async (ms) => { t += ms },
     _exec: ballotExec({ rowSeq }),
+    // DIVE-2914: `_nudge` MUST be injected. It is a live rail (nudgeSeatAgent -> `5dive agent send`),
+    // not part of the collect loop, so stubbing `_exec` alone does NOT make this harness offline —
+    // that is exactly how this file emitted to a real seat. Sibling harnesses
+    // (council_dispatch_unit, council_liveness_unit) already inject all three seams; this one did not.
+    _nudge: () => ({ ok: true }),
+    _emitBallot: async () => ({ delivered: false, reason: 'offline unit' }),
   })(seat, { question: 'ratify?', round: 1 })
 }
 


### PR DESCRIPTION
## What

`dispatchBallotVote` takes three injectable seams. `_exec` and `_emitBallot` are inert by default; the third, `_nudge`, defaults to **a live rail** — `nudgeSeatAgent()` shells `5dive agent send <seat> …` into a real agent's pane. So stubbing the collect loop did **not** make a harness offline, and nothing said so.

`tests/council_abstain_engagement_unit.mjs` (added by DIVE-2891, merged in #532) injected `_exec` alone, with its fixture seat set to the literal id `codex` — a live seat. Every council-suite run sent **three** real notices to that agent asking it to close ballot `DIVE-77`: a stub ident on no board, deadline `1970-01-01T00:00:05.000Z` (`--ballot-deadline=5` on a zeroed mock clock). `codex` escalated twice, correctly, and burned turns voting on ballots that were never minted — while it was the quota-locked seat.

## Evidence — captured, not fingerprinted

Ran the suite with a logging stand-in for the fleet binary (`nudgeSeatAgent` honours `COUNCIL_5DIVE_BIN`, so the send is captured rather than emitted):

| tree | live `agent send` attempts |
|---|---|
| `origin/main` (unfixed) | **3**, byte-identical to what the seat received |
| this branch | **0** |

Isolated mutation control, same driver (`_exec` stubbed, `_nudge` omitted) against both trees: unfixed **1 send**, fixed **0**, both exit 0 — so the check is capable of failing and the zero is real, not a crash.

`5dive task show DIVE-77` → no such task, and the task store contains no `DIVE-77` row. **No ballot task was ever minted against live seats** — which is exactly why the notices were unanswerable.

## Regression

- council `.mjs`: **513 assertions pass**, identical to `origin/main` (measured twice, plus a per-file diff showing zero deltas).
- council `.sh`: **11 pass / 0 fail / 7 environment-skips**, tripwire recorded **0** send attempts across the whole suite.
- Bundle (`src/cmd_council.sh`) regenerated and carries exactly these two changes.

## Changes

- **Harness is offline for real** — injects `_nudge` + `_emitBallot`; seat id is now the reserved fake `seat-under-test` (repo convention: a fixture is precisely where a real-looking value never needs to be real).
- **Seam fails closed** — in `dispatchBallotVote` and `preflightLiveness`, a caller that stubbed the *other* exec rail (`_exec` / `_health`) has declared itself offline, so the wake rail defaults to a no-op that **records why** instead of shelling out. That recorded non-delivery is also the honest ledger entry: nothing was sent.

Production (`seatVoteFor`) injects **no** seams at all, so prod behaviour is byte-for-byte unchanged. The two sibling harnesses (`council_dispatch_unit`, `council_liveness_unit`) already injected all three seams — this was the sole outlier.

Fixes DIVE-2914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
