### PR TITLE
feat(memory): structural evidence back-refs + advisory write-time dedup (DIVE-3106)

### DIFF
--- a/src/cmd_memory.sh
+++ b/src/cmd_memory.sh
@@ -38,7 +38,7 @@ _memory_usage() {
                    [--type=user|feedback|project|reference] [--store=mine|wiki]
                    [--tags=a,b] [--valid-to=YYYY-MM-DD] [--supersedes=<slug>]
                    [--confidence=high|medium|low] [--provenance="<source>"]
-                   [--force]   (body on stdin)
+                   [--evidence=<kind>:<ref>]... [--no-dedup] [--force]  (body on stdin)
       Compile a durable memory: writes a frontmatter markdown file into your
       own store (default) or the shared team wiki (--store=wiki, the publish
       path other agents can search), stamps provenance (who/when), appends the
@@ -49,11 +49,21 @@ _memory_usage() {
       (that one is then demoted in recall instead of silently lingering);
       --confidence = how sure; --provenance = where the fact came from. Recall
       demotes + flags expired / superseded / low-confidence facts (never hides).
+      Evidence back-refs (DIVE-3106, idea-derived from TencentDB-Agent-Memory,
+      MIT): --evidence is repeatable and STRUCTURAL, so "re-verify this claim"
+      is a mechanical walk instead of re-reading prose. Kinds:
+        file:<path>[:line]  task:DIVE-1234  cmd:<command that proves it>
+        sha:<gitsha>  url:<https://...>  run:<id>
+      It sits BESIDE --provenance (free text), which is unchanged. A memory
+      with no evidence is not flagged, demoted, or degraded.
+      Write-time dedup: `add` WARNS (never refuses) when the body overlaps an
+      existing memory in the same store — silence it with --no-dedup.
 
   5dive memory doctor [--roots=a,b] [--agent=<name>] [--code-root=<dir>] [--json]
       Hygiene pass over the memory store(s): index drift (MEMORY.md vs files on
       disk), dangling [[wiki-links]], stale source refs (file:line no longer in
-      the codebase), and near-duplicate memories. Also runs inside the
+      the codebase), near-duplicate memories, and dangling structural
+      evidence back-refs (--evidence file: targets). Also runs inside the
       `memory` category of `5dive doctor` for the whole box.
 
 Searches the agent's own ~/.claude/projects/*/memory stores (+ the shared wiki
@@ -254,9 +264,82 @@ MEMJS
 # to --store=wiki is the PUBLISH path that makes a fact fleet-searchable —
 # cross-agent recall happens by publishing here, never by opening the 0600
 # per-agent stores (deny-by-default, same posture as the DIVE-481 gate).
+# _memory_emit_evidence <indent> [ref...] — emit the structural evidence list as
+# YAML. Values are double-quoted (a cmd: ref carries arbitrary shell text).
+_memory_emit_evidence() {
+  local indent="$1"; shift
+  [ $# -gt 0 ] || return 0
+  printf '%sevidence:\n' "$indent"
+  local r
+  for r in "$@"; do
+    printf '%s  - "%s"\n' "$indent" "$(printf '%s' "$r" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+  done
+}
+
+# _memory_dedup_warn <target-file> <store-dir> — DIVE-3106 write-time dedup.
+# ADVISORY ONLY, by lodar's constraint (2026-08-09): `memory add` already carries
+# one load-bearing refusal (the secret tripwire) and a second refusal on the same
+# verb would make compiling feel adversarial — a duplicate memory is cheaper than
+# a false refusal on a write path. So: warn on stderr, exit 0, always.
+# Same Jaccard-over-body-words shape as the doctor's near-dup check, so the two
+# agree. Body arrives on stdin. python3 absent (customer boxes) = silently skip.
+# NOTE the body arrives as a FILE, not on stdin. The heredoc that carries this
+# program IS python3's stdin, so a piped body would be swallowed by `python3 -`
+# and sys.stdin.read() would return the tail of the program. (Caught by the
+# harness, not by review: the dedup silently never fired.)
+_memory_dedup_warn() {
+  local target="$1" dir="$2" bodyfile="$3"
+  command -v python3 >/dev/null 2>&1 || return 0
+  python3 - "$target" "$dir" "$bodyfile" <<'DEDUPPY' >&2 || true
+import os, re, sys
+target, store, bodyfile = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    body = open(bodyfile, encoding="utf-8", errors="replace").read()
+except OSError:
+    sys.exit(0)
+WORD = re.compile(r"[a-z0-9_./-]{3,}")
+def words(t):
+    t = re.sub(r"\A---\n.*?\n---\n", "", t, flags=re.S)   # drop frontmatter
+    return set(WORD.findall(t.lower()))
+mine = words(body)
+if len(mine) < 12:
+    sys.exit(0)
+hits = []
+try:
+    entries = sorted(os.listdir(store))
+except OSError:
+    sys.exit(0)
+for f in entries:
+    if not f.endswith(".md") or f in ("MEMORY.md", "index.md"):
+        continue
+    path = os.path.join(store, f)
+    if os.path.abspath(path) == os.path.abspath(target):
+        continue                                  # --force update-in-place
+    try:
+        w = words(open(path, encoding="utf-8", errors="replace").read())
+    except OSError:
+        continue
+    if len(w) < 12:
+        continue
+    inter = len(mine & w)
+    if not inter:
+        continue
+    jac = inter / len(mine | w)
+    if jac >= 0.6:
+        hits.append((jac, f))
+for jac, f in sorted(hits, reverse=True)[:3]:
+    sys.stderr.write(
+        "\u26a0 near-duplicate: %d%% token overlap with %s \u2014 consider updating "
+        "it in place (--force) or --supersedes; writing anyway "
+        "(--no-dedup silences this)\n" % (int(jac * 100), f))
+DEDUPPY
+  return 0
+}
+
 _memory_add() {
-  local name="" type="" desc="" store="mine" tags="" force=0
+  local name="" type="" desc="" store="mine" tags="" force=0 no_dedup=0
   local valid_to="" supersedes="" confidence="" provenance=""
+  local evidence=()
   while [ $# -gt 0 ]; do
     case "$1" in
       --name=*)        name="${1#*=}" ;;
@@ -268,6 +351,8 @@ _memory_add() {
       --supersedes=*)  supersedes="${1#*=}" ;;
       --confidence=*)  confidence="${1#*=}" ;;
       --provenance=*)  provenance="${1#*=}" ;;
+      --evidence=*)    evidence+=("${1#*=}") ;;
+      --no-dedup)      no_dedup=1 ;;
       --force)         force=1 ;;
       -h|--help)       _memory_usage; return 0 ;;
       *)               fail "$E_USAGE" "memory add: unknown arg: $1" ;;
@@ -289,6 +374,24 @@ _memory_add() {
   if [ -n "$confidence" ]; then case "$confidence" in high|medium|low) : ;; *) fail "$E_VALIDATION" "--confidence must be high|medium|low" ;; esac; fi
   if [ -n "$supersedes" ]; then printf '%s' "$supersedes" | grep -qE '^[a-z0-9][a-z0-9_-]{0,63}$' \
       || fail "$E_VALIDATION" "--supersedes must be the slug of the memory it replaces"; fi
+  # DIVE-3106 evidence back-refs: a STRUCTURAL path from the claim to the ground
+  # truth, so re-verification is a mechanical walk. The kind prefix is what makes
+  # it walkable — a free-text ref would just be a second --provenance.
+  local _ev
+  for _ev in ${evidence+"${evidence[@]}"}; do
+    case "$_ev" in
+      file:?*|task:?*|cmd:?*|sha:?*|url:?*|run:?*) : ;;
+      *) fail "$E_VALIDATION" "--evidence must be <kind>:<ref> (file|task|cmd|sha|url|run), got: $_ev" ;;
+    esac
+    case "$_ev" in
+      task:*) printf '%s' "${_ev#task:}" | grep -qE '^[A-Z]+-[0-9]+$' \
+          || fail "$E_VALIDATION" "--evidence task: wants a board ident like DIVE-1234, got: ${_ev#task:}" ;;
+      sha:*)  printf '%s' "${_ev#sha:}" | grep -qE '^[0-9a-f]{7,40}$' \
+          || fail "$E_VALIDATION" "--evidence sha: wants a git sha, got: ${_ev#sha:}" ;;
+      url:*)  printf '%s' "${_ev#url:}" | grep -qE '^https?://' \
+          || fail "$E_VALIDATION" "--evidence url: wants an http(s) URL, got: ${_ev#url:}" ;;
+    esac
+  done
   [ -t 0 ] && fail "$E_USAGE" "memory add reads the body on stdin — pipe or heredoc it"
   local body; body=$(cat)
   [ -n "$(printf '%s' "$body" | tr -d '[:space:]')" ] || fail "$E_USAGE" "empty body on stdin — nothing to remember"
@@ -334,6 +437,15 @@ _memory_add() {
     fail "$E_CONFLICT" "$(basename "$file") already exists — update it with --force, or pick a new --name"
   fi
   local existed=0; [ -f "$file" ] && existed=1
+  # Advisory dedup (never refuses) — before the write, so the warning is useful.
+  if [ "$no_dedup" -ne 1 ]; then
+    local _bf; _bf=$(mktemp "${TMPDIR:-/tmp}/5dive-mem-dedup.XXXXXX") || _bf=""
+    if [ -n "$_bf" ]; then
+      printf '%s' "$body" > "$_bf"
+      _memory_dedup_warn "$file" "$dir" "$_bf"
+      rm -f "$_bf"
+    fi
+  fi
 
   if [ "$store" = "wiki" ]; then
     { printf -- '---\ntitle: %s\n' "$name"
@@ -342,6 +454,7 @@ _memory_add() {
       [ -n "$valid_to" ]   && printf 'valid_to: %s\n' "$valid_to"
       [ -n "$supersedes" ] && printf 'supersedes: %s\n' "$supersedes"
       [ -n "$provenance" ] && printf 'provenance: "%s"\n' "$(printf '%s' "$provenance" | sed 's/"/\\"/g')"
+      _memory_emit_evidence "" ${evidence+"${evidence[@]}"}
       printf 'updated: %s\ncompiled_by: %s\n---\n\n%s\n' "$today" "$who" "$body"
     } > "$file"
   else
@@ -352,6 +465,7 @@ _memory_add() {
       [ -n "$valid_to" ]   && printf '  valid_to: %s\n' "$valid_to"
       [ -n "$supersedes" ] && printf '  supersedes: %s\n' "$supersedes"
       [ -n "$provenance" ] && printf '  provenance: "%s"\n' "$(printf '%s' "$provenance" | sed 's/"/\\"/g')"
+      _memory_emit_evidence "  " ${evidence+"${evidence[@]}"}
       printf -- '---\n\n%s\n' "$body"
     } > "$file"
   fi
@@ -492,6 +606,33 @@ def typo_suspect(target, slugs):
                 break
     return best if best_d <= thresh else None
 
+EVID_ITEM_RE = re.compile(r'^\s*-\s*"?([a-z]+:[^"\n]*?)"?\s*$')
+
+def evidence_of(text):
+    """Structural --evidence back-refs out of the frontmatter (DIVE-3106).
+    Both layouts: top-level `evidence:` (wiki) and nested under `metadata:`
+    (own store). Returns a list of '<kind>:<ref>' strings."""
+    if not text.startswith("---"):
+        return []
+    end = text.find("\n---", 3)
+    if end == -1:
+        return []
+    out, collecting = [], False
+    for ln in text[3:end].splitlines():
+        st = ln.strip()
+        if re.match(r'^evidence:\s*$', st):
+            collecting = True
+            continue
+        if collecting:
+            m = EVID_ITEM_RE.match(ln)
+            if m:
+                out.append(m.group(1).strip())
+                continue
+            if st and not st.startswith("-"):
+                collecting = False
+    return out
+
+
 def ref_exists(store_dir, token):
     if os.path.isabs(token):
         return os.path.exists(token)
@@ -533,6 +674,7 @@ for store in stores:
 
     all_slugs = set()
     docs = {}   # fname -> (name, mtype, body, wordset)
+    evid = {}   # fname -> ['<kind>:<ref>', ...]  (DIVE-3106 back-refs)
     for f in mem_files:
         try:
             with open(os.path.join(store, f), encoding="utf-8", errors="replace") as fh:
@@ -542,6 +684,7 @@ for store in stores:
         name, mtype, body = split_front(text)
         all_slugs |= slugs_of(f, name)
         docs[f] = (name, mtype, body, set(WORD_RE.findall(body.lower())))
+        evid[f] = evidence_of(text)
 
     # --- index drift ---
     if index_file:
@@ -582,6 +725,25 @@ for store in stores:
                 if ("/" in tok or f"{tok}:" in body) and not ref_exists(store, tok):
                     add(sname, f, "stale-ref", "warn",
                         f"cites '{tok}' which no longer exists in the codebase")
+
+    # --- evidence back-refs (DIVE-3106) ---
+    # ONLY file: targets are mechanically walkable offline; task:/cmd:/url:/run:/
+    # sha: need the board, a shell, or the network, so the doctor stays silent on
+    # them rather than crying wolf. A memory with NO evidence is never flagged —
+    # back-refs are additive and their absence is not a defect (lodar, 08-09).
+    for f, refs in evid.items():
+        for r in refs:
+            if not r.startswith("file:"):
+                continue
+            tok = r[5:].strip()
+            tok = re.sub(r':\d+$', '', tok)          # strip :line
+            if not tok:
+                add(sname, f, "evidence-ref", "warn",
+                    "evidence 'file:' back-ref is empty")
+            elif basenames and not ref_exists(store, tok):
+                add(sname, f, "evidence-ref", "warn",
+                    f"evidence back-ref '{tok}' no longer exists — the claim "
+                    f"can't be re-walked")
 
     # --- near-duplicate (Jaccard over body word-sets, same store) ---
     names = list(docs)

--- a/tests/memory_evidence_dedup_unit.sh
+++ b/tests/memory_evidence_dedup_unit.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# DIVE-3106 unit harness for the two additive `memory add` mechanisms lifted
+# (idea-derived, not code-derived) from TencentDB-Agent-Memory (MIT):
+#
+#   1. EVIDENCE BACK-REFS — --evidence=<kind>:<ref>, repeatable, structural, so
+#      "re-verify this claim" is a mechanical walk instead of re-reading prose.
+#      Plus the doctor's new evidence-ref check that walks file: targets.
+#   2. WRITE-TIME DEDUP — advisory ONLY. It must WARN and STILL WRITE; a second
+#      refusal on the same verb as the secret tripwire is exactly what lodar
+#      ruled out on 2026-08-09.
+#
+# Both are ADDITIVE: a memory with no --evidence must be byte-identical to what
+# pre-3106 `memory add` produced, and must not be flagged by the doctor. The
+# negative controls below are the point of this harness, not decoration.
+# Run: bash tests/memory_evidence_dedup_unit.sh
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/mem-ev-unit.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do
+  source "$SRC/$f"
+done
+# shellcheck source=/dev/null
+source "$SRC/cmd_memory.sh"
+JSON_MODE=0
+set +e
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "  ok   — $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "  FAIL — $1"; }
+check(){ if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3', got '$2')"; fi; }
+
+# Isolated fake agent home so `--store=mine` resolves here and nothing touches
+# the real store. _memory_add picks the dir that already has a MEMORY.md.
+STORE="$TMP/home/.claude/projects/proj/memory"
+mkdir -p "$STORE"; : > "$STORE/MEMORY.md"
+export HOME="$TMP/home"
+
+# add <args...> ; body on stdin. Subshell: `fail` exits, and we want the code.
+add() { ( _memory_add "$@" ) ; }
+
+BODY_A='The provisioning queue takes a postgres advisory lock so a second api
+instance declines to dispatch instead of claiming queued rows and firing real
+customer hetzner builds against the production database.'
+
+echo "── evidence back-refs (own store) ──"
+printf '%s\n' "$BODY_A" | add --name=ev-one --type=reference \
+  --description="advisory lock on the provision queue" \
+  --evidence=file:src/cmd_memory.sh:586 --evidence=task:DIVE-3106 \
+  --evidence="cmd:5dive task show DIVE-3106" >/dev/null 2>&1
+check "add with --evidence exits 0" "$?" "0"
+F="$STORE/reference_ev_one.md"
+[ -f "$F" ] && ok "file written" || bad "file written"
+grep -q '^  evidence:$' "$F" && ok "nested evidence: key under metadata" || bad "nested evidence: key under metadata"
+grep -q '^    - "file:src/cmd_memory.sh:586"$' "$F" && ok "file: ref emitted" || bad "file: ref emitted"
+grep -q '^    - "task:DIVE-3106"$' "$F" && ok "task: ref emitted" || bad "task: ref emitted"
+grep -q '^    - "cmd:5dive task show DIVE-3106"$' "$F" && ok "cmd: ref emitted (spaces survive)" || bad "cmd: ref emitted"
+check "all three refs, in order" "$(grep -c '^    - "' "$F")" "3"
+
+echo "── --evidence validation refuses a ref that could not be walked ──"
+for badref in "notakind:x" "file:" "task:dive-3106" "task:DIVE" "sha:zzzz" "url:ftp://x/y" "bare-string"; do
+  printf '%s\n' "$BODY_A" | add --name=ev-bad --type=reference --description=d \
+    --evidence="$badref" >/dev/null 2>&1
+  [ "$?" -ne 0 ] && ok "refused --evidence=$badref" || bad "refused --evidence=$badref"
+done
+[ -f "$STORE/reference_ev_bad.md" ] && bad "refusal wrote no file" || ok "refusal wrote no file"
+for goodref in "file:a/b.ts" "task:DIVE-1" "sha:40fdcbf" "url:https://x/y" "run:abc123" "cmd:echo hi"; do
+  printf '%s\n' "$BODY_A" | add --name=ev-ok --type=reference --description=d \
+    --evidence="$goodref" --force --no-dedup >/dev/null 2>&1
+  [ "$?" -eq 0 ] && ok "accepted --evidence=$goodref" || bad "accepted --evidence=$goodref"
+done
+
+echo "── ADDITIVE: no --evidence ⇒ no evidence key at all (negative control) ──"
+printf 'A wholly unrelated fact about caddy reverse proxy ports and shelld.\n' \
+  | add --name=ev-none --type=reference --description="nothing cited here" >/dev/null 2>&1
+grep -qE '^ *evidence:' "$STORE/reference_ev_none.md" \
+  && bad "absent --evidence leaves NO evidence key" || ok "absent --evidence leaves NO evidence key"
+grep -q '^  provenance:' "$STORE/reference_ev_none.md" \
+  && bad "no provenance key when unset" || ok "no provenance key when unset"
+
+echo "── --provenance is untouched and coexists with --evidence ──"
+printf '%s\n' "$BODY_A" | add --name=ev-both --type=reference --description=d \
+  --provenance="measured by main 2026-08-09" --evidence=task:DIVE-3106 \
+  --no-dedup >/dev/null 2>&1
+grep -q '^  provenance: "measured by main 2026-08-09"$' "$STORE/reference_ev_both.md" \
+  && ok "--provenance still emitted verbatim" || bad "--provenance still emitted verbatim"
+grep -q '^    - "task:DIVE-3106"$' "$STORE/reference_ev_both.md" \
+  && ok "--evidence sits beside it" || bad "--evidence sits beside it"
+
+echo "── write-time dedup: WARNS, and still writes (advisory, never refuses) ──"
+ERR="$TMP/err.txt"
+printf '%s\n' "$BODY_A" | add --name=ev-dup --type=reference \
+  --description="a near copy of ev-one" >/dev/null 2>"$ERR"
+check "near-duplicate add still exits 0" "$?" "0"
+[ -f "$STORE/reference_ev_dup.md" ] && ok "near-duplicate STILL WRITTEN" || bad "near-duplicate STILL WRITTEN"
+grep -q 'near-duplicate' "$ERR" && ok "warned on stderr" || bad "warned on stderr ($(cat "$ERR"))"
+grep -q 'reference_ev_one.md' "$ERR" && ok "names the overlapping file" || bad "names the overlapping file"
+
+echo "── dedup negative control: a distinct body warns about nothing ──"
+printf 'Caddy terminates tls on 443 and shelld owns the ssh recovery path for a
+locked out box; unrelated vocabulary throughout this particular sentence.\n' \
+  | add --name=ev-distinct --type=reference --description=d >/dev/null 2>"$ERR"
+grep -q 'near-duplicate' "$ERR" && bad "no warning on a distinct body" || ok "no warning on a distinct body"
+
+echo "── --no-dedup silences the warning ──"
+printf '%s\n' "$BODY_A" | add --name=ev-dup2 --type=reference --description=d \
+  --no-dedup >/dev/null 2>"$ERR"
+grep -q 'near-duplicate' "$ERR" && bad "--no-dedup silences" || ok "--no-dedup silences"
+
+echo "── --force update-in-place must not match ITSELF ──"
+printf '%s\n' "$BODY_A" | add --name=ev-one --type=reference --description=d \
+  --force >/dev/null 2>"$ERR"
+grep -q 'reference_ev_one.md' "$ERR" && bad "self not reported as its own dup" || ok "self not reported as its own dup"
+
+echo "── REGRESSION: the secret tripwire still refuses, --force does not bypass ──"
+printf 'the token is sk-abcdefghijklmnop and it is live\n' \
+  | add --name=ev-secret --type=reference --description=d --force >/dev/null 2>&1
+[ "$?" -ne 0 ] && ok "tripwire still refuses (with --force)" || bad "tripwire still refuses (with --force)"
+
+echo "── wiki store: evidence is TOP-LEVEL, not nested ──"
+# Point _memory_wiki_root at a fake wiki INSIDE $HOME so the real
+# /home/claude/projects/5dive/community/wiki is never written by a test.
+WIKI="$HOME/projects/5dive/community/wiki"; mkdir -p "$WIKI"; : > "$WIKI/index.md"
+check "wiki root resolves inside the sandbox" "$(_memory_wiki_root)" "$WIKI"
+printf '%s\n' "$BODY_A" | add --name=ev-wiki --store=wiki --description="w" \
+  --evidence=file:src/cmd_memory.sh --evidence=task:DIVE-3106 >/dev/null 2>&1
+check "wiki add exits 0" "$?" "0"
+grep -q '^evidence:$' "$WIKI/ev-wiki.md" && ok "top-level evidence: key" || bad "top-level evidence: key"
+grep -q '^  - "task:DIVE-3106"$' "$WIKI/ev-wiki.md" && ok "wiki ref emitted" || bad "wiki ref emitted"
+grep -q '^updated: ' "$WIKI/ev-wiki.md" && ok "wiki frontmatter still closes correctly" || bad "wiki frontmatter still closes correctly"
+python3 - "$WIKI/ev-wiki.md" <<'PYCHK' && ok "wiki frontmatter is parseable YAML-ish (evidence is a list)" || bad "wiki frontmatter parses"
+import re,sys
+t=open(sys.argv[1]).read()
+fm=t.split("---")[1]
+assert re.search(r'^evidence:\n(  - ".*"\n)+', fm, re.M), fm
+PYCHK
+printf '%s\n' "$BODY_A" | add --name=ev-wiki2 --store=wiki --description="w2" >/dev/null 2>&1
+grep -qE '^ *evidence:' "$WIKI/ev-wiki2.md" && bad "wiki without --evidence has no key" || ok "wiki without --evidence has no key"
+
+echo "── doctor: evidence-ref walks file: targets only ──"
+CODE="$TMP/code"; mkdir -p "$CODE/src"; : > "$CODE/src/real_file.ts"
+DS="$TMP/dstore"; mkdir -p "$DS"
+cat > "$DS/reference_walkable.md" <<'EOF'
+---
+name: walkable
+description: "d"
+metadata:
+  type: reference
+  evidence:
+    - "file:src/real_file.ts:12"
+    - "task:DIVE-3106"
+    - "cmd:5dive task show DIVE-3106"
+    - "url:https://example.com/x"
+---
+
+A body long enough to be considered by the other checks in this scanner pass.
+EOF
+cat > "$DS/reference_dangling.md" <<'EOF'
+---
+name: dangling
+description: "d"
+metadata:
+  type: reference
+  evidence:
+    - "file:src/deleted_file.ts:3"
+---
+
+Another body of prose that exists purely so the scanner has something to read.
+EOF
+cat > "$DS/reference_noevidence.md" <<'EOF'
+---
+name: noevidence
+description: "d"
+metadata:
+  type: reference
+---
+
+A third body with no evidence key whatsoever, which must not be flagged at all.
+EOF
+SCAN=$(_memory_scan_json "$CODE" "$DS")
+N_EV=$(printf '%s' "$SCAN" | jq '[.findings[]|select(.kind=="evidence-ref")]|length')
+check "exactly one evidence-ref finding" "$N_EV" "1"
+HIT=$(printf '%s' "$SCAN" | jq -r '[.findings[]|select(.kind=="evidence-ref")][0].file')
+check "it is the dangling one" "$HIT" "reference_dangling.md"
+MSG=$(printf '%s' "$SCAN" | jq -r '[.findings[]|select(.kind=="evidence-ref")][0].message')
+case "$MSG" in *deleted_file.ts*) ok "message names the dead ref" ;; *) bad "message names the dead ref ($MSG)" ;; esac
+SEV=$(printf '%s' "$SCAN" | jq -r '[.findings[]|select(.kind=="evidence-ref")][0].severity')
+check "severity is warn, never error" "$SEV" "warn"
+printf '%s' "$SCAN" | jq -e '[.findings[]|select(.file=="reference_noevidence.md" and .kind=="evidence-ref")]|length==0' >/dev/null \
+  && ok "a memory with NO evidence is not flagged" || bad "a memory with NO evidence is not flagged"
+
+echo "── doctor: no code-root ⇒ evidence-ref stays silent (no crying wolf) ──"
+SCAN2=$(_memory_scan_json "" "$DS")
+check "silent without a code-root" \
+  "$(printf '%s' "$SCAN2" | jq '[.findings[]|select(.kind=="evidence-ref")]|length')" "0"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes DIVE-3106.

Two of the three mechanisms lodar approved lifting from **TencentCloud/TencentDB-Agent-Memory (MIT)**. **Idea-derived — no files copied**, so the MIT notice does not attach; the boundary is recorded in the source at the time of writing rather than reconstructed later.

Both are **additive**, per lodar 2026-08-09: *"we already have a lot of memory features so pls be careful not to break but rather to improve."*

## 1. Evidence back-refs — `memory add --evidence=<kind>:<ref>`, repeatable

`--provenance` is a free-text string an agent types. This is a structural link you can follow, so "re-verify this claim" is a mechanical walk instead of archaeology. Kinds: `file:` `task:` `cmd:` `sha:` `url:` `run:`.

The failure it fixes is not hypothetical — two claims on 2026-08-09 could not be re-walked: DIVE-2911 carried *"api.openai.com — ZERO occurrences"* (actually 8; the scan read the JS shim, never the compiled binary), and DIVE-3100 carried a root cause nobody could reproduce.

**`--provenance` is untouched. A memory with no `--evidence` is not flagged, demoted, or degraded** — there is a negative control asserting the frontmatter is byte-identical to pre-3106 output.

`memory doctor` gains an `evidence-ref` check that walks **`file:` targets only**. The other five kinds need the board, a shell, the network or a repo; a checker that cannot distinguish *false* from *not checkable here* trains people to ignore it. `warn` severity, never `error`, and silent with no code-root. Malformed refs are still caught at **write** time for all six.

## 2. Write-time dedup — advisory, and it must stay advisory

Same Jaccard-over-body-words shape the doctor's `near-dup` check already used, moved to the moment of the write. It **warns on stderr, writes anyway, exits 0**; `--no-dedup` silences it.

`memory add` already carries one load-bearing refusal — the secret tripwire — and a second refusal on the same verb makes the compile step feel adversarial. The asymmetry decides it: a duplicate memory costs a merge later, a false refusal on a write path costs the fact entirely. Measure the hit rate against the real store before anyone argues for teeth.

## The bug the harness found and review would not have

The dedup helper was first written in the shape of the doctor's scanner:

```sh
python3 - "$target" "$dir" <<'PYEOF' >&2     # the heredoc IS python3's stdin
body = sys.stdin.read()                      # ...so this reads the PROGRAM, not the body
```

**A `python3 - <<'EOF'` helper cannot also accept data on stdin.** It failed **silently and open**: empty body, under the word floor, `exit 0` — the check never fired on any input, while exit code, file-written and every other reviewer-visible signal stayed green.

What caught it was asserting the **positive** case (*this add must WARN and name the overlapping file*) rather than only the safe properties, which passed throughout. Body is now passed as a path in argv.

## Testing

`tests/memory_evidence_dedup_unit.sh` — **46 assertions, 0 failures**. The negative controls are the point: no `--evidence` emits no key at all; a distinct body warns about nothing; `--force` update-in-place does not match itself; a memory with no evidence is never flagged by the doctor; `evidence-ref` is silent without a code-root; and the **secret tripwire still refuses under `--force`**.

**Baseline first, then diffed** (a suite that was already red proves nothing about what you changed):

| suite | before | after | output |
|---|---|---|---|
| `memory_doctor_unit` | PASS | PASS | identical |
| `inherit_memory_unit` | PASS | PASS | identical |
| `pack_memory_leakscan_unit` | PASS | PASS | identical |
| `pack_export_memory_dir_missing_unit` | PASS | PASS | identical |

`shellcheck -S warning` code counts unchanged vs `origin/main` (SC2148×1, SC2178×2, SC2128×1 — all pre-existing). Bundle builds. Verified live end-to-end against the built bundle in an isolated `$HOME`, and the wiki page below was itself compiled **through the new `--evidence` flag**.

## Not in this PR, on purpose

Mechanism 3 (clock/idle write triggers). **The CLI does not observe turns — the harness does**, so an every-N-turns trigger has nowhere to live. The only clock we own is the heartbeat, which makes idle-capture the sole expressible variant and puts it on a fleet-wide load-bearing path with a blast radius nothing here has. Design + constraints recorded in the DIVE-3106 body.

Knowledge compiled to `community/wiki/an-idea-lift-records-its-licence-boundary-at-write-time.md` (+ index line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
