### PR TITLE
fix(task): fence the board WRITE path against harness runs, and raise a signal the fence reads (DIVE-3077)

### DIFF
--- a/scripts/run-harnesses.sh
+++ b/scripts/run-harnesses.sh
@@ -44,6 +44,36 @@
 # NOT part of total_s and the report says so.
 set -uo pipefail
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 2
+
+# DIVE-3077 — RAISE A SIGNAL THE BOARD-WRITE FENCE READS. `_task_human_send_allowed`
+# (DIVE-1506) has refused on FIVEDIVE_TEST since it was written; measured across the
+# 344-harness corpus on 2026-08-09, FIVEDIVE_TEST was set by ZERO files and
+# FIVEDIVE_E2E by ZERO. A control that reads a flag nobody sets is not a weak
+# control, it is an absent one wearing a control's shape — which is why 98 fixture
+# rows reached the prod board in one day (DIVE-3075).
+#
+# THE FIX IS ONE PLACE, NOT 344. Asking harness authors to set a marker is opt-OUT
+# of production and needs every author to remember; two stores have now proved they
+# do not. Setting it in the runner covers every harness including ones not yet
+# written, and inverts the default to opt-IN to production: only an invocation that
+# bypasses this script can reach the prod board at all.
+#
+# WHY THIS IS NOT `export FIVEDIVE_TEST=1`, which is what DIVE-3077 was filed asking
+# for and was MEASURED not to work. FIVEDIVE_TEST is read by
+# `_task_human_send_allowed`, where it forces refuse REGARDLESS of store path. But 29
+# harnesses point FIVEDIVE_PROD_TASKS_DB at their own fixture store precisely so they
+# can exercise that predicate's ALLOWED arm — simulating prod is their job. Exporting
+# FIVEDIVE_TEST here flips all of them to refuse. Measured on this branch, 2026-08-09:
+# 0/29 fail without the marker, 25/29 fail with it. Re-using the send rail's sentinel
+# for the write rail overloads one flag with two incompatible meanings, so the write
+# rail gets its own.
+#
+# KNOWN LIMIT, recorded rather than smoothed: this assumes the runner is the only
+# path to a harness. `bash tests/foo.sh` by hand bypasses it. That gap is real and
+# smaller — one person at a keyboard, not a nightly fleet — so this marker is a
+# FLOOR, not a proof. The durable fix in that direction is a writer-set scope column
+# as provenance (DIVE-3075), not a name match on the title.
+export FIVEDIVE_HARNESS=1
 # shellcheck source=tests/lib/tier.sh
 . tests/lib/tier.sh
 

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -986,6 +986,10 @@ _org_resolve_assignee() {
 }
 
 cmd_task_add() {
+  # DIVE-3077: a run that has declared itself a test may not write to the PROD
+  # board. Refuse BEFORE tasks_db_init so a refused call touches nothing.
+  _task_board_write_allowed || fail "$E_PERMISSION" \
+    "refusing to write to the production task board from a test run (FIVEDIVE_HARNESS/FIVEDIVE_TEST/FIVEDIVE_E2E/COUNCIL_MOCK/FIVEDIVE_NO_HUMAN_SEND is set and TASKS_DB resolves to $(_task_real_prod_tasks_db)). Point TASKS_DB/STATE_DIR at a throwaway store."
   tasks_db_init
   local body="" priority="medium" assignee="" parent="" from="" recurring="" fresh="" project="dive"
   local accept="" verify_cmd="" max_iters="" verifier="" task_budget="" no_verify="" branch=""
@@ -9835,6 +9839,58 @@ _task_human_send_allowed() {
   ra="$(readlink -f "$active" 2>/dev/null || printf '%s' "$active")"
   rp="$(readlink -f "$prod" 2>/dev/null || printf '%s' "$prod")"
   [[ -n "$ra" && "$ra" == "$rp" ]]
+}
+
+# DIVE-3077 — the same fail-closed store-identity idea, applied to the board WRITE
+# path. On 2026-08-09 the prod board read 128 open rows of which 98 were test
+# fixtures filed that same day by three agents (`prose A`-`prose E`, `stamp arm
+# C/D/E`), burying a 27-row real backlog. The cost was not the count, it was
+# occlusion: a backlog you cannot read is one you cannot triage.
+#
+# WHY THIS IS NOT `! _task_human_send_allowed`, which is the obvious edit and is
+# wrong. That predicate refuses on EITHER a marker OR a non-prod store, because a
+# human send from a fixture store is never wanted. A board WRITE from a fixture
+# store into that fixture's OWN throwaway DB is the normal, correct case — it is
+# what nearly every harness in the corpus does. Inverting the send predicate here
+# would refuse all of them. The write rail cares about exactly one combination:
+# a run that has DECLARED itself a test, writing to the REAL production store.
+#
+#   refuse  <=>  (a test/harness marker is set)  AND  (the active TASKS_DB is the
+#                                                      real prod board)
+#
+# WHY THE PROD PATH HERE IGNORES FIVEDIVE_PROD_TASKS_DB, which is the one real
+# asymmetry with the send predicate and is deliberate. That variable exists so a
+# harness can DECLARE its own fixture store to be "prod" and exercise the send
+# predicate's allowed arm — 29 harnesses in the corpus do exactly that. A fence
+# that lets the caller redefine the thing it is protecting is fail-open by
+# construction, and honouring it here would refuse those 29 harnesses' own writes
+# to their own throwaway stores. The defect this closes was 98 fixture rows landing
+# on ONE file, so this fence names that file.
+#
+# THE SEAM, and why it is a SECOND variable rather than reusing the one above.
+# tests/task_board_write_fence_unit.sh must drive `task add` end to end against
+# "the prod board" to grade that the fence is WIRED and not merely correct. With
+# no seam its only option is to point TASKS_DB at the real board — and the arm
+# that grades "the fence refuses" then WRITES A REAL FIXTURE ROW the moment the
+# fence regresses. That is not hypothetical: it happened during this ticket's own
+# mutation testing and put DIVE-3082/3083/3084 on the live board. A guard whose
+# test reproduces, on its failure path, the exact defect the guard exists to
+# prevent is worse than no test. FIVEDIVE_FENCE_PROD_DB is set by that harness and
+# by nothing else; unset, this resolves to the real board, which the harness
+# asserts before it uses the seam.
+# Returns 0=allow, 1=refuse.
+_task_real_prod_tasks_db() { printf '%s' "${FIVEDIVE_FENCE_PROD_DB:-/var/lib/5dive/tasks/tasks.db}"; }
+_task_board_write_allowed() {
+  [[ -n "${FIVEDIVE_HARNESS:-}" || -n "${FIVEDIVE_NO_HUMAN_SEND:-}" \
+     || -n "${COUNCIL_MOCK:-}" || -n "${FIVEDIVE_E2E:-}" \
+     || -n "${FIVEDIVE_TEST:-}" ]] || return 0
+  local active prod ra rp
+  active="${TASKS_DB:-${STATE_DIR:-/var/lib/5dive}/tasks/tasks.db}"
+  prod="$(_task_real_prod_tasks_db)"
+  ra="$(readlink -f "$active" 2>/dev/null || printf '%s' "$active")"
+  rp="$(readlink -f "$prod" 2>/dev/null || printf '%s' "$prod")"
+  [[ -n "$ra" && "$ra" == "$rp" ]] && return 1
+  return 0
 }
 
 # DIVE-2010: fence a task-store-driven audit_log call on STORE IDENTITY, reusing

--- a/tests/task_board_write_fence_unit.sh
+++ b/tests/task_board_write_fence_unit.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# DIVE-3077 — the board WRITE fence, and the runner marker that raises its signal.
+#
+# WHAT THIS GRADES, and why each arm is here rather than only the happy one:
+#
+#   1. The runner exports a marker AT ALL. DIVE-3075 measured the failure mode this
+#      closes: `_task_human_send_allowed` has read FIVEDIVE_TEST since DIVE-1506, and
+#      across 344 harnesses FIVEDIVE_TEST was set by ZERO files. A control that reads
+#      a flag nobody sets is an absent control wearing a control's shape, so "the
+#      predicate exists" is NOT the property to assert — "something raises it" is.
+#
+#   2. The marker the runner exports is NOT FIVEDIVE_TEST. That was the filed fix and
+#      it was measured to break 25 of the 29 harnesses that point
+#      FIVEDIVE_PROD_TASKS_DB at their own fixture store to exercise the SEND
+#      predicate's allowed arm. This arm pins the separation so a later "simplifying"
+#      edit that collapses the two flags back together goes red here instead of in
+#      those 25.
+#
+#   3. The fence REFUSES a marked run writing to the real prod board.
+#   4. The fence ALLOWS a marked run writing to its own throwaway store — the case
+#      nearly every harness in the corpus is, and the one an inverted send-predicate
+#      would have broken.
+#   5. The fence ALLOWS an unmarked run against prod — this is an ORDINARY agent
+#      filing a real row, and a fence that blocked it would be a product outage.
+#      Without this arm every other arm is satisfied by a fence that refuses always.
+#   6. The refusal is ANNOUNCED and non-zero. A silent no-op fence is the same
+#      fail-open shape as no fence (DIVE-1968 assertion 2).
+#   7. FIVEDIVE_PROD_TASKS_DB cannot talk the fence out of the real prod path — the
+#      deliberate asymmetry with the send predicate, asserted so it is not "fixed".
+set -uo pipefail
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+D=$(mktemp -d)
+# DIVE-2692: the corpus HARNESS-RC contract. The temp-dir cleanup is FOLDED IN
+# rather than registered as a second EXIT trap — bash keeps only the last one.
+trap 'rc=$?; rm -rf "$D"; echo "HARNESS-RC=$rc"' EXIT
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 2
+
+PASS=0; FAIL=0
+ok() { printf 'ok   - %s\n' "$1"; PASS=$((PASS+1)); }
+no() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+# ---------------------------------------------------------------- arms 1 and 2
+RUNNER=scripts/run-harnesses.sh
+if grep -Eq '^export FIVEDIVE_HARNESS=1' "$RUNNER"; then
+  ok "the runner exports FIVEDIVE_HARNESS=1 (something raises the signal the fence reads)"
+else
+  no "$RUNNER does not export FIVEDIVE_HARNESS=1 — the fence reads a flag nobody sets"
+fi
+if grep -Eq '^export FIVEDIVE_TEST=' "$RUNNER"; then
+  no "$RUNNER exports FIVEDIVE_TEST — that forces _task_human_send_allowed to refuse regardless of store path and reds the 29 harnesses that simulate prod (measured 25/29)"
+else
+  ok "the runner does NOT export FIVEDIVE_TEST (send rail left alone)"
+fi
+
+# ------------------------------------------------- load the predicate under test
+# Source the built bundle's function in isolation. Sourcing the whole CLI would run
+# its dispatcher, so extract just what this fence needs.
+# Extract to a file and source it: the definition spans continuation lines, which
+# `eval "$(...)"` mangles.
+# NB `_task_real_prod_tasks_db` is a ONE-LINER — its closing brace is not at column
+# 0, so a `/^}/`-terminated range would run past it and swallow the next function.
+grep -E '^_task_real_prod_tasks_db\(\)' src/cmd_task.sh  >"$D/fence.sh"
+sed -n '/^_task_board_write_allowed()/,/^}/p' src/cmd_task.sh >>"$D/fence.sh"
+# shellcheck disable=SC1090
+. "$D/fence.sh"
+
+if ! declare -F _task_board_write_allowed >/dev/null; then
+  no "could not load _task_board_write_allowed out of src/cmd_task.sh"
+  printf '%d passed, %d failed\n' "$PASS" "$FAIL"; exit 1
+fi
+
+# With the seam UNSET the fence must resolve the real board — otherwise every arm
+# below grades a fence pointed at nothing.
+PROD=$(unset FIVEDIVE_FENCE_PROD_DB; _task_real_prod_tasks_db)
+[[ "$PROD" == "/var/lib/5dive/tasks/tasks.db" ]] \
+  && ok "with FIVEDIVE_FENCE_PROD_DB unset the fence's prod path is the REAL board ($PROD)" \
+  || no "unexpected prod path with the seam unset: $PROD"
+
+# From here on, "prod" is a FAKE in a temp dir. The e2e arms drive a real `task add`
+# down the refuse path, and if the fence regresses that call SUCCEEDS — so pointing
+# it at the real board would file a live fixture row on exactly the run that is
+# telling you the guard broke. That happened during this ticket's mutation testing
+# and put DIVE-3084 on the live board. The test for a fence must not be able to
+# commit the act the fence prevents.
+FAKE_PROD="$D/fakeprod/tasks/tasks.db"
+mkdir -p "$D/fakeprod/tasks"
+export FIVEDIVE_FENCE_PROD_DB="$FAKE_PROD"
+PROD="$FAKE_PROD"
+
+# ------------------------------------------------------------------- arms 3-5,7
+for m in FIVEDIVE_HARNESS FIVEDIVE_TEST FIVEDIVE_E2E COUNCIL_MOCK FIVEDIVE_NO_HUMAN_SEND; do
+  ( export "$m=1"; export TASKS_DB="$PROD"; unset FIVEDIVE_PROD_TASKS_DB
+    _task_board_write_allowed ) && rc=0 || rc=1
+  [[ "$rc" == "1" ]] \
+    && ok "REFUSED: $m set + TASKS_DB is the prod board" \
+    || no "$m set + prod board was ALLOWED — the fence is open"
+done
+
+( export FIVEDIVE_HARNESS=1; export TASKS_DB="$D/tasks.db"; _task_board_write_allowed ) && rc=0 || rc=1
+[[ "$rc" == "0" ]] \
+  && ok "ALLOWED: marked run writing to its OWN throwaway store (the normal harness case)" \
+  || no "a marked run was refused against its own store — this would break the corpus"
+
+# The control arm whose expected value is NON-ZERO: without it, a fence that always
+# refuses passes every arm above.
+( unset FIVEDIVE_HARNESS FIVEDIVE_TEST FIVEDIVE_E2E COUNCIL_MOCK FIVEDIVE_NO_HUMAN_SEND
+  export TASKS_DB="$PROD"; _task_board_write_allowed ) && rc=0 || rc=1
+[[ "$rc" == "0" ]] \
+  && ok "ALLOWED: UNMARKED run against the prod board (an ordinary agent filing a real row)" \
+  || no "an unmarked run was refused against prod — the fence is a product outage"
+
+# arm 7: the caller may not redefine what it is being fenced away from.
+( export FIVEDIVE_HARNESS=1; export TASKS_DB="$PROD"
+  export FIVEDIVE_PROD_TASKS_DB="$D/not-prod.db"; _task_board_write_allowed ) && rc=0 || rc=1
+[[ "$rc" == "1" ]] \
+  && ok "FIVEDIVE_PROD_TASKS_DB cannot talk the fence off the real prod path" \
+  || no "an override of FIVEDIVE_PROD_TASKS_DB opened the fence — fail-open by construction"
+
+# --------------------------------------------------- arm 6: announced, end to end
+# Drive the real built CLI, not the extracted function, so the wiring at the
+# cmd_task_add call site is graded and not only the predicate.
+BUNDLE=./5dive
+if [[ -x "$BUNDLE" ]]; then
+  out=$(FIVEDIVE_HARNESS=1 FIVEDIVE_FENCE_PROD_DB="$FAKE_PROD" TASKS_DB="$PROD" TASKS_DIR="$D/fakeprod/tasks" STATE_DIR="$D/fakeprod" "$BUNDLE" task add "fence probe DIVE-3077" 2>&1); rc=$?
+  [[ "$rc" != "0" ]] \
+    && ok "e2e: \`task add\` under the marker against prod EXITS NON-ZERO (rc=$rc)" \
+    || no "e2e: \`task add\` under the marker against prod exited 0 — the row landed"
+  # Match the fence's OWN sentence, not merely a non-zero exit: `task add` has other
+  # rc!=0 paths (an uninitialised store also exits 10), so a bare rc check would be
+  # satisfied by the CLI failing for an unrelated reason.
+  grep -qi 'refusing to write to the production task board' <<<"$out" \
+    && ok "e2e: the refusal is ANNOUNCED by the fence itself, not a silent no-op or an unrelated error" \
+    || no "e2e: no fence refusal in output; got: ${out:0:200}"
+  # And the corresponding non-zero control: the same call against a throwaway store
+  # must SUCCEED, or the arm above is satisfied by the CLI being broken.
+  # tasks_db_init refuses to create TASKS_DIR as non-root, so seed it the way the
+  # rest of the corpus does.
+  mkdir -p "$D/state/tasks"
+  out2=$(FIVEDIVE_HARNESS=1 STATE_DIR="$D/state" TASKS_DIR="$D/state/tasks" \
+         TASKS_DB="$D/state/tasks/tasks.db" \
+         "$BUNDLE" task add "fence control DIVE-3077" 2>&1); rc2=$?
+  [[ "$rc2" == "0" ]] \
+    && ok "e2e control: the same call against a throwaway store SUCCEEDS (rc=0)" \
+    || no "e2e control: throwaway-store add failed rc=$rc2 — ${out2:0:200}"
+else
+  no "no built bundle at $BUNDLE — run ./build.sh first (the e2e arms did not run)"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+# The EXIT trap emits HARNESS-RC — do not echo it here too (DIVE-2692).
+[[ "$FAIL" == "0" ]] || exit 1
+exit 0


### PR DESCRIPTION
Closes DIVE-3077 (out of DIVE-3075).

## What broke

98 test-fixture rows reached the **production** task board in one day, from three
agents, burying a 27-row real backlog inside 128. The cost was not the count, it was
occlusion: a backlog you cannot read is one you cannot triage.

The guard that would have stopped every one of them **already existed and was already
correct** — `_task_human_send_allowed` (DIVE-1506) refuses on
`FIVEDIVE_TEST`/`FIVEDIVE_E2E`/`COUNCIL_MOCK`/`FIVEDIVE_NO_HUMAN_SEND` and fail-closed
compares the active `TASKS_DB` against prod. It is wired to **human sends only**, and
measured across the 344-harness corpus, two of the four sentinels it reads are set by
**zero** files. A control that reads a flag nobody sets is not a weak control; it is an
absent one wearing a control's shape.

## The change

1. `scripts/run-harnesses.sh` exports `FIVEDIVE_HARNESS=1`. One line covers all 344
   harnesses including ones not yet written, and inverts the default from
   opt-**out**-of-prod to opt-**in**: only an invocation that bypasses the runner can
   reach the prod board at all.
2. `_task_board_write_allowed` fences `task add` — refuse iff a test/harness marker is
   set **and** the active `TASKS_DB` is the real prod board.

## Deviation from the filed fix, measured rather than assumed

DIVE-3077 asked for `export FIVEDIVE_TEST=1` in the runner. **That does not work, and
this branch measured it.** `FIVEDIVE_TEST` forces `_task_human_send_allowed` to refuse
*regardless of store path*, and 29 harnesses point `FIVEDIVE_PROD_TASKS_DB` at their own
fixture store precisely to exercise that predicate's ALLOWED arm — simulating prod is
their job.

| runner exports | harnesses failing (of the 29/30) |
|---|---|
| nothing (control) | **0** |
| `FIVEDIVE_TEST=1` (as filed) | **25** |
| `FIVEDIVE_HARNESS=1` (this PR) | **0** |

So the write rail gets its own sentinel instead of overloading the send rail's. For the
same reason the fence resolves prod **without** honouring `FIVEDIVE_PROD_TASKS_DB`: a
fence that lets the caller redefine what it is protecting is fail-open by construction,
and honouring it would refuse those 29 harnesses' writes to their own stores.

## The harness reproduced the defect it guards against

During mutation testing the new harness's e2e arm — which drives a real `task add` down
the refuse path — was pointed at the **real** board. With the fence mutated out, that arm
**wrote live fixture rows**: DIVE-3082, DIVE-3083, DIVE-3084 landed on the production
board and have been cancelled with the reason recorded. A guard whose test commits the
exact act the guard prevents, on its failure path, is worse than no test. Fixed by the
`FIVEDIVE_FENCE_PROD_DB` seam: the harness asserts the fence resolves the real board with
the seam unset, then points it at a fake prod inside its temp dir. Re-verified — the
failure path now writes `DIVE-1` into the throwaway store and nothing to prod.

## Evidence

- `tests/task_board_write_fence_unit.sh` — **14 arms, 14 pass**, green both with and
  without the marker already in the environment.
- **Mutation-tested, 5 mutants, each reproduces a distinct defect and pristine is green:**
  runner exports nothing → 1 red; runner exports `FIVEDIVE_TEST` → 2 red; fence always
  allows → 8 red; fence honours the caller's `FIVEDIVE_PROD_TASKS_DB` → 1 red; call site
  removed from `cmd_task_add` (predicate right, unwired) → 2 red.
- **Two control arms whose expected value is NON-ZERO**, without which every other arm is
  satisfied by a fence that refuses always: an UNMARKED run against prod must still be
  ALLOWED (an ordinary agent filing a real row), and a marked run against its own
  throwaway store must SUCCEED.
- Core tier via `scripts/run-harnesses.sh --tier=core`: **1 failure,
  `tests/grok_freeze_guard_unit.sh`, confirmed PRE-EXISTING** — it fails identically on a
  pristine `origin/main` worktree. `tests/ui_views_e2e.sh` failed on the first run and
  passed on the second with no change; it passes standalone both ways (flake, not
  attributed to this branch).
- Corpus contracts `harness_rc_corpus_contract_unit.sh` and
  `names_the_tree_contract_unit.sh` both green (the new harness violated both on first
  write; fixed here).
- `scripts/pii-scan.sh` over the diff: clean.

## Known limit, recorded rather than smoothed

`bash tests/foo.sh` by hand bypasses the runner, so the marker is a **floor, not a
proof**. The durable fix in that direction is a writer-set scope column as provenance
(DIVE-3075), not a name match on the title — excluding by `title LIKE 'prose %'` is the
same class of mistake as the thing being fenced. This PR also does not cover `task need`,
`task done` or any other board writer; it fences `task add`, which is the writer the 98
rows came through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
