### PR TITLE
fix(tests): graded-but-unmerged fixture collided with the real agent named dev (DIVE-3098)

### DIFF
--- a/tests/graded_but_unmerged_terminal_unit.sh
+++ b/tests/graded_but_unmerged_terminal_unit.sh
@@ -57,7 +57,17 @@ bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 addt()  { ( cmd_task_add "$@" ) 2>/dev/null | jq -r '.data.id'; }
 
 ME=$(task_actor "")     # this harness's actor == the VERIFIER in every fixture
-MAKER="dev"             # deliberately NOT $ME, so graded_by <> maker_agent holds
+# MAKER must never equal $ME. It was hardcoded "dev", which is a REAL agent on this
+# fleet: run by agent-dev, ME=="dev"=="$MAKER", `task add` correctly refuses
+# assignee==verifier (a maker cannot grade itself), EVERY fixture failed to create,
+# and the harness reported a wall of red that reads as a product regression. It was
+# green for every other seat, so it looked tree-related and got blamed on main.
+# A reserved fake cannot collide with any actor, present or future, and is what
+# projects/5dive/CLAUDE.md already requires of fixtures. Asserted, not assumed:
+# a future rename that reintroduces the collision must fail loudly here, not silently
+# stop creating rows.
+MAKER="fixturemaker"
+[[ "$MAKER" != "$ME" ]] || { printf 'FATAL: fixture maker (%s) == this harness actor (%s); every row would be refused as assignee==verifier. Pick a MAKER no real agent can be named.\n' "$MAKER" "$ME" >&2; exit 1; }
 
 # mkrow <mode> — build one delivered maker->verifier row, aged past the nudge
 # window, then apply the mode. Modes are the four populations the predicate must


### PR DESCRIPTION
The harness hardcoded MAKER="dev" with the comment "deliberately NOT $ME". That
holds for every seat except one: run by agent-dev, ME=="dev"=="$MAKER", and
`task add` correctly refuses assignee==verifier because a maker cannot grade
itself. Every fixture then failed to CREATE, and the harness emitted a wall of
red that reads as a product regression rather than a fixture bug.

Measured on origin/main, same tree, two seats: as agent-dev, zero fixtures
created; as agent-main, 22 passed 0 failed. Because it was green for everyone
else it looked tree-related, and it was reported as a pre-existing failure of
main while it was blocking one agent's core tier on every PR they opened.

MAKER is now a reserved fake, which no actor can ever be named and which
projects/5dive/CLAUDE.md already requires of fixtures. The inequality is also
asserted rather than assumed: if a future rename reintroduces the collision the
harness exits FATAL naming both values, instead of silently not creating rows.

Verified as three REAL unix seats (agent-dev, agent-main, agent-olivia): 22/0
each. Note a stubbed task_actor is NOT a valid way to test this — the actor
claim is corroborated against the kernel uid, so a stub fails for reasons
unrelated to the fixture.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

