### PR TITLE
fix(gate): a tier-2 tap names the HUMAN who tapped, not the relaying bot (DIVE-3128)

### DIFF
--- a/changelog.d/DIVE-3128.md
+++ b/changelog.d/DIVE-3128.md
@@ -1,0 +1,37 @@
+## Unreleased — fix(task): a tier-2 button tap now names the HUMAN who tapped, not the bot that relayed it (DIVE-3128)
+
+`need_answered_by` is the one field whose entire job is to prove a human was in the loop on a
+tier-2 gate. It did not do that job. The stamp was built as `human:$(task_actor …)` — the
+`human:` prefix pasted onto the identity of the PROCESS that ran `task answer` — and on the
+Telegram tap path that process is a bot. So a gate delivered through an agent's bot and tapped
+by a person landed as `need_answered_by='human:<that agent's name>'`, indistinguishable from
+the agent clearing its own human gate (the DIVE-3045 record, whose `need_answered_uid` belonged
+to an agent account). Nothing was forged; it is the honest output of asking the wrong question.
+
+Three changes:
+
+- **The tapper is stamped.** `task answer` takes `--tap-uid=`, `--tap-username=`, `--tap-msg=`
+  and `--relay-agent=`. The team-bot listener forwards them straight off Telegram's
+  `callback_query.from`, which the relaying agent does not choose. The uid resolves through
+  `${STATE_DIR}/humans.json`, then the Telegram handle on the same callback, then `tg:<uid>` —
+  an honest partial identity. There is deliberately no rung that falls back to the relay's
+  name; that rung is the bug.
+- **The relay is recorded separately, not folded in.** New `need_answered_relay` and
+  `need_answered_tap_uid` columns. `need_answered_by` says who decided; `need_answered_relay`
+  says whose bot carried it.
+- **A `human:` stamp may not name an agent.** Checked on every human stamp, not just the tap
+  path: if the name is one the roster measures as an agent, the claim is refused and stored as
+  `unattributed:<name>`, with a warning and an audit row naming the reason. The answer itself
+  still lands — what is refused is the claim, not the decision — and because the value no
+  longer starts with `human:`, every consumer that counts human touches (`cmd_trace`,
+  `cmd_digest`, `cmd_proof`, the precedent engine) stops counting it with no change on their
+  side. A roster that cannot be READ is reported as unmeasured rather than silently waved
+  through.
+
+A button tap is also now auditable from the record alone: `${STATE_DIR}/gate-taps.jsonl` logs
+the tapping uid, handle, message id, gate, relay, resolved human, stamp, whether a per-gate
+nonce was presented, and the verdict. The raw nonce is never written — only whether one was.
+
+**Note for relays outside this repo:** until a bridge forwards `--tap-uid`, its taps stamp
+`unattributed:<agent>` instead of `human:<agent>`. That is the intended, loud consequence — the
+old value was a claim the record could not support.

--- a/src/cmd_agent_teambot.sh
+++ b/src/cmd_agent_teambot.sh
@@ -839,6 +839,27 @@ async function handleCallback(cq: any): Promise<void> {
     extra.push('--human')
     if (humanProof) extra.push(`--human-proof=${humanProof}`)
   }
+  // DIVE-3128: FORWARD WHO PRESSED THE BUTTON. Telegram puts the tapping user on
+  // `callback_query.from` — an id and a handle this listener did not choose and
+  // the relaying agent cannot set for someone else — and until now none of it
+  // left this function. So the CLI had only its own process identity to stamp,
+  // and a tier-2 gate cleared by a person came back reading as an AGENT name
+  // wearing a `human:` prefix (DIVE-3045).
+  //
+  // Sanitised before they become argv: a Telegram id is digits (negative for
+  // channels) and a username is Telegram's own handle grammar. Anything else is
+  // dropped rather than passed through — the CLI re-validates, but a relay should
+  // not be the thing that ships a malformed identity to a provenance field.
+  const tapUid = String(cq.from?.id ?? '')
+  if (/^-?\d{1,20}$/.test(tapUid)) extra.push(`--tap-uid=${tapUid}`)
+  const tapUser = String(cq.from?.username ?? '')
+  if (/^[A-Za-z][A-Za-z0-9_]{4,31}$/.test(tapUser)) extra.push(`--tap-username=${tapUser}`)
+  const tapMsg = String(cq.message?.message_id ?? '')
+  if (/^\d{1,19}$/.test(tapMsg)) extra.push(`--tap-msg=${tapMsg}`)
+  // The relay is THIS listener. It is named explicitly rather than inferred, so
+  // the row records the carrier as a separate fact instead of the carrier's name
+  // being what the `human:` prefix lands on.
+  extra.push('--relay-agent=team-bot-listener')
   const ans = five(['task', 'answer', taskId, ...r.answerArgs, ...extra])
   if (ans?.ok) {
     await ackCallback(cbId, `Answered: ${r.ack}`)

--- a/src/cmd_task.sh
+++ b/src/cmd_task.sh
@@ -47,6 +47,8 @@ _task_usage() {
       [--secret-key=<ENV> --connector=<stem> | --out-of-band="<where>"]   (--type=secret needs one)
   need <id> --withdraw                          cancel a pending gate that is now moot
   answer <id> --value="..." [--proof=<token>] [--channel-proof=<chat> [--channel-msg=<id>]]
+      [--tap-uid=<tg user id> [--tap-username=<handle>] [--tap-msg=<message id>]]
+      [--relay-agent=<name>]     a button tap: WHO tapped, and whose bot carried it
   clear-recs --channel-proof=<chat_id> [--only=<id>]     apply pending recommendations
   inbox [--send [--channel-proof=<chat>]]       human-gated rows; --send DMs the owner
   coordinator [--json]                          the agent fronting the needs-you banner
@@ -1400,7 +1402,7 @@ cmd_task_ls() {
     # regression test asserts against (tests/task_reject_trace_unit.sh, arm C).
     # NB: no inline SQL `--` comments in this string —
     # dbfmt flattens newlines, so a `--` would comment out the rest of the query.
-    rows=$(dbfmt -json "SELECT id, ident, title, status, priority, assignee, created_by, parent_id, created_at, done_at, body, result, delivery_ref, need_type, ask, need_options, recommend, precedent_ref, precedent_kind, need_answer, need_answered_at, need_answered_by, tier, kind, schedule, last_fired_at, last_skipped_at, parked_at, park_reason, wake_at, project_key, maker_agent, verifier,
+    rows=$(dbfmt -json "SELECT id, ident, title, status, priority, assignee, created_by, parent_id, created_at, done_at, body, result, delivery_ref, need_type, ask, need_options, recommend, precedent_ref, precedent_kind, need_answer, need_answered_at, need_answered_by, need_answered_relay, need_answered_tap_uid, tier, kind, schedule, last_fired_at, last_skipped_at, parked_at, park_reason, wake_at, project_key, maker_agent, verifier,
              CASE WHEN maker_agent IS NOT NULL AND assignee=verifier AND status NOT IN ('done','cancelled')
                   THEN CASE WHEN handoff_ack_at IS NOT NULL THEN 'reviewing' ELSE 'delivered' END
                   ELSE NULL END AS handoff_state,
@@ -11519,9 +11521,96 @@ _loop_answer_is_bounce() {
   return 1
 }
 
+# ── DIVE-3128: a button tap, attributed and recorded ─────────────────────────
+#
+# WHO the tapping Telegram uid IS. Resolution order, widest evidence first:
+#
+#   1. ${STATE_DIR}/humans.json  — `{"humans": {"<tg-uid>": "<name>"}}`. An
+#      explicit operator-maintained map. It is the only source that can give a
+#      person the name the org actually calls them, so it wins.
+#   2. the Telegram @username carried on the SAME callback. Telegram owns this
+#      field; the relaying bot cannot set it for someone else. Shape-checked to
+#      Telegram's own handle grammar so nothing exotic reaches a provenance
+#      string.
+#   3. `tg:<uid>` — the honest non-answer.
+#
+# RUNG 3 IS THE POINT OF THE LADDER, not its fallback embarrassment. The defect
+# this closes is a row that named the WRONG principal, not a row that named
+# nobody: `human:tg:1234567890` says "a person we have not put a name to tapped
+# this", which a reader can act on, and it cannot collide with a roster name
+# because agent names are bare tokens and this one carries a colon. There is
+# deliberately no rung that falls back to the RELAYING AGENT'S name — that rung
+# is precisely DIVE-3045.
+#
+# The map file is read at CALL time, not resolved at source time, so a harness
+# that sets STATE_DIR after sourcing (every harness in tests/) points at its own
+# fixture rather than the box's.
+_gate_tap_human_name() {
+  local uid="${1:-}" uname="${2:-}" mapped=""
+  [[ "$uid" =~ ^-?[0-9]{1,20}$ ]] || { printf ''; return 1; }
+  local map="${HUMANS_MAP:-${STATE_DIR}/humans.json}"
+  if [[ -r "$map" ]]; then
+    mapped=$(jq -r --arg u "$uid" '(.humans[$u] // empty)' "$map" 2>/dev/null || true)
+    # A mapped value still has to be a plain token: this string is about to be
+    # concatenated into `human:<name>` and stored as provenance, and a mapping
+    # file carrying `lodar human:root` would forge a second field.
+    [[ "$mapped" =~ ^[A-Za-z][A-Za-z0-9_.-]{0,31}$ ]] && { printf '%s' "$mapped"; return 0; }
+  fi
+  uname="${uname#@}"
+  # Telegram's own handle rule: 5-32 chars, letters/digits/underscore, letter
+  # first. Same grammar cmd_telegram_resolve_handle validates against.
+  [[ "$uname" =~ ^[A-Za-z][A-Za-z0-9_]{4,31}$ ]] && { printf '%s' "$uname"; return 0; }
+  printf 'tg:%s' "$uid"
+}
+
+# THE TAP LEDGER. Before this, an inline-button tap was the LEAST logged path in
+# the system for the control that is supposed to be the most rigorously evidenced:
+# the callback arrived, a `task answer` ran, and the only trace was whatever the
+# answer itself stored. Reconstructing "did a human really press this, and which
+# human" meant reading someone else's shell history.
+#
+# Append-only JSONL next to the other append-only ledgers (the council's
+# veto-audit.jsonl), same permissions posture: 0600, root-owned when we are root.
+# Best-effort by construction — a box that cannot write this file must not lose a
+# human's answer over it — but "best effort" here means the WRITE may fail, never
+# that the call is skipped.
+#
+# THE RAW NONCE IS NEVER WRITTEN. `human_nonce_hash` is hash-only at rest for the
+# reason DIVE-916 gives, and a ledger that recorded the presented nonce would undo
+# that at a second address. We record only WHETHER one was presented.
+_gate_tap_log() {
+  local log="${GATE_TAP_LOG:-${STATE_DIR}/gate-taps.jsonl}"
+  local dir="${log%/*}"
+  [[ -d "$dir" ]] || mkdir -p "$dir" 2>/dev/null || return 0
+  local line
+  line=$(jq -cn \
+    --arg ts        "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    --arg ident     "${1:-}" \
+    --arg tier      "${2:-}" \
+    --arg type      "${3:-}" \
+    --arg tap_uid   "${4:-}" \
+    --arg tap_user  "${5:-}" \
+    --arg tap_msg   "${6:-}" \
+    --arg relay     "${7:-}" \
+    --arg resolved  "${8:-}" \
+    --arg stamp     "${9:-}" \
+    --arg nonce     "${10:-}" \
+    --arg verdict   "${11:-}" \
+    --arg via       "${12:-}" \
+    '{ts:$ts, gate:$ident, tier:$tier, type:$type, tap_uid:$tap_uid,
+      tap_username:$tap_user, tap_message_id:$tap_msg, relay_agent:$relay,
+      resolved_human:$resolved, resolved_via:$via, stamped_as:$stamp,
+      human_proof:$nonce, verdict:$verdict}' 2>/dev/null) || return 0
+  printf '%s\n' "$line" >>"$log" 2>/dev/null || return 0
+  chmod 0600 "$log" 2>/dev/null || true
+  [[ $EUID -eq 0 ]] && chown root:root "$log" 2>/dev/null || true
+  return 0
+}
+
 cmd_task_answer() {
   tasks_db_init
   local value="" value_set=0 from="" human=0 human_proof="" channel_proof="" channel_msg=""
+  local tap_uid="" tap_username="" tap_msg="" relay_agent=""
   local -a positional=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -11556,6 +11645,22 @@ cmd_task_answer() {
       # WHICH conversation, and only this says the human actually spoke in it —
       # and it is checked against Telegram, not against the caller's word.
       --channel-msg=*) channel_msg="${1#*=}" ;;
+      # DIVE-3128: WHO TAPPED, and WHOSE BOT CARRIED IT — two flags because they
+      # are two facts. The tap handler reads both straight off Telegram's
+      # `callback_query`: `.from.id` is the person who pressed the button and
+      # `.from.username` is their handle, neither of which the relaying agent
+      # chooses. Before this the relay's own identity was all that reached the
+      # row and it wore the `human:` prefix (DIVE-3045).
+      #
+      # These are PROVENANCE, not authority. Nothing below is authorized by them:
+      # a tap still clears a tier-2 gate on the DIVE-916 nonce or a non-agent
+      # SUDO_UID exactly as before, and passing --tap-uid without that evidence
+      # buys nothing. What they change is what the record SAYS about an answer
+      # that was already going to land.
+      --tap-uid=*)      tap_uid="${1#*=}" ;;
+      --tap-username=*) tap_username="${1#*=}" ;;
+      --tap-msg=*)      tap_msg="${1#*=}" ;;
+      --relay-agent=*)  relay_agent="${1#*=}" ;;
       --)        shift; positional+=("$@"); break ;;
       -*)        fail "$E_USAGE" "unknown flag: $1" ;;
       *)         positional+=("$1") ;;
@@ -12218,7 +12323,88 @@ cmd_task_answer() {
   if (( human && ! _human_evid )) && [[ "$_lead_clear" == "1" ]]; then
     human=0
   fi
-  (( human )) && answered_by="human:${answered_by}"
+  # ── DIVE-3128: NAME THE PERSON, NOT THE PIPE ──────────────────────────────
+  #
+  # `$answered_by` at this point is the ACTOR — the identity of the process that
+  # ran `task answer`. On the tap path that process is a BOT, so prefixing it with
+  # `human:` produced `human:olivia`: an assertion about a person, built out of a
+  # measurement of a relay. That is DIVE-3045, and it is not a forgery — it is the
+  # honest output of asking the wrong question.
+  #
+  # So when the caller carried a tap, the person who pressed the button is what
+  # gets stamped, and the relay is recorded in its OWN column further down. When
+  # no tap was carried, nothing here changes: `$answered_by` stays the actor and
+  # every existing path keeps its current stamp.
+  #
+  # `(( human ))` fences the whole thing. --tap-uid is provenance, never
+  # authority: an answer that did not already qualify as human-sourced does not
+  # become one by naming a Telegram id, so a tap presented without the DIVE-916
+  # nonce or a non-agent SUDO_UID is still refused upstream and never reaches here.
+  local _tap_name="" _tap_src="none"
+  if (( human )) && [[ -n "$tap_uid" ]]; then
+    _tap_name=$(_gate_tap_human_name "$tap_uid" "$tap_username") || _tap_name=""
+    if [[ -n "$_tap_name" ]]; then
+      case "$_tap_name" in tg:*) _tap_src="unnamed-uid" ;; *) _tap_src="resolved" ;; esac
+      answered_by="$_tap_name"
+    else
+      # A tap_uid that is not a Telegram id at all. Do NOT fall through to the
+      # actor — that silently restores the exact substitution this block removes.
+      _tap_src="bad-uid"
+      answered_by="tg:invalid"
+    fi
+  fi
+
+  # ── DIVE-3128: A `human:` STAMP MAY NOT NAME AN AGENT ─────────────────────
+  #
+  # The cheap invariant, and it is checked on EVERY human stamp rather than only
+  # on the tap path — because the tap path is where this was DISCOVERED, not the
+  # only place it can happen. Any relay that clears a gate while running as an
+  # agent reaches this line with an agent name in `$answered_by`, and the fix
+  # above only covers the callers that were taught to send `--tap-uid`.
+  #
+  # REFUSED, NOT REPAIRED. There is no honest repair available here: the code knows
+  # the name is wrong and has nothing better to put in its place, so it declines to
+  # make the claim. `unattributed:<name>` keeps every fact that WAS measured (a
+  # --human answer arrived, this process ran it) while withholding the one that was
+  # not, and it does not start with `human:` — so cmd_trace, cmd_digest, cmd_proof
+  # and the precedent engine, all of which key on `need_answered_by LIKE 'human:%'`,
+  # stop counting it as a human touch with no change on their side. That is the
+  # DIVE-2406 demotion pattern one screen up, applied to a different lie.
+  #
+  # It is a DEMOTION rather than a `fail`, deliberately. The answer itself is
+  # already authorized by evidence this block does not re-litigate, and refusing
+  # the WRITE would discard a decision a person may really have made and leave a
+  # tier-2 gate open with no way to close it. What is refused is the CLAIM.
+  #
+  # `human` is deliberately NOT cleared: the two `(( ! human ))` guards below add
+  # `lead:` / `lead:standing:` prefixes, and firing them here would relabel a
+  # refused human claim as an authorized lead clear — a second wrong answer.
+  local _attr_why="" _attr_unverified=0
+  if (( human )); then
+    if actor_human_name_ok "$answered_by"; then
+      [[ "${ACTOR_HUMAN_NAME_WHY:-}" == "roster-unmeasured" ]] && _attr_unverified=1
+      answered_by="human:${answered_by}"
+    else
+      local _attr_name="$answered_by"
+      _attr_why="${ACTOR_HUMAN_NAME_WHY:-refused}"
+      answered_by="unattributed:${_attr_name}"
+      warn "$ident: refusing to record this answer as human:${_attr_name} — '${_attr_name}' is a name on the AGENT roster, so the stamp would assert a human where the record can only show a relay (DIVE-3128). Stored as '${answered_by}'. A button tap should carry --tap-uid=<telegram user id> so the person who pressed it is named."
+      # STDERR IS NOT REDIRECTED HERE, and that is a correction rather than a
+      # style choice. `_task_store_audit_log`'s off-prod-store withholding is
+      # announced ONCE per invocation (DIVE-2010, `_TASK_STORE_AUDIT_FENCED`), so
+      # a `2>/dev/null` on the FIRST call through it eats the announcement for
+      # every later one — measured against tests/gate_answer_audit_unit.sh, whose
+      # "a silent fence is the same fail-open shape as no fence" arm went red the
+      # moment this row was added ahead of the write-site row with its stderr
+      # discarded. The sibling refusal sites can redirect because each of them
+      # `fail`s immediately after; this one returns and the write-site row still
+      # has to be able to speak.
+      _task_store_audit_log "task answer human-attribution" error 0 -- \
+        "task=$ident" "type=$nt" "tier=$gtier" "reason=$_attr_why" \
+        "refused_stamp=human:${_attr_name}" "stored=${answered_by}" \
+        "tap_uid=${tap_uid:-none}" "relay_agent=${relay_agent:-none}" || true
+    fi
+  fi
   # DIVE-1182: a routed builder gate cleared by its designated lead is recorded as
   # lead-sourced provenance (NOT human:*) — honest that an agent lead, not a human,
   # cleared it. Never overrides a genuine human:* answer.
@@ -12397,6 +12583,43 @@ cmd_task_answer() {
     "$(( ${_hp:-0} || ${_t2_hp:-0} ))" "$(( ${_su:-0} || ${_t2_su:-0} ))" \
     "${_cs_ok:-0}" "${_cp_ok:-0}" "${_lead_clear:-0}")
   db "UPDATE tasks SET human_evidence=$(sqlq "${_evform:-none}") WHERE id=${id};"
+
+  # DIVE-3128: the RELAY and the TAPPING UID, in their own columns.
+  #
+  # Written unconditionally (empty when there was no tap) so the columns mean
+  # "this is what the answer carried", not "somebody remembered to set them".
+  # A reader can now separate the two questions the old single string conflated:
+  # `need_answered_by` says who decided, `need_answered_relay` says whose bot
+  # carried it.
+  #
+  # NOT INSIDE THE DIVE-756 SIGNED CLOSURE, and say so rather than let a reader
+  # assume otherwise. The closure signs need_answer/at/by/uid — so the HUMAN NAME
+  # is tamper-evident, which is the field this ticket is about — while the relay
+  # is corroborating context that a raw DB edit could change without failing
+  # `gate-proof verify`. Widening the signed payload would invalidate every
+  # signature already stored on the board, so it is a separate decision.
+  db "UPDATE tasks SET need_answered_relay=$(sqlq "${relay_agent}"), need_answered_tap_uid=$(sqlq "${tap_uid}") WHERE id=${id};"
+
+  # DIVE-3128: THE TAP LEDGER. A button tap was the least-recorded path in the
+  # system for the most rigorously evidenced control. Written AFTER the row, and
+  # reading the persisted stamp back out rather than the variable, for the
+  # DIVE-2090 reason: a ledger built from intent greens identically whether or not
+  # the write landed.
+  if [[ -n "$tap_uid" || -n "$relay_agent" || -n "$tap_msg" ]]; then
+    local _tap_persisted; _tap_persisted=$(db "SELECT COALESCE(need_answered_by,'') FROM tasks WHERE id=${id};")
+    # THE VERDICT IS THREE-VALUED for the same reason the roster predicate is:
+    # `stored` must mean "checked the name against the roster and it was clean",
+    # never "could not look". A run with no readable registry says so in the
+    # ledger instead of producing a line indistinguishable from a verified one.
+    local _tap_verdict="stored"
+    if [[ -n "$_attr_why" ]]; then _tap_verdict="refused:${_attr_why}"
+    elif (( _attr_unverified )); then _tap_verdict="stored:roster-unmeasured"
+    fi
+    local _tap_nonce="absent"; [[ -n "$human_proof" ]] && _tap_nonce="presented"
+    _gate_tap_log "$ident" "${gtier:-}" "$nt" "$tap_uid" "$tap_username" "$tap_msg" \
+      "$relay_agent" "${_tap_name:-}" "$_tap_persisted" \
+      "$_tap_nonce" "$_tap_verdict" "$_tap_src" || true
+  fi
 
   # DIVE-2099: the authoritative record of a STANDING-authority clear. Emitted
   # AFTER the write and reading `need_answered_by` BACK OUT of the row, so it

--- a/src/lib/actor.sh
+++ b/src/lib/actor.sh
@@ -374,3 +374,82 @@ actor_claim_note() {
 # refusing the claim, and it costs no legitimate relay. A refusal would still be the
 # right tool for a verb where a claim cannot be provenance — there is not one today,
 # and adding the mechanism before there is a member is how guards end up unexercised.
+
+# ---------------------------------------------------------------------------
+# WHO TAPPED THE BUTTON (DIVE-3128)
+#
+# A tier-2 gate exists to prove a HUMAN was in the loop, and `need_answered_by`
+# is the one field whose entire job is to carry that proof. It did not.
+#
+# MEASURED, DIVE-3045: a gate delivered through agent-olivia's Telegram bot and
+# tapped by a person landed as `need_answered_by='human:olivia'` with
+# `need_answered_uid` = an AGENT's uid. "olivia" is a name on the roster, so the
+# row is indistinguishable from `the olivia agent answered its own human gate` —
+# the exact claim tier 2 exists to rule out. Nothing was forged and nobody
+# misused a flag: `task_actor` derives the RELAYING process's identity, which on
+# the tap path is the bot, and the `human:` prefix was pasted onto it.
+#
+# Two facts were collapsed into one string. They are separated here:
+#   need_answered_by       WHO decided        -> the tapping human
+#   need_answered_relay    WHOSE BOT carried it -> the relaying agent
+#
+# and one cheap invariant now holds over the first: a `human:<name>` where
+# `<name>` is a name the ROSTER knows is an agent is not a human attribution, so
+# it is refused rather than written.
+
+# actor_name_is_registered_agent <name> — is this name on the agent roster?
+#
+# THREE-STATE, and the third state is why this is not `[[ -n $(...) ]]`. The
+# registry answers "yes", "no, measured" and "I could not look", and a guard that
+# folds the third onto either of the other two is the not-reached-vs-pass collapse
+# `tier_unmeasured` exists to prevent (lib/registry.sh). Fold it onto "yes" and an
+# unreadable registry refuses every human tap on the box; fold it onto "no" and
+# the guard silently stops guarding.
+#   0  the roster MEASURES this name as an agent  -> refuse a human: stamp on it
+#   1  MEASURED, and it is not an agent           -> a human: stamp is fine
+#   2  could not measure                          -> say so, decide nothing here
+#
+# `unknown:no-tier` / `unknown:malformed-tier` return 0, NOT 2: per agent_tier's
+# own contract both mean the key IS under `.agents` and only the tier value was
+# unusable. The roster answered "this is an agent"; whether it also has a legible
+# isolation tier is a different question and not the one being asked.
+actor_name_is_registered_agent() {
+  local n="${1:-}"
+  [[ -n "$n" ]] || return 1
+  local t; t=$(agent_tier "$n" 2>/dev/null) || t="unknown:lookup-failed"
+  case "$t" in
+    unknown:unregistered)                   return 1 ;;
+    unknown:no-tier|unknown:malformed-tier) return 0 ;;
+    unknown:*)                              return 2 ;;
+    *)                                      return 0 ;;
+  esac
+}
+
+# actor_human_name_ok <name> — may `human:<name>` be written?
+#
+# THE RETURN CODE IS THE DECISION; ACTOR_HUMAN_NAME_WHY is the NOTE and is never
+# a second copy of it. 0 accepts, non-zero refuses. A name that could not be
+# MEASURED against the roster is ACCEPTED — there is no evidence of a collision —
+# but the note says `roster-unmeasured` so the record can distinguish "checked,
+# clean" from "could not check", which is the whole point of the three states
+# above. A caller that branches on `[[ -n "$ACTOR_HUMAN_NAME_WHY" ]]` instead of
+# on the status has re-collapsed them.
+#
+# `tg:<digits>` is accepted without consulting the roster at all. It is the
+# fallback identity the tap path mints when it cannot name the person, and it is
+# structurally incapable of colliding with an agent name (agent names are bare
+# tokens; this one carries a colon), so asking the registry about it would only
+# create a way for the fallback to fail.
+actor_human_name_ok() {
+  local n="${1:-}"
+  ACTOR_HUMAN_NAME_WHY=""
+  if [[ -z "$n" ]]; then ACTOR_HUMAN_NAME_WHY="empty-name"; return 1; fi
+  [[ "$n" == tg:* ]] && return 0
+  local rc=0
+  actor_name_is_registered_agent "$n" || rc=$?
+  case "$rc" in
+    0) ACTOR_HUMAN_NAME_WHY="roster-agent";      return 1 ;;
+    2) ACTOR_HUMAN_NAME_WHY="roster-unmeasured"; return 0 ;;
+    *) return 0 ;;
+  esac
+}

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -303,6 +303,18 @@ CREATE TABLE IF NOT EXISTS tasks (
   -- DIVE-1518: independently records which authenticated evidence form cleared
   -- the current gate (tap nonce, sudo uid, channel session, or proof).
   human_evidence   TEXT,
+  -- DIVE-3128: the RELAY, kept OUT of need_answered_by rather than folded into
+  -- it. A Telegram button tap reaches this CLI through some agent's bot, and
+  -- until now the relaying agent's own identity was what got the `human:`
+  -- prefix — so `human:olivia` meant either "a person tapped, olivia's bot
+  -- carried it" or "the olivia agent cleared its own human gate", with nothing
+  -- in the row to tell them apart (DIVE-3045). Two columns, two facts:
+  --   need_answered_by     WHO decided
+  --   need_answered_relay  WHOSE BOT carried the decision
+  -- need_answered_tap_uid is the Telegram user id of the person who tapped, kept
+  -- as TEXT because Telegram ids are opaque identifiers, not arithmetic.
+  need_answered_relay   TEXT,
+  need_answered_tap_uid TEXT,
   -- Recurring task templates (DIVE step 1). kind='recurring' marks a row as a
   -- TEMPLATE, not work: it's excluded from the work board, the heartbeat TODO
   -- count + wake, and the human inbox, so it's never picked up directly.
@@ -1174,6 +1186,9 @@ _TASKS_ADDITIVE_COLUMNS=(
   'originated_by_objective INTEGER' 'originated_cycle INTEGER'
   'verify_unavailable INTEGER' 'last_skipped_at TEXT'
   'human_evidence TEXT' 'derived_actor TEXT' 'floor_provenance TEXT'
+  # DIVE-3128: the tapping human vs the relaying bot, separated. See the CREATE
+  # TABLE comment above for why folding them into one string was the defect.
+  'need_answered_relay TEXT' 'need_answered_tap_uid TEXT'
   # DIVE-3098: a verifier grade recorded by `task verify --no-done`. Structural on
   # purpose — the terminal-for-verifier predicate must not key on result TEXT,
   # which the MAKER's `task deliver --result=` also writes.

--- a/tests/gate_lead_clear_stamp_unit.sh
+++ b/tests/gate_lead_clear_stamp_unit.sh
@@ -68,8 +68,21 @@ FIXTURE_MARK="dive2406-fixture"
 [[ -r "$REALLOG" ]] && REALLOG_OFFSET=$(wc -c <"$REALLOG" 2>/dev/null || echo 0)
 
 STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+# DIVE-3128: PIN THE ROSTER. `header.sh` computes REGISTRY at SOURCE time from the
+# default STATE_DIR, so moving STATE_DIR afterwards leaves it pointing at
+# /var/lib/5dive/agents.json — the box's real fleet. The new roster guard on the
+# `human:` stamp reads it, so without this pin arms 2 and 4 below grade differently
+# depending on which agents happen to exist on the machine running the suite: on a
+# control-plane box `main` IS registered and arm 2 sees the refusal, on a bare CI
+# runner there is no registry at all and it does not. `main` and `dev` are on this
+# fixture roster and `lodar` is deliberately NOT, which is what makes arm 4 a real
+# non-vacuity check rather than an accident of the host.
+REGISTRY="$TMP/agents.json"
 JSON_MODE=1
 mkdir -p "$TASKS_DIR"
+cat >"$REGISTRY" <<'REG'
+{"schemaVersion": 1, "agents": {"main": {"isolation": "vm"}, "dev": {"isolation": "vm"}}}
+REG
 set +e   # AFTER sourcing: header.sh turns `set -e` back on.
 tasks_db_init
 export FIVEDIVE_PROD_TASKS_DB="$TASKS_DB"   # DIVE-2010 fence: let the row through
@@ -143,18 +156,37 @@ else
   bad_t "a demotion the log cannot show is a demotion nobody can audit" "row='$ROW1'"
 fi
 
-# --- 2. lead-clear + CORROBORATED --human -> human:. ALREADY GREEN before the --
-#        fix; this is the arm that fails if the demotion is made unconditional.
+# --- 2. lead-clear + CORROBORATED --human -> NOT the lead: demotion. ----------
+#        THE PROPERTY THIS ARM GUARDS IS UNCHANGED — "a corroborated --human must
+#        not be relabelled as a lead clear" — but the string it lands on moved,
+#        and the reason is worth stating because the expected value looks like a
+#        regression and is not.
+#
+#        This arm used to expect `human:main`, and DIVE-3128 says that stamp was
+#        never a legitimate human attribution: `main` is a name on the AGENT
+#        roster, so `human:main` cannot distinguish "a person cleared this through
+#        main's session" from "the main agent cleared its own human gate" — which
+#        is the one thing the field exists to establish. It is the DIVE-3045 shape
+#        exactly, arriving through the lead path instead of a Telegram tap. So the
+#        claim is now refused and stored as `unattributed:main`.
+#
+#        THE ARM STILL GRADES WHAT IT WAS BUILT FOR. `unattributed:main` is not
+#        `lead:main`: make the DIVE-2400 demotion unconditional and this arm reds,
+#        exactly as before. What it no longer does is assert that an agent name may
+#        wear a `human:` prefix.
 reset
 SUDO_NONAGENT=0            # non-agent SUDO_UID: a real human-evidence form
 t2=$(mkgate "ship the persona batch" "fixture routed approval, real human $FIXTURE_MARK")
 ( actor_seam_as main; cmd_task_answer "$t2" --value="approved" --human --from=main >/dev/null 2>&1 )
 BY2=$(nby "$t2")
-if [[ "$BY2" == "human:main" ]]; then
-  ok_t "a CORROBORATED --human still stamps human:main (no genuine tap relabelled)"
-else
+if [[ "$BY2" == "unattributed:main" ]]; then
+  ok_t "a CORROBORATED --human is NOT demoted to lead: — and, DIVE-3128, is not stamped human:<roster agent> either"
+elif [[ "$BY2" == "lead:main" ]]; then
   bad_t "the fix must not demote an evidenced human answer" \
-        "need_answered_by='$BY2' (expected human:main)"
+        "need_answered_by='$BY2' — an evidenced human answer took the lead-clear demotion"
+else
+  bad_t "unexpected provenance on the corroborated lead-clear" \
+        "need_answered_by='$BY2' (expected unattributed:main)"
 fi
 
 # --- 3. DISTINCTNESS: the two cases must not be the same string ---------------

--- a/tests/gate_tap_human_attribution_unit.sh
+++ b/tests/gate_tap_human_attribution_unit.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# DIVE-3128 isolated unit harness: a tier-2 gate answered by a BUTTON TAP must
+# name the person who tapped, and must never name a roster AGENT as the human.
+#
+# THE DEFECT. `cmd_task_answer` built its provenance stamp as
+# `human:$(task_actor …)` — the `human:` prefix pasted onto the identity of the
+# PROCESS that ran the command. On the Telegram tap path that process is a bot,
+# so a gate delivered through an agent's bot and tapped by a person landed as
+# `need_answered_by='human:<agent name>'`. Nothing was forged: it is the honest
+# output of asking the wrong question. But tier 2 exists for exactly one reason —
+# to prove a human was in the loop — and `need_answered_by` is the one field
+# whose whole job is to carry that proof, so a value that cannot distinguish
+# "a human tapped, relayed through that agent's bot" from "that agent cleared its
+# own human gate" is the control failing at its only task.
+#
+# THE REFERENCE CASE is the DIVE-3045 record: a stamp naming a roster agent as
+# the human, alongside a `need_answered_uid` belonging to an AGENT account. That
+# shape is modelled below with reserved fakes — a fixture registry whose agent is
+# `relaybot` and Telegram id 1234567890 — per this repo's no-real-identifiers
+# rule. The real names and ids from that incident are deliberately NOT copied in;
+# what is reproduced is the SHAPE, which is what the guard keys on.
+#
+# WHAT IS PINNED:
+#   T1  a tap carrying --tap-uid stamps THE TAPPER, not the relaying process
+#   T2  the relay is recorded in its own column, not folded into the stamp
+#   T3  the tap is written to the tap ledger (uid, message id, gate, verdict)
+#   T4  an unnamed tapper degrades to `human:tg:<uid>` — never to the relay's name
+#   T5  MUTATION-GRADED: a `human:` stamp naming a ROSTER AGENT is refused and
+#       stored as `unattributed:<name>`, with an audit row saying why
+#   T6  the refusal is not a blanket ban on the word: the same run, same registry,
+#       a NON-roster name still stamps `human:` — so T5 cannot pass by refusing
+#       everything
+#   T7  the guard is MEASURED, not assumed: `actor_name_is_registered_agent`
+#       separates "is an agent", "measured, is not" and "could not look"
+#
+# Isolation: source src/ libs, throwaway STATE_DIR and a FIXTURE registry — the
+# live shared tasks.db and the box's real agents.json are NEVER touched.
+# Run: bash tests/gate_tap_human_attribution_unit.sh   (no root, no network)
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/gate-3128-unit.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+GATE_PROOF_KEY="$STATE_DIR/gate-proof.key"
+GATE_PROOF_ENFORCE="$STATE_DIR/gate-proof.enforce"
+# THE REGISTRY IS REDIRECTED, and this is load-bearing rather than tidy. header.sh
+# computes REGISTRY at SOURCE time from the default STATE_DIR, so a harness that
+# only moves STATE_DIR afterwards leaves the roster guard reading /var/lib/5dive
+# — i.e. grading against whichever agents happen to exist on the box running the
+# suite. Every arm below would then be host-dependent, and T6 in particular would
+# pass or fail on an accident.
+REGISTRY="$TMP/agents.json"
+HUMANS_MAP="$TMP/humans.json"
+GATE_TAP_LOG="$TMP/gate-taps.jsonl"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"; set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+tasks_db_init
+touch "$GATE_PROOF_ENFORCE"   # tier-2 enforcement ON
+
+# THE FIXTURE ROSTER. `relaybot` stands in for the agent whose bot relayed the
+# DIVE-3045 tap. Reserved-fake name on purpose: the guard keys on "this name is
+# under .agents", not on any particular name, so a fake exercises the same code.
+cat >"$REGISTRY" <<'REG'
+{"schemaVersion": 1, "agents": {"relaybot": {"isolation": "vm", "type": "claude"}}}
+REG
+
+# Reserved fakes only (repo convention): Telegram ids -> 1234567890.
+TAP_UID="1234567890"
+TAP_UID_UNNAMED="1234567891"
+TAP_MSG="4242"
+
+cat >"$HUMANS_MAP" <<REG
+{"humans": {"$TAP_UID": "tapper"}}
+REG
+
+# No DM on gate filing. Capture audit rows to a file so the refusal arm can
+# assert the forensic row exists, not merely that a string changed.
+task_need_notify() { :; }
+AUDIT_LOG_FILE="$TMP/audit.log"
+audit_log() { printf '%s\n' "$*" >>"$AUDIT_LOG_FILE"; }
+# DIVE-2010 fence: gate rows route through `_task_store_audit_log`, which emits
+# only on the PRODUCTION store. On a fixture DB the row is deliberately withheld,
+# which would make the audit assertion structurally unsatisfiable. Open it for
+# this fixture; the stub above stays the sink.
+_task_human_send_allowed() { return 0; }
+
+# Deterministic nonce so every arm can present the tap's real --human-proof.
+KNOWN_NONCE="deadbeefdeadbeefdeadbeefdeadbeef"
+_human_nonce_mint() { printf '%s' "$KNOWN_NONCE"; }
+
+# The tap path's OWN shape: the immediate caller IS an agent (the bot), which is
+# why the nonce is the evidence form and why the actor is the wrong thing to
+# stamp. Pinned to 0 so no arm depends on which uid runs the suite.
+FAKE_NONAGENT=0
+_gate_sudo_uid_nonagent() { [[ "$FAKE_NONAGENT" == "1" ]]; }
+_gate_caller_cgroup() {
+  if [[ "$FAKE_NONAGENT" == "1" ]]; then printf '%s' '/system.slice/shelld.service'
+  else printf '%s' '/system.slice/system-5dive.slice/5dive-agent@relaybot.service'; fi
+}
+# LIVENESS BOTH WAYS before anything leans on the switch (the sense-inversion trap
+# tests/gate_tier2_nonce_evidence_unit.sh records).
+FAKE_NONAGENT=1; _gate_human_principal \
+  || { printf 'NOT OK - human-principal pin inert: FAKE_NONAGENT=1 did not read as human\n'; exit 1; }
+FAKE_NONAGENT=0; _gate_human_principal \
+  && { printf 'NOT OK - human-principal pin inert: FAKE_NONAGENT=0 read as human\n'; exit 1; }
+
+# THE ACTOR THE OLD CODE WOULD HAVE STAMPED. A synthetic passwd row makes this
+# harness name `relaybot` as the acting agent on ANY host, including a CI runner
+# where no agent-* account exists — so the defect being graded is reproduced here
+# rather than borrowed from the box.
+_gate_passwd_stream() { printf 'agent-relaybot:x:424242:424242::/nonexistent:/bin/false\n'; }
+_gate_caller_uid()    { printf '%s' 424242; }
+_probe="$(_gate_uid_to_agent 424242)"
+[[ "$_probe" == "relaybot" ]] \
+  || { printf 'NOT OK - the identity resolver is not live: _gate_uid_to_agent returned %s (expected relaybot). Is lib/actor.sh sourced?\n' "'$_probe'"; exit 1; }
+# And the derivation really does reach the answer path as `relaybot` — otherwise
+# T5 would be grading a stamp nobody would ever have written.
+_board="$(task_actor "")"
+[[ "$_board" == "relaybot" ]] \
+  || { printf 'NOT OK - actor derivation inert: task_actor returned %s (expected relaybot)\n' "'$_board'"; exit 1; }
+
+seed()    { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','relaybot');"; }
+t2gate()  {
+  cmd_task_need "$1" --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 \
+    --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+}
+answered(){ db "SELECT CASE WHEN need_answered_at IS NULL THEN 'open' ELSE 'closed' END FROM tasks WHERE ident='$1';"; }
+provby()  { db "SELECT COALESCE(need_answered_by,'')      FROM tasks WHERE ident='$1';"; }
+relayof() { db "SELECT COALESCE(need_answered_relay,'')   FROM tasks WHERE ident='$1';"; }
+tapuidof(){ db "SELECT COALESCE(need_answered_tap_uid,'') FROM tasks WHERE ident='$1';"; }
+
+# --- T1: THE TAPPER IS STAMPED, not the relaying process. --------------------
+# The old code produced `human:relaybot` here; `relaybot` is the actor pinned
+# above, and it is also on the fixture roster, so under the fix it is refused
+# twice over. What must land is the PERSON.
+seed DIVE-301; t2gate DIVE-301
+out=$(cmd_task_answer DIVE-301 --value=A --human --human-proof="$KNOWN_NONCE" \
+        --tap-uid="$TAP_UID" --tap-username=tapperhandle --tap-msg="$TAP_MSG" \
+        --relay-agent=relaybot 2>&1); rc=$?
+[[ "$(answered DIVE-301)" == "closed" && $rc -eq 0 ]] \
+  && ok_t "T1a a genuine tap still CLEARS the tier-2 gate (no regression on the real path)" \
+  || bad_t "T1a tap clears" "rc=$rc state=$(answered DIVE-301) out=$out"
+[[ "$(provby DIVE-301)" == "human:tapper" ]] \
+  && ok_t "T1b the stamp names the TAPPING HUMAN (human:tapper), not the relay" \
+  || bad_t "T1b tapper stamped" "need_answered_by='$(provby DIVE-301)' (expected human:tapper)"
+[[ "$(provby DIVE-301)" == *relaybot* ]] \
+  && bad_t "T1c relay name must not appear in the human stamp" "need_answered_by='$(provby DIVE-301)'" \
+  || ok_t "T1c the relaying agent's name is ABSENT from need_answered_by"
+
+# --- T2: the relay is recorded SEPARATELY, not conflated. --------------------
+# The point of the ticket is not that the relay is unimportant — it is that it is
+# a DIFFERENT FACT. If it were dropped entirely the record would lose the audit
+# trail; if it were folded back in, the defect returns.
+[[ "$(relayof DIVE-301)" == "relaybot" ]] \
+  && ok_t "T2a the relaying agent is recorded in need_answered_relay" \
+  || bad_t "T2a relay column" "need_answered_relay='$(relayof DIVE-301)' (expected relaybot)"
+[[ "$(tapuidof DIVE-301)" == "$TAP_UID" ]] \
+  && ok_t "T2b the tapping telegram uid is recorded in need_answered_tap_uid" \
+  || bad_t "T2b tap uid column" "need_answered_tap_uid='$(tapuidof DIVE-301)'"
+
+# --- T3: the tap is AUDITABLE FROM THE RECORD ALONE. -------------------------
+# Before this the button tap was the least-logged path in the system for the most
+# rigorously evidenced control: reconstructing it meant reading someone's shell
+# history. Assert the fields a reader would need, individually — a bare
+# "the file is non-empty" would green on a line containing none of them.
+if [[ -s "$GATE_TAP_LOG" ]]; then
+  _rec=$(grep -F '"gate":"DIVE-301"' "$GATE_TAP_LOG" | tail -1)
+  _miss=""
+  for _pair in "\"tap_uid\":\"$TAP_UID\"" "\"tap_message_id\":\"$TAP_MSG\"" \
+               "\"relay_agent\":\"relaybot\"" "\"stamped_as\":\"human:tapper\"" \
+               "\"resolved_human\":\"tapper\"" "\"resolved_via\":\"resolved\"" \
+               "\"human_proof\":\"presented\"" "\"verdict\":\"stored\""; do
+    [[ "$_rec" == *"$_pair"* ]] || _miss+=" $_pair"
+  done
+  [[ -z "$_miss" ]] \
+    && ok_t "T3 the tap ledger records uid, message id, gate, relay, stamp and verdict" \
+    || bad_t "T3 tap ledger fields" "missing:$_miss  line=$_rec"
+else
+  bad_t "T3 tap ledger written" "$GATE_TAP_LOG is empty or absent"
+fi
+
+# --- T4: an UNNAMED tapper degrades to tg:<uid>, never to the relay. ---------
+# The failure mode this ticket closes is naming the WRONG principal, not naming
+# nobody. `human:tg:<id>` is an honest partial answer a reader can chase; falling
+# back to the relay's name is the original bug wearing a fallback's clothes.
+seed DIVE-302; t2gate DIVE-302
+cmd_task_answer DIVE-302 --value=A --human --human-proof="$KNOWN_NONCE" \
+  --tap-uid="$TAP_UID_UNNAMED" --relay-agent=relaybot >/dev/null 2>&1
+[[ "$(provby DIVE-302)" == "human:tg:${TAP_UID_UNNAMED}" ]] \
+  && ok_t "T4a an unmapped tapper stamps human:tg:<uid> (honest partial identity)" \
+  || bad_t "T4a unnamed tapper" "need_answered_by='$(provby DIVE-302)' (expected human:tg:${TAP_UID_UNNAMED})"
+[[ "$(relayof DIVE-302)" == "relaybot" ]] \
+  && ok_t "T4b …and the relay is still recorded separately" \
+  || bad_t "T4b relay on unnamed tap" "need_answered_relay='$(relayof DIVE-302)'"
+
+# --- T5: MUTATION-GRADED. The DIVE-3045 SHAPE — a `human:` stamp naming a name
+#     that is on the AGENT ROSTER — is REFUSED. -------------------------------
+# This is the arm that reds if the guard is deleted. It answers WITHOUT a tap, so
+# `$answered_by` is the derived actor `relaybot`, which the fixture registry lists
+# as an agent. Delete `actor_human_name_ok` from the stamp block and the row goes
+# back to reading `human:relaybot` — T5a fails on the value it now holds, T5b
+# fails on the value it now lacks, and T5c fails because the forensic row is gone.
+# Three independent failures, so a partial revert cannot leave this green.
+: >"$AUDIT_LOG_FILE"
+seed DIVE-303; t2gate DIVE-303
+out=$(cmd_task_answer DIVE-303 --value=A --human --human-proof="$KNOWN_NONCE" 2>&1); rc=$?
+_p303="$(provby DIVE-303)"
+[[ "$_p303" != human:* ]] \
+  && ok_t "T5a a stamp that would name a ROSTER AGENT as the human is REFUSED" \
+  || bad_t "T5a roster-agent human stamp refused" "need_answered_by='$_p303' — the guard did not fire; a roster agent is recorded as the human"
+[[ "$_p303" == "unattributed:relaybot" ]] \
+  && ok_t "T5b …and is stored as unattributed:<name>, keeping what WAS measured" \
+  || bad_t "T5b unattributed stamp" "need_answered_by='$_p303' (expected unattributed:relaybot)"
+grep -q 'task answer human-attribution.*error.*reason=roster-agent' "$AUDIT_LOG_FILE" \
+  && ok_t "T5c …and the refusal wrote a forensic audit row naming the reason" \
+  || bad_t "T5c refusal audit row" "no human-attribution error row in $AUDIT_LOG_FILE"
+# The answer itself must still LAND. Refusing the write would discard a decision a
+# person may really have made and leave a tier-2 gate permanently unanswerable —
+# what is refused is the CLAIM, not the answer.
+[[ "$(answered DIVE-303)" == "closed" ]] \
+  && ok_t "T5d the answer still lands — the CLAIM is refused, not the decision" \
+  || bad_t "T5d answer lands" "gate is $(answered DIVE-303)"
+
+# --- T6: NON-VACUITY. The guard is not "refuse every human stamp". -----------
+# Same run, same fixture registry, a name that is NOT on it. Without this arm,
+# T5 is satisfied by a mutation that simply never writes `human:` at all — which
+# would destroy the control while turning every assertion above green.
+seed DIVE-304; t2gate DIVE-304
+cmd_task_answer DIVE-304 --value=A --human --human-proof="$KNOWN_NONCE" \
+  --tap-uid="$TAP_UID" --relay-agent=relaybot >/dev/null 2>&1
+[[ "$(provby DIVE-304)" == "human:tapper" ]] \
+  && ok_t "T6 a NON-roster name still stamps human: (the guard discriminates, it does not blanket-refuse)" \
+  || bad_t "T6 non-roster name still stamps human:" "need_answered_by='$(provby DIVE-304)'"
+
+# --- T7: the roster predicate reports THREE states, not two. ----------------
+# "could not look at the roster" must not read like "looked, it is not an agent"
+# — fold them and an unreadable registry silently switches the guard off. Graded
+# directly because no arm above can distinguish the two through cmd_task_answer.
+actor_name_is_registered_agent relaybot; _rc_agent=$?
+actor_name_is_registered_agent tapper;   _rc_human=$?
+( REGISTRY="$TMP/does-not-exist.json"; actor_name_is_registered_agent relaybot ); _rc_blind=$?
+[[ $_rc_agent -eq 0 ]] \
+  && ok_t "T7a a roster name MEASURES as an agent (rc 0)" \
+  || bad_t "T7a roster name" "rc=$_rc_agent (expected 0)"
+[[ $_rc_human -eq 1 ]] \
+  && ok_t "T7b a non-roster name MEASURES as not-an-agent (rc 1)" \
+  || bad_t "T7b non-roster name" "rc=$_rc_human (expected 1)"
+[[ $_rc_blind -eq 2 ]] \
+  && ok_t "T7c an unreadable roster is UNMEASURED (rc 2), not silently 'not an agent'" \
+  || bad_t "T7c unmeasurable roster" "rc=$_rc_blind (expected 2)"
+
+echo "-----"
+printf 'gate_tap_human_attribution_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/tasks_db_restore_guard_unit.sh
+++ b/tests/tasks_db_restore_guard_unit.sh
@@ -173,9 +173,10 @@ out=$(TASKS_BACKUP_DIR="$paired_backups" tasks_db_init 2>&1); rc=$?
 
 # --- Case 9 (DIVE-2808): canonical schema is complete at birth ----------------
 # Eight columns lived only in the migration list. The completed CREATE must have
-# the full 75-column tasks surface before the skip-gate is allowed to save work.
+# the full 77-column tasks surface before the skip-gate is allowed to save work.
 # (71 at the time this case was written; DIVE-2853 added recurring_stall_escalated_at
-# on main, DIVE-2848 added gate_rubber_stamp, and DIVE-3098 added graded_at+graded_by.
+# on main, DIVE-2848 added gate_rubber_stamp, DIVE-3098 added graded_at+graded_by, and
+# DIVE-3128 added need_answered_relay + need_answered_tap_uid.
 # The count is asserted literally on purpose — this case exists to catch a canonical
 # CREATE that silently drops a column, so it must not derive its own expectation from
 # the thing under test.)
@@ -193,8 +194,8 @@ actual=$(sqlite3 "$TASKS_DB" \
     WHERE name IN ('delivery_ref','delivered_at','delivery_ref_iteration','parked_at','park_reason','escalated_at','escalated_by','human_evidence')
     ORDER BY name;" 2>/dev/null | tr '\n' ' ' | sed 's/ $//')
 column_count=$(sqlite3 "$TASKS_DB" "SELECT count(*) FROM pragma_table_info('tasks');" 2>/dev/null)
-[[ $rc -eq 0 && "$actual" == "$required" && "$column_count" == "75" ]] \
-  && ok "fresh schema: all 75 columns, including the eight former holes, are present" \
+[[ $rc -eq 0 && "$actual" == "$required" && "$column_count" == "77" ]] \
+  && ok "fresh schema: all 77 columns, including the eight former holes, are present" \
   || bad "fresh schema: init returned a partial tasks table" "rc=$rc count=$column_count got=[$actual] want=[$required] out=$out"
 
 # --- Case 10 (DIVE-2197): migrate arm still rejects a failed ALTER ------------


### PR DESCRIPTION
Closes DIVE-3128. Built by dev2, graded PASS by main at 05:35Z — and then **left stranded on a local branch for three hours**, which is the part worth reading.

## What it fixes

A tier-2 gate answered through the Telegram inline button was stamped `need_answered_by = human:<THE RELAYING AGENT>`. On DIVE-3045 that landed as `human:olivia` with `need_answered_uid=1011` — an agent's uid. There is no human named olivia, so the field asserted a human and named an agent, and no reader could tell a relayed human tap from an agent answering its own gate. Tier 2 exists to prove a person was in the loop; that was the one field that had to survive and the one that did not.

Now: the tap stamps the **tapping human**, resolved from `callback_query.from.id` rather than the relaying process's identity; the relay is recorded separately in `need_answered_relay` / `need_answered_tap_uid`; any `human:<name>` resolving to a roster agent is **refused** and demoted to `unattributed:<name>` with a warn and an audit row; and every tap is logged to `gate-taps.jsonl` so the next instance is attributable from the record alone.

## Verification

Graded by main, mutation-checked rather than taken on report — `tests/gate_tap_human_attribution_unit.sh` 16/16, and two independent mutations run in a private copy:

- killing the roster guard (`actor_human_name_ok` always returns 0) → exactly T5a/T5b/T5c red
- collapsing the three-state (`unknown:*` → 1 instead of 2) → exactly T7c red

Also `gate_lead_clear_stamp_unit` 8/8 and `tasks_db_restore_guard_unit` 56/56, the two suites this branch modifies. `merge-tree` against current `origin/main` returns clean.

The part read hardest was `actor.sh`'s three-state: an unmeasurable roster **accepts** with `why=roster-unmeasured` rather than folding onto either verdict. That is the not-reached-vs-pass collapse this class of guard usually gets wrong.

## Why this PR exists three hours late

The row closed `done` at 05:35 with the code on a local branch and nothing pushed. My own grade result said so in as many words — *"the code is NOT on main… if nobody lands it the fix evaporates with the worktree"* — and I then told another agent, in writing, that the fix **had merged at 05:35**. It had not. That claim reached a compiled wiki page before it was caught.

`done` is not `merged`, the row said so, and the person who wrote that sentence still got it wrong two hours later. The branch was never on the remote at all until this push.

## Known residuals, disclosed by dev2 and confirmed

1. `plugins/telegram/tna.ts` (a different repo) does not yet forward `--tap-uid`, so a real tap reads `unattributed:<agent>` until that lands. That is a degradation to **honest** — the false `human:<agent>` claim becomes impossible to write — not a regression.
2. `need_answered_relay` sits outside the DIVE-756 signed closure.
