### PR TITLE
fix(push,task): a refusal must not recommend a remedy the code will refuse (DIVE-2801 clauses 2+3)

### DIFF
--- a/changelog.d/DIVE-2801.md
+++ b/changelog.d/DIVE-2801.md
@@ -42,3 +42,61 @@ passes cleanly, which is what keeps this from being "always warn".
 
 Complements DIVE-2760, which warns the **answerer** when a closure mints unsigned; this speaks to
 the **actor**, who is a different agent in a different session and could not have prevented it.
+
+---
+
+## Unreleased — fix(push,task): a refusal must not recommend a remedy the code will refuse (DIVE-2801 clauses 2 and 3)
+
+The clause above is one of three the row grew. The other two are the same defect at a
+different surface: not a rehearsal reporting a verdict it did not compute, but a **refusal
+stating a rule broader than the condition it actually evaluated**. A wrong reason travels
+further than a wrong answer, because the answer gets audited and the reason does not.
+
+**Clause 2 — `push` offered a remedy its own next step refuses.** The usage refusal said
+`pass --branch=<name> or add a 'Branch: <name>' line`. `--branch` satisfies *that* check and
+is then refused by the DIVE-1462 gate binding in `_push_do`, which reads the branch fresh
+from the task body — so the remedy named first was the one that cannot work. The refusal now
+names the body line as REQUIRED and `--branch` as an override of *which* branch is read.
+`docs/delegated-push.md` presented the two as interchangeable and its quickstart showed an
+invocation that cannot succeed; both are fixed, and the doc's dry-run section is written
+against the strings this row's clause 1 actually lands (`closure signature ABSENT` /
+`present but NOT verified here` / `VERIFIED against the root HMAC` / `NOT CHECKED`), not
+against an earlier draft's wording.
+
+**Clause 3 — `task answer` stated a property of the CALLER as a property of the GATE.** The
+refusal read *"only a human can clear it … an agent can't self-answer an approval/secret/
+manual gate."* False: the gate's lead-clear seat reaches that branch with `_lead_clear=1` and
+clears it with no human at all (`DIVE-2599`, `DIVE-2665`, `DIVE-2654` are live instances,
+all `type=approval`, all `answered_by=lead:…`). Human-only is the **fall-through for a caller
+without standing**, not a law about the type. The agent it refused read it as the law, and
+that misreading drove four attempts across three agents on DIVE-2798 — retype, re-file,
+re-route — when routing × tier was the actual defect and type was never involved.
+
+It now names the caller and the row: *"$ident is a '$nt' gate and you ('$_caller') do not
+hold lead-clear standing on it … This is about YOUR standing on THIS gate, not a law about
+'$nt' gates."* The remedy is computed per-row rather than asserted, because the same
+discipline applies one clause later and it fails in **three** directions:
+
+| row | remedy |
+|---|---|
+| routed, tier < 2 | the routed reviewer, who can answer with no human involved |
+| routed, **tier 2** | a human — the tier-2 floor escalates even the reviewer's own answer |
+| unrouted | a human — no seat holds lead-clear standing on this gate |
+
+The tier-2 case was found by self-audit *inside this fix*: the first cut told a tier-2 caller
+their routed reviewer could clear it, which `gtier == 2 && ! human` (the same floor E1
+measures) escalates instead. That is this row's own defect committed inside its own remedy,
+and the arm that catches it (E6) has its own killer.
+
+**Also carried, and it is the same class inside the measuring instrument:** the over-budget
+banner in `scripts/run-harnesses.sh` asserted `NO TEST FAILED` unconditionally while
+computing "N of M" from the very `failed` array that contradicted it — a real run printed
+`NO TEST FAILED — 241 of 243 harnesses passed`. It now reports both facts and which exit code
+wins (the failure, exit 1, not the budget's 4).
+
+Test arms, each with its own killer: `push_unit` (branch refusal names the body requirement),
+`gate_nonce_unit` T8/T8b (re-keyed onto the string the refusal now carries — a control left
+on a deleted string cannot fail), `gate_t2_routed_escalate_unit` E2 (unrouted remedy), E5
+(the positive control: a caller **with** standing clears its own gate and sees no refusal at
+all — every other arm grades a caller without standing and would pass against a build that
+refuses everyone), E6 (the tier-2 remedy), `corpus_tier_budget_unit` (over-budget AND red).

--- a/docs/delegated-push.md
+++ b/docs/delegated-push.md
@@ -110,19 +110,58 @@ before this shipped can be re-provisioned, or you can add that one line to their
 
 ## 5. First push
 
-From inside the repo's work tree, on the branch you want to ship:
+**First add a `Branch:` line to the task body.** This is required, not an
+alternative to `--branch` — the cleared gate binds to the branch the *task*
+declares (DIVE-1462), so a push whose task body names no branch is refused even
+when `--branch` is passed:
 
-```sh
-# dry run — checks gate + author, mints nothing, pushes nothing:
-5dive push DIVE-123 --branch=my-feature --dry-run
-
-# real push (after the task's ship gate has been answered):
-5dive push DIVE-123 --branch=my-feature
+```
+Branch: my-feature
 ```
 
-The branch can also come from a `Branch: my-feature` line in the task body
-instead of `--branch`. Point at a different repo with `--repo=https://github.com/<org>/<repo>`
-(defaults to the repo configured for your deployment).
+Then, from inside the repo's work tree, on the branch you want to ship:
+
+```sh
+# dry run — checks gate authority + author, mints nothing, pushes nothing:
+5dive push DIVE-123 --dry-run
+
+# real push (after the task's ship gate has been answered):
+5dive push DIVE-123
+```
+
+`--branch=my-feature` overrides *which* branch is read; it does not remove the
+need for the body line. Point at a different repo with
+`--repo=https://github.com/<org>/<repo>` (defaults to the repo configured for
+your deployment).
+
+### What the dry run does NOT check
+
+The dry run is a **rehearsal, not the performance**. It runs the agent-side
+preflight, which checks gate *authority*; the real push re-verifies everything
+inside root and additionally verifies a **root-HMAC signed closure**. Signing
+needs a seat whose sudo grant reaches `5dive gate-proof sign` — a
+narrowly-scoped agent seat silently stores an unsigned closure when it answers a
+gate, and before DIVE-2801 that refusal only surfaced at push time (DIVE-2760).
+
+So the dry run now names its own limits rather than implying it checked them.
+Every dry run prints exactly one of these, and the same three states are carried
+in `--json` as `gateSignature`:
+
+- `closure signature ABSENT` — **the dry run refuses here** (exit 3) rather than
+  previewing a push that cannot happen. An empty signature cannot pass the
+  executor's check, so this outcome is knowable without the root key. Re-answer
+  the gate on a box that can sign; `5dive task answer` warns when a closure
+  mints unsigned (DIVE-2760).
+- `closure signature present but NOT verified here — the root executor verifies
+  it at push time` — the normal, honest dry-run result. The rehearsal is saying
+  which check it did not run, not warning you about a problem.
+- `closure signature VERIFIED against the root HMAC` — only the root executor
+  reaches this; it is the real verdict, not a rehearsal.
+- `closure signature NOT CHECKED — no gate check ran in this process` — no gate
+  check ran at all. A dry run that stayed silent because it never measured is
+  the same false green in a different costume.
+
+Confirm a closure with `sudo 5dive gate-proof verify <task>` (root only).
 
 ## Security model
 

--- a/scripts/run-harnesses.sh
+++ b/scripts/run-harnesses.sh
@@ -627,9 +627,24 @@ elif (( total_ms > EFF_MS )); then
   # DIVE-2592: SAY WHAT THIS RED IS, in the output that carries it. `exit 4` beside a
   # green assertion count cost the author of #395 an hour: it reads as systemic to the
   # person whose PR it stopped and as flake to the next reader, and it is neither.
-  printf 'NO TEST FAILED — %d of %d harnesses passed. This is a BUDGET failure (exit 4), not a\n' \
-    "$(( ${#CORPUS[@]} - ${#failed[@]} ))" "${#CORPUS[@]}"
-  printf 'test failure (exit 1): nothing in your diff is broken, the CORPUS no longer fits its cap.\n'
+  # DIVE-2801: the no-test-failed claim is only true when nothing failed, and this
+  # branch had been asserting it unconditionally — while computing "N of M" from
+  # the very `failed` array that contradicts it. On a run with 2 failures it
+  # printed "NO TEST FAILED — 241 of 243 harnesses passed", which is a verdict the
+  # printer did not compute, in the output whose whole job is to say what this red
+  # IS. Exactly the class this row exists to fix, occurring inside the measurement
+  # of it. Both facts are true at once here and the reader needs both, plus which
+  # exit code wins.
+  if (( ${#failed[@]} == 0 )); then
+    printf 'NO TEST FAILED — %d of %d harnesses passed. This is a BUDGET failure (exit 4), not a\n' \
+      "$(( ${#CORPUS[@]} - ${#failed[@]} ))" "${#CORPUS[@]}"
+    printf 'test failure (exit 1): nothing in your diff is broken, the CORPUS no longer fits its cap.\n'
+  else
+    printf '%d HARNESS(ES) ALSO FAILED — %d of %d passed. This run is BOTH over budget AND red.\n' \
+      "${#failed[@]}" "$(( ${#CORPUS[@]} - ${#failed[@]} ))" "${#CORPUS[@]}"
+    printf 'The FAILURE takes precedence and this run exits 1, not 4: fix the failing harness(es)\n'
+    printf 'first, then re-read the budget — a red run is not a trustworthy timing sample either.\n'
+  fi
   if (( confirmed )); then
     printf 'It was measured TWICE (%ds, then %ds) before this was printed, so it is not variance.\n' \
       "$first_total_s" "$total_s"

--- a/src/cmd_push.sh
+++ b/src/cmd_push.sh
@@ -366,8 +366,14 @@ cmd_push() {
     local body; body=$(db "SELECT COALESCE(body,'') FROM tasks WHERE id=${id};")
     branch=$(_push_branch_from_body "$body")
   fi
+  # DIVE-2801: name BOTH requirements. `--branch` satisfies this usage check but
+  # NOT the DIVE-1462 gate binding in _push_do, which reads the branch fresh from
+  # the task body — so offering `--branch` alone as an alternative sends the
+  # caller down a path whose only outcome is the next refusal. Same defect as the
+  # dry-run this row is named for: an early check answering on behalf of a later
+  # one it does not share a predicate with.
   [[ -n "$branch" ]] || fail "$E_USAGE" \
-    "no branch for ${ident}: pass --branch=<name> or add a 'Branch: <name>' line to the task body (push refuses to guess)."
+    "no branch for ${ident}: add a 'Branch: <name>' line to the task body (push refuses to guess). The task body is REQUIRED — the cleared gate binds to the branch the task itself declares (DIVE-1462), so --branch=<name> alone gets past this check and is then refused by that binding; pass it as well only to override which branch is read."
   case "$branch" in
     main|master|HEAD) fail "$E_VALIDATION" "refusing to push to protected branch '${branch}' — delegated push targets feature branches only." ;;
   esac

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -11301,7 +11301,36 @@ cmd_task_answer() {
       # No audit_log here: the blocked caller is an agent user that can't write
       # the root-owned audit log anyway (it would only leak a perms error to
       # stderr). The fail + non-zero exit is the record.
-      fail "$E_AUTH_REQUIRED" "$ident is a '$nt' gate — only a human can clear it. Answer it from Telegram (tap the button) or the dashboard; an agent can't self-answer an approval/secret/manual gate."
+      # DIVE-2801: state the CALLER's standing, not a law about the gate type.
+      # "an agent can't self-answer an approval gate" is false — the gate's
+      # lead-clear seat reaches here with _lead_clear=1 and clears it with no
+      # human at all (see the branch above; DIVE-2599/2665/2654 are live
+      # instances). Human-only is the FALL-THROUGH for a caller without that
+      # standing, not the rule for the type. The old wording was read as a
+      # general rule by the agent it refused, who then rebuilt the gate around
+      # it — a refusal that describes the wrong subject sends the reader to fix
+      # the wrong thing, and unlike a wrong answer nobody audits a reason.
+      # ...and the same discipline applies to the REMEDY, one clause later. An
+      # unrouted gate has no lead-clear seat, so "its lead-clear seat can answer
+      # this with no human involved" is, on that gate, the identical defect in
+      # the opposite direction: a sentence true of the type and false of the row
+      # in front of the reader. Only the routed branch may claim a seat exists.
+      # ...and the same discipline again on TIER, which is the third way this
+      # sentence can be true of the type and false of the row. The tier-2 floor
+      # at `gtier == 2 && ! human` sits BELOW this refusal, so the routed
+      # reviewer never reaches it from here — but they hit it on their own
+      # answer, and it ESCALATES them to a human rather than letting them clear.
+      # Telling a tier-2 caller "your routed reviewer can answer this with no
+      # human involved" would therefore recommend a remedy this code refuses,
+      # which is the very defect this row exists to fix, committed inside its
+      # own fix. Only a sub-tier-2 routed gate may claim a seat that can finish.
+      local _who_can="a human — this gate has no routed reviewer, so no seat holds lead-clear standing on it"
+      if [[ -n "$_routed_rev" && "$gtier" == "2" ]]; then
+        _who_can="a human: this gate is routed to '${_routed_rev}', but it is TIER 2, and the tier-2 floor escalates even the routed reviewer's answer to a human tap rather than clearing it"
+      elif [[ -n "$_routed_rev" ]]; then
+        _who_can="'${_routed_rev}', this gate's routed reviewer, who holds lead-clear standing and can answer it with no human involved — or by a human"
+      fi
+      fail "$E_AUTH_REQUIRED" "$ident is a '$nt' gate and you ('${_caller}') do not hold lead-clear standing on it, so your answer is refused. This is about YOUR standing on THIS gate, not a law about '$nt' gates. It can be cleared by ${_who_can}. A human answers from Telegram (tap the button) or the dashboard."
     fi
     # DIVE-2054: routed_reviewer is task-store state for $ident — fenced.
     # DIVE-2099: `standing=` distinguishes the two clearances that reach here.

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -541,6 +541,25 @@ if [[ "$C2" == *"cover it"* && "$C2" == *"always.sh"* ]]; then
   ok "the budget red names the smallest set of harnesses that COVERS the overage"
 else bad "the budget red names the smallest set of harnesses that COVERS the overage" "$C2"; fi
 
+# DIVE-2801: OVER BUDGET **AND** RED. The arm above is the no-failures case; this is
+# its pair. The banner used to assert "NO TEST FAILED" unconditionally inside the
+# over-budget branch while computing "N of M" from the very `failed` array that
+# contradicts it — a real run printed "NO TEST FAILED — 241 of 243 harnesses
+# passed". That is a verdict the printer did not compute, in the output whose only
+# job is to say what the red IS, and it is the same defect this row exists to fix.
+# Both facts are true here and the reader needs both plus which exit wins.
+rm -f "$TMP"/*.seen
+printf '#!/usr/bin/env bash\nexit 1\n' > "$TMP/broken.sh"
+C3="$(bash "$RUNNER" --no-calibrate --corpus-dir="$TMP" --tier=full --budget=1 --label=t 2>&1)"; RC3=$?
+want "over budget AND a failing harness exits 1 (the failure wins, not 4)" "1" "$RC3"
+if [[ "$C3" != *"NO TEST FAILED"* ]]; then
+  ok "an over-budget run WITH failures does not claim NO TEST FAILED (DIVE-2801)"
+else bad "an over-budget run WITH failures still claims NO TEST FAILED (DIVE-2801)" "$C3"; fi
+if [[ "$C3" == *"ALSO FAILED"* && "$C3" == *"BOTH over budget AND red"* && "$C3" == *"exits 1, not 4"* ]]; then
+  ok "the both-red banner states both facts and which exit code wins (DIVE-2801)"
+else bad "the both-red banner states both facts and which exit code wins (DIVE-2801)" "$C3"; fi
+rm -f "$TMP/broken.sh"
+
 # --confirm-top may only make this gate STRICTER. The rescued corpus, confirmation
 # off, must red — an override that can turn a red green is the hatch, not the control.
 cat > "$TMP/flaps.sh" <<'FLAPS'

--- a/tests/gate_nonce_unit.sh
+++ b/tests/gate_nonce_unit.sh
@@ -235,16 +235,29 @@ touch "$GATE_PROOF_ENFORCE"
 FAKE_CALLER="agent-evil"
 seed_task DIVE-800; cmd_task_need DIVE-800 --type=manual --ask="do it" >/dev/null 2>&1
 out=$(cmd_task_answer DIVE-800 --value=done --human 2>&1); rc=$?
-[[ "$(answered DIVE-800)" == "open" && $rc -ne 0 && "$out" == *"only a human"* ]] \
+# DIVE-2801: the refusal must name the CALLER's standing, not claim a property of
+# the gate type. "only a human can clear it" was false — the gate's lead-clear
+# seat clears these with no human at all — and the agent it refused read it as a
+# general rule and rebuilt the gate around it. Assert the mechanism (refused, gate
+# still open) AND that the wording describes the caller, since pinning the old
+# sentence is what made the wrong reason durable.
+[[ "$(answered DIVE-800)" == "open" && $rc -ne 0 && "$out" == *"lead-clear standing"* ]] \
   && ok_t "T8 agent-* immediate caller blocked on manual gate (defense-in-depth)" \
   || bad_t "T8 agent-* caller blocked on manual" "rc=$rc state=$(answered DIVE-800) out=$out"
+[[ "$out" != *"only a human can clear it"* ]] \
+  && ok_t "T8 refusal does not assert a gate-type law it cannot support (DIVE-2801)" \
+  || bad_t "T8 refusal still claims 'only a human can clear it'" "out=$out"
 
 # T8b: the CONTROL. Non-agent caller, everything else identical — must NOT hit
 # the agent refusal. Without this arm T8 grades a message, not a mechanism.
 FAKE_CALLER="root"
 seed_task DIVE-801; cmd_task_need DIVE-801 --type=manual --ask="do it" >/dev/null 2>&1
 out8b=$(cmd_task_answer DIVE-801 --value=done --human 2>&1); rc8b=$?
-[[ "$out8b" != *"only a human can clear it"* ]] \
+# DIVE-2801: keyed on the phrase the refusal ACTUALLY carries now. Left on the old
+# sentence this control would pass for any build — including one where the refusal
+# fires on every caller — because the string it looked for no longer exists
+# anywhere. A control that cannot fail has stopped being a control.
+[[ "$out8b" != *"lead-clear standing"* ]] \
   && ok_t "T8b CONTROL: non-agent caller does NOT hit the agent refusal (rc=$rc8b)" \
   || bad_t "T8b non-agent caller wrongly hit the agent refusal" "rc=$rc8b out=$out8b"
 

--- a/tests/gate_t2_routed_escalate_unit.sh
+++ b/tests/gate_t2_routed_escalate_unit.sh
@@ -180,9 +180,21 @@ out=$(cmd_task_answer DIVE-302 --value=approved 2>&1); rc=$?
 [[ -z "$(_nf)" ]] \
   && ok_t "E2 no escalation ping on a non-routed gate" \
   || bad_t "E2 no ping" "notified='$(_nf)'"
-[[ "$out" == *"only a human"* || "$out" == *"tier-2 human gate"* ]] \
-  && ok_t "E2 keeps the original tier-2 refusal message" \
+# DIVE-2801 CHANGED THE EXPECTED STRING, not this arm's claim. The claim here is
+# "refused, and by the plain refusal rather than the escalation path" — it was
+# keyed on "only a human", a sentence that row deleted for being false (the
+# lead-clear seat answers these with no human). Re-keyed onto what still
+# discriminates the two paths: the standing refusal names the caller's standing,
+# and escalation would have flagged itself (E1 asserts that flag's presence).
+[[ "$out" == *"lead-clear standing"* && "$out" != *"escalated_to_human"* ]] \
+  && ok_t "E2 gets the plain standing refusal, not the escalation path" \
   || bad_t "E2 refusal message" "out=$out"
+# And the remedy it offers must fit THIS gate: DIVE-302 is unrouted, so there is
+# no lead-clear seat to point at. Asserting the absence is the whole point — the
+# type-level sentence is exactly what would reappear here.
+[[ "$out" == *"no routed reviewer"* ]] \
+  && ok_t "E2 unrouted gate is not told a lead-clear seat can answer it (DIVE-2801)" \
+  || bad_t "E2 unrouted remedy names a seat that does not exist" "out=$out"
 
 # --- E3: a routed tier-2 manual gate cleared by a real HUMAN (--human) clears normally —
 #     escalation only fires for the NON-human refusal path (DIVE-525: taps never break). -
@@ -243,6 +255,57 @@ out=$(cmd_task_answer DIVE-304 --value=approved 2>&1); rc=$?
   && ok_t "E4 enforce OFF: the human was notified with a tap — escalation fires identically to enforce ON" \
   || bad_t "E4 escalation fires with enforce OFF" "notified='$(_nf)'"
 touch "$GATE_PROOF_ENFORCE"
+
+# --- E5: DIVE-2801's POSITIVE CONTROL. Every arm above grades a caller WITHOUT
+#     lead-clear standing, so all of them would still pass against a build that
+#     refuses every caller — and that build is precisely what the old wording
+#     ("only a human can clear it") described. The row's claim is that standing,
+#     not gate type, decides; a claim about a discriminator is not tested until
+#     both sides of it are run. Same caller identity as E2, tier-1 approval gate
+#     routed to that caller: it must clear, and see no refusal at all.
+#     (Ident DIVE-306, not 305: E3b already holds 305. Seeded onto a taken ident
+#     `seed_task` hits a UNIQUE constraint, the gate filing is refused as already
+#     filed, and the arm then grades the PREVIOUS arm's leftover row — which is
+#     how the first draft of this control passed while proving nothing.)
+seed_task DIVE-306
+cmd_task_need DIVE-306 --type=approval --tier=1 --ask="ship it" >/dev/null 2>&1
+[[ "$(tierof DIVE-306)" == "1" ]] \
+  && ok_t "E5 precond: a tier-1 approval gate is filed on a FRESH ident" \
+  || bad_t "E5 precond: fixture is not the gate this arm claims" "tier='$(tierof DIVE-306)' — a collided ident would grade a leftover row"
+route_to DIVE-306 marcus
+_nf_reset
+out5=$(cmd_task_answer DIVE-306 --value=approve 2>&1); rc5=$?
+[[ "$(answered DIVE-306)" == "closed" && $rc5 -eq 0 ]] \
+  && ok_t "E5 CONTROL: the caller WITH lead-clear standing clears its own gate, no human" \
+  || bad_t "E5 standing caller could not clear" "rc=$rc5 state=$(answered DIVE-306) out=$out5"
+[[ "$out5" != *"lead-clear standing"* && "$out5" != *"only a human"* ]] \
+  && ok_t "E5 CONTROL: standing caller sees no refusal text (standing decides, not type)" \
+  || bad_t "E5 standing caller was refused" "out=$out5"
+
+# --- E6: DIVE-2801, THE REMEDY MUST FIT THE TIER TOO. E2 covers "no routed
+#     reviewer, so no seat"; this covers the third way that sentence goes wrong:
+#     a gate that IS routed, but at tier 2, where the floor at `gtier == 2 &&
+#     ! human` escalates even the routed reviewer's own answer (E1 measures
+#     exactly that) instead of letting them clear it. Telling a caller here that
+#     the reviewer "can answer it with no human involved" recommends a remedy
+#     this code refuses — the row's own defect, committed inside its own fix.
+#     Caller is marcus (see FAKE_CALLER above); routing to a different seat is
+#     what removes their standing, which is the state under test.
+seed_task DIVE-307
+cmd_task_need DIVE-307 --type=approval --tier=2 --ask="spend the money" >/dev/null 2>&1
+[[ "$(tierof DIVE-307)" == "2" ]] \
+  && ok_t "E6 precond: a TIER-2 approval gate is filed on a fresh ident" \
+  || bad_t "E6 precond: fixture is not the gate this arm claims" "tier='$(tierof DIVE-307)'"
+route_to DIVE-307 not-me-agent
+_nf_reset
+out6=$(cmd_task_answer DIVE-307 --value=approved 2>&1); rc6=$?
+[[ "$(answered DIVE-307)" == "open" && $rc6 -ne 0 && "$out6" == *"lead-clear standing"* ]] \
+  && ok_t "E6 a caller without standing on a routed tier-2 gate gets the standing refusal" \
+  || bad_t "E6 standing refusal" "rc=$rc6 state=$(answered DIVE-307) out=$out6"
+[[ "$out6" == *"TIER 2"* && "$out6" == *"escalates"* \
+   && "$out6" != *"can answer it with no human involved"* ]] \
+  && ok_t "E6 the tier-2 remedy names the escalation, not a seat that cannot finish (DIVE-2801)" \
+  || bad_t "E6 tier-2 remedy recommends a clearance the floor refuses" "out=$out6"
 
 echo "-----"
 printf 'gate_t2_routed_escalate_unit: %d passed, %d failed\n' "$PASS" "$FAIL"

--- a/tests/push_unit.sh
+++ b/tests/push_unit.sh
@@ -998,6 +998,21 @@ else
         "source shape gave '${_src_out:-<died before the fallback>}', unguarded control gave '${_unguarded_out:-<died, correct>}' — the source's own shape must reach the fallback AND the unguarded control must not"
 fi
 
+# ---------------------------------------------------------------------------
+# DIVE-2801 clause 2: the usage refusal must not recommend a remedy it cannot
+# honour. `--branch` satisfies THIS check but not the DIVE-1462 gate binding in
+# _push_do, which reads the branch from the task body — so offering it as the
+# alternative sends the caller straight into the next refusal. Same defect as
+# the dry-run clause (landed separately on #519), one step up the command.
+seed_task DIVE-992 "no branch line in this body" approval "2026-07-18 00:00:00" "yes"
+out=$(run_push DIVE-992 --dry-run 2>&1); rc=$?
+{ [[ $rc -ne 0 ]] \
+    && grep -q "Branch: <name>" <<<"$out" \
+    && grep -q "body is REQUIRED" <<<"$out" \
+    && ! grep -q "pass --branch=<name> or add" <<<"$out"; } \
+  && ok_t "branch refusal names the body requirement, not --branch alone (DIVE-2801)" \
+  || bad_t "branch refusal names the body requirement, not --branch alone (DIVE-2801)" "rc=$rc :: $out"
+
 echo "-----"
 printf 'push_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Clauses **2 and 3** of DIVE-2801. Clause 1 (the dry-run) landed on #519, now merged as `0d024b6`; this branch is cut from that main and carries **only** what #519 does not, per dev3's iteration-1 handoff condition. #497 is superseded and should be closed unmerged: its clause-1 cut (an `ok`/rc=0 `"would NOT push"` line) is the entire `src/cmd_push.sh` conflict between the two branches, and it resolves in favour of #519's design — a human reads "would NOT push", a script reads `0`.

## The one defect, at three surfaces

The row is named for a rehearsal reporting a verdict it did not compute. Clauses 2 and 3 are the same defect where the sentence is a **refusal** rather than a rehearsal: a step states a rule broader than the condition it actually evaluated. **A wrong reason travels further than a wrong answer, because the answer gets audited and the reason does not.**

### Clause 2 — `push` recommended a remedy its own next step refuses

`no branch for X: pass --branch=<name> or add a 'Branch: <name>' line to the task body`

`--branch` satisfies *that* usage check and is then refused by the DIVE-1462 gate binding in `_push_do`, which reads the branch **fresh from the task body**. The remedy offered first is the one that cannot work. The refusal now names the body line as REQUIRED and `--branch` as an override of *which* branch is read.

`docs/delegated-push.md` presented the two as interchangeable and its quickstart showed an invocation that cannot succeed. Fixed — and its dry-run section is written against the strings **#519 actually landed** (`closure signature ABSENT` / `present but NOT verified here` / `VERIFIED against the root HMAC` / `NOT CHECKED`), not #497's earlier `unsigned` / `WILL refuse this push` draft, which would have shipped documentation describing code that is not on main.

### Clause 3 — `task answer` stated a property of the CALLER as a property of the GATE

> `$ident is a '$nt' gate — only a human can clear it. … an agent can't self-answer an approval/secret/manual gate.`

False as written. `_lead_clear=1` is set for the gate's lead-clear seat above that branch, so the refusal fires **only for a caller without lead-clear standing on that row**. Live counter-instances on the board: `DIVE-2599`, `DIVE-2665`, `DIVE-2654` — all `type=approval`, all `answered_by=lead:…`, no human anywhere. Human-only is the **fall-through**, not the rule.

Measured cost: main read its own refusal as a fact about approval gates rather than about main's standing, and reported it that way. Four attempts across three agents on DIVE-2798 — retype → answer → authority fails → withdraw → re-file → answer → signature fails → manual push. **Gate type was never the defect; routing × tier was, and type was a red herring introduced by a misread refusal.**

The refusal now names the caller and the row, and **computes** the remedy instead of asserting it:

| row | remedy the refusal names |
|---|---|
| routed, tier < 2 | the routed reviewer, who can answer with no human involved |
| routed, **tier 2** | a human — the tier-2 floor escalates even the reviewer's own answer |
| unrouted | a human — no seat holds lead-clear standing on this gate |

**The tier-2 row was found by self-audit inside this fix, and it is the reason to read this PR rather than skim it.** The first cut had two branches, routed and unrouted. On a routed **tier-2** gate that text tells the caller their reviewer can clear it with no human — and `gtier == 2 && ! human` (the same floor `E1` measures) *escalates* the reviewer's own answer to a human tap instead of clearing it. That is this row's defect committed inside its own remedy. Arm `E6` covers it and has its own killer: reverting the tier branch leaves E6 the only red.

### Also carried — the same class inside the measuring instrument

`scripts/run-harnesses.sh` asserted `NO TEST FAILED` unconditionally inside the over-budget branch while computing "N of M" from the very `failed` array that contradicts it. A real run printed `NO TEST FAILED — 241 of 243 harnesses passed`. It now states both facts and which exit code wins (the failure, `1`, not the budget's `4`). This is not clause 2 or 3 and I am naming it rather than letting it ride: it came over from #497, it is self-contained with its own arm, and deleting a correct fix to make a scope statement cleaner is a worse trade than declaring it.

## How it was checked

Every changed surface has an arm, and each arm has a killer — an absence-assertion passes on empty output, so "it went green" is not evidence on its own.

| harness | arms | result |
|---|---|---|
| `push_unit` | branch refusal names the body requirement, not `--branch` alone | 103 passed, 0 failed |
| `gate_nonce_unit` | T8 refusal names standing; **T8b control re-keyed** | 20 passed, 0 failed |
| `gate_t2_routed_escalate_unit` | E2 unrouted remedy; **E5** standing caller clears, sees no refusal; **E6** tier-2 remedy | 25 passed, 0 failed |
| `corpus_tier_budget_unit` | over-budget **and** red: no `NO TEST FAILED`, exit 1 wins | 109 passed, 0 failed |

Two arms are load-bearing in a way that is easy to miss:

- **`E5` is the positive control for the whole clause.** Every other arm grades a caller *without* standing, so all of them would still pass against a build that refuses **every** caller — and that build is precisely what the old wording described. A claim about a discriminator is not tested until both sides of it run.
- **`T8b` was re-keyed, not merely updated.** It asserted `out != "only a human can clear it"` — a string this change deletes. Left as it was, it would pass for any build, including one where the refusal fires on every caller. **A control left pinned to a deleted string cannot fail.**

**Blast radius of the string deletions**, since a string change's radius is the harnesses that grep it: `only a human can clear it` survives at `src/cmd_task.sh:11504` and that is correct — it is the **tier-2 floor's** refusal, a different condition where human-only genuinely is the rule. No stale grepper is left anywhere in `src/ tests/ docs/ scripts/`.

`shellcheck -S error` clean on all four changed shell files (the two `SC2148` hits are the pre-existing sourced-fragment artifact of invoking it on library files directly, not from this diff).

Related: #519 (clause 1, merged), DIVE-2760 (the executor's signature requirement), DIVE-1462 (the gate binds to the branch the body declares), DIVE-2798 (the measured cost).
