### PR TITLE
fix(task): make the --result negative arms mutation-survivable, and add --result-file= to deliver/verify (DIVE-3018)

### DIFF
--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -25,8 +25,9 @@ _task_usage() {
                                                 -> done, or hand to the verifier if one is set
                                                 verifiers: put \`graded-sha: <sha>\` in the result;
                                                 --no-graded-sha is the audited escape
-  deliver <id> --pr=<url> [--result=]           record the delivery PR, hand to the verifier
-  verify <id> [--cmd=] [--no-done] [--timeout=] run the check; exit 0 = pass
+  deliver <id> --pr=<url> [--result=|--result-file=<path>]   record the delivery PR, hand to the verifier
+  verify <id> [--cmd=] [--result=|--result-file=<path>] [--no-done] [--timeout=]
+                                                run the check; exit 0 = pass
   reject <id> [--feedback=<what to fix>]        verifier FAIL: bounce back to the maker
   cancel <id> [--result=<text>]                 -> cancelled
   done|cancel [--keep-worktree]                 keep node_modules in that row's worktrees
@@ -4949,14 +4950,22 @@ _task_live_blocker() {
 # stays in_progress: a verifier must close it after the merge (done ≠ delivered).
 cmd_task_deliver() {
   tasks_db_init
-  local task="" pr="" result="" want_result=0
+  local task="" pr="" result="" want_result=0 result_src=""
   local append_result=0 force_result=0   # DIVE-2476: the two sanctioned answers to the
                                          # already-closed-row refusal, spelled exactly
                                          # as `task done|cancel` spells them.
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --pr=*)          pr="${1#*=}" ;;
-      --result=*)      result="${1#*=}"; want_result=1 ;;
+      # DIVE-3018: --result-file mirrors `task done`'s (DIVE-2627). The argv form
+      # only fails once the text is long enough to hit a shell-quoting mistake —
+      # i.e. it fails invisibly in exactly the cases nobody tests with, and what
+      # lands is a permanently wrong record rather than an error.
+      --result=*)      _prose_flag_dupe --result "$result_src"
+                       result="${1#*=}"; want_result=1; result_src="--result" ;;
+      --result-file=*) _prose_flag_dupe --result-file "$result_src"
+                       _read_prose_file --result-file "${1#*=}"
+                       result="$_PROSE_FILE_VALUE"; want_result=1; result_src="--result-file" ;;
       --append-result) append_result=1 ;;
       --force-result)  force_result=1 ;;
       -*)              fail "$E_USAGE" "unknown flag: $1" ;;
@@ -4964,7 +4973,7 @@ cmd_task_deliver() {
     esac
     shift
   done
-  [[ -n "$task" ]] || fail "$E_USAGE" "usage: 5dive task deliver <id|DIVE-N> --pr=<url> [--result=<text>] [--append-result|--force-result]"
+  [[ -n "$task" ]] || fail "$E_USAGE" "usage: 5dive task deliver <id|DIVE-N> --pr=<url> [--result=<text>|--result-file=<path>] [--append-result|--force-result]"
   [[ -n "$pr" ]]   || fail "$E_USAGE" "task deliver requires --pr=<url> (the PR that delivers this task; done stays blocked until it is MERGED — DIVE-1830)"
   # Basic sanity: a delivery ref must look like a PR URL, not a bare word.
   if [[ "$pr" != http*://* && "$pr" != *github.com* ]]; then
@@ -5950,7 +5959,7 @@ cmd_task_loop() {
 # --no-done (alias --check) runs the check and records it WITHOUT flipping.
 cmd_task_verify() {
   tasks_db_init
-  local task="" cmd="" no_done=0 timeout_s="" prose="" have_prose=0
+  local task="" cmd="" no_done=0 timeout_s="" prose="" have_prose=0 prose_src=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --cmd=*)      cmd="${1#*=}" ;;
@@ -5958,7 +5967,14 @@ cmd_task_verify() {
       # DIVE-2832: the verifier's own words. Every other writer of this column is
       # either the MAKER's verb (deliver) or machine output, so a verifier who
       # graded by READING had no way to put a prose PASS on an OPEN row at all.
-      --result=*)   prose="${1#*=}"; have_prose=1 ;;
+      --result=*)   _prose_flag_dupe --result "$prose_src"
+                    prose="${1#*=}"; have_prose=1; prose_src="--result" ;;
+      # DIVE-3018: same file sibling as `task done` / `task deliver`. A verifier's
+      # verdict is the LONGEST prose any of these verbs takes, so this is the one
+      # most exposed to the quoting trap the argv form carries.
+      --result-file=*) _prose_flag_dupe --result-file "$prose_src"
+                    _read_prose_file --result-file "${1#*=}"
+                    prose="$_PROSE_FILE_VALUE"; have_prose=1; prose_src="--result-file" ;;
       --timeout=*)  timeout_s="${1#*=}" ;;
       -*)           fail "$E_USAGE" "unknown flag: $1" ;;
       *)            [[ -z "$task" ]] && task="$1" || fail "$E_USAGE" "unexpected arg: $1" ;;
@@ -5966,7 +5982,7 @@ cmd_task_verify() {
     shift
   done
   [[ -n "$task" ]] \
-    || fail "$E_USAGE" "usage: 5dive task verify <id|DIVE-N> [--cmd=\"<command>\"] [--result=\"<prose verdict>\"] [--no-done] [--timeout=<seconds>]"
+    || fail "$E_USAGE" "usage: 5dive task verify <id|DIVE-N> [--cmd=\"<command>\"] [--result=\"<prose verdict>\"|--result-file=<path>] [--no-done] [--timeout=<seconds>]"
   [[ -z "$timeout_s" || "$timeout_s" =~ ^[1-9][0-9]*$ ]] \
     || fail "$E_VALIDATION" "--timeout must be a positive integer (seconds)"
   resolve_task_id "$task"; local id="$RESOLVED_TASK_ID" ident="$RESOLVED_TASK_IDENT"

--- a/tests/verify_prose_result_open_row_unit.sh
+++ b/tests/verify_prose_result_open_row_unit.sh
@@ -69,8 +69,24 @@ res "$A" | grep -q "NO command was run" \
   && ok_t "A: the record says NO COMMAND RAN — not mistakable for a machine verdict" \
   || bad_t "A: the record says NO COMMAND RAN" "an unexecuted grade renders like an exit-0 one"
 
+# DIVE-3018. This arm used to assert ONLY that the row stayed todo, and that graded
+# NOTHING: replace the guard it names with `if false; then` and the suite still went
+# 9/0, because the now-open prose+close path dies under `set -euo pipefail` with the
+# generic "exited 1 without reporting a reason" BEFORE it can flip the row. "Did it
+# fail?" and "is the state unchanged?" are the SAME predicate in a system where
+# failing early is how nothing happens — any abort satisfies both, including a crash,
+# a typo'd ident or an unrelated guard firing first. So the status check stays (it is
+# the property we care about) but it can no longer carry the arm alone: we assert the
+# refusal's OWN output, which only this guard can produce.
+# See community/wiki/a-negative-arm-that-greps-for-failure-passes-on-any-failure.md
 B=$(mk "prose B")
-"$CLI" task verify "$B" --result="should be refused" >/dev/null 2>&1
+b_out=$("$CLI" task verify "$B" --result="should be refused" 2>&1); b_rc=$?
+[[ "$b_rc" -eq 2 ]] \
+  && ok_t "B NEGATIVE: the refusal exits E_USAGE(2), not a generic abort" \
+  || bad_t "B NEGATIVE: the refusal exits E_USAGE(2)" "got rc=$b_rc — any nonzero would satisfy a state-only assertion"
+grep -q "requires --no-done" <<<"$b_out" \
+  && ok_t "B NEGATIVE: and says 'requires --no-done' — a token only THIS guard emits" \
+  || bad_t "B NEGATIVE: the refusal names itself" "got: $(head -c 120 <<<"$b_out")"
 [[ "$(st "$B")" == "status=todo" ]] \
   && ok_t "B NEGATIVE: --result without --no-done cannot close the row" \
   || bad_t "B NEGATIVE: --result without --no-done cannot close" "got $(st "$B")"
@@ -78,8 +94,16 @@ res "$B" | grep -q "should be refused" \
   && bad_t "B NEGATIVE: a refused call must record nothing" "wrote a result on a refusal" \
   || ok_t "B NEGATIVE: a refused call recorded nothing"
 
+# DIVE-3018: C carried the same defect as B in a different costume — an ABSENCE
+# assertion ("no verdict was stored") is satisfied by every abort too. Same cure.
 C=$(mk "prose C")
-"$CLI" task verify "$C" --no-done --result="   " >/dev/null 2>&1
+c_out=$("$CLI" task verify "$C" --no-done --result="   " 2>&1); c_rc=$?
+[[ "$c_rc" -eq 3 ]] \
+  && ok_t "C NEGATIVE: the empty-verdict refusal exits E_VALIDATION(3)" \
+  || bad_t "C NEGATIVE: the empty-verdict refusal exits E_VALIDATION(3)" "got rc=$c_rc"
+grep -q "EMPTY value" <<<"$c_out" \
+  && ok_t "C NEGATIVE: and names the empty value — not a generic abort" \
+  || bad_t "C NEGATIVE: the refusal names the empty value" "got: $(head -c 120 <<<"$c_out")"
 res "$C" | grep -qE "verify (PASS|FAIL)" \
   && bad_t "C NEGATIVE: an EMPTY --result must be refused" "stored a blank verdict" \
   || ok_t "C NEGATIVE: an empty --result is refused, not stored (DIVE-2483)"
@@ -92,6 +116,57 @@ grep -q "task has no stored verify_command" <<<"$out" \
 grep -qi "graded by READING" <<<"$out" \
   && ok_t "D: and that refusal now NAMES --result as the exit" \
   || bad_t "D: the refusal names --result as the exit" "a refusal that hides its own exit is what this row is about"
+
+# ── DIVE-3018 item 2: --result-file= on the verbs that already take --result= ──
+# `task done` got this in DIVE-2627; `task deliver` and `task verify` did not. The
+# argv form only fails once the text is long enough to hit a shell-quoting mistake,
+# so it fails invisibly in exactly the cases nobody tests with — and what lands is a
+# permanently wrong record, not an error. These arms assert the FILE form on both
+# verbs plus the two refusals that make it safe to reach for.
+F=$(mk "prose F")
+printf 'graded by reading the diff.\n\nSecond paragraph with a `backtick`, an apostrophe'"'"'s worth of trouble, and $NOT_A_VAR.\n' > "$TMP/verdict.txt"
+"$CLI" task verify "$F" --no-done --result-file="$TMP/verdict.txt" >/dev/null 2>&1
+f_rc=$?
+[[ "$f_rc" -eq 0 ]] \
+  && ok_t "F: task verify --result-file records a prose verdict on an OPEN row" \
+  || bad_t "F: task verify --result-file exits 0" "got rc=$f_rc"
+res "$F" | grep -q 'a `backtick`' \
+  && ok_t "F: backticks/apostrophes/\$vars survive the FILE path verbatim" \
+  || bad_t "F: the file text survives verbatim" "the quoting trap this flag exists to remove"
+[[ "$(st "$F")" == "status=todo" ]] \
+  && ok_t "F: --result-file is a RECORDING path too — the row stays open" \
+  || bad_t "F: --result-file must not close the row" "got $(st "$F")"
+
+# NEGATIVE, and asserted on the refusal's own words rather than on absence.
+G=$(mk "prose G")
+g_out=$("$CLI" task verify "$G" --no-done --result=inline --result-file="$TMP/verdict.txt" 2>&1); g_rc=$?
+[[ "$g_rc" -eq 2 ]] && grep -q "conflicts with" <<<"$g_out" \
+  && ok_t "G NEGATIVE: --result and --result-file together are REFUSED (E_USAGE + names the conflict)" \
+  || bad_t "G NEGATIVE: inline+file must be refused" "rc=$g_rc out=$(head -c 120 <<<"$g_out")"
+: > "$TMP/empty.txt"
+h_out=$("$CLI" task verify "$G" --no-done --result-file="$TMP/empty.txt" 2>&1); h_rc=$?
+[[ "$h_rc" -eq 3 ]] && grep -q "is empty" <<<"$h_out" \
+  && ok_t "G NEGATIVE: an EMPTY file is refused, not recorded as blank (E_VALIDATION)" \
+  || bad_t "G NEGATIVE: an empty file must be refused" "rc=$h_rc out=$(head -c 120 <<<"$h_out")"
+i_out=$("$CLI" task verify "$G" --no-done --result-file="$TMP/nope.txt" 2>&1); i_rc=$?
+[[ "$i_rc" -eq 2 ]] && grep -q "no such file" <<<"$i_out" \
+  && ok_t "G NEGATIVE: a missing file is refused by NAME (E_USAGE)" \
+  || bad_t "G NEGATIVE: a missing file must be refused" "rc=$i_rc out=$(head -c 120 <<<"$i_out")"
+
+# The other verb the ticket names. deliver needs a --pr= URL to run at all.
+J=$(mk "prose J")
+"$CLI" task deliver "$J" --pr=https://github.com/5dive-ai/5dive/pull/1 --result-file="$TMP/verdict.txt" >/dev/null 2>&1
+j_rc=$?
+[[ "$j_rc" -eq 0 ]] \
+  && ok_t "J: task deliver --result-file works too (the second verb the ticket names)" \
+  || bad_t "J: task deliver --result-file exits 0" "got rc=$j_rc"
+res "$J" | grep -q 'a `backtick`' \
+  && ok_t "J: and deliver's file text survives verbatim" \
+  || bad_t "J: deliver's file text survives verbatim"
+k_out=$("$CLI" task deliver "$J" --pr=https://github.com/5dive-ai/5dive/pull/1 --result=x --result-file="$TMP/verdict.txt" 2>&1); k_rc=$?
+[[ "$k_rc" -eq 2 ]] && grep -q "conflicts with" <<<"$k_out" \
+  && ok_t "J NEGATIVE: deliver refuses inline+file too — one answer per question" \
+  || bad_t "J NEGATIVE: deliver must refuse inline+file" "rc=$k_rc out=$(head -c 120 <<<"$k_out")"
 
 E=$(mk "prose E")
 "$CLI" task verify "$E" --no-done --cmd=true --result="both given" >/dev/null 2>&1


### PR DESCRIPTION
Closes DIVE-3018. Follow-up to DIVE-2832 iteration-3 grading (olivia). Two items, neither blocking.


Follow-up to DIVE-2832 iteration-3 grading. Two items, neither blocking.

## 1. The negative arms graded nothing

Arm B asserted only that the row stayed `todo` after `task verify --result`
without `--no-done`. Replace the guard it names with `if false; then`, rebuild,
and the suite still went 9 passed, 0 failed — because the now-open prose+close
path dies under `set -euo pipefail` with the generic "exited 1 without reporting
a reason" BEFORE it can flip the row.

"Did it fail?" and "is the state unchanged?" are the same predicate in a system
where failing early is how nothing happens. Any abort satisfies both.

Arm C carried the identical defect one costume over: it asserted an ABSENCE
(no verdict stored), which every abort also satisfies. So the class is wider
than a state read — it is any assertion whose success condition is that the
system did not act.

Both now assert the refusal's OWN output — its exit code (E_USAGE 2 /
E_VALIDATION 3) plus a token only that guard emits (`requires --no-done`,
`EMPTY value`) — alongside the original property, which is kept but demoted
rather than deleted.

## 2. --result-file= on deliver and verify

`task done` got this in DIVE-2627; `task deliver` and `task verify` did not.
The argv form only fails once the text is long enough to hit a shell-quoting
mistake, i.e. it fails invisibly in exactly the cases nobody tests with, and
what lands is a permanently wrong record rather than an error. Mirrors the
existing arm exactly, reusing `_read_prose_file` / `_prose_flag_dupe` from
lib/validation.sh — no new helper, that file is untouched.

## Mutation matrix (re-measured on the rebased tip; all five verified applied)

  pristine                          22/0
  requires --no-done guard off      20/2   B x2
  empty-verdict guard deleted       19/3   C x3
  verify --result-file deleted      17/5   F x2, G x3
  deliver --result-file deleted     20/2   J x2
  inline-vs-file conflict off       20/2   G conflict, J conflict

Note three mutations score an identical 20/2 and are separable only by WHICH
assertions red, per stubbed-boundary-format-contract rule 5.

Differential, same mutant and same rebuilt bundle:
  pre-fix harness   9 passed, 0 failed   (reproduces olivia's finding exactly)
  hardened harness  20 passed, 2 failed

Two of the five mutations silently no-opped on the first attempt and returned
the pristine tally — one decorated the grepped token instead of destroying it,
the other hit the byte-identical arm in the wrong verb. Both are written up in
community/wiki/a-mutation-that-did-not-apply-returns-a-clean-run.md, along with
the sweep that was contaminated by running beside a rebuilding mutation harness.

shellcheck warning count unchanged vs origin/main (11 = 11).
src/lib/validation.sh unchanged.




🤖 Generated with [Claude Code](https://claude.com/claude-code)
