### PR TITLE
fix(guard): compute the harness-tree remediation per-file, and reject a source line that cannot resolve (DIVE-3074)

### DIFF
--- a/scripts/harness-tree-guard.sh
+++ b/scripts/harness-tree-guard.sh
@@ -41,6 +41,11 @@
 #     reporting clear. Nothing was actually checked in that case, and a guard
 #     that reports clean when it checked nothing is worse than no guard.
 #
+# DIVE-3074: the remediation this guard PRINTS is computed per-file, and a source
+# line that matches the regex but cannot RESOLVE is itself a violation. See the
+# rel_grading_tree/source_line_resolves block below for why the text match alone
+# was not the property.
+#
 # Usage: harness-tree-guard.sh <new-rev> [<base-rev>=origin/main]
 # Exit 0 = clear to push. Exit 1 = blocked, reason + fix snippet on stderr.
 set -uo pipefail
@@ -94,22 +99,112 @@ while IFS= read -r line; do
 done <<< "$diff_out"
 (( ${#ADDED[@]} == 0 )) && exit 0
 
-# The exact two functional lines every passing harness carries, plus the
-# short comment explaining the load-bearing absence of `2>/dev/null` (see
-# tests/lib/grading_tree.sh for the full rationale). Safe to hardcode here,
-# unlike inside the contract test itself: this file is not in tests/*.sh, so
-# it is never part of the corpus this snippet's own regex scans, and cannot
-# create the self-matching trap the contract test's comment warns about.
-read -r -d '' FIX_SNIPPET <<'SNIPPET' || true
+# DIVE-3074: THE REMEDIATION IS DEPTH-DEPENDENT, so it is COMPUTED, not fixed.
+#
+# The canonical line `. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh"` is
+# correct only for a file directly in `tests/`. From `tests/meta/` it resolves to
+# `tests/meta/lib/grading_tree.sh` — a path that cannot exist — so the harness
+# prints `grading tree: UNRESOLVED` on every invocation. GRADING_TREE_SOURCE_RE is
+# a TEXT match (`.*lib/grading_tree\.sh`), so the broken paste SATISFIES this guard.
+# An author doing exactly what this guard told them to do got: guard GREEN,
+# property ABSENT, nothing anywhere saying the two disagreed.
+#
+# The same wrongness was already known for ONE directory — see the `tests/lib/*`
+# exclusion above, whose comment spells out the identical `tests/lib/lib/...`
+# arithmetic — and was not generalised. It is generalised here: the guard already
+# knows the path it is refusing, so it can emit the right number of `../`.
+#
+# The comment about the load-bearing absence of `2>/dev/null` (see
+# tests/lib/grading_tree.sh for the full rationale) rides along unchanged.
+# Safe to spell the snippet here, unlike inside the contract test itself: this
+# file is not in tests/*.sh, so it is never part of the corpus this snippet's own
+# regex scans, and cannot create the self-matching trap the contract test warns of.
+
+# rel_grading_tree <path-under-tests> -> the path the snippet must use from that
+# file's own directory, e.g. tests/foo.sh -> lib/grading_tree.sh,
+# tests/meta/foo.sh -> ../lib/grading_tree.sh, tests/a/b/foo.sh -> ../../lib/...
+rel_grading_tree() {
+  local f="$1" dir depth=0
+  dir="$(dirname "$f")"
+  # Anything the guard enumerates is under tests/ by construction (the pathspec).
+  # If that ever stops being true, fall back to the canonical spelling rather
+  # than inventing arithmetic for a path shape nobody has reasoned about.
+  [[ "$dir" == "tests" || "$dir" == tests/* ]] || { printf 'lib/grading_tree.sh'; return; }
+  local rest="${dir#tests}"; rest="${rest#/}"
+  if [[ -n "$rest" ]]; then
+    local IFS=/ part
+    for part in $rest; do [[ -n "$part" && "$part" != "." ]] && depth=$((depth+1)); done
+  fi
+  local up="" i
+  for (( i = 0; i < depth; i++ )); do up+="../"; done
+  printf '%slib/grading_tree.sh' "$up"
+}
+
+# fix_snippet_for <path-under-tests> -> the paste-able block for THAT file.
+fix_snippet_for() {
+  local rel; rel="$(rel_grading_tree "$1")"
+  cat <<SNIPPET
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 # Three-state: if the helper is unreachable (a staged copy that did not carry
 # tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
-# `set -e` harness is not killed by a failed source.
-# NOTE the absence of `2>/dev/null`. Redirecting the source's stderr would also
+# \`set -e\` harness is not killed by a failed source.
+# NOTE the absence of \`2>/dev/null\`. Redirecting the source's stderr would also
 # swallow the helper's own stderr line, which IS the payload.
-. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
-  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+. "\$(dirname "\${BASH_SOURCE[0]}")/$rel" \\
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\\n' >&2
 SNIPPET
+}
+
+# norm_path <slashy/path> -> the same path with `.` and `..` resolved LEXICALLY.
+# Lexical is what we want: the target is a fixed repo path, there are no symlinks
+# in tests/, and we are reasoning about a blob in git, not the working tree.
+norm_path() {
+  local c oldIFS="$IFS"
+  local -a out=() parts=()
+  IFS='/'; read -r -a parts <<< "$1"; IFS="$oldIFS"
+  for c in ${parts[@]+"${parts[@]}"}; do
+    case "$c" in
+      ''|.) ;;
+      ..)
+        if (( ${#out[@]} > 0 )) && [[ "${out[$(( ${#out[@]} - 1 ))]}" != ".." ]]; then
+          out=( ${out[@]+"${out[@]:0:$(( ${#out[@]} - 1 ))}"} )
+        else
+          out+=("..")
+        fi
+        ;;
+      *) out+=("$c") ;;
+    esac
+  done
+  local joined=""
+  for c in ${out[@]+"${out[@]}"}; do joined="${joined:+$joined/}$c"; done
+  printf '%s' "$joined"
+}
+
+# source_line_resolves <file-path> <file-content>
+# Answers: does this file carry a source line that actually REACHES
+# tests/lib/grading_tree.sh — not merely one that matches the text regex?
+#
+# Only the `$(dirname ...)`-relative family can be judged statically, and it is
+# exactly the family this guard prints, so it is exactly the family that can be
+# silently wrong because of this guard. Any OTHER spelling (a $VAR, an absolute
+# path, a computed root) is not judged here: rc 2 = "cannot tell", and the caller
+# defers to CI rather than blocking on a shape it did not reason about.
+#   rc 0 = at least one dirname-relative line resolves to tests/lib/grading_tree.sh
+#   rc 1 = every matching line is dirname-relative and NONE of them resolve
+#   rc 2 = no dirname-relative matching line to judge
+source_line_resolves() {
+  local f="$1" content="$2" dir line sfx judged=0
+  dir="$(dirname "$f")"
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    sfx="$(printf '%s\n' "$line" | sed -n 's|.*dirname[^)]*)\(/[^"]*lib/grading_tree\.sh\).*|\1|p')"
+    [[ -n "$sfx" ]] || continue
+    judged=1
+    [[ "$(norm_path "$dir$sfx")" == "tests/lib/grading_tree.sh" ]] && return 0
+  done < <(printf '%s\n' "$content" | grep -E "$GRADING_TREE_SOURCE_RE")
+  (( judged )) && return 1
+  return 2
+}
 
 fail=0
 for f in "${ADDED[@]}"; do
@@ -118,12 +213,28 @@ for f in "${ADDED[@]}"; do
     fail=1
     continue
   fi
+  violation=""
   if ! printf '%s\n' "$content" | grep -qE "$GRADING_TREE_SOURCE_RE"; then
-    echo "harness-tree-guard: BLOCKED -- $f is a new harness that does not source tests/lib/grading_tree.sh (DIVE-2211 contract)." >&2
+    violation="$f is a new harness that does not source tests/lib/grading_tree.sh (DIVE-2211 contract)."
+  else
+    # DIVE-3074: the text match is not the property. A `$(dirname ...)`-relative
+    # line can satisfy the regex and still resolve nowhere, which prints
+    # "grading tree: UNRESOLVED" forever while every check reads green. Only the
+    # family this guard itself prints is judged; rc 2 (some other spelling) is
+    # deliberately left to CI.
+    source_line_resolves "$f" "$content"
+    case $? in
+      1) violation="$f sources a grading_tree.sh path that CANNOT RESOLVE from $(dirname "$f")/ -- it matches the DIVE-2211 regex but reaches no file, so the harness would print 'grading tree: UNRESOLVED' on every run (DIVE-3074)." ;;
+    esac
+  fi
+  if [[ -n "$violation" ]]; then
+    echo "harness-tree-guard: BLOCKED -- $violation" >&2
     echo "  FIX -- paste this immediately after \`set -uo pipefail\` in $f:" >&2
     echo "" >&2
-    printf '%s\n' "$FIX_SNIPPET" | sed 's/^/      /' >&2
+    fix_snippet_for "$f" | sed 's/^/      /' >&2
     echo "" >&2
+    echo "  The relative path above is computed for THIS file's directory -- the canonical" >&2
+    echo "  \`/lib/grading_tree.sh\` spelling is correct only directly inside tests/." >&2
     echo "  Keep the ABSENCE of \`2>/dev/null\` on the source line: it would swallow the" >&2
     echo "  helper's own stderr line, which IS the payload, and no other check would notice." >&2
     fail=1

--- a/tests/harness_tree_guard_unit.sh
+++ b/tests/harness_tree_guard_unit.sh
@@ -172,5 +172,94 @@ fi
 bash "$GUARD" "$c2" "$c0" >/dev/null 2>&1
 assert_exit "guard: sanity — a valid BASE right beside the bad one above still passes a compliant add" 0 "$?"
 
+# --- DIVE-3074: the printed remediation is DEPTH-DEPENDENT ---------------
+# The canonical `")/lib/grading_tree.sh"` is correct ONLY for a file directly in
+# tests/. From tests/meta/ it resolves to tests/meta/lib/grading_tree.sh, which
+# cannot exist -- yet it still SATISFIES the text regex. An author who pasted
+# exactly what this guard printed got guard GREEN and property ABSENT, with the
+# harness printing `grading tree: UNRESOLVED` on every run and nothing saying so.
+# Measured on tests/meta/harness-graded-union.sh (DIVE-3017), the first file added
+# under tests/meta/ since this guard shipped.
+
+git checkout -q "$c0"
+
+NESTED_GOOD='#!/usr/bin/env bash
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/../lib/grading_tree.sh" \
+  || printf "grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n" >&2
+echo hi'
+
+# A spelling this guard cannot statically judge (no $(dirname ...)): it must be
+# ALLOWED, not blocked. Deliberate negative control on the resolution check --
+# without it, "blocks the nested case" is satisfied by a check that blocks
+# everything it does not recognise.
+VAR_PATH_HARNESS='#!/usr/bin/env bash
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/tests/lib/grading_tree.sh" \
+  || printf "grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n" >&2
+echo hi'
+
+mkdir -p tests/meta
+m1="$(commit_add_harness "meta/nested_missing_unit.sh" "$BAD_HARNESS" "add a nested harness with no source line")"
+out="$(bash "$GUARD" "$m1" "$c0" 2>&1)"; rc=$?
+assert_exit "guard: blocks a new tests/meta/ harness missing the source line" 1 "$rc"
+if [[ "$out" == *'. "$(dirname "${BASH_SOURCE[0]}")/../lib/grading_tree.sh"'* ]]; then
+  ok_t "guard: prints a ../lib/ remediation for a file one level under tests/"
+else
+  bad_t "guard: prints a ../lib/ remediation for a file one level under tests/" "$out"
+fi
+if [[ "$out" != *'"${BASH_SOURCE[0]}")/lib/grading_tree.sh'* ]]; then
+  ok_t "guard: does NOT print the depth-0 spelling for a nested file"
+else
+  bad_t "guard: does NOT print the depth-0 spelling for a nested file" "$out"
+fi
+
+git checkout -q "$c0"
+mkdir -p tests/a/b
+m2="$(commit_add_harness "a/b/deep_missing_unit.sh" "$BAD_HARNESS" "add a two-level-deep harness with no source line")"
+out="$(bash "$GUARD" "$m2" "$c0" 2>&1)"
+if [[ "$out" == *'. "$(dirname "${BASH_SOURCE[0]}")/../../lib/grading_tree.sh"'* ]]; then
+  ok_t "guard: prints ../../lib/ for a file two levels under tests/"
+else
+  bad_t "guard: prints ../../lib/ for a file two levels under tests/" "$out"
+fi
+
+# THE CLASS-CLOSING CASE: the file carries the guard's OWN canonical line, so the
+# text regex is satisfied -- and the path reaches nothing. Before DIVE-3074 this
+# exited 0.
+git checkout -q "$c0"
+mkdir -p tests/meta
+m3="$(commit_add_harness "meta/nested_unresolvable_unit.sh" "$GOOD_HARNESS" "nested harness carrying the depth-0 line (matches, resolves nowhere)")"
+out="$(bash "$GUARD" "$m3" "$c0" 2>&1)"; rc=$?
+assert_exit "guard: BLOCKS a nested harness whose source line matches but CANNOT RESOLVE" 1 "$rc"
+if [[ "$out" == *"CANNOT RESOLVE"* ]]; then
+  ok_t "guard: names the unresolvable-path failure distinctly from a missing line"
+else
+  bad_t "guard: names the unresolvable-path failure distinctly from a missing line" "$out"
+fi
+
+# ...and the corrected spelling passes, so the block above is about resolution
+# and not simply about being under tests/meta/.
+git checkout -q "$c0"
+mkdir -p tests/meta
+m4="$(commit_add_harness "meta/nested_ok_unit.sh" "$NESTED_GOOD" "nested harness with the depth-correct line")"
+bash "$GUARD" "$m4" "$c0" >/dev/null 2>&1
+assert_exit "guard: allows a nested harness whose ../lib/ line actually resolves" 0 "$?"
+
+# Negative control for the resolution check: an unjudgeable spelling is deferred
+# to CI, not blocked.
+git checkout -q "$c0"
+mkdir -p tests/meta
+m5="$(commit_add_harness "meta/nested_varpath_unit.sh" "$VAR_PATH_HARNESS" "nested harness sourcing via a computed \$ROOT")"
+bash "$GUARD" "$m5" "$c0" >/dev/null 2>&1
+assert_exit "guard: does not block a spelling it cannot statically judge (defers to CI)" 0 "$?"
+
+# Regression: depth 0 is unchanged -- the canonical line still passes in tests/.
+git checkout -q "$c0"
+r0="$(commit_add_harness "still_fine_unit.sh" "$GOOD_HARNESS" "depth-0 harness, canonical line")"
+bash "$GUARD" "$r0" "$c0" >/dev/null 2>&1
+assert_exit "guard: regression — the canonical line still passes directly in tests/" 0 "$?"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 (( FAIL == 0 ))


### PR DESCRIPTION
Closes DIVE-3074.

## The defect

`scripts/harness-tree-guard.sh` printed exactly one remediation, regardless of where the offending file lived:

```
. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
  || printf 'grading tree: UNRESOLVED (...)\n' >&2
```

That is correct only for a file directly in `tests/`. From `tests/meta/` it resolves to `tests/meta/lib/grading_tree.sh` — a path that cannot exist — so the `||` branch fires and the harness prints `grading tree: UNRESOLVED` on every invocation.

`GRADING_TREE_SOURCE_RE` is a **text** match (`.*lib/grading_tree\.sh`), so the broken paste **satisfies the guard**. An author who did exactly what the guard told them to do got: guard GREEN, property ABSENT, and no signal anywhere that the two disagreed. DIVE-2211's whole subject is "no log can be silent about which tree it graded"; the printed fix produced a log that is silent about it, in the approved spelling.

The same arithmetic was already known for **one** directory — the `:(exclude)tests/lib/*` comment spells out the identical `tests/lib/lib/...` case — and was not generalised.

## The change

1. **`rel_grading_tree()` / `fix_snippet_for()`** — the remediation is computed from the offending file's own directory (`lib/`, `../lib/`, `../../lib/`, …). The guard already knew the path it was refusing.
2. **`source_line_resolves()`** — makes **resolution** the property, not the text. Only the `$(dirname ...)`-relative family is judged, because that is exactly the family this guard prints and therefore exactly the family it can make silently wrong. Any other spelling (a `$VAR`, an absolute path, a computed root) returns "cannot tell" and is **deferred to CI**, not blocked on a shape nobody reasoned about.

This is suggestion 1 plus a scoped form of suggestion 2 from the ticket. Suggestion 3 (backfilling the grandfathered `tests/meta/*.sh`) is deliberately **not** done here — the ticket calls it lower-value and a separate decision.

## Verification

- `tests/harness_tree_guard_unit.sh`: **22/22** (9 new). Includes a deliberate **negative control** — a `$ROOT`-computed source line under `tests/meta/` must still PASS, so "blocks the nested case" cannot be satisfied by a check that blocks everything it fails to recognise.
- **Mutation-tested per half, disjoint failures:** reverting the depth computation → 19/22 (fails the 3 remediation-shape tests); stubbing `source_line_resolves` to always-OK → 20/22 (fails the 2 resolution tests). Neither half is carried by the other's tests.
- **Real-world replay, in an isolated clone**, against `12a5c6a` — the actual DIVE-3017 commit that added `tests/meta/harness-graded-union.sh`: **rc 0** as shipped (`../lib/`, resolves); **rc 1** on a counterfactual carrying the depth-0 line, with the correct `CANNOT RESOLVE` message and a remediation offering `../lib/`.
- Whole-corpus contract `tests/names_the_tree_contract_unit.sh`: green, 347 harnesses.
- `shellcheck -S warning scripts/harness-tree-guard.sh`: clean.

graded-sha: 7951e22e2e224e44d8623efae1866d479e470700

🤖 Generated with [Claude Code](https://claude.com/claude-code)
