### PR TITLE
fix(skills): centralize install dir callers (DIVE-2609)

### DIFF
--- a/src/cmd_selfupdate.sh
+++ b/src/cmd_selfupdate.sh
@@ -198,7 +198,16 @@ _agent_payload_fingerprint() {
   # function on its own), and the .claude entries below mean an empty map still
   # yields the documented fallback set rather than nothing.
   local -a rels=()
-  for rel in "${SKILLS_INSTALL_DIR[@]-}" "${TYPE_PERSONA_FILE[@]-}"; do
+  # DIVE-2609: the skills dirs come from `skills_install_dirs_all`, NOT from a second
+  # read of SKILLS_INSTALL_DIR. The map has exactly one executable value-read in src/
+  # (the resolver in header.sh) and this file used to be a second one — a real
+  # regression, caught by tests/skills_install_dir_callers_unit.sh on its first
+  # contact with this code. TYPE_PERSONA_FILE has no such contract and is still read
+  # directly; `[@]-` keeps that safe under `set -u` when the map is absent.
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] && rels+=("$rel")
+  done < <(skills_install_dirs_all)
+  for rel in "${TYPE_PERSONA_FILE[@]-}"; do
     [[ -n "$rel" ]] && rels+=("$rel")
   done
   rels+=(".claude/skills" ".claude/CLAUDE.md" \

--- a/src/cmd_skill.sh
+++ b/src/cmd_skill.sh
@@ -119,7 +119,7 @@ cmd_skill_add() {
   type=$(agent_type "$name")
   [[ -n "$type" ]] || fail "$E_NOT_FOUND" "agent '$name' has no type recorded in registry"
   agent_id="${SKILLS_AGENT_ID[$type]:-claude-code}"
-  install_dir="${SKILLS_INSTALL_DIR[$type]:-.claude/skills}"
+  install_dir=$(skills_install_dir "$type")
 
   # Determine isolation so we can choose the right install strategy.
   local isolation
@@ -321,7 +321,7 @@ _skill_list_json() {
   local type agent_id install_dir
   type=$(agent_type "$name")
   agent_id="${SKILLS_AGENT_ID[$type]:-claude-code}"
-  install_dir="${SKILLS_INSTALL_DIR[$type]:-.claude/skills}"
+  install_dir=$(skills_install_dir "$type")
 
   # `npx skills list --json` prints clean JSON when available. If the
   # skills CLI isn't reachable (no network, npx cache cold) we fall back
@@ -428,7 +428,7 @@ cmd_skill_rm() {
 
   local type install_dir
   type=$(agent_type "$name")
-  install_dir="${SKILLS_INSTALL_DIR[$type]:-.claude/skills}"
+  install_dir=$(skills_install_dir "$type")
 
   # DIVE-2338: assert the CONCATENATED path stays inside the install dir. The name check
   # above is exact but is a refusal of two tokens; this is the structural one, and it is

--- a/src/header.sh
+++ b/src/header.sh
@@ -457,7 +457,7 @@ declare -A SKILLS_AGENT_ID=(
 # Used for post-install verification, the cmd_skill_list dir-scan fallback,
 # and cmd_skill_rm. Probed empirically against npx skills v0.x — if upstream
 # changes a path, update here. Unknown types fall through to ".claude/skills"
-# in the lookup sites below.
+# in the resolver below.
 #
 # DIVE-2583 — THE CONTRACT, because prose elsewhere in this repo contradicted it:
 # every value here is $HOME-RELATIVE (it is joined to /home/agent-<name>/ at every
@@ -549,13 +549,13 @@ skill_default_source() {
 }
 
 # skills_install_dir <type> -> the $HOME-relative dir an installed skill body
-# lands in for that type. THE resolver: this is the expression cmd_pack.sh's
-# import path, cmd_skill add/list/rm and agent_setup.sh each spell by hand, and
-# DIVE-2583 exists because a rendered sentence stated a DIFFERENT answer than the
-# one the installer computed. Anything that TELLS a user where skills go must ask
-# this function, so the claim and the behaviour cannot drift apart. Total by
-# construction — never empty, for any input — which is exactly why "a harness with
-# no skills directory" describes nothing here.
+# lands in for that type. THE resolver: cmd_pack.sh's import path, cmd_skill
+# add/list/rm and agent_setup.sh all call this function. DIVE-2583 exists because
+# a rendered sentence stated a DIFFERENT answer than the installer computed.
+# Anything that tells or acts on where skills go must ask this function, so the
+# claim and behaviour cannot drift apart. Total by construction — never empty,
+# for any input — which is exactly why "a harness with no skills directory"
+# describes nothing here.
 skills_install_dir() {
   printf '%s\n' "${SKILLS_INSTALL_DIR[${1:-}]:-.claude/skills}"
 }

--- a/src/header.sh
+++ b/src/header.sh
@@ -560,6 +560,35 @@ skills_install_dir() {
   printf '%s\n' "${SKILLS_INSTALL_DIR[${1:-}]:-.claude/skills}"
 }
 
+# skills_install_dirs_all -> every distinct skills dir, one per line, sorted.
+#
+# WHY A SECOND VERB AND NOT "JUST USE THE RESOLVER" (DIVE-2609 x DIVE-3172,
+# 2026-08-11). The two rows collided head-on: DIVE-3172 stopped hardcoding
+# `.claude` literals in the self-update payload fingerprint and derived the paths
+# from the per-type maps — the right instinct — and did it by reading
+# SKILLS_INSTALL_DIR directly, which is exactly what DIVE-2609's contract forbids.
+# Neither could see the other; #558 sat 108 commits behind main.
+#
+# The obvious repair is not available. `skills_install_dir` takes a TYPE and returns
+# ONE path; the fingerprint needs EVERY value, because a payload set is a union over
+# types and not a lookup. Routing an enumeration through a single-key resolver is a
+# circle, so the shape gets its own verb rather than an exemption — a contract that
+# grows a hole every time a caller is inconvenient stops being a contract, and this
+# one caught a real regression on its first contact with it.
+#
+# NOTE WHAT IT ITERATES: the KEYS (`${!SKILLS_INSTALL_DIR[@]}`), then asks the
+# resolver for each one. So there is still exactly one executable read of the map's
+# VALUES in src/, the resolver's own, and this verb cannot drift from it by
+# construction — it is a caller, not a second copy. That is the property DIVE-2609
+# is protecting, and the reason a keys-expansion here is not the thing it forbids.
+skills_install_dirs_all() {
+  declare -p SKILLS_INSTALL_DIR >/dev/null 2>&1 || return 0
+  local _t
+  for _t in "${!SKILLS_INSTALL_DIR[@]}"; do
+    skills_install_dir "$_t"
+  done | LC_ALL=C sort -u
+}
+
 # api-key target per type: the env file (in /etc/5dive/connectors for the
 # default profile) and the env var inside it. Claude-family is special-cased
 # in cmd_auth_set — `sk-ant-oat01-*` tokens write CLAUDE_CODE_OAUTH_TOKEN,

--- a/src/lib/agent_setup.sh
+++ b/src/lib/agent_setup.sh
@@ -494,7 +494,8 @@ install_default_skill_for_agent() {
   local name="$1" type="$2" source="$3" skill="$4"
   local user="agent-${name}" home="/home/agent-${name}"
   local agent_id="${SKILLS_AGENT_ID[$type]:-claude-code}"
-  local install_dir="${SKILLS_INSTALL_DIR[$type]:-.claude/skills}"
+  local install_dir
+  install_dir=$(skills_install_dir "$type")
   # DIVE-2370: today every caller passes an internal template constant, so this is a
   # pre-emptive guard rather than a fix for a live hole HERE — recorded as such so nobody
   # reads it as an incident. It is still the right place for it: the sibling site in

--- a/tests/self_update_restart_predicate_unit.sh
+++ b/tests/self_update_restart_predicate_unit.sh
@@ -58,12 +58,24 @@ fi
 # map the installer actually writes through, and the drift would be invisible.
 maps="$(sed -n '/^declare -A SKILLS_INSTALL_DIR=(/,/^)$/p; /^declare -A TYPE_PERSONA_FILE=(/,/^)$/p' \
   src/header.sh)"
+# DIVE-2609: the block no longer reads SKILLS_INSTALL_DIR itself — it asks
+# `skills_install_dirs_all`, which asks the resolver. Both functions therefore have to
+# come across with the maps, and their ABSENCE has to be fatal HERE rather than
+# silently degrading. If they were missing, the enumeration would yield nothing, the
+# fingerprint would fall back to its documented `.claude/*` set, and the derived-path
+# arms below would pass while grading exactly the blind spot this harness exists to
+# catch. That is the same vacuous-pass trap the map extraction above guards, one
+# dependency further along.
+resolver="$(sed -n '/^skills_install_dir() {/,/^}$/p; /^skills_install_dirs_all() {/,/^}$/p' \
+  src/header.sh)"
 if grep -q 'SKILLS_INSTALL_DIR=(' <<<"$maps" && grep -q 'TYPE_PERSONA_FILE=(' <<<"$maps" \
-   && grep -q '\.agents/skills' <<<"$maps" && grep -q '\.codex/AGENTS\.md' <<<"$maps"; then
-  ok_t "per-type payload maps are extractable from src/header.sh (non-.claude paths present)"
+   && grep -q '\.agents/skills' <<<"$maps" && grep -q '\.codex/AGENTS\.md' <<<"$maps" \
+   && grep -q 'skills_install_dir() {' <<<"$resolver" \
+   && grep -q 'skills_install_dirs_all() {' <<<"$resolver"; then
+  ok_t "per-type payload maps + the skills-dir resolver/enumerator are extractable from src/header.sh (non-.claude paths present)"
 else
-  bad_t "per-type payload maps missing" \
-        "SKILLS_INSTALL_DIR / TYPE_PERSONA_FILE not extractable — the derived-path arms below would grade a .claude-only fallback and pass vacuously"
+  bad_t "per-type payload maps or the skills-dir resolver missing" \
+        "SKILLS_INSTALL_DIR / TYPE_PERSONA_FILE / skills_install_dir / skills_install_dirs_all not extractable — the derived-path arms below would grade a .claude-only fallback and pass vacuously"
   echo; echo "$PASS passed, $FAIL failed"; exit 1
 fi
 
@@ -73,6 +85,7 @@ WORK="$(mktemp -d)"
 fp() {
   bash -c "set -uo pipefail
 $maps
+$resolver
 $block
 _agent_payload_fingerprint \"\$1\" \"\$2\"" _ "$1" "$2"
 }

--- a/tests/skills_install_dir_callers_unit.sh
+++ b/tests/skills_install_dir_callers_unit.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# DIVE-2609 — every skill-dir caller must resolve through skills_install_dir().
+#
+# Four callers used to repeat the map lookup. The values agreed, but nothing
+# coupled those copies to the resolver. This harness grades both halves:
+#   1. the resolver owns the only executable SKILLS_INSTALL_DIR read in src/;
+#   2. each caller's actual assignment is executed for every mapped type and
+#      must equal the resolver. Synthetic unique values make a copied constant
+#      agree for at most one type instead of hiding behind today's duplicates.
+set -uo pipefail
+
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'printf "HARNESS-RC=%d\n" "$?"' EXIT
+cd "$(dirname "$0")/.." || exit
+
+SRC=src
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do
+  source "$SRC/$f"
+done
+# Both files are function definitions only at source time.
+# shellcheck source=/dev/null
+source "$SRC/cmd_skill.sh"
+# shellcheck source=/dev/null
+source "$SRC/lib/agent_setup.sh"
+set +e
+
+pass=0 fail=0
+ok_t()  { pass=$((pass + 1)); printf '  ok   %s\n' "$1"; }
+bad_t() { fail=$((fail + 1)); printf '  FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+# Source enumeration is intentional for this half: the defect is a second
+# executable read. Comments that document the map are not reads, so match the
+# parameter expansion itself. Exactly one is allowed, in the resolver body.
+mapfile -t direct_reads < <(
+  rg -n '\$\{SKILLS_INSTALL_DIR\[' "$SRC" \
+    | rg -v '^[^:]+:[0-9]+:[[:space:]]*#'
+)
+if [[ ${#direct_reads[@]} -eq 1 && "${direct_reads[0]}" == src/header.sh:* ]]; then
+  ok_t 'skills_install_dir owns the only executable SKILLS_INSTALL_DIR read in src/'
+else
+  bad_t 'direct SKILLS_INSTALL_DIR reads remain outside the resolver' "${direct_reads[*]:-none found}"
+fi
+
+# Pull the real assignment out of the sourced function. We execute this text
+# below; merely finding a function name or grepping for a call is not a grade.
+caller_assignment() {
+  local fn="$1"
+  declare -f "$fn" | awk '
+    /^[[:space:]]*install_dir=/ { sub(/^[[:space:]]*/, ""); print; found++ }
+    END { if (found != 1) exit 1 }
+  '
+}
+
+resolve_at_caller() {
+  local fn="$1" type="$2" assignment install_dir=""
+  assignment=$(caller_assignment "$fn") || return 2
+  eval "$assignment" || return 3
+  printf '%s\n' "$install_dir"
+}
+
+mapfile -t mapped_types < <(printf '%s\n' "${!SKILLS_INSTALL_DIR[@]}" | sort)
+if [[ ${#mapped_types[@]} -ge 8 && ${#mapped_types[@]} -eq ${#SKILLS_INSTALL_DIR[@]} ]]; then
+  ok_t 'mapped-type sweep is non-vacuous'
+else
+  bad_t 'mapped-type sweep is vacuous or incomplete' "visited=${#mapped_types[@]} map=${#SKILLS_INSTALL_DIR[@]}"
+fi
+
+# Make every expected value unique. With the production map, several types
+# legitimately share .agents/skills; that would let one hardcoded string pass
+# multiple iterations and weaken this arm.
+for type in "${mapped_types[@]}"; do
+  SKILLS_INSTALL_DIR["$type"]="dive-2609-probe/$type"
+done
+
+callers=(cmd_skill_add _skill_list_json cmd_skill_rm install_default_skill_for_agent)
+for fn in "${callers[@]}"; do
+  bad=""; ran=0
+  for type in "${mapped_types[@]}"; do
+    got=$(resolve_at_caller "$fn" "$type")
+    expected=$(skills_install_dir "$type")
+    [[ "$got" == "$expected" ]] || bad+=" $type(got:${got:-none},want:$expected)"
+    ran=$((ran + 1))
+  done
+  if [[ -z "$bad" && $ran -eq ${#mapped_types[@]} ]]; then
+    ok_t "$fn resolves the helper's value for every mapped type"
+  else
+    bad_t "$fn diverges from skills_install_dir" "${bad:-ran $ran of ${#mapped_types[@]}}"
+  fi
+done
+
+# Harness control: under the unique probe map, a copied constant must not pass
+# more than one iteration. This proves the loop above distinguishes derivation
+# from a value that merely happens to be right for one caller/type today.
+constant="${SKILLS_INSTALL_DIR[${mapped_types[0]}]}"; constant_matches=0
+for type in "${mapped_types[@]}"; do
+  [[ "$constant" == "$(skills_install_dir "$type")" ]] && constant_matches=$((constant_matches + 1))
+done
+if [[ $constant_matches -eq 1 ]]; then
+  ok_t 'control: a hardcoded directory passes at most one mapped type'
+else
+  bad_t 'control could not distinguish a hardcoded directory' "matches=$constant_matches"
+fi
+
+printf '\nskills_install_dir_callers_unit: %d passed, %d failed\n' "$pass" "$fail"
+(( fail == 0 ))

--- a/tests/skills_install_dir_callers_unit.sh
+++ b/tests/skills_install_dir_callers_unit.sh
@@ -105,5 +105,84 @@ else
   bad_t 'control could not distinguish a hardcoded directory' "matches=$constant_matches"
 fi
 
+# ---- the enumerating caller is GRADED, not merely counted ------------------
+# Arm 1 above is a COUNT: exactly one executable read of the map's values, in
+# the resolver. It is satisfied by an enumerator that calls the resolver and
+# then throws the answer away. DIVE-3172's `_agent_payload_fingerprint` is the
+# first real caller that needs every value at once (DIVE-2609 x DIVE-3172,
+# 2026-08-11), and what actually matters about it is not the shape of its read
+# but whether the payload set it hashes MOVES WITH THE MAP.
+#
+# So: put a probe directory into SKILLS_INSTALL_DIR and prove the fingerprint
+# changes when that directory changes. THE CONTROL IS THE HALF THAT MATTERS —
+# an identical directory that is NOT in the map must leave the fingerprint
+# still. Without it, a fingerprint that simply hashed the whole agent home
+# would pass the first half while being coupled to nothing.
+#
+# The subject is extracted from the shipped bytes by its own markers, the way
+# its own harness extracts it (tests/self_update_restart_predicate_unit.sh:45),
+# because a re-source would grade this file's idea of cmd_selfupdate.sh rather
+# than cmd_selfupdate.sh. The resolver pair is lifted the same way, for the
+# same reason and for one more: without them in scope the enumeration yields
+# NOTHING, the fingerprint quietly falls back to its documented .claude/* set,
+# and every arm below would pass while grading the blind spot. That failure is
+# silent, so the precondition is loud.
+_fp_block="$(sed -n '/^# >>> DIVE-3172 agent payload fingerprint/,/^# <<< DIVE-3172 agent payload fingerprint/p' \
+  "$SRC/cmd_selfupdate.sh")"
+_fp_maps="$(sed -n '/^declare -A SKILLS_INSTALL_DIR=(/,/^)$/p; /^declare -A TYPE_PERSONA_FILE=(/,/^)$/p' \
+  "$SRC/header.sh")"
+_fp_resolver="$(sed -n '/^skills_install_dir() {/,/^}$/p; /^skills_install_dirs_all() {/,/^}$/p' \
+  "$SRC/header.sh")"
+if ! grep -q '_agent_payload_fingerprint()' <<<"$_fp_block"; then
+  bad_t 'enumerating caller is UNGRADED' \
+        "no _agent_payload_fingerprint between the DIVE-3172 markers in $SRC/cmd_selfupdate.sh"
+elif ! grep -q 'skills_install_dir()' <<<"$_fp_resolver" \
+     || ! grep -q 'skills_install_dirs_all()' <<<"$_fp_resolver"; then
+  bad_t 'resolver pair not extractable from src/header.sh' \
+        'skills_install_dir / skills_install_dirs_all missing — the enumeration would yield nothing and the arms below would grade the .claude/* fallback and pass vacuously'
+else
+  _W="$(mktemp -d)"; mkdir -p "$_W/home/dive2609-probe" "$_W/home/dive2609-unmapped" "$_W/lib"
+  printf 'before\n' >"$_W/home/dive2609-probe/body.md"
+  printf 'before\n' >"$_W/home/dive2609-unmapped/body.md"
+  # The probe type is ADDED to the map rather than replacing an entry: the
+  # fingerprint also hashes a fixed .claude/* set, so an arm built on a value
+  # that is already in that set could not tell the map from the fallback.
+  _fp() {
+    bash -c "set -uo pipefail
+$_fp_maps
+SKILLS_INSTALL_DIR[dive2609probe]=\"dive2609-probe\"
+$_fp_resolver
+$_fp_block
+_agent_payload_fingerprint \"\$1\" \"\$2\"" _ "$_W/home" "$_W/lib"
+  }
+  _a=$(_fp); _c=$(_fp)
+  printf 'after\n' >"$_W/home/dive2609-probe/body.md";     _b=$(_fp)
+  printf 'after\n' >"$_W/home/dive2609-unmapped/body.md";  _d=$(_fp)
+  # AN EMPTY FINGERPRINT IS THE COUPLING FAILURE, not a broken probe, and the
+  # two must not share a label. The probe directory exists and has bytes in it,
+  # so the only way the hash comes back empty is that the derived path set never
+  # reached it and the fixture home matched none of the four .claude/* literals
+  # — i.e. the enumeration yielded nothing. Measured: stubbing
+  # skills_install_dirs_all to `return 0` lands here, and the first cut of this
+  # arm called that "probe unusable", which sends the next reader to the harness
+  # when the defect is in the source.
+  if [[ -z "$_a" ]]; then
+    bad_t 'the enumerating caller does NOT track the map (nothing enumerated)' \
+          'the payload set came back empty with a populated mapped directory on disk — skills_install_dirs_all yielded nothing and the fingerprint fell through to its .claude/* literals'
+  elif [[ "$_a" != "$_c" ]]; then
+    bad_t 'fingerprint is not usable as a probe' \
+          "unstable across two identical runs (a=$_a c=$_c)"
+  elif [[ "$_a" == "$_b" ]]; then
+    bad_t 'the enumerating caller does NOT track the map' \
+          'a directory in SKILLS_INSTALL_DIR changed on disk and the payload fingerprint did not move'
+  elif [[ "$_b" != "$_d" ]]; then
+    bad_t 'control: the enumerating caller tracks directories OUTSIDE the map' \
+          'an unmapped directory moved the fingerprint, so the arm above proves nothing about the map'
+  else
+    ok_t 'the enumerating caller is coupled to the map (a mapped dir moves the payload fingerprint, an unmapped one does not)'
+  fi
+  rm -rf "$_W"
+fi
+
 printf '\nskills_install_dir_callers_unit: %d passed, %d failed\n' "$pass" "$fail"
 (( fail == 0 ))

--- a/tests/skills_install_dir_callers_unit.sh
+++ b/tests/skills_install_dir_callers_unit.sh
@@ -27,7 +27,8 @@ source "$SRC/cmd_skill.sh"
 source "$SRC/lib/agent_setup.sh"
 set +e
 
-pass=0 fail=0
+pass=0
+fail=0
 ok_t()  { pass=$((pass + 1)); printf '  ok   %s\n' "$1"; }
 bad_t() { fail=$((fail + 1)); printf '  FAIL %s%s\n' "$1" "${2:+ — $2}"; }
 

--- a/tests/skills_install_dir_callers_unit.sh
+++ b/tests/skills_install_dir_callers_unit.sh
@@ -35,8 +35,8 @@ bad_t() { fail=$((fail + 1)); printf '  FAIL %s%s\n' "$1" "${2:+ — $2}"; }
 # executable read. Comments that document the map are not reads, so match the
 # parameter expansion itself. Exactly one is allowed, in the resolver body.
 mapfile -t direct_reads < <(
-  rg -n '\$\{SKILLS_INSTALL_DIR\[' "$SRC" \
-    | rg -v '^[^:]+:[0-9]+:[[:space:]]*#'
+  grep -RInF -- '${SKILLS_INSTALL_DIR[' "$SRC" \
+    | awk -F: '$3 !~ /^[[:space:]]*#/'
 )
 if [[ ${#direct_reads[@]} -eq 1 && "${direct_reads[0]}" == src/header.sh:* ]]; then
   ok_t 'skills_install_dir owns the only executable SKILLS_INSTALL_DIR read in src/'

--- a/tests/skills_install_dir_callers_unit.sh
+++ b/tests/skills_install_dir_callers_unit.sh
@@ -12,7 +12,7 @@ set -uo pipefail
 # shellcheck disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
-trap 'printf "HARNESS-RC=%d\n" "$?"' EXIT
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT
 cd "$(dirname "$0")/.." || exit
 
 SRC=src


### PR DESCRIPTION
DIVE-2609 — centralize the `SKILLS_INSTALL_DIR` callers. Built by codex; pushed and opened by main, which holds the gh credential.

Iteration 2: the branch was rebased onto current `main`, so it now sits on top of today's merges (DIVE-2306 `#555`, DIVE-2813 `#521`, DIVE-3117 `#556` and `#557`) rather than on the 08-05 base the first push used.

## Provenance of this push, recorded because it was not a clean relay

The relay request named `72fcfcadf2492380155b45bc212084dfd50201aa` as the SHA to push. **That object does not exist** — `git cat-file -t` on it returns `could not get object info`. The worktree's actual HEAD is `72fcfca2b45652ebf9839d8505975817f5a1e31a`: the same first seven characters, different thereafter. Pushed the SHA that exists, not the one that was named.

The force was legitimate and non-destructive in substance. The remote held `a20d3f4`, which is **the same commit subject** pre-rebase, and the divergence is exactly that rebase — no unique work was discarded. Verified before pushing rather than after:

- `merge-base --is-ancestor a20d3f4 72fcfca2` → divergent, so a force genuinely would drop something
- `log a20d3f4 --not 72fcfca2` → one commit, `fix(skills): centralize install dir callers (DIVE-2609)`, the pre-rebase twin of the local one

Pushed with `--force-with-lease` pinned to `a20d3f4ce168c10434779fe44dbbc3d6af48d9c1`, so it would have refused had the remote moved.
