### PR TITLE
fix(agent): refuse openclaw BYO create that writes a key with no model pin (DIVE-3130)

### DIFF
--- a/changelog.d/DIVE-3130.md
+++ b/changelog.d/DIVE-3130.md
@@ -1,0 +1,22 @@
+## Unreleased — fix(agent): refuse an openclaw BYO create that would write a key with no model pin (DIVE-3130)
+
+`agent create --type=openclaw --provider=zai` reported success, booted a seat that
+`agent list` showed as `AUTH ok`, and then failed **every** message with *"auth or
+provider access failed for openai"*. `OPENCLAW_PROVIDER_MODEL` has no `zai` row, so
+with no `--model` the resolved model was empty, no `agents.defaults.model.primary`
+was written, and openclaw fell back to its built-in default — whose first path
+segment picks the provider *and* the credential, so the seat authenticated as
+openai with no openai key.
+
+DIVE-3113's precondition could not catch this: it is guarded by `[[ -n "$model" ]]`,
+so it fails closed on a *wrong* model id and cannot fire at all on an *absent* one.
+A key with no model pin is now a refusal for **every** provider, before anything is
+written — which also closes the same hole on `minimax`, `qwen` and `huggingface`.
+The message names the remedy (`--model=<id>`) and the oracle to grade the id with
+(`openclaw models list --provider <native> --plain`).
+
+`zai` is **kept** as an openclaw BYO option rather than dropped. openclaw
+2026.7.1-2 enumerates no `zai/` models, but an unenumerated namespace is a
+NO-ORACLE state, not proof that the provider is unroutable, and the DIVE-1826
+coding-endpoint pin still applies — so a zai seat now requires an explicit
+`--model` instead of silently producing a 401 seat.

--- a/src/cmd_agent_create.sh
+++ b/src/cmd_agent_create.sh
@@ -1119,6 +1119,27 @@ _apply_byo_openclaw() {
   # costs them a profile that lies about being healthy.
   local openclaw_base_url="${OPENCLAW_PROVIDER_URL[$canonical]:-}"
   local model="${override_model:-${OPENCLAW_PROVIDER_MODEL[$canonical]:-}}"
+  # DIVE-3130: KEY WRITTEN + NO MODEL PIN IS A REFUSAL FOR EVERY PROVIDER, not
+  # only for the ones the check below can reach. The DIVE-3113 block above fails
+  # closed on a model id that names the WRONG provider — but it is guarded by
+  # `[[ -n "$model" ]]`, so a canonical id with NO OPENCLAW_PROVIDER_MODEL row and
+  # no --model resolves to the empty string and walks straight through it. That
+  # produces the exact state DIVE-3113 exists to prevent: openclaw falls back to
+  # its BUILT-IN default (openai/gpt-5.5), whose first path segment picks the
+  # provider AND the credential, so the seat authenticates as openai with no
+  # openai key and every message dies on "auth or provider access failed for
+  # openai" — while `agent list` still prints AUTH ok, because the sentinel is
+  # the credential file and the credential file is there.
+  # Measured 2026-08-10 on this host (openclaw 2026.7.1-2) via --provider=zai;
+  # the same hole is open for minimax, qwen and huggingface, which also have an
+  # OPENCLAW_PROVIDER_ID row and no model row.
+  # The remedy is deliberately NOT "add a model row": an id must be graded
+  # against `openclaw models list --provider <native> --plain` first (see the
+  # OPENCLAW_PROVIDER_MODEL header), and for zai that list is empty on this
+  # version — so the honest outcome is an explicit --model from the operator,
+  # not a pin we guessed.
+  [[ -n "$model" ]] \
+    || fail "$E_VALIDATION" "openclaw has no default model for provider '$canonical' (native id: $native), and no --model was given. Writing the key with no model pin would create a seat that reports AUTH ok and returns 401 on every message: openclaw would fall back to its built-in default, whose provider prefix selects a credential you have not supplied. Pass --model=<id> that openclaw routes to '$native' — grade it with: openclaw models list --provider $native --plain"
   if [[ -n "$model" ]]; then
     local normalized
     if ! normalized=$(openclaw_normalize_model "$native" "$model"); then

--- a/src/header.sh
+++ b/src/header.sh
@@ -718,6 +718,17 @@ declare -A OPENCLAW_PROVIDER_ID=(
   [moonshot]="moonshot"
   [openrouter]="openrouter"
   [nous]=""
+  # DIVE-3130: openclaw 2026.7.1-2's catalog enumerates NO zai models
+  # (`models list --provider zai --plain` → "No models found"; the GLM ids it
+  # carries sit under byteplus/, novita/, nvidia/, together/ and volcengine/).
+  # zai is KEPT rather than dropped, deliberately: an unenumerated namespace is a
+  # NO-ORACLE state, not a proof of unroutability (see
+  # community/wiki/a-byo-model-pin-can-only-be-graded-off-ci.md), and the
+  # DIVE-1826 coding-endpoint pin in OPENCLAW_PROVIDER_URL still applies. What
+  # changed is that a zai seat can no longer be created WITHOUT a model: with no
+  # OPENCLAW_PROVIDER_MODEL row, _apply_byo_openclaw now refuses unless the
+  # operator passes --model. Do not add a [zai] model row here until an id is
+  # graded against `models list --provider zai --plain` on the installed version.
   [zai]="zai"
   [minimax]="minimax"
   [qwen]="qwen"

--- a/tests/openclaw_empty_model_refusal_unit.sh
+++ b/tests/openclaw_empty_model_refusal_unit.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# DIVE-3130: `--type=openclaw --provider=<p>` where <p> has NO
+# OPENCLAW_PROVIDER_MODEL row (zai, minimax, qwen, huggingface) and no --model
+# must REFUSE before the credential write, instead of writing a key with no
+# model pin. openclaw then falls back to its built-in default, whose first path
+# segment picks the provider AND the credential, so the seat reports AUTH ok and
+# 401s on every message ("auth or provider access failed for openai").
+#
+# The DIVE-3113 wrong-provider check cannot cover this: it is guarded by
+# `[[ -n "$model" ]]`, so an EMPTY resolved model walks through it. This harness
+# grades the empty case specifically — see
+# community/wiki/an-unconfigured-model-authenticates-against-the-wrong-provider.md
+#
+# Static/behavioural: `fail` and every writer (install/mktemp/mv/chown/chmod/
+# sudo) are stubbed, so no root, no network, no filesystem state outside a
+# tempdir, and no credential is ever written by the run.
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMPD:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+
+SRC=src
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh cmd_auth.sh cmd_agent_create.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f" 2>/dev/null || { echo "source FAIL: $f"; exit 7; }
+done
+set +e
+
+TMPD=$(mktemp -d)
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# Run _apply_byo_openclaw with every mutating call stubbed. Prints the refusal
+# message on stdout; prints WROTE_AUTH=1 if the credential write was reached.
+run_byo() { # <native> <canonical> [model]
+  (
+    export TMPD
+    fail()    { printf 'FAIL[%s]: %s\n' "$1" "$2"; exit 90; }
+    step()    { :; }
+    warn()    { :; }
+    install() { :; }
+    chown()   { :; }
+    chmod()   { :; }
+    sudo()    { :; }
+    mktemp()  { command mktemp -p "$TMPD" oc.XXXXXX; }
+    mv()      { printf 'WROTE_AUTH=1\n'; command rm -f "$1"; }
+    _apply_byo_openclaw "$1" "$2" "sk-test-0123456789" "" "${3:-}"
+  ) 2>&1
+}
+
+# ── Defect arm: the exact create from the ticket (zai, no --model) ────────────
+out=$(run_byo zai zai); rc=$?
+if (( rc == 90 )) && [[ "$out" == *"no default model for provider 'zai'"* ]]; then
+  ok_t "openclaw+zai with no --model refuses (rc=$rc)"
+else
+  bad_t "openclaw+zai with no --model did not refuse" "rc=$rc out=$out"
+fi
+[[ "$out" != *WROTE_AUTH=1* ]] \
+  && ok_t "the refusal lands BEFORE the credential write (no auth-profiles.json)" \
+  || bad_t "a credential was written despite the empty model pin" "$out"
+[[ "$out" == *"--model"* && "$out" == *"models list --provider zai --plain"* ]] \
+  && ok_t "refusal names the remedy and the oracle to grade it with" \
+  || bad_t "refusal does not tell the operator how to proceed" "$out"
+
+# Same hole, other providers with an id row and no model row.
+for p in minimax qwen huggingface; do
+  out=$(run_byo "$p" "$p"); rc=$?
+  (( rc == 90 )) && [[ "$out" == *"no default model for provider '$p'"* ]] \
+    && ok_t "openclaw+$p with no --model refuses too" \
+    || bad_t "openclaw+$p was allowed through with no model pin" "rc=$rc out=$out"
+done
+
+# ── Control arm, expected value NON-ZERO: a provider WITH a catalog row must
+# still create, and so must zai WITH an explicit --model. If either of these
+# also refused, the guard above would be indistinguishable from a blanket
+# breakage of the openclaw BYO path.
+out=$(run_byo openai openai); rc=$?
+[[ "$out" != *"no default model"* ]] \
+  && ok_t "openclaw+openai (has a catalog row) is not caught by the guard" \
+  || bad_t "the guard fires on a provider that HAS a model row" "rc=$rc out=$out"
+out=$(run_byo zai zai "zai/glm-4.6"); rc=$?
+[[ "$out" != *"no default model"* ]] \
+  && ok_t "openclaw+zai WITH --model still proceeds (zai kept, not dropped)" \
+  || bad_t "an explicit --model does not satisfy the guard" "rc=$rc out=$out"
+
+# ── Ordering, structurally: the refusal must sit inside the DIVE-3113
+# precondition block, above the auth-profiles.json write. The behavioural arms
+# above run with a stubbed writer; this one holds the ordering on any box.
+body=$(declare -f _apply_byo_openclaw)
+guard_line=$(grep -n 'no default model for provider' <<<"$body" | head -1 | cut -d: -f1)
+write_line=$(grep -n 'Writing openclaw BYO auth-profiles.json' <<<"$body" | head -1 | cut -d: -f1)
+if [[ -n "$guard_line" && -n "$write_line" ]] && (( guard_line < write_line )); then
+  ok_t "empty-model refusal precedes the credential write in the source"
+else
+  bad_t "empty-model refusal is not above the credential write" \
+        "guard=$guard_line write=$write_line"
+fi
+
+# The guard must not be re-nested under the `if [[ -n "$model" ]]` arm that made
+# DIVE-3113 unable to see this case. Graded against the SOURCE, not `declare -f`:
+# declare -f re-renders a line continuation as one line and would read the same
+# either way.
+create_src=$(<src/cmd_agent_create.sh)
+grep -Eq '^  \[\[ -n "\$model" \]\] \\$' <<<"$create_src" \
+  && ok_t "guard is an unconditional [[ -n \$model ]] || fail, not a nested if" \
+  || bad_t "guard is not present in its unconditional form" \
+           "$(grep -n 'n "\$model"' src/cmd_agent_create.sh)"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+(( FAIL == 0 ))


### PR DESCRIPTION
Closes DIVE-3130.

## The bug

`sudo 5dive agent create <n> --type=openclaw --provider=zai --api-key=-` reports success,
the seat boots, `agent list` prints **AUTH ok** — and every message dies on
*"auth or provider access failed for openai. Run /auth openai to refresh credentials"*.

`OPENCLAW_PROVIDER_MODEL` has no `[zai]` row, so `${override_model:-${OPENCLAW_PROVIDER_MODEL[$canonical]:-}}`
resolves to the empty string, the `if [[ -n $model ]]` pin is skipped, and
`agents.defaults.model.primary` is never written. openclaw falls back to its built-in
default (`openai/gpt-5.5`) — and in openclaw the **first path segment picks the provider
AND the credential**, so the seat authenticates as `openai` with no openai key.

This is exactly the state DIVE-3113's preconditions exist to prevent ("a profile that
HOLDS A KEY AND NO MODEL PIN ... does not read as broken"). That guard is not wrong, it
is **scoped to providers that have a model row**: it is itself guarded by `[[ -n "$model" ]]`,
so it fails closed on a *wrong* model id and cannot fire at all on an *absent* one.

## The fix

`key written + no model pin` is now a **refusal for every provider**, placed inside the
DIVE-3113 precondition block above the `auth-profiles.json` write, so a refusal costs a
re-run rather than a half-provisioned profile. The message names the remedy (`--model=<id>`)
and the oracle to grade the id with (`openclaw models list --provider <native> --plain`).

Same hole, now also closed: **`minimax`, `qwen`, `huggingface`** — all three have an
`OPENCLAW_PROVIDER_ID` row and no model row, so they produced the identical 401 seat.

## The zai decision: kept, not dropped

Measured on this host, openclaw `2026.7.1-2`: `models list --provider zai --plain` →
*"No models found"*, and the GLM ids the catalog carries sit under `byteplus/`, `novita/`,
`nvidia/`, `together/`, `volcengine/`. The ticket asked whether zai stays under a new
native id or is dropped for openclaw.

**Kept.** An unenumerated openclaw namespace is one of the three documented NO-ORACLE
states (`community/wiki/a-byo-model-pin-can-only-be-graded-off-ci.md`), not proof that the
provider is unroutable, and the DIVE-1826 coding-endpoint pin in `OPENCLAW_PROVIDER_URL`
still applies. Dropping the id is the irreversible read of ambiguous evidence; requiring an
explicit `--model` is the reversible one. No `[zai]` model row was added — per the
`OPENCLAW_PROVIDER_MODEL` header, an id must be graded against the installed version's own
per-provider list first, and here that list is empty. The reasoning is written next to
`OPENCLAW_PROVIDER_ID[zai]` so the next reader does not re-derive it.

## How it was checked

New harness `tests/openclaw_empty_model_refusal_unit.sh` (core tier, **0.16s measured on
the 5dive control plane, 2026-08-10** — no root, no network, every writer stubbed, no
credential written by the run). 10 assertions: the ticket's exact create refuses; the
refusal lands **before** the credential write; the message names remedy + oracle; the same
for minimax/qwen/huggingface.

**Control arms with a non-zero expected value** (so the guard cannot pass by breaking the
whole BYO path): `--provider=openai` (has a catalog row) is untouched, and `--provider=zai
--model=zai/glm-4.6` still proceeds.

**Mutation-graded, one per part of the fix:**
1. guard deleted → 7 of 10 red, including `a credential was written despite the empty model
   pin` (`WROTE_AUTH=1`) — i.e. the harness reproduces the *defect*, not just its absence;
2. guard re-nested under `if [[ -n "$model" ]]` (the DIVE-3113 blind spot) → 7 of 10 red.
   Both control arms stayed green in both mutations.

Neighbouring harnesses pass: `byo_model_create_unit`, `hermes_openclaw_byo_model_unit`,
`openclaw_zai_baseurl_unit`, `openclaw_init_provider_unit`, `openclaw_runtime_unit`.

Full core tier locally: 263/269 pass. The 6 failures (`install_checksum_unit`, `ledger_unit`,
`policy_refusals_unit`, `task_board_write_fence_unit`, `verify_close_merge_gate_stamp_unit`,
`verify_prose_result_open_row_unit`) **fail identically on a clean `origin/main` worktree on
this box** — pre-existing here (no built `./5dive` bundle), not introduced by this change.
The budget line reads UNDETERMINED (`exit 6`) for the same reason, which is a local
artifact; CI grades it.

## Not covered

- **Runtime behaviour of a zai seat is untested** — it needs a GLM Coding-Plan key, which
  this host does not hold. This PR only stops the silent bad create.
- **hermes is not audited for the same hole.** `_apply_byo_hermes` resolves its model from
  `HERMES_PROVIDER_MODEL`, which also has no `[zai]` row; whether hermes then falls back to
  a foreign provider is unmeasured and deliberately out of scope here.
