### PR TITLE
feat(task): a graded-but-unmerged row is terminal for the VERIFIER, not for the ROW (DIVE-3098)

### DIFF
--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -1399,6 +1399,28 @@ _hb_loop_terminal_clause() {
   vfier="${row%%|*}"; rest="${row#*|}"; maker="${rest%%|*}"; creator="${rest#*|}"
   [[ -n "$vfier" ]] || return 0
 
+  # DIVE-3098 — GRADED-AND-WAITING, and it is checked FIRST because it is the one
+  # state in which every variant below gives actively wrong advice: the maker variant
+  # tells a maker to deliver what is already delivered AND graded, the routing variant
+  # tells them nothing is delivered, and the verifier variant tells a verifier to grade
+  # what they have already graded. The row is terminal for the VERIFIER and open for
+  # the ROW, so the only outstanding act is a MERGE — and the goal must stop rather
+  # than re-wake someone into a loop whose remaining step belongs to someone else.
+  # This is the case that closed DIVE-2645/#427 and DIVE-2743/#485 as false dones.
+  #
+  # Not a fail-open, by the same rule as the variants below: read from graded_at,
+  # which ONLY `task verify --no-done` stamps, plus a bound delivery_ref and
+  # grader != maker. No prose an agent can type reaches it. It applies to EITHER role
+  # (maker still holding it, or verifier) — once graded-and-waiting, neither owes
+  # another pass, so it is deliberately not gated on which one was woken.
+  if [[ "$(db "SELECT 1 FROM tasks WHERE id=${task_id} AND ${_TASKS_TFV_SQL};" 2>/dev/null)" == "1" ]]; then
+    local _tfv_owner
+    _tfv_owner=$(db "SELECT COALESCE(NULLIF(maker_agent,''), COALESCE(assignee,'?')) FROM tasks WHERE id=${task_id};" 2>/dev/null)
+    printf ' NOTE — %s is GRADED AND WAITING ON A MERGE: a verifier grade is recorded and a delivery ref is bound, so the verifier has discharged their role and this is TERMINAL FOR THIS GOAL. Treat the goal as MET and stop — %s renders it as %s. The row stays OPEN on purpose and closes only when the work MERGES, because %s keeps meaning merged-to-main; the outstanding act is a MERGE owed by %s, not another pass by you. Do NOT re-grade it, re-deliver it, or close it to make the loop stop.' \
+      "$task_ident" "'5dive task ls'" "'graded->merge:${_tfv_owner}'" "'done'" "${_tfv_owner:-the maker}"
+    return 0
+  fi
+
   if [[ "$vfier" != "$name" ]]; then
     # MAKER variant — delivery is the second terminal state.
     printf ' NOTE — %s carries a maker→verifier loop (verifier: %s), so your %s does NOT close it: it DELIVERS it (status stays todo and the task moves to %s to be graded). That delivery is a SECOND terminal state for THIS goal: treat the goal as MET, and stop, once %s prints a %s line under %s naming %s. Report that you delivered. Do NOT re-run %s, remove the verifier, or self-verify to force a status of done — the terminal close is %s'"'"'s, in their own session, and forcing it past them is a bypass, not progress.' \
@@ -2425,6 +2447,7 @@ _hb_stall_sweep() {
                  AND handoff_ack_at IS NULL AND handoff_stale_pinged_at IS NULL
                  AND handoff_delivered_at IS NOT NULL
                  AND NOT (need_type IS NOT NULL AND need_answered_at IS NULL)
+                 AND NOT (${_TASKS_TFV_SQL})
                  AND handoff_delivered_at <= datetime('now','-${_HB_VERIFY_STALE_MIN} minutes');")
 
   # (a2) DIVE-2693 — a materialized RECURRING instance that was never STARTED.

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -1429,9 +1429,25 @@ cmd_task_ls() {
     # render the missing value explicitly instead of turning it into another
     # invisible blank.  The default open queue stays compact.
     if [[ "$status" == "done" || $all -eq 1 ]]; then
-      dbfmt -box "SELECT ident, status, priority, COALESCE(assignee,'-') AS assignee, COALESCE(NULLIF(delivery_ref,''),'absent') AS delivery_ref, title FROM tasks WHERE ${where} ${order};"
+      # DIVE-3098: the audit view renders graded-and-waiting the same way as the
+      # compact one. Two branches, one predicate — if only the default view knew,
+      # `--all` would still paint the row `todo` and the reader who went looking for
+      # detail would get the LESS accurate answer.
+      dbfmt -box "SELECT ident,
+             CASE WHEN ${_TASKS_TFV_SQL}
+                  THEN 'graded->merge:'||COALESCE(NULLIF(maker_agent,''), COALESCE(assignee,'?'))
+                  ELSE status END AS status,
+             priority, COALESCE(assignee,'-') AS assignee, COALESCE(NULLIF(delivery_ref,''),'absent') AS delivery_ref, title FROM tasks WHERE ${where} ${order};"
     else
-      dbfmt -box "SELECT ident, status, priority, COALESCE(assignee,'-') AS assignee, title FROM tasks WHERE ${where} ${order};"
+      # DIVE-3098: a graded-and-waiting row must not read as todo/blocked/in_progress
+      # to the eye, and the render must name who owes the MERGE - the maker or ship
+      # approver, never the verifier, who has already finished. Folded into the status
+      # cell rather than a new column so the compact board stays compact.
+      dbfmt -box "SELECT ident,
+             CASE WHEN ${_TASKS_TFV_SQL}
+                  THEN 'graded->merge:'||COALESCE(NULLIF(maker_agent,''), COALESCE(assignee,'?'))
+                  ELSE status END AS status,
+             priority, COALESCE(assignee,'-') AS assignee, title FROM tasks WHERE ${where} ${order};"
     fi
   fi
 }
@@ -4948,6 +4964,38 @@ _task_live_blocker() {
 # reuses the DIVE-477 in-review handoff — it does NOT invent a new status. When
 # there is no distinct verifier, the delivery is still recorded but the task
 # stays in_progress: a verifier must close it after the merge (done ≠ delivered).
+# _task_terminal_for_verifier <id> — DIVE-3098. TRUE (exit 0) when the row is
+# TERMINAL FOR THE VERIFIER and still NON-TERMINAL FOR THE ROW:
+#
+#   a verifier grade recorded by `task verify --no-done` (graded_at stamped,
+#   graded_by != maker_agent)  AND  delivery_ref bound.
+#
+# Such a row SATISFIES the goal Stop hook and is EXEMPT from the rot-nudger — the
+# verifier has discharged their role and the remaining work is a MERGE, owed by the
+# maker or the ship approver. `status` stays open; the row closes only on merge, so
+# `done` keeps meaning merged-to-main (DIVE-1835) and nobody gains a terminal-looking
+# verb short of it. That anti-goal is why this is a PREDICATE and not a status value.
+#
+# Both halves are load-bearing and the negative arms prove it: a grade with no
+# delivery_ref is a verdict nobody can check, and a delivery_ref with no grade is the
+# ungraded case the nudger exists for. Neither alone qualifies.
+_task_terminal_for_verifier() {
+  local id="$1"
+  [[ "$id" =~ ^[0-9]+$ ]] || return 1
+  local hit
+  hit=$(db "SELECT 1 FROM tasks WHERE id=${id} AND ${_TASKS_TFV_SQL};" 2>/dev/null) || return 1
+  [[ "$hit" == "1" ]]
+}
+
+# _task_merge_owner <id> — who owes the merge on a graded-and-waiting row. The maker
+# built it and the verifier has finished; naming the verifier here would point at the
+# one person with nothing left to do. Falls back to the assignee.
+_task_merge_owner() {
+  local id="$1" who
+  who=$(db "SELECT COALESCE(NULLIF(maker_agent,''), COALESCE(assignee,'?')) FROM tasks WHERE id=${id};" 2>/dev/null)
+  printf '%s' "${who:-?}"
+}
+
 cmd_task_deliver() {
   tasks_db_init
   local task="" pr="" result="" want_result=0 result_src=""
@@ -6243,7 +6291,19 @@ cmd_task_verify() {
     # overnight (OSS-27 closed via `task verify`, cascade never ran).
     _task_cascade_unblock "$id" || true
   else
-    db "UPDATE tasks SET result=$(sqlq "$result_txt") WHERE id=${id};"
+    # DIVE-3098: --no-done records a VERIFIER GRADE. Stamp it structurally as well
+    # as in prose, because the predicate that exempts this row from the goal hook
+    # and the rot-nudger must not be forgeable. `task deliver --result=` is the
+    # MAKER's verb and writes the same column; if the predicate keyed on result
+    # TEXT, a maker could satisfy it by typing the right words and walking away —
+    # exactly the fail-open _hb_loop_terminal_clause already warns about one layer
+    # up. graded_by is the ACTOR, so terminal_for_verifier can additionally require
+    # grader != maker and a self-verified close cannot buy the exemption.
+    # COALESCE: first grade wins, same rule as done_at (DIVE-2477).
+    db "UPDATE tasks SET result=$(sqlq "$result_txt"),
+           graded_at=COALESCE(graded_at, datetime('now')),
+           graded_by=COALESCE(graded_by, $(sqlq "$(task_actor "")"))
+        WHERE id=${id};"
   fi
 
   if (( JSON_MODE )); then

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -165,7 +165,7 @@ require_sqlite() {
 # NOTE: projects/loop_runs/supervisor_events are ALSO defined inside gated
 # one-shot migration blocks in _tasks_db_migrate() below — edit both copies
 # together; tests/schema_sync_unit.sh fails CI if they diverge.
-_TASKS_SCHEMA_EPOCH='2808-1'
+_TASKS_SCHEMA_EPOCH='3098-1'   # DIVE-3098: +graded_at, +graded_by
 _tasks_schema() {
   cat <<'SQL'
 PRAGMA journal_mode=WAL;
@@ -224,6 +224,15 @@ CREATE TABLE IF NOT EXISTS tasks (
   -- array column is already present. Keeping the two definitions complete makes
   -- that fast path both safe and cheap; the convergence assertion is the backstop.
   derived_actor TEXT,
+  -- DIVE-3098: a verifier grade recorded by `task verify --no-done` (graded_at) and
+  -- the actor who recorded it (graded_by). Structural on purpose — the
+  -- terminal-for-verifier predicate must not key on result TEXT, which the MAKER's
+  -- `task deliver --result=` also writes, or a maker could buy the exemption by
+  -- typing the right words. Declared HERE as well as in _TASKS_ADDITIVE_COLUMNS,
+  -- per the rule directly above: a fresh store takes this CREATE and never runs the
+  -- ALTER loop, so array-only lands a store that fails the DIVE-2197 assertion.
+  graded_at TEXT,
+  graded_by TEXT,
   -- DIVE-2615: why this gate has this tier — axis=pinned|type-default|secret-type
   -- |ask|title|title-fallback|none, plus ;term=<t> where a term is what fired.
   -- Declared HERE as well as in _TASKS_ADDITIVE_COLUMNS: a fresh store takes this
@@ -1165,7 +1174,38 @@ _TASKS_ADDITIVE_COLUMNS=(
   'originated_by_objective INTEGER' 'originated_cycle INTEGER'
   'verify_unavailable INTEGER' 'last_skipped_at TEXT'
   'human_evidence TEXT' 'derived_actor TEXT' 'floor_provenance TEXT'
+  # DIVE-3098: a verifier grade recorded by `task verify --no-done`. Structural on
+  # purpose — the terminal-for-verifier predicate must not key on result TEXT,
+  # which the MAKER's `task deliver --result=` also writes.
+  'graded_at TEXT' 'graded_by TEXT'
 )
+
+# DIVE-3098 - TERMINAL FOR THE VERIFIER, as ONE SQL boolean expression.
+#
+# Three readers evaluate this: `task ls`'s render, `_task_terminal_for_verifier`
+# (the goal Stop hook's answer), and the heartbeat rot-nudger's exclusion. They MUST
+# agree - a row the nudger exempts but the render still paints `todo` is the original
+# bug wearing different clothes. So it is written once here and interpolated, never
+# retyped. (Same rule that produced broker_strip_md_quotes: a two-reader binding
+# diverges the moment someone fixes one side.)
+#
+# Every conjunct is load-bearing:
+#   graded_at                - stamped ONLY by `task verify --no-done`, never by the
+#                              maker's `task deliver --result=`, so it cannot be
+#                              forged in prose.
+#   graded_by <> maker_agent - a self-verified close does not buy the exemption.
+#   delivery_ref             - a verdict with nothing to merge is not awaiting a merge.
+# status stays OPEN: terminal for the VERIFIER, non-terminal for the ROW.
+# NOT `readonly`: several harnesses and code paths source this lib twice, and a
+# readonly re-assignment errors on the second source — measured, it broke 8 arms of
+# tests/gate_route_delivery_unit.sh with a stderr line and nothing else. Every other
+# constant in this file (incl. _TASKS_SCHEMA_EPOCH) is a plain assignment for the
+# same reason; match the file.
+_TASKS_TFV_SQL="graded_at IS NOT NULL
+       AND delivery_ref IS NOT NULL AND TRIM(delivery_ref) <> ''
+       AND (maker_agent IS NULL OR graded_by IS NULL OR graded_by <> maker_agent)
+       AND status NOT IN ('done','cancelled')"
+
 _TASKS_DB_GATE_COLUMNS=''
 _TASKS_DB_GATE_EPOCH=''
 _TASKS_DB_GATE_SEEDS=''

--- a/tests/graded_but_unmerged_terminal_unit.sh
+++ b/tests/graded_but_unmerged_terminal_unit.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# DIVE-3098 — a GRADED-BUT-UNMERGED row is TERMINAL FOR THE VERIFIER and
+# NON-TERMINAL FOR THE ROW. Policy decided by olivia
+# (olivia/decisions/2026-08-09-graded-but-unmerged-is-terminal-for-the-verifier.md);
+# this harness grades the BUILD.
+#
+# WHY THE ROW EXISTS. main's false-done sweep found DIVE-2645/#427 and
+# DIVE-2743/#485 closed `done` with the work not on main. The prescribed remedy
+# ("bind delivery_ref before you close") is unfollowable for that class: #427's PR
+# was created 12 minutes AFTER the close, #485's TEN SECONDS after. The close and
+# the PR-open are one motion and the close runs first, because the close is the half
+# a goal loop reads as finished. So verifiers were pushed to a false `done` by the
+# instruments. See community/wiki/the-close-runs-before-the-pr-exists.md.
+#
+# ONE PREDICATE, FOUR READERS — the whole point of the change. `_TASKS_TFV_SQL`
+# (lib/tasks_db.sh) is evaluated by `task ls`'s render, `_task_terminal_for_verifier`,
+# the goal-hook clause, and the rot-nudger's exclusion. A row the nudger exempts but
+# the render still paints `todo` is the original bug in different clothes, so the arms
+# below check all four against the SAME fixture.
+#
+# ANTI-GOAL, asserted not assumed: no new `status` value. `done` keeps meaning
+# merged-to-main and the row stays OPEN — arm C3.
+#
+# Run: bash tests/graded_but_unmerged_terminal_unit.sh (no root, no network)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/dive3098.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_heartbeat.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1; mkdir -p "$TASKS_DIR"; set +e
+
+SEND_LOG="$TMP/sent"; : >"$SEND_LOG"
+cmd_send() { local tgt="$1" msg=""; shift
+  for a in "$@"; do case "$a" in --message=*) msg="${a#--message=}";; esac; done
+  printf '%s\t%s\n' "$tgt" "$msg" >>"$SEND_LOG"; }
+audit_log() { return 0; }
+registry_read() { printf '%s' '{"agents":{}}'; }
+_hb_agent_idle() { return 0; }
+
+tasks_db_init
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+addt()  { ( cmd_task_add "$@" ) 2>/dev/null | jq -r '.data.id'; }
+
+ME=$(task_actor "")     # this harness's actor == the VERIFIER in every fixture
+MAKER="dev"             # deliberately NOT $ME, so graded_by <> maker_agent holds
+
+# mkrow <mode> — build one delivered maker->verifier row, aged past the nudge
+# window, then apply the mode. Modes are the four populations the predicate must
+# separate. handoff_delivered_at is aged so the CAUSE of a nudge is genuinely
+# arranged: every mode below WOULD be pinged if the exemption did not fire, which
+# is what makes an absence informative (acceptance b).
+mkrow() {
+  local mode="$1" id
+  # assignee=MAKER at creation: `task add` refuses assignee==verifier by design
+  # (a maker cannot grade itself). The UPDATE below then reproduces exactly what
+  # _task_route_to_verifier does at delivery — assignee moves to the verifier and
+  # maker_agent records who built it.
+  id=$(addt "row-$mode" --assignee="$MAKER" --verifier="$ME" --priority=medium)
+  [[ "$id" =~ ^[0-9]+$ ]] || { bad_t "FIXTURE $mode could not be created" "addt returned '$id'"; printf '0'; return; }
+  db "UPDATE tasks SET maker_agent='${MAKER}', assignee='${ME}', verifier='${ME}',
+        handoff_delivered_at=datetime('now','-${_HB_VERIFY_STALE_MIN} minutes','-30 minutes'),
+        handoff_ack_at=NULL, handoff_stale_pinged_at=NULL, status='todo'
+      WHERE id=${id};"
+  case "$mode" in
+    graded_and_bound)
+      ( cmd_task_verify "$id" --no-done --result="graded by reading the diff" ) >/dev/null 2>&1
+      db "UPDATE tasks SET delivery_ref='https://github.com/5dive-ai/5dive/pull/1' WHERE id=${id};" ;;
+    graded_no_ref)
+      ( cmd_task_verify "$id" --no-done --result="graded by reading the diff" ) >/dev/null 2>&1 ;;
+    ref_no_grade)
+      db "UPDATE tasks SET delivery_ref='https://github.com/5dive-ai/5dive/pull/1' WHERE id=${id};" ;;
+    self_graded)   # the forgery arm: maker graded their own row
+      db "UPDATE tasks SET graded_at=datetime('now'), graded_by='${MAKER}',
+            delivery_ref='https://github.com/5dive-ai/5dive/pull/1' WHERE id=${id};" ;;
+  esac
+  printf '%s' "$id"
+}
+# Match the GAP#2 delivery nudge specifically. `grep -q .` would also match the
+# gap#3 fleet-idle alarm, so an unrelated alarm would read as "the delivery was
+# nudged" — assert on a signal only the system under test can produce.
+# Must match the gap#2 nudge FOR THIS ROW. Two earlier versions of this helper were
+# wrong in the same direction and both produced a confident green: `grep -q .` also
+# matched the gap#3 fleet-idle alarm, and matching the gap#2 text alone also matched
+# a nudge fired for a DIFFERENT row in the same sweep — the positive-control row is
+# eligible on every call. Scope the assertion to the subject, not just the signal.
+nudged() {
+  local id="$1" ident hits
+  ident=$(db "SELECT COALESCE(ident,'DIVE-'||id) FROM tasks WHERE id=${id};")
+  [[ -n "$ident" ]] || { bad_t "nudged(): could not resolve ident for id=$id" "any match would be vacuous"; return 1; }
+  # Clear the throttle BEFORE the sweep, not after. gap#2 skips any row whose
+  # handoff_stale_pinged_at is already set, and an EARLIER nudged() call in this
+  # harness sweeps the whole board — so a row pinged during someone else's call is
+  # silently throttled out of its own. Measured: with the clear afterwards, deleting
+  # the nudger exemption outright still scored 22/0, i.e. arm B graded nothing.
+  db "UPDATE tasks SET handoff_stale_pinged_at=NULL WHERE id=${id};"
+  : >"$SEND_LOG"
+  _hb_stall_sweep >/dev/null 2>&1
+  # Count gap#2 lines naming THIS row. Word-boundary anchored so DIVE-1 does not
+  # match DIVE-10, and counted rather than piped: a `grep A | grep -q B` pipeline
+  # reports the exit status of the second grep over the FIRST grep's output, which
+  # is easy to get subtly wrong and returns a confident wrong answer either way.
+  hits=$(grep -E 'Delivered-awaiting-verifier|delivered to you for review' "$SEND_LOG" 2>/dev/null \
+         | grep -cE "\b${ident}\b" 2>/dev/null)
+  [[ "${hits:-0}" -gt 0 ]]
+}
+
+echo "── the real verb stamps the structural marker (it must not be prose) ──"
+G=$(mkrow graded_and_bound)
+[[ "$(db "SELECT COALESCE(graded_at,'')<>'' FROM tasks WHERE id=${G};")" == "1" ]] \
+  && ok_t "task verify --no-done --result= stamps graded_at" || bad_t "graded_at stamped"
+[[ "$(db "SELECT COALESCE(graded_by,'') FROM tasks WHERE id=${G};")" == "$ME" ]] \
+  && ok_t "graded_by records the ACTOR who graded ($ME)" || bad_t "graded_by is the actor" "got $(db "SELECT graded_by FROM tasks WHERE id=${G};")"
+D=$(mkrow ref_no_grade)
+( cmd_task_deliver "$D" --pr=https://github.com/5dive-ai/5dive/pull/2 --result="the maker typing a grade-shaped sentence" ) >/dev/null 2>&1
+# The absence below is only meaningful if the row EXISTS and deliver actually wrote
+# to it — otherwise this arm passes on a missing fixture, which is the same defect
+# the positive control in (b) exists to prevent.
+[[ "$(db "SELECT COALESCE(result,'') LIKE '%grade-shaped%' FROM tasks WHERE id=${D};")" == "1" ]] \
+  && ok_t "PRECONDITION: deliver did write the maker's prose to this row" \
+  || bad_t "PRECONDITION: deliver wrote the row" "the absence arm below would be vacuous"
+[[ -z "$(db "SELECT COALESCE(graded_at,'') FROM tasks WHERE id=${D};")" ]] \
+  && ok_t "the MAKER's task deliver --result= does NOT stamp graded_at (not forgeable in prose)" \
+  || bad_t "deliver must not stamp graded_at" "a maker could buy the exemption by typing"
+
+echo "── (a) the predicate, and the goal hook it answers ──"
+_task_terminal_for_verifier "$G" && ok_t "A: predicate TRUE for grade + bound delivery_ref" || bad_t "A: predicate true"
+clause=$(_hb_loop_terminal_clause "$ME" "$G" "DIVE-$G")
+grep -q "GRADED AND WAITING ON A MERGE" <<<"$clause" \
+  && ok_t "A: the goal-hook clause names it TERMINAL FOR THIS GOAL" || bad_t "A: hook clause emitted" "got: ${clause:0:90}"
+grep -q "Treat the goal as MET and stop" <<<"$clause" \
+  && ok_t "A: and tells the agent to STOP — the hook does not re-fire" || bad_t "A: clause says stop"
+grep -q "$MAKER" <<<"$clause" && ok_t "A: the clause NAMES the merge owner ($MAKER)" || bad_t "A: clause names owner"
+grep -q "does NOT close it: it DELIVERS it" <<<"$clause" \
+  && bad_t "A: graded-and-waiting must OUTRANK the maker variant" "maker advice on an already-graded row" \
+  || ok_t "A: it outranks the maker variant (no 'go deliver' on a graded row)"
+
+echo "── (b) the rot-nudger, with the CAUSE arranged, plus its positive control ──"
+P=$(mkrow ref_no_grade)
+nudged "$P" && ok_t "B/POSITIVE CONTROL: an aged, ungraded delivery IS nudged (the window really elapsed)" \
+             || bad_t "B/POSITIVE CONTROL: the nudger was going to fire" "absence below would prove nothing"
+if nudged "$G"; then
+  bad_t "B: a graded+bound row must be EXEMPT from the nudger" "still pinged; log=$(tr '\n' ';' <"$SEND_LOG" | head -c 300)"
+  printf '   DEBUG tfv=%s ident=%s\n' \
+    "$(db "SELECT CASE WHEN ${_TASKS_TFV_SQL} THEN 'TRUE' ELSE 'FALSE' END FROM tasks WHERE id=${G};")" \
+    "$(db "SELECT COALESCE(ident,'DIVE-'||id) FROM tasks WHERE id=${G};")"
+else
+  ok_t "B: graded+bound is EXEMPT from the rot-nudger"
+fi
+
+echo "── (c) task ls renders it as its own thing and names the merge owner ──"
+render=$( ( JSON_MODE=0; cmd_task_ls --all ) 2>/dev/null | grep "DIVE-${G}\|row-graded_and_bound" | head -1 )
+printf '   render: %s\n' "$(sed 's/^ *//' <<<"$render")"
+grep -q "graded->merge:${MAKER}" <<<"$render" \
+  && ok_t "C: renders 'graded->merge:${MAKER}' — distinct, and names who owes the merge" \
+  || bad_t "C: distinct render naming the owner" "got: $render"
+grep -qE '\| *todo *\||\| *blocked *\||\| *in_progress *\|' <<<"$render" \
+  && bad_t "C: must not read as todo/blocked/in_progress to the eye" "got: $render" \
+  || ok_t "C: does not read as todo/blocked/in_progress"
+[[ "$(db "SELECT status FROM tasks WHERE id=${G};")" == "todo" ]] \
+  && ok_t "C3/ANTI-GOAL: underlying status is STILL todo — no new status value, done still means merged" \
+  || bad_t "C3: no new status value" "status was mutated"
+
+echo "── (d) NEGATIVE ARMS: neither half alone qualifies ──"
+N1=$(mkrow graded_no_ref)
+_task_terminal_for_verifier "$N1" && bad_t "D1: grade with NO delivery_ref must NOT qualify" "predicate true" || ok_t "D1: grade with NO delivery_ref does not qualify"
+nudged "$N1" && ok_t "D1: and it still nudges" || bad_t "D1: still nudges"
+grep -q "GRADED AND WAITING" <<<"$(_hb_loop_terminal_clause "$ME" "$N1" "DIVE-$N1")" \
+  && bad_t "D1: and it must still fail the hook" "hook satisfied without a delivery_ref" || ok_t "D1: and it still fails the hook"
+N2=$(mkrow ref_no_grade)
+_task_terminal_for_verifier "$N2" && bad_t "D2: delivery_ref with NO grade must NOT qualify" "predicate true" || ok_t "D2: delivery_ref with NO grade does not qualify"
+nudged "$N2" && ok_t "D2: and it still nudges" || bad_t "D2: still nudges"
+grep -q "GRADED AND WAITING" <<<"$(_hb_loop_terminal_clause "$ME" "$N2" "DIVE-$N2")" \
+  && bad_t "D2: and it must still fail the hook" "hook satisfied without a grade" || ok_t "D2: and it still fails the hook"
+N3=$(mkrow self_graded)
+_task_terminal_for_verifier "$N3" && bad_t "D3: a SELF-GRADED row must NOT qualify" "maker bought its own exemption" || ok_t "D3: self-graded (graded_by == maker) does not qualify"
+nudged "$N3" && ok_t "D3: and it still nudges" || bad_t "D3: still nudges"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/tasks_db_restore_guard_unit.sh
+++ b/tests/tasks_db_restore_guard_unit.sh
@@ -173,11 +173,12 @@ out=$(TASKS_BACKUP_DIR="$paired_backups" tasks_db_init 2>&1); rc=$?
 
 # --- Case 9 (DIVE-2808): canonical schema is complete at birth ----------------
 # Eight columns lived only in the migration list. The completed CREATE must have
-# the full 73-column tasks surface before the skip-gate is allowed to save work.
+# the full 75-column tasks surface before the skip-gate is allowed to save work.
 # (71 at the time this case was written; DIVE-2853 added recurring_stall_escalated_at
-# on main, and DIVE-2848 added gate_rubber_stamp. The count is asserted literally on
-# purpose — this case exists to catch a canonical CREATE that silently drops a column,
-# so it must not derive its own expectation from the thing under test.)
+# on main, DIVE-2848 added gate_rubber_stamp, and DIVE-3098 added graded_at+graded_by.
+# The count is asserted literally on purpose — this case exists to catch a canonical
+# CREATE that silently drops a column, so it must not derive its own expectation from
+# the thing under test.)
 #
 # NOTE for the next person who merges main into a branch that adds a column: this
 # literal is exactly where that merge goes wrong SILENTLY. Two branches each adding
@@ -192,8 +193,8 @@ actual=$(sqlite3 "$TASKS_DB" \
     WHERE name IN ('delivery_ref','delivered_at','delivery_ref_iteration','parked_at','park_reason','escalated_at','escalated_by','human_evidence')
     ORDER BY name;" 2>/dev/null | tr '\n' ' ' | sed 's/ $//')
 column_count=$(sqlite3 "$TASKS_DB" "SELECT count(*) FROM pragma_table_info('tasks');" 2>/dev/null)
-[[ $rc -eq 0 && "$actual" == "$required" && "$column_count" == "73" ]] \
-  && ok "fresh schema: all 73 columns, including the eight former holes, are present" \
+[[ $rc -eq 0 && "$actual" == "$required" && "$column_count" == "75" ]] \
+  && ok "fresh schema: all 75 columns, including the eight former holes, are present" \
   || bad "fresh schema: init returned a partial tasks table" "rc=$rc count=$column_count got=[$actual] want=[$required] out=$out"
 
 # --- Case 10 (DIVE-2197): migrate arm still rejects a failed ALTER ------------


### PR DESCRIPTION
DIVE-3098 — DIVE-2832 requirement 2. Policy decided by olivia in
`olivia/decisions/2026-08-09-graded-but-unmerged-is-terminal-for-the-verifier.md`;
this is the build. Wiki: `community/wiki/the-close-runs-before-the-pr-exists.md`.

## What forced it

main's false-done sweep found two rows closed `done` with the work not on main:
DIVE-2645/#427 and DIVE-2743/#485. The prescribed remedy — bind `delivery_ref` before you
close — is unfollowable for that class: #427's PR was created **12 minutes after** the
close, #485's **ten seconds after**. Nobody forgot anything in ten seconds. The close and
the PR-open are one motion and the close runs first, because the close is the half a goal
loop reads as finished. Verifiers were being pushed to a false `done` by the instruments.

## The change — one predicate, four readers

"Has the verifier responded?" and "is the row finished?" are different questions. The goal
Stop hook and the rot-nudger both evaluated the second and reported the first. That is one
bug in two places, so it gets one predicate, written once in `lib/tasks_db.sh` and
interpolated — never retyped. A row the nudger exempts but the render still paints `todo`
is the original bug in different clothes.

```
_TASKS_TFV_SQL := graded_at IS NOT NULL
              AND delivery_ref bound
              AND graded_by <> maker_agent
              AND status NOT IN ('done','cancelled')
```

Readers: `task ls`'s render (both the compact and `--all` branches), the goal Stop hook
clause in `_hb_loop_terminal_clause`, `_task_terminal_for_verifier`, and the gap#2
rot-nudger's exclusion.

- **The grade is stamped structurally, not read out of prose.** `task verify --no-done`
  now writes `graded_at`/`graded_by`. It must not key on `result` TEXT, because the
  MAKER's `task deliver --result=` writes that same column — a maker could otherwise buy
  the exemption by typing the right words. `graded_by` is the actor, so a self-verified
  close does not qualify either.
- **`task ls` renders `graded->merge:<maker>`** — not `todo`, not `blocked`, not
  `in_progress`, and it names who owes the merge. The verifier is deliberately not named:
  they are the one person with nothing left to do.
- **No new status value.** `status` stays open and the row closes only on merge, so `done`
  keeps meaning merged-to-main. That anti-goal is the whole reason this is a predicate.

Out of scope by the decision doc: the human-facing reporting breakdown (graded-and-waiting
/ ungraded / abandoned) is olivia's to enforce in what she sends, not a CLI change.

## Evidence

`tests/graded_but_unmerged_terminal_unit.sh` — **22 passed, 0 failed, 3.7s** (core tier).

Mutation-graded; every mutation produces a **distinct** kill signature, so no arm is
passing for a reason other than the one it claims:

| mutation | result |
|---|---|
| predicate stubbed TRUE | 14/8 — incl. the positive control |
| drop `graded_at` conjunct | 18/4 |
| drop `delivery_ref` conjunct | 19/3 |
| drop `graded_by <> maker_agent` | 20/2 |
| nudger exclusion removed | 21/1 |
| goal-hook clause removed | 20/2 |
| `verify` stops stamping | 16/6 |
| `task ls` render reverted | 21/1 |
| merge owner rendered as the verifier | 21/1 |

Acceptance (b) arranges its own cause — the nudge window genuinely elapses and a
positive-control row IS pinged in the same sweep, so the absence on the exempt row is
informative rather than an observation against a nudger that was never going to fire.

**Demonstrated on real rows**, on a copy of the 1701-row production task store (a copy so
an unmerged branch never writes the live board): DIVE-2829 (real maker `dev`, real PR #527)
rendered `todo` before, was graded with the real `task verify --no-done` verb, and rendered
`graded->merge:dev` after — with `status` still `todo`. DIVE-2808, same shape but ungraded,
was the control and still gets the "you are the VERIFIER, go grade" clause. The additive
migration ran against that real store with all 1701 rows intact.

Regression: 22 affected harnesses green (`task_core` 61/0, `heartbeat_goal_loop_terminal`
51/0, `heartbeat_stall_sweep` 34/0, `schema_sync`, `task_self_grade_writers` 14/0,
`verifier_gate_ack` 27/0, …). `tasks_db_restore_guard` case 9 went 56/0 → 55/1 on its
literal column count and is updated to 75 in the second commit — that guard fired
correctly and updating it is the maintenance it exists to force. `gate_route_delivery_unit`
is red at 21/11 **on HEAD~1 as well** — pre-existing, not this change.

Bundle builds clean (`./build.sh && bash -n 5dive`).
