### PR TITLE
fix(task): surface cited-not-delivered as a PRE-close check, not a warning that arrives with the close (DIVE-2096)

### DIFF
--- a/changelog.d/DIVE-2096.md
+++ b/changelog.d/DIVE-2096.md
@@ -1,0 +1,32 @@
+## Unreleased — fix(task): surface cited-not-delivered BEFORE the close, not with it (DIVE-2096)
+
+Two agents hit the identical wall from opposite sides inside ~2h on 2026-07-26 — olivia on
+DIVE-2064, main on DIVE-2080. main closed, and the merge-gate warned **in the same breath as
+closing** that PR #209 was CITED not DELIVERED, so nothing bound it and its merge state was
+never checked. `done` then froze the body, so the record could not be repaired, and the only
+remedy the warning could name — bounce it back to the maker to fix the verifier's own
+metadata — is wildly disproportionate to the error. Two operators, one tool defect: the
+diagnosis and the point of no return arrived together, and nothing anywhere hinted at the
+correct sequence (merge → `task deliver --pr` → `done`) while there was still time to follow it.
+
+`task done` now **refuses, pre-commit**, when the result/body names a pull request and
+**nothing binds one to the task** — no `delivery_ref`, no `Branch:` line — and names the
+remedy with the ident already filled in. Status, result and body are untouched by the refusal,
+which is the entire point: the record is still repairable.
+
+**The shape is ordering, not inference.** DIVE-1962 was CANCELLED for proposing to infer the
+binding from a PR number in prose, because that overclaims — an incidental number stamps an
+unrelated close UNVERIFIED. So prose is the **trigger** for the prompt and never the **source**
+of the binding: nothing reads the number into `delivery_ref`, and a test arm pins that. DIVE-1965's
+delivered-vs-cited distinction is likewise untouched — this refuses, it never reclassifies.
+
+Escapes, both audited: `--no-pr` is the named opt-out for DIVE-1965's genuine reports-on
+category (a review, triage, audit or coordination close that ships no code of its own), and
+`--force-merge-gate` overrides as it does everywhere else. `--no-pr` is a **claim about the
+close**, so it lands a `task.done-no-pr` audit row — an unrecorded assertion is
+indistinguishable from a bypass when someone reads the row back later.
+
+Mutation-graded (`tests/task_done_cited_preclose_unit.sh`, 19 arms): the harness re-runs itself
+against two mutant trees — the pre-check neutered, and the `--no-pr` opt-out neutered — and
+**requires each to red**, because assertions about a refusal and about absences of one both pass
+trivially against a build where the check does nothing.

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -3467,6 +3467,7 @@ _task_status_cmd() {
   local newstatus="$1" extra="$2" verb="$3"; shift 3
   tasks_db_init
   local result="" want_result=0 notify=0 no_preflight=0 force_merge_gate=0 keep_wt=0
+  local no_pr=0                          # DIVE-2096: "this close REPORTS ON a PR, it delivers none"
   local append_result=0 force_result=0   # DIVE-2464
   # DIVE-1955 (review, Marcus): every reason the merge-gate could NOT reach an answer,
   # accumulated so the close can be stamped UNVERIFIED in the DURABLE RECORD. A stderr
@@ -3494,6 +3495,11 @@ _task_status_cmd() {
       --notify)       notify=1 ;;
       --no-preflight) no_preflight=1 ;;
       --force-merge-gate) force_merge_gate=1 ;;  # DIVE-1835: audited escape from the mandatory auto-detect gate
+      # DIVE-2096: the NAMED opt-out for DIVE-1965's reports-on category. Distinct
+      # from --force-merge-gate on purpose: that one overrides a gate that RAN and
+      # disagreed; this one ASSERTS a fact about the close ("no PR is mine to bind"),
+      # which is a claim the operator can be held to and the audit row records.
+      --no-pr)        no_pr=1 ;;
       # DIVE-1967: opt OUT of the node_modules reclaim a close performs (you are
       # about to reuse the worktree and do not want to pay for another npm ci).
       --keep-worktree) keep_wt=1 ;;
@@ -4040,6 +4046,61 @@ _task_status_cmd() {
     _task_slug=$(_gate_task_repo_slug "$_dref" "$_body")
     if [[ -z "$_dref" ]]; then
       _branch=$(_push_branch_from_body "$_body")
+    fi
+    # -----------------------------------------------------------------------
+    # DIVE-2096 — THE ORDERING PRE-CHECK: cited-not-delivered, BEFORE the close.
+    #
+    # Two agents hit the identical wall from opposite sides inside ~2h on
+    # 2026-07-26 (olivia on DIVE-2064, main on DIVE-2080). That is a tool defect,
+    # not two operator slips. The DIVE-2414 disclosure below already MEASURES a
+    # cited PR's state and says so — but it says so in the same breath as the
+    # close, and `done` freezes the body. The diagnosis and the point of no
+    # return arrive together, so the only remedy the warning can name (bounce it
+    # back to the maker to fix the verifier's own metadata) is wildly
+    # disproportionate to the error. Nothing anywhere hints at the correct
+    # sequence — merge -> `task deliver --pr` -> `done` — until it is too late to
+    # act on it. This is that hint, moved to the moment it is still actionable.
+    #
+    # THE SHAPE IS ORDERING, NOT INFERENCE, and that boundary is load-bearing:
+    #   * DIVE-1965 (done) deliberately separates a PR the task DELIVERED from one
+    #     it merely REPORTS ON. Kept intact — this refuses, it does not reclassify.
+    #   * DIVE-1962 (CANCELLED) proposed INFERRING the binding from a PR number in
+    #     prose. It was cancelled because that OVERCLAIMS: an incidental number
+    #     stamps an unrelated close UNVERIFIED. So prose is the TRIGGER for the
+    #     prompt and NEVER the SOURCE of the binding. Nothing below reads the
+    #     number into `delivery_ref`; the operator does that, with `task deliver`,
+    #     and only they can say which of the named refs is theirs.
+    #
+    # FIRES ONLY WITH NO DECLARED BINDING AT ALL — neither `delivery_ref` nor a
+    # `Branch:` line. Both are structured, intentional declarations, and either
+    # one sends this close down the DIVE-1830 declared path where the delivery IS
+    # verified (PR state, or ancestry+attribution for a branch). Refusing there
+    # would add friction to the fleet's dominant delegated-push flow and buy no
+    # safety, so "the field is bound" leaves behaviour byte-identical.
+    #
+    # The trigger is `_gate_text_names_a_ref`, deliberately the BROAD predicate
+    # (bash-only, no grep, no subprocess): it answers "was a PR mentioned", not
+    # "which one". An over-match here costs one refusal that `--no-pr` answers in
+    # a keystroke; an under-match costs the whole ticket. The sharp extractor is
+    # used only to NAME numbers in the message, and it is allowed to come back
+    # empty — a refusal must never depend on a parser that may be unusable.
+    if [[ -z "$_dref" && -z "$_branch" ]] && _gate_text_names_a_ref "$result
+$_body"; then
+      local _cnd_refs=""
+      if _gate_pr_refs_engine_ok; then
+        _cnd_refs=$(_gate_pr_refs_qualified_from_text "$result
+$_body" 2>/dev/null | sed 's/^.*|/#/' | head -3 | paste -sd, - || true)
+      fi
+      local _cnd_named="${_cnd_refs:+ (${_cnd_refs//,/, })}"
+      if [[ $no_pr -eq 1 ]]; then
+        # The assertion is recorded, not just honoured. `--no-pr` is a CLAIM about
+        # this close ("no pull request here is mine"), and an unrecorded claim is
+        # indistinguishable from a bypass when someone reads the row back.
+        warn "$ident: closing with --no-pr — the PR reference(s)${_cnd_named:- named in the result/body} are asserted to be REPORTED ON, not delivered by this task (DIVE-2096, audited)."
+        _task_store_audit_log "task.done-no-pr" ok 0 -- "$ident" "refs=${_cnd_refs:-unparsed}"
+      elif [[ $force_merge_gate -eq 0 ]]; then
+        policy_refuse "$E_CONFLICT" done-cited-not-delivered DIVE-2096 "$ident" "$ident cannot close YET: its result/body names a pull request${_cnd_named} but NOTHING BINDS one to this task — \`delivery_ref\` is empty and the body declares no \`Branch:\` line. A citation in prose is not a binding: only the field is (DIVE-1962 was CANCELLED for trying to infer one from prose). Closing now would leave the named PR's merge state UNCHECKED, and \`done\` freezes the body, so you would learn that only after it was unfixable (DIVE-2096). CORRECT ORDER: merge it, then \`5dive task deliver $ident --pr=<url>\`, then \`5dive task done $ident\`. If this close only REPORTS ON that PR and delivers no code of its own — a review, triage, audit or coordination close, DIVE-1965's category — say so and it proceeds: \`5dive task done $ident --no-pr\` (audited). \`--force-merge-gate\` also overrides."
+      fi
     fi
     # DIVE-2682 (implements the DIVE-2671 design call): a binding can OUTLIVE the
     # iteration it was made for. The gate below asks "did the bound PR land"; it

--- a/tests/task_done_cited_preclose_unit.sh
+++ b/tests/task_done_cited_preclose_unit.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# TIER: nightly — 12.3s measured on the 5dive control plane (3 runs of the arms: the mutation grading re-executes the whole harness twice more, by design). Does not fit the 300s PR core; the nightly sweep runs it.
+# DIVE-2096 isolated unit harness — cited-not-delivered as a PRE-CLOSE check.
+#
+# THE DEFECT. Two agents hit the identical wall from opposite sides inside ~2h on
+# 2026-07-26: olivia on DIVE-2064, main on DIVE-2080. main closed, and the
+# merge-gate warned IN THE SAME BREATH AS CLOSING that PR #209 was CITED not
+# DELIVERED — so nothing bound it and its merge state was never checked. `done`
+# then froze the body, so the record could not be repaired, and the only remedy
+# the warning could name (bounce it back to the maker to fix the verifier's own
+# metadata) is wildly disproportionate to the error. The diagnosis and the point
+# of no return arrived together. Nothing hinted at the correct sequence — merge ->
+# `task deliver --pr` -> `done` — until it was too late to act on it.
+#
+# THE FIX IS ORDERING, NOT INFERENCE, and the boundary is the whole design:
+#   * DIVE-1965 (done) separates a PR the task DELIVERED from one it REPORTS ON.
+#     Kept: this refuses, it never reclassifies.
+#   * DIVE-1962 (CANCELLED) proposed INFERRING the binding from a PR number in
+#     prose, and was cancelled because that OVERCLAIMS. So prose is the TRIGGER
+#     for the prompt and NEVER the SOURCE of the binding — arm 8 is the pin: after
+#     an opt-out close, `delivery_ref` is STILL empty. Nothing was inferred.
+#
+# What is pinned here:
+#   1. a prose PR token with NO binding refuses, PRE-COMMIT, with the remedy named;
+#   2. the refusal is genuinely pre-commit — status, result and body are untouched,
+#      which is the entire point of the ticket and not a side detail;
+#   3. a bound `delivery_ref` is unchanged (the declared DIVE-1830 path still runs);
+#   4. a `Branch:` line is unchanged — it is the same structured declaration, and
+#      the fleet's dominant delegated-push flow must not gain friction;
+#   5. no PR token at all is unchanged — zero regression on research/docs closes;
+#   6. `--no-pr` is the named opt-out for DIVE-1965's reports-on category, and it
+#      is AUDITED (an unrecorded assertion is indistinguishable from a bypass);
+#   7. `--force-merge-gate` also overrides (one escape hatch, not two policies);
+#   8. NOTHING IS INFERRED — the DIVE-1962 line, pinned as an assertion;
+#   9. a body-only citation triggers it too (the ask says "--result/body");
+#  10. `task cancel` is untouched — abandoning a task is not closing one.
+#
+# MUTATION-GRADED (community/wiki/grade-absence-assertions-by-mutation.md). An
+# absence assertion that asserts nothing looks exactly like a passing one, so the
+# harness ends by re-running ITSELF against two mutant trees and REQUIRING each to
+# red: (M1) the pre-check neutered, (M2) the `--no-pr` opt-out neutered. A build
+# where either survives green is a harness that is grading nothing.
+#
+# Isolation matches the sibling gate harnesses: source src/ into a throwaway
+# STATE_DIR (the live tasks.db is NEVER touched); gh is STUBBED on PATH.
+# Run: bash tests/task_done_cited_preclose_unit.sh  (no root, no network).
+set -uo pipefail
+
+# The mutant re-run points this at a patched copy of src/. It is deliberately NOT
+# FIVE_-prefixed: tests/lib/env_isolation.sh (sourced by grading_tree.sh, below)
+# CLEARS inherited FIVE_* knobs so a harness never grades the caller's env, and a
+# FIVE_-prefixed name here would be wiped between this line and its first use.
+MUT_SRC="${MUT_SRC:-}"
+MUTANT_CHILD="${MUTANT_CHILD:-}"
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# NOTE the absence of `2>/dev/null` — the obvious hardening also swallows the
+# helper's own stderr line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+# DIVE-2770: the merge gate has a CREDENTIAL-FREE rail (unauthenticated read of a
+# public repo). Left on, the arms below would reach the real network and grade a
+# LIVE PR instead of the fixture. Must sit AFTER grading_tree.sh, which clears
+# inherited FIVE_* knobs.
+export FIVE_GATE_NO_ANON=1
+
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+REPO_ROOT="$PWD"
+SRC="${MUT_SRC:-src}"
+TMP="$(mktemp -d /tmp/cited-preclose-unit.XXXXXX)"
+
+mkdir -p "$TMP/bin"
+cat >"$TMP/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf 'ARGS=%s\n' "$*" >>"$GH_ARGS_LOG"
+if [[ "$1" == "auth" && "$2" == "token" ]]; then printf '%s\n' "${GH_STUB_AUTH_TOKEN:-}"; [[ -n "${GH_STUB_AUTH_TOKEN:-}" ]] || exit 1; exit 0; fi
+a=("$@"); expr='.'; repo=""; i=0
+while [[ $i -lt ${#a[@]} ]]; do
+  case "${a[$i]}" in
+    -q)      expr="${a[$((i+1))]}"; i=$((i+2)) ;;
+    -q*)     expr="${a[$i]#-q}";    i=$((i+1)) ;;
+    --repo)  repo="${a[$((i+1))]}"; i=$((i+2)) ;;
+    *)       i=$((i+1)) ;;
+  esac
+done
+rkey() { local k="${1##*/}"; printf '%s' "${k//[^A-Za-z0-9]/_}"; }
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  ref="$3"
+  if [[ -z "$repo" && "$ref" == https://github.com/* ]]; then repo=$(printf '%s' "$ref" | cut -d/ -f4,5); fi
+  n="${ref##*/}"
+  fx="GH_STUB_PR_$(rkey "$repo")_${n}"; json="${!fx:-}"
+  [[ -n "$json" ]] || exit 1
+  printf '%s' "$json" | jq -r "$expr" 2>/dev/null; exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  lx="GH_STUB_PRLIST_$(rkey "$repo")"
+  printf '%s' "${!lx:-[]}" | jq -r "$expr" 2>/dev/null; exit 0
+fi
+exit 0
+STUB
+chmod +x "$TMP/bin/gh"
+# sudo must be stubbed or the token resolver reaches the HOST's real gh login.
+printf '#!/usr/bin/env bash\nexit 1\n' >"$TMP/bin/sudo"; chmod +x "$TMP/bin/sudo"
+export PATH="$TMP/bin:$PATH"
+export GH_ARGS_LOG="$TMP/gh.args"; : >"$GH_ARGS_LOG"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh \
+         lib/registry.sh lib/tasks_db.sh lib/actor.sh cmd_push.sh \
+         cmd_task.sh; do
+  source "$SRC/$f"
+done
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+# DIVE-2010 STORE IDENTITY fence: declare the fixture store as prod so the
+# `task.done-no-pr` audit-row assertion exercises the real path.
+export FIVEDIVE_PROD_TASKS_DB="$TASKS_DB"
+JSON_MODE=0
+mkdir -p "$TASKS_DIR"; set +e
+tasks_db_init
+task_need_notify() { :; }
+_task_close_notify() { :; }
+AUDIT_CALLS="$TMP/audit.calls"; : >"$AUDIT_CALLS"
+audit_log() { printf '%s\n' "$*" >>"$AUDIT_CALLS"; }
+export GH_STUB_AUTH_TOKEN="tok"
+export FIVE_GATE_REPOS="5dive-ai/5dive,lodar/5dive-api,lodar/5dive-frontend"
+
+MERGED_OK='{"state":"MERGED","mergedAt":"2026-07-26T02:52:00Z","statusCheckRollup":[{"conclusion":"SUCCESS"}],"title":"unrelated","headRefName":"unrelated"}'
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+seed()     { db "DELETE FROM tasks WHERE ident='$1';
+                 INSERT INTO tasks (ident, title, body, status, created_by, assignee)
+                   VALUES ('$1','t',$(sqlq "${2:-}"),'in_progress','main','main');"; }
+statusof() { db "SELECT status FROM tasks WHERE ident='$1';"; }
+resultof() { db "SELECT COALESCE(result,'') FROM tasks WHERE ident='$1';"; }
+bodyof()   { db "SELECT COALESCE(body,'')   FROM tasks WHERE ident='$1';"; }
+drefof()   { db "SELECT COALESCE(delivery_ref,'') FROM tasks WHERE ident='$1';"; }
+run_done() { OUT=$(cmd_task_done "$@" 2>&1); RC=$?; }
+
+# The distinctive sentence of THIS refusal. Every "unchanged" arm below asserts
+# its ABSENCE, so it is defined once — a per-arm literal is how a typo turns an
+# absence assertion into a tautology.
+MARK='A citation in prose is not a binding'
+
+# --- 1. the refusal itself ----------------------------------------------------
+seed CIT-1 'no binding here'
+run_done CIT-1 --result='shipped, see PR #209 for the change'
+[[ $RC -ne 0 && "$OUT" == *"$MARK"* ]] \
+  && ok_t '1. prose PR token + no binding REFUSES' \
+  || bad_t '1. must refuse' "rc=$RC out=$OUT"
+[[ "$OUT" == *"task deliver CIT-1 --pr="* ]] \
+  && ok_t '1b. the refusal names the remedy, with the ident already filled in' \
+  || bad_t '1b. remedy must be actionable' "out=$OUT"
+[[ "$OUT" == *"--no-pr"* ]] \
+  && ok_t '1c. the refusal names the opt-out for the reports-on case' \
+  || bad_t '1c. must name --no-pr' "out=$OUT"
+[[ "$OUT" == *"#209"* ]] \
+  && ok_t '1d. the refusal names the ref it saw' \
+  || bad_t '1d. must name the ref' "out=$OUT"
+
+# --- 2. PRE-COMMIT is the whole ticket ---------------------------------------
+# The DIVE-2414 disclosure this replaces was correct and useless: it arrived WITH
+# the irreversible close. If the row moved, the fix did not happen.
+[[ "$(statusof CIT-1)" == "in_progress" ]] \
+  && ok_t '2. status is untouched — the close did not commit' \
+  || bad_t '2. status must not move' "status=$(statusof CIT-1)"
+[[ -z "$(resultof CIT-1)" ]] \
+  && ok_t '2b. result is untouched — the record is still repairable' \
+  || bad_t '2b. result must not be written' "result=$(resultof CIT-1)"
+[[ "$(bodyof CIT-1)" == 'no binding here' ]] \
+  && ok_t '2c. body is untouched — it did not freeze' \
+  || bad_t '2c. body must not move' "body=$(bodyof CIT-1)"
+
+# --- 3. a bound delivery_ref is UNCHANGED ------------------------------------
+export GH_STUB_PR_5dive_api_209="$MERGED_OK"
+seed CIT-3 'declared'
+db "UPDATE tasks SET delivery_ref='https://github.com/lodar/5dive-api/pull/209',
+                     delivered_at=datetime('now') WHERE ident='CIT-3';"
+run_done CIT-3 --result='shipped, see PR #209 for the change'
+[[ "$OUT" != *"$MARK"* ]] \
+  && ok_t '3. a bound delivery_ref never reaches this refusal' \
+  || bad_t '3. bound field must be unchanged' "out=$OUT"
+[[ "$(statusof CIT-3)" == "done" ]] \
+  && ok_t '3b. ...and the declared DIVE-1830 path still closes it' \
+  || bad_t '3b. bound+merged+green must close' "status=$(statusof CIT-3) out=$OUT"
+
+# --- 4. a `Branch:` line is UNCHANGED ----------------------------------------
+# The other structured declaration (DIVE-1462). It routes to the declared path,
+# where the delivery IS verified by ancestry — so refusing here would add friction
+# to the fleet's dominant delegated-push flow and buy no safety. Asserted on the
+# refusal's ABSENCE, not on the close: the ancestry scan has its own verdicts and
+# this arm is not about them.
+seed CIT-4 'Branch: dive-2096-cited-preclose
+
+work landed, see PR #209'
+run_done CIT-4 --result='landed'
+[[ "$OUT" != *"$MARK"* ]] \
+  && ok_t '4. a `Branch:` binding never reaches this refusal' \
+  || bad_t '4. Branch: must be unchanged' "out=$OUT"
+
+# --- 5. no PR token at all is UNCHANGED --------------------------------------
+seed CIT-5 'a research task'
+run_done CIT-5 --result='wrote the analysis; no code'
+[[ $RC -eq 0 && "$(statusof CIT-5)" == "done" && "$OUT" != *"$MARK"* ]] \
+  && ok_t '5. no PR token: closes clean, zero regression' \
+  || bad_t '5. must close clean' "rc=$RC status=$(statusof CIT-5) out=$OUT"
+
+# --- 6. --no-pr is the named opt-out, and it is AUDITED ----------------------
+: >"$AUDIT_CALLS"
+seed CIT-6 'a review close'
+run_done CIT-6 --no-pr --result='reviewed PR #209 for olivia; nothing of mine to ship'
+[[ $RC -eq 0 && "$(statusof CIT-6)" == "done" ]] \
+  && ok_t '6. --no-pr closes the genuine reports-on case (DIVE-1965 category)' \
+  || bad_t '6. --no-pr must close' "rc=$RC status=$(statusof CIT-6) out=$OUT"
+[[ "$OUT" == *"--no-pr"*"REPORTED ON"* ]] \
+  && ok_t '6b. the assertion is announced, not silently honoured' \
+  || bad_t '6b. --no-pr must warn' "out=$OUT"
+grep -q 'task.done-no-pr' "$AUDIT_CALLS" \
+  && ok_t '6c. ...and it lands an audit row — an unrecorded claim is a bypass' \
+  || bad_t '6c. --no-pr must be audited' "audit=$(cat "$AUDIT_CALLS")"
+
+# --- 7. --force-merge-gate also overrides ------------------------------------
+seed CIT-7 'forced'
+run_done CIT-7 --force-merge-gate --result='shipped, see PR #209'
+[[ "$OUT" != *"$MARK"* && "$(statusof CIT-7)" == "done" ]] \
+  && ok_t '7. --force-merge-gate overrides it too (one escape, not two policies)' \
+  || bad_t '7. force must override' "status=$(statusof CIT-7) out=$OUT"
+
+# --- 8. NOTHING IS INFERRED — the DIVE-1962 line -----------------------------
+# The cancelled ticket's whole failure was reading a prose number into the
+# binding. Prose is the TRIGGER for the prompt; the operator supplies the SOURCE.
+[[ -z "$(drefof CIT-6)" ]] \
+  && ok_t '8. no delivery_ref was inferred from the prose ref (DIVE-1962 stays dead)' \
+  || bad_t '8. must never infer a binding' "dref=$(drefof CIT-6)"
+[[ -z "$(drefof CIT-7)" ]] \
+  && ok_t '8b. ...on the forced path either' \
+  || bad_t '8b. must never infer a binding' "dref=$(drefof CIT-7)"
+
+# --- 9. a BODY-only citation triggers it too ---------------------------------
+# The ask says "--result/body". A maker who put the PR in the body and closed with
+# a bare `--result` is the same defect wearing a different hat.
+seed CIT-9 'follow-up to PR #209'
+run_done CIT-9 --result='done'
+[[ $RC -ne 0 && "$OUT" == *"$MARK"* && "$(statusof CIT-9)" == "in_progress" ]] \
+  && ok_t '9. a body-only citation refuses as well' \
+  || bad_t '9. body must be read too' "rc=$RC status=$(statusof CIT-9) out=$OUT"
+
+# --- 10. `task cancel` is untouched ------------------------------------------
+# Abandoning a task is not closing one: there is no delivery to bind, and a gate
+# that blocks the abandon path is how a bad row becomes immortal.
+seed CIT-10 'abandoned'
+OUT=$(cmd_task_cancel CIT-10 --result='superseded by PR #209' 2>&1); RC=$?
+[[ "$(statusof CIT-10)" == "cancelled" && "$OUT" != *"$MARK"* ]] \
+  && ok_t '10. cancel is unaffected' \
+  || bad_t '10. cancel must not be gated' "status=$(statusof CIT-10) out=$OUT"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+
+# --- MUTATION GRADING --------------------------------------------------------
+# Everything above is an assertion about a REFUSAL and about absences of one.
+# Both shapes pass trivially against a build where the check does nothing, so the
+# arms are worth exactly what the mutants below say they are.
+if [[ -z "$MUTANT_CHILD" ]]; then
+  MPASS=0; MFAIL=0
+  mutate() { # <name> <sed-expr> <must-red-arm-hint>
+    local name="$1" expr="$2" hint="$3" md out rc
+    md="$TMP/mut-$name"; mkdir -p "$md"; cp -r "$REPO_ROOT/src/." "$md/"
+    if ! sed -i "$expr" "$md/cmd_task.sh"; then
+      MFAIL=$((MFAIL+1)); printf 'FAIL - mutant %s: sed could not apply\n' "$name"; return
+    fi
+    if diff -q "$REPO_ROOT/src/cmd_task.sh" "$md/cmd_task.sh" >/dev/null; then
+      # A mutation that changed nothing greens for the wrong reason and would
+      # read as "the mutant survived was not even built".
+      MFAIL=$((MFAIL+1)); printf 'FAIL - mutant %s: the sed matched NOTHING — the anchor moved\n' "$name"; return
+    fi
+    out=$(MUT_SRC="$md" MUTANT_CHILD=1 bash "$REPO_ROOT/tests/$(basename "$0")" 2>&1); rc=$?
+    if [[ $rc -ne 0 ]]; then
+      MPASS=$((MPASS+1)); printf 'ok   - mutant %s reds the harness (%s)\n' "$name" "$hint"
+    else
+      MFAIL=$((MFAIL+1)); printf 'FAIL - mutant %s SURVIVED — the arms for %s assert nothing\n   %s\n' \
+        "$name" "$hint" "$(printf '%s' "$out" | tail -3 | tr '\n' ' ')"
+    fi
+  }
+  printf '\n--- mutation grading (community/wiki/grade-absence-assertions-by-mutation.md) ---\n'
+  mutate precheck \
+    's#if \[\[ -z "$_dref" \&\& -z "$_branch" \]\] \&\& _gate_text_names_a_ref "$result#if false \&\& _gate_text_names_a_ref "$result#' \
+    'arms 1, 2, 9 — the pre-check itself'
+  mutate optout \
+    's#^      if \[\[ $no_pr -eq 1 \]\]; then$#      if false; then#' \
+    'arm 6 — the --no-pr opt-out'
+  printf '%d mutants killed, %d survived\n' "$MPASS" "$MFAIL"
+  [[ $FAIL -eq 0 && $MFAIL -eq 0 ]]
+else
+  [[ $FAIL -eq 0 ]]
+fi

--- a/tests/task_done_cited_preclose_unit.sh
+++ b/tests/task_done_cited_preclose_unit.sh
@@ -264,8 +264,8 @@ printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 # Everything above is an assertion about a REFUSAL and about absences of one.
 # Both shapes pass trivially against a build where the check does nothing, so the
 # arms are worth exactly what the mutants below say they are.
+MPASS=0; MFAIL=0
 if [[ -z "$MUTANT_CHILD" ]]; then
-  MPASS=0; MFAIL=0
   mutate() { # <name> <sed-expr> <must-red-arm-hint>
     local name="$1" expr="$2" hint="$3" md out rc
     md="$TMP/mut-$name"; mkdir -p "$md"; cp -r "$REPO_ROOT/src/." "$md/"
@@ -293,7 +293,13 @@ if [[ -z "$MUTANT_CHILD" ]]; then
     's#^      if \[\[ $no_pr -eq 1 \]\]; then$#      if false; then#' \
     'arm 6 — the --no-pr opt-out'
   printf '%d mutants killed, %d survived\n' "$MPASS" "$MFAIL"
-  [[ $FAIL -eq 0 && $MFAIL -eq 0 ]]
-else
-  [[ $FAIL -eq 0 ]]
 fi
+# THE VERDICT IS ONE STATEMENT ON THE LAST EXECUTABLE LINE, reachable in BOTH the
+# parent and the MUTANT_CHILD re-exec. Stranding it in an if/else put the probe's
+# injection point (the `else` arm) on a branch the parent never takes, while the
+# parent's exit came from the other arm — so tests/meta/harness-verdict-probe.sh
+# reported this file UNWIRED: an exit status that cannot fail CI. The child's own
+# canary file then defeated the not-reached classification, so the miss surfaced
+# as a flat accusation with a green 19/19 sitting next to it. MFAIL is initialised
+# to 0 above the branch, so the child (which never mutates) reads 0.
+[[ $FAIL -eq 0 && $MFAIL -eq 0 ]]

--- a/tests/task_merge_gate_delivered_vs_cited_unit.sh
+++ b/tests/task_merge_gate_delivered_vs_cited_unit.sh
@@ -137,7 +137,14 @@ seed()     { db "DELETE FROM tasks WHERE ident='$1';
 statusof() { db "SELECT status FROM tasks WHERE ident='$1';"; }
 resultof() { db "SELECT COALESCE(result,'') FROM tasks WHERE ident='$1';"; }
 refusals() { db "SELECT COUNT(*) FROM policy_refusals WHERE ident='$1';"; }
-run_done() { OUT=$(cmd_task_done "$@" 2>&1); RC=$?; }
+# DIVE-2096: these harnesses grade the PROSE text-binding gate (DIVE-1935/1965/2414),
+# which by definition is exercised with NO `delivery_ref` and no `Branch:` line — and
+# that is now exactly the shape the DIVE-2096 pre-close check refuses, before any of
+# this gate runs. It is not a coverage loss: after DIVE-2096 the prose gate is reached
+# by ASSERTING the reports-on case (`--no-pr`), so asserting it here is what keeps
+# these arms grading the same code as before. `--no-pr` is inert on the arms that DO
+# bind a delivery_ref, so it is applied at the wrapper rather than arm by arm.
+run_done() { OUT=$(cmd_task_done "$@" --no-pr 2>&1); RC=$?; }
 clear_fx() { unset "${!GH_STUB_PR_@}" "${!GH_STUB_PRLIST_@}" "${!GH_STUB_LIST_FAIL_@}" 2>/dev/null; }
 
 # --- 1. the classifier itself -------------------------------------------------
@@ -197,7 +204,7 @@ export GH_STUB_PR_5dive_api_10="$OPEN_X"
 export GH_STUB_PR_5dive_api_17="$OPEN_X"
 : >"$AUDIT_CALLS"
 seed INVOFF-1
-out=$(FIVEDIVE_PROD_TASKS_DB="$TMP/somewhere-else/tasks.db" cmd_task_done INVOFF-1 \
+out=$(FIVEDIVE_PROD_TASKS_DB="$TMP/somewhere-else/tasks.db" cmd_task_done INVOFF-1 --no-pr \
   --result='Shipped as PR #168, merged and green. Follow-ups still open: PR #10 and PR #17 in the api repo.' \
   2>"$TMP/offstore.err"); rc=$?
 [[ $rc -eq 0 && "$(statusof INVOFF-1)" == "done" ]] \

--- a/tests/task_merge_gate_inferred_repo_unit.sh
+++ b/tests/task_merge_gate_inferred_repo_unit.sh
@@ -137,7 +137,13 @@ seed()     { db "DELETE FROM tasks WHERE ident='$1';
 statusof() { db "SELECT status FROM tasks WHERE ident='$1';"; }
 resultof() { db "SELECT COALESCE(result,'') FROM tasks WHERE ident='$1';"; }
 refusals() { db "SELECT COUNT(*) FROM policy_refusals WHERE ident='$1';"; }
-run_done() { OUT=$(cmd_task_done "$@" 2>&1); RC=$?; }
+# DIVE-2096: this harness grades the PROSE text-binding gate, which by definition
+# runs with NO `delivery_ref` and no `Branch:` line — now exactly the shape the
+# DIVE-2096 pre-close check refuses before this gate is reached. Asserting the
+# reports-on case (`--no-pr`) is what keeps these arms grading the same code as
+# before; it is inert on the arms that DO bind a delivery_ref, so it goes on the
+# wrapper rather than arm by arm.
+run_done() { OUT=$(cmd_task_done "$@" --no-pr 2>&1); RC=$?; }
 clear_fx() { unset "${!GH_STUB_PR_@}" "${!GH_STUB_PRLIST_@}" "${!GH_STUB_LIST_FAIL_@}" 2>/dev/null; }
 
 # --- 1. what DECLARES a repo, and what merely mentions one -------------------

--- a/tests/task_merge_gate_multirepo_unit.sh
+++ b/tests/task_merge_gate_multirepo_unit.sh
@@ -158,7 +158,13 @@ seed()     { db "DELETE FROM tasks WHERE ident='$1';
                    VALUES ('$1','t',$(sqlq "${2:-}"),'in_progress','main','main');"; }
 statusof() { db "SELECT status FROM tasks WHERE ident='$1';"; }
 refusals() { db "SELECT COUNT(*) FROM policy_refusals WHERE ident='$1';"; }
-run_done() { OUT=$(cmd_task_done "$@" 2>&1); RC=$?; }
+# DIVE-2096: this harness grades the PROSE text-binding gate, which by definition
+# runs with NO `delivery_ref` and no `Branch:` line — now exactly the shape the
+# DIVE-2096 pre-close check refuses before this gate is reached. Asserting the
+# reports-on case (`--no-pr`) is what keeps these arms grading the same code as
+# before; it is inert on the arms that DO bind a delivery_ref, so it goes on the
+# wrapper rather than arm by arm.
+run_done() { OUT=$(cmd_task_done "$@" --no-pr 2>&1); RC=$?; }
 clear_fx() { unset "${!GH_STUB_PR_@}" "${!GH_STUB_PRLIST_@}" "${!GH_STUB_LIST_FAIL_@}" 2>/dev/null; }
 
 # --- 1. the QUALIFIED extractor ----------------------------------------------

--- a/tests/task_merge_gate_result_pr_unit.sh
+++ b/tests/task_merge_gate_result_pr_unit.sh
@@ -163,7 +163,14 @@ PASS=0; FAIL=0
 ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 # run `task done` capturing stdout+stderr and the exit code.
-run_done() { OUT=$(cmd_task_done "$@" 2>&1); RC=$?; }
+# DIVE-2096: these harnesses grade the PROSE text-binding gate (DIVE-1935/1965/2414),
+# which by definition is exercised with NO `delivery_ref` and no `Branch:` line — and
+# that is now exactly the shape the DIVE-2096 pre-close check refuses, before any of
+# this gate runs. It is not a coverage loss: after DIVE-2096 the prose gate is reached
+# by ASSERTING the reports-on case (`--no-pr`), so asserting it here is what keeps
+# these arms grading the same code as before. `--no-pr` is inert on the arms that DO
+# bind a delivery_ref, so it is applied at the wrapper rather than arm by arm.
+run_done() { OUT=$(cmd_task_done "$@" --no-pr 2>&1); RC=$?; }
 
 # --- 1. the reference extractor: NAMED equivalence fixtures --------------------
 # The extractor was rewritten from PCRE to POSIX ERE to delete a silent-empty


### PR DESCRIPTION
`task done` now refuses **before** it commits anything when the result or body names a PR and nothing binds one — no `delivery_ref`, no `Branch:` line. Today that condition is a warning that arrives *with* the close, which is too late to act on: the row is already `done` and its body is frozen.

## Why this is worth landing tonight

Measured on the board a few hours ago, and this change is the fix for it: **DIVE-2645 and DIVE-2743 are on the board as `done` with their work absent from `main`.** Verified three ways each — the files their PRs add are missing from `origin/main`, and neither PR head is an ancestor of main. Both PRs are still open.

Both closed with `delivery_ref` unbound, so the DIVE-1835 `done=merged-to-main` gate had nothing to grade and stayed silent. It is not a weak gate — it refused two closes of mine the same day, on rows that *did* carry a binding. A gate that only fires on an optional field is an optional gate, and this PR is what makes the field non-optional at the moment it matters.

**One thing this does NOT fix, stated so the remedy is not over-sold** (olivia, on DIVE-2645): her PR #427 was created at `2026-08-03T21:51:08Z` and she closed the row at `21:39:12` — the PR did not exist for another twelve minutes. "Bind the PR before you close" could not have saved that row, because there was nothing to bind. The pre-close refusal catches the *cited-but-unbound* shape; the *closed-before-the-artifact-exists* shape is a different hole and needs a board state for "verified good, not landed" that we do not currently have.

## How it was checked

Verified independently by main before pushing, on the branch as it stands:

- `tests/task_done_cited_preclose_unit.sh` — green, and **mutation-graded: 2 mutants killed, 0 survived**, including an arm that reds on the `--no-pr` opt-out.
- Four sibling harnesses went red on first cut because this check sits *in front of* the prose gate they grade. They were restored by asserting the new entry condition at their wrappers, **not** by deleting arms — and they are back at exact baseline: `task_merge_gate_delivered_vs_cited_unit` 39/39, `task_close_needs_a_reason_unit` 19/19, `task_done_delivered_guard_unit` 20/20, `task_core_unit` 61/61.
- Branch is descended from current `main` (`8cc3a506`), so CI here grades the tree it will land on. This repo's protection is `strict=FALSE`, so that is a property to check rather than assume.

Maker: dev. **Verifier of record: main2** — route the grade there, not to the pusher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
