### PR TITLE
fix(push): a markdown-quoted Branch: value can no longer make a cleared gate unsatisfiable (DIVE-3081)

### DIFF
--- a/src/cmd_push.sh
+++ b/src/cmd_push.sh
@@ -45,10 +45,18 @@ _push_expected_author() {
 
 # _push_branch_from_body <body> — pull a "Branch: <name>" line out of a task
 # body (case-insensitive, first match). Empty if absent.
+#
+# DIVE-3081: strips a markdown/quote wrapper via broker_strip_md_quotes, and MUST
+# keep doing so in lockstep with broker_task_target's use of the same helper — the
+# DIVE-1462 refusal compares this function's value against the broker's, so a
+# strip applied to only one side still refuses, just with a different pair of
+# look-alike names. Same reason the helper is shared rather than inlined.
 _push_branch_from_body() {
+  local raw
   # `|| true` so a no-match grep can't trip `set -euo pipefail` when this runs
   # inside a command substitution (branch=$(...)).
-  printf '%s\n' "$1" | grep -ioP '^\s*branch:\s*\K\S+' | head -1 || true
+  raw=$(printf '%s\n' "$1" | grep -ioP '^\s*branch:\s*\K\S+' | head -1 || true)
+  broker_strip_md_quotes "$raw"
 }
 
 # _push_repo_slug <url> — OWNER/REPO from an https/ssh github URL, no .git.

--- a/src/lib/broker.sh
+++ b/src/lib/broker.sh
@@ -70,6 +70,14 @@ broker_surface() {
     push.target)   printf 'branch' ;;
     push.ask)      printf 'approve delegated push for review of branch <b>' ;;
     push.ticket)   printf 'DIVE-1462' ;;
+    # DIVE-3081: the verb that OWNS the body line, named in the look-alike-values
+    # refusal so the reader is pointed at the canonical writer instead of hand-
+    # editing the body again (hand-editing is how the malformed value got in).
+    # Empty is a legal answer — deploy has no such verb yet, and the refusal then
+    # just omits the repair sentence rather than naming a command that does not
+    # exist. Any surface added here must answer this field.
+    push.fixcmd)   printf '5dive task set-branch' ;;
+    deploy.fixcmd) printf '' ;;
     deploy.noun)   printf 'deploy' ;;
     deploy.Noun)   printf 'Deploy' ;;
     deploy.cap)    printf 'delegated_deploy' ;;
@@ -248,6 +256,43 @@ broker_gate_sig_note() {
   esac
 }
 
+# broker_strip_md_quotes <value> — DIVE-3081. Drop the markdown/quote wrapper a
+# human reflexively puts around a value that lives in a PROSE body.
+#
+# The `<Key>: <value>` line is simultaneously human prose (it renders as markdown
+# on the dashboard) and a machine binding (it is the value a cleared gate binds
+# to). A maker note that opens "Branch: `my-branch` — head `abc123`, PR #521" is
+# the natural way to write the first and an unsatisfiable value for the second:
+# `\S+` keeps the backticks, and no git ref can ever equal `` `my-branch` ``. The
+# gate is answered, the push refuses with DIVE-1462's ANTI-SUBSTITUTION error, and
+# the two names it quotes differ only by two invisible characters — so the error
+# reads as "the binding is stale, re-file the gate" and spends a second human tap
+# for zero semantic change. See
+# community/wiki/a-markdown-quoted-value-cannot-satisfy-a-machine-read-binding.md
+#
+# Symmetric by construction: the ONLY safe fix is one both readers of the line
+# apply, because the refusal compares two independently-parsed values. Stripping
+# in one parser and not the other converts an unsatisfiable binding into a
+# DIFFERENT unsatisfiable binding. Hence one function, called by both
+# broker_task_target (the authoritative bound value) and _push_branch_from_body
+# (the value push derives to act on). Do not inline this.
+#
+# Strips only PAIRED wrappers, and only ones no legal git ref name can contain
+# anyway (backtick, single/double quote, <>, and a trailing markdown comma/period
+# is NOT stripped — a ref may legally end in a period-free token and we refuse to
+# guess where prose ends). An unpaired leading backtick is left alone: that is a
+# malformed line, and a value we silently half-repaired is worse than a refusal.
+broker_strip_md_quotes() {
+  local v="$1"
+  case "$v" in
+    '`'*'`')  v="${v#\`}"; v="${v%\`}" ;;
+    '"'*'"')  v="${v#\"}"; v="${v%\"}" ;;
+    "'"*"'")  v="${v#\'}"; v="${v%\'}" ;;
+    '<'*'>')  v="${v#<}";  v="${v%>}"  ;;
+  esac
+  printf '%s' "$v"
+}
+
 # broker_task_target <surface> <id> — the target a task AUTHORITATIVELY declares
 # via a "<Key>: <value>" line in its body. Empty if the task names none. This is
 # the server-side value a cleared gate binds to, read fresh from the DB.
@@ -255,9 +300,11 @@ broker_task_target() {
   local surface="$1" id="$2"
   local key; key=$(broker_surface "$surface" key)
   local body; body=$(db "SELECT COALESCE(body,'') FROM tasks WHERE id=${id};")
+  local raw
   # `|| true` so a no-match grep can't trip `set -euo pipefail` when this runs
   # inside a command substitution.
-  printf '%s\n' "$body" | grep -ioP "^\s*${key}:\s*\K\S+" | head -1 || true
+  raw=$(printf '%s\n' "$body" | grep -ioP "^\s*${key}:\s*\K\S+" | head -1 || true)
+  broker_strip_md_quotes "$raw"
 }
 
 # broker_bind_target <surface> <id> <ident> <value> — DIVE-1462 (STEER-4),
@@ -281,7 +328,25 @@ broker_bind_target() {
     fail "$E_VALIDATION" "task ${ident} declares no ${target} — add a '${key}: <name>' line to its body so the cleared gate binds to a specific ${target} (delegated ${noun} refuses an unbound ${target})."
   fi
   if [[ "$value" != "$task_value" ]]; then
-    fail "$E_VALIDATION" "${target} '${value}' is not the ${target} bound to ${ident}'s cleared gate ('${task_value}') — a cleared gate authorizes only its task's own declared ${target}. ${Noun} refused (${ticket})."
+    # DIVE-3081: this refusal is DIVE-1462's anti-substitution guard, so its plain
+    # reading is "someone is acting on the wrong ${target}" and the natural repair
+    # is to re-file the gate — a second human tap. But when the two values differ
+    # only in characters that do not survive a glance (a leftover markdown wrapper,
+    # a stray quote, a trailing CR from a pasted body), the binding is not stale and
+    # re-filing changes nothing. Say so INSIDE the refusal: the reader is looking at
+    # two strings they have already decided are identical, and asking them to diff
+    # bytes only works if something tells them to. Cheap comparison, and it fires
+    # only on the look-alike case — a genuinely different ${target} gets the plain
+    # message, unchanged.
+    local hint="" a b fixcmd
+    a=$(printf '%s' "$value"      | tr -d '`'"'"'"<>[](),. \r\t')
+    b=$(printf '%s' "$task_value" | tr -d '`'"'"'"<>[](),. \r\t')
+    if [[ -n "$a" && "$a" == "$b" ]]; then
+      hint=" NOTE: these two differ only in punctuation/whitespace, so the binding is NOT stale and re-filing the gate will not change that — the declared '${key}:' line is malformed."
+      fixcmd=$(broker_surface "$surface" fixcmd)
+      [[ -n "$fixcmd" ]] && hint+=" Rewrite it with the verb that owns it: ${fixcmd} ${ident} ${a}"
+    fi
+    fail "$E_VALIDATION" "${target} '${value}' is not the ${target} bound to ${ident}'s cleared gate ('${task_value}') — a cleared gate authorizes only its task's own declared ${target}. ${Noun} refused (${ticket}).${hint}"
   fi
 }
 

--- a/tests/push_branch_binding_md_quotes_unit.sh
+++ b/tests/push_branch_binding_md_quotes_unit.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# DIVE-3081 — a markdown-quoted value cannot satisfy a machine-read binding.
+#
+# THE DEFECT. The `Branch: <name>` line in a task body is simultaneously human
+# prose (it renders as markdown on the dashboard) and a machine binding (it is the
+# value DIVE-1462's cleared-gate check binds a push to). Both readers parsed it
+# with `\S+`, which keeps a markdown wrapper. A maker note opening
+#
+#     Branch: `dive-2813-ui-once-cleanup-and-race` — head `fd81f7b`, PR #521
+#
+# therefore bound the gate to a string no git ref can equal. The gate was answered
+# and correct; the push refused with the ANTI-SUBSTITUTION error, whose two quoted
+# names differ only by two invisible characters — so it reads as "the binding is
+# stale, re-file the gate", spending a second human tap for zero semantic change.
+#
+# WHAT THIS FILE GRADES, and why all three arms are needed. The refusal compares
+# two INDEPENDENTLY-PARSED values: `_push_branch_from_body` (cmd_push.sh — the
+# value push derives to act on) against `broker_task_target` (lib/broker.sh — the
+# authoritative bound value). Fixing one parser and not the other does not fix the
+# bug, it produces a DIFFERENT unsatisfiable binding, which is why arm A and arm B
+# are separate arms over separate functions and arm C grades them agreeing
+# end-to-end through the real `broker_bind_target`.
+#
+# MUTATION EVIDENCE — four mutants, one per part of the fix, MEASURED on this file
+# (a green suite proves nothing about whether it can go red). Pristine tree:
+# PASS=17 FAIL=0. Each mutant reproduces the DEFECT — an unsatisfiable binding, or
+# a refusal that misattributes one — not merely a changed string:
+#
+#   m1  drop the strip in _push_branch_from_body   -> 5 red: A(x4) + C1
+#   m2  drop the strip in broker_task_target       -> 7 red: B(x2) + C1 + C2 + D(x3)
+#   m3  broker_strip_md_quotes -> pass-through     -> 11 red: A + B + C + D
+#   m4  blank the look-alike `hint`                -> 2 red: D's NOTE arms
+#
+# Two results here are load-bearing and were NOT what I predicted before running:
+#   * m1 kills only C1, never C2. C2 hands the binder a bare ref and so cannot see
+#     a broken cmd_push parser at all. C1 exists because of that measurement — on
+#     the first draft of this file (C2 alone) a one-sided fix in cmd_push.sh left
+#     the whole end-to-end section GREEN, which is the very "fixed one of the two
+#     readers" trap this bug is made of, reproduced inside its own regression test.
+#   * m4 is a PARTIAL mutant: blanking `hint` leaves the later `hint+=` appending
+#     the repair sentence, so D's third arm survives. Recorded as partial rather
+#     than dressed up as a clean kill; the NOTE arms do go red, which is the claim.
+#
+# See community/wiki/a-markdown-quoted-value-cannot-satisfy-a-machine-read-binding.md
+#
+# Run: bash tests/push_branch_binding_md_quotes_unit.sh   (no root, no network.)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/push-md-quotes-unit.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh \
+         lib/registry.sh lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh \
+         cmd_project.sh cmd_push.sh; do
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"
+TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"
+set +e   # header.sh enabled `set -e`; these arms expect non-zero exits
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+want()  { if eval "$2"; then ok_t "$1"; else bad_t "$1" "${3:-}"; fi; }
+
+tasks_db_init
+mk() { # mk <body> -> task id, body set verbatim (the HAND-EDITED path, which is
+       # how the real one got in: `task set-branch` and `task add --branch` both
+       # already validate, so they cannot produce these bodies.)
+  local id; id=$( (cmd_task_add --assignee=alice -- "binding fixture") 2>/dev/null | jq -r '.data.id' )
+  db "UPDATE tasks SET body=$(sqlq "$1") WHERE id=${id};"
+  printf '%s' "$id"
+}
+
+BR=dive-2813-ui-once-cleanup-and-race
+PROSE=$'Branch: `'"$BR"$'` — head `fd81f7b`, PR #521, all 24 check-runs green.\n'
+
+echo "== A. cmd_push.sh's parser (_push_branch_from_body)"
+want "backticked prose line yields the BARE ref" \
+     "[[ \"\$(_push_branch_from_body \"\$PROSE\")\" == \"\$BR\" ]]" \
+     "got: $(_push_branch_from_body "$PROSE")"
+want "double-quoted value yields the bare ref" \
+     "[[ \"\$(_push_branch_from_body 'Branch: \"feat/x\"')\" == 'feat/x' ]]"
+want "single-quoted value yields the bare ref" \
+     "[[ \"\$(_push_branch_from_body \"Branch: 'feat/x'\")\" == 'feat/x' ]]"
+want "angle-bracketed value yields the bare ref" \
+     "[[ \"\$(_push_branch_from_body 'Branch: <feat/x>')\" == 'feat/x' ]]"
+# Regression fence: the pre-existing contract must not move.
+want "a BARE value is untouched" \
+     "[[ \"\$(_push_branch_from_body 'Branch: feat/x')\" == 'feat/x' ]]"
+want "case + leading/trailing space still tolerated" \
+     "[[ \"\$(_push_branch_from_body '  branch:   feat/x  ')\" == 'feat/x' ]]"
+want "no Branch: line is still EMPTY (not a spuriously-stripped value)" \
+     "[[ -z \"\$(_push_branch_from_body 'no binding here')\" ]]"
+# An UNPAIRED wrapper is malformed, and half-repairing it would bind a push to a
+# value nobody wrote. Refusing beats guessing, so it must survive verbatim.
+want "an UNPAIRED leading backtick is NOT half-stripped" \
+     "[[ \"\$(_push_branch_from_body 'Branch: \`feat/x')\" == '\`feat/x' ]]"
+
+echo
+echo "== B. the broker's authoritative parser (broker_task_target)"
+idp=$(mk "$PROSE")
+want "broker_task_target strips the same wrapper on the same body" \
+     "[[ \"\$(broker_task_target push \$idp)\" == \"\$BR\" ]]" \
+     "got: $(broker_task_target push "$idp")"
+idd=$(mk $'Deploy: `app@feat/x`\n')
+want "the strip is surface-generic (deploy's own key too)" \
+     "[[ \"\$(broker_task_target deploy \$idd)\" == 'app@feat/x' ]]"
+
+echo
+echo "== C. THE BUG, end to end: a cleared gate's binding is SATISFIABLE"
+# C1 reproduces cmd_push's ACTUAL sequence (cmd_push.sh: derive the branch from
+# the body with _push_branch_from_body, then _push_bind_branch it), so it is the
+# arm that goes red on a strip applied to EITHER parser alone. C2 hands the bare
+# ref straight to the binder, isolating the broker side. Measured: without C1, a
+# one-sided fix in cmd_push.sh leaves this whole section green (see m1 above) —
+# which is the same "fixed one of two readers" trap the bug itself is made of.
+derived=$(_push_branch_from_body "$(db "SELECT COALESCE(body,'') FROM tasks WHERE id=${idp};")")
+out1=$( (broker_bind_target push "$idp" DIVE-3081 "$derived") 2>&1 ); rc1=$?
+want "C1 the real push path (parse body -> bind) is ACCEPTED (rc=0)" \
+     "[[ $rc1 -eq 0 ]]" "derived='$derived' rc=$rc1: $out1"
+out=$( (broker_bind_target push "$idp" DIVE-3081 "$BR") 2>&1 ); rc=$?
+want "C2 pushing the real branch named in a backticked body is ACCEPTED (rc=0)" \
+     "[[ $rc -eq 0 ]]" "rc=$rc: $out"
+# The guard must still guard: DIVE-1462 is a security control, not a formatter.
+out2=$( (broker_bind_target push "$idp" DIVE-3081 some-other-branch) 2>&1 ); rc2=$?
+want "a genuinely DIFFERENT branch is still refused (rc!=0)" "[[ $rc2 -ne 0 ]]" "$out2"
+
+echo
+echo "== D. the refusal names a look-alike difference instead of implying staleness"
+# Force the one-sided case the fix is meant to make impossible, so the hint is
+# graded on its own: parse the body, then hand bind the WRAPPED value directly.
+wrapped='`'"$BR"'`'
+outh=$( (broker_bind_target push "$idp" DIVE-3081 "$wrapped") 2>&1 )
+want "look-alike values get the punctuation NOTE" \
+     "[[ \"\$outh\" == *'differ only in punctuation/whitespace'* ]]" "$outh"
+want "...and say re-filing the gate will NOT help" \
+     "[[ \"\$outh\" == *'binding is NOT stale'* ]]" "$outh"
+want "...and name the verb that owns the line" \
+     "[[ \"\$outh\" == *'5dive task set-branch'* ]]" "$outh"
+# Absence-assertion, graded so it cannot pass on empty output (the arm above
+# proves outh is non-empty): a real mismatch must NOT be excused as punctuation.
+want "a genuinely different branch does NOT get the NOTE" \
+     "[[ -n \"\$out2\" && \"\$out2\" != *'differ only in punctuation'* ]]" "$out2"
+
+echo
+printf 'PASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Closes DIVE-3081.

## The defect

The `Branch: <name>` line in a task body is at once **human prose** (it renders as markdown on the dashboard) and a **machine binding** (it is the value DIVE-1462's cleared-gate check binds a push to). Both readers parsed it with `\S+`, which keeps a markdown wrapper. A maker note opening

```
Branch: `dive-2813-ui-once-cleanup-and-race` — head `fd81f7b`, PR #521, all 24 check-runs green.
```

bound the gate to a string **no git ref can ever equal**. The gate was answered and correct; the push refused with the anti-substitution error, whose two quoted names differ only by two invisible characters — so it read as *"the binding is stale, re-file the gate"* and spent a second human tap for zero semantic change.

## The non-obvious part: the fix has to be symmetric

The ticket suggested stripping in `_push_branch_from_body`. That alone does **not** fix it. The refusal compares two **independently-parsed** values:

| reader | file | role |
|---|---|---|
| `_push_branch_from_body` | `src/cmd_push.sh` | the value push derives to act on (`cmd_push.sh`, branch resolution) |
| `broker_task_target` | `src/lib/broker.sh` | the **authoritative** bound value quoted in the refusal |

Stripping one and not the other converts an unsatisfiable binding into a *different* unsatisfiable binding. Hence one shared `broker_strip_md_quotes`, called by both — not an inlined regex in each, which is exactly the fork INST-5 consolidated away.

## What changed

- **`broker_strip_md_quotes`** (`src/lib/broker.sh`) — strips only **paired** wrappers, and only ones no legal git ref can contain (`` ` ``, `"`, `'`, `<>`). An **unpaired** wrapper survives verbatim: that line is malformed, and binding a push to a value nobody wrote is worse than refusing. Called by both parsers.
- **The refusal now distinguishes a look-alike from a substitution** (`broker_bind_target`). When the two values differ only in punctuation/whitespace it says so, says re-filing the gate will not help, and names the verb that owns the line (`5dive task set-branch <ident> <branch>`). The reader is staring at two strings they have already decided are identical; diffing bytes only occurs to them if something says to. A genuinely different branch gets the plain message, **unchanged**, and is still refused — DIVE-1462 is a security control, not a formatter.
- **`push.fixcmd` / `deploy.fixcmd`** added to `broker_surface`. Empty is a legal answer (deploy has no such verb yet) and the refusal then omits the repair sentence rather than naming a command that does not exist.

Suggestion (b) from the ticket — validate at declaration time — was **already closed**: `task set-branch` and `task add --branch` both validate the ref name against `^[A-Za-z0-9][A-Za-z0-9._/-]*$`. The uncovered path is a **hand-edited body**, which is how this one got in, so the parser-tolerance fix is the one that had to land.

## How it was checked

`tests/push_branch_binding_md_quotes_unit.sh` — **17 arms, PASS=17 FAIL=0**, no root, no network. Covers both parsers separately (A, B), end-to-end through the real `broker_bind_target` (C), and the refusal text (D), plus regression fences that a bare value, case/whitespace tolerance, an absent line, and an unpaired wrapper all behave as before.

**Mutation evidence — measured, not asserted:**

| mutant | result |
|---|---|
| m1 drop the strip in `_push_branch_from_body` | 5 red: A(×4) + C1 |
| m2 drop the strip in `broker_task_target` | 7 red: B(×2) + C1 + C2 + D(×3) |
| m3 `broker_strip_md_quotes` → pass-through | 11 red: A + B + C + D |
| m4 blank the look-alike `hint` | 2 red: D's NOTE arms |

Two results were **not** what I predicted before running, and both are recorded in the test header:

- **m1 kills only C1, never C2.** C2 hands the binder a bare ref and cannot see a broken `cmd_push` parser at all. C1 exists *because of that measurement* — the first draft of this file (C2 alone) stayed **green** under a one-sided fix in `cmd_push.sh`, reproducing this bug's own "fixed one of two readers" trap inside its own regression test.
- **m4 is a partial mutant** — blanking `hint` leaves the later `hint+=` appending the repair sentence, so D's third arm survives. Recorded as partial rather than dressed up as a clean kill.

**Neighbouring suites, on this branch:**

- `tests/broker_surface_unit.sh` — **68 passed, 0 failed.** This is the standing pinned-baseline fence asserting push's refusal text and exit statuses have not moved since before INST-5. It is green because no existing arm uses a wrapped value, so the change is inert on every path that was already working. **The pin did not need moving.**
- `tests/task_set_branch_unit.sh` — **8 passed, 0 failed.**
- `shellcheck -S warning` on both changed files — every finding is pre-existing (lines 1, 226, 345, 376, 438); none in added code.
- `scripts/pii-scan.sh` — clean.

## Not covered

No smoke run: this touches no provisioning or key-sync path, and the harness is unavailable on this host per DIVE-2847. The change is control-plane-only shell with unit coverage and a differential fence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
