### PR TITLE
DIVE-2129: ship-ledger liveness — a ZERO in the ship ledger is a measurement, not an absence

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -224,11 +224,25 @@ jobs:
       # never be earned here by adding another job, which is the difference
       # between an allowlist and a skip. Every other probe must be REACHED by
       # this job or the installed-host one, and the union below asserts it.
+      #
+      # DIVE-2129: `ship-ledger-liveness` is allowlisted for the same STRUCTURAL
+      # reason and not a convenience one — its denominator is pushes that crossed
+      # the production push rail since the running bundle acquired the ledger
+      # writer, and an ephemeral runner has never pushed through that rail and
+      # never will. No number of extra jobs earns it here. It is therefore the one
+      # probe whose verdict paths are graded HERMETICALLY instead:
+      # tests/ship_ledger_liveness_unit.sh drives all of LIVE / BROKEN / the five
+      # not-reached reasons over fixture sinks, and carries the two negative
+      # controls that matter (a refused push must not manufacture a BROKEN; ledger
+      # rows must not certify their own denominator). That harness runs in the
+      # `test` job, so this allowlist entry costs coverage of the probe's WIRING on
+      # a real box, not of its logic — and a real box is exactly where a human runs
+      # `5dive selfcheck --only=ship-ledger-liveness`.
       - name: Do the rails ACT? (pristine)
         run: |
           # DIVE-2091: bundle is generated at tag time, not committed on main.
           ./build.sh
-          bash ./5dive selfcheck --allow=snapshot-rails \
+          bash ./5dive selfcheck --allow=snapshot-rails,ship-ledger-liveness \
             --label=pristine --report=selfcheck-pristine.txt
       - uses: actions/upload-artifact@v4
         if: always()
@@ -314,13 +328,13 @@ jobs:
         run: |
           # DIVE-2091: bundle is generated at tag time, not committed on main.
           ./build.sh
-          bash ./5dive selfcheck --allow=snapshot-rails \
+          bash ./5dive selfcheck --allow=snapshot-rails,ship-ledger-liveness \
             --label=installed-host --report=selfcheck-installed.txt
       - name: Do the rails ACT? (installed host, root)
         run: |
           # DIVE-2091: bundle is generated at tag time, not committed on main.
           ./build.sh
-          sudo bash ./5dive selfcheck --allow=snapshot-rails \
+          sudo bash ./5dive selfcheck --allow=snapshot-rails,ship-ledger-liveness \
             --label=installed-root --report=selfcheck-root.txt
           sudo chown "$USER" selfcheck-root.txt
       - uses: actions/upload-artifact@v4

--- a/changelog.d/DIVE-2129.md
+++ b/changelog.d/DIVE-2129.md
@@ -1,0 +1,27 @@
+## Unreleased — feat(selfcheck): ship-ledger liveness, so a ZERO in the ship ledger is a measurement and not an absence (DIVE-2129)
+
+`5dive selfcheck` gains a `ship-ledger-liveness` probe. DIVE-1923 built the ship
+ledger (`5dive push` → `ship_events`) and closed saying that no row appearing after
+the fleet rolled and pushed would be a real signal. Measured, it was not: the
+instrument armed at 23:35:15Z and the last push through the rail was at 23:14:41Z,
+so there had been **zero** pushes since arming and the watch would have fired on
+nothing. An uninstalled or unexercised instrument renders identically to a healthy
+one with no events.
+
+The probe reports three verdicts, never two — `LIVE` (a post-arming push and a
+matching row: the capture path is proven end to end), `BROKEN` (a post-arming push
+and zero rows: the only alarming state), and `NOT-REACHED` (no push has crossed the
+rail since arming, stated with the arming and last-push stamps, and never folded
+into a pass).
+
+The non-vacuity denominator is the deliverable. It never comes from `ship_events`,
+since counting pushes from the table under test makes `0/0` self-certifying forever.
+It counts only `result=ok` pushes, because a refused push never reaches the writer
+and counting one manufactures a false `BROKEN`. It is anchored to the running
+bundle's acquisition of the writer — read as a symbol in the artifact, not as a
+version string — and a `BROKEN` is written down so a nightly roll that moves the
+bundle's mtime cannot silently reset the alarm with the window. And because 5dive's
+own audit sink was measured recording push events non-uniformly, an *empty*
+denominator is trusted only when two independent sinks (the agent audit log and
+sudo's journal) are both proven to be writing and both agree; a disagreement is its
+own named not-reached reason rather than a silent preference for one of them.

--- a/scripts/grade-release-commit.sh
+++ b/scripts/grade-release-commit.sh
@@ -239,7 +239,7 @@ fi
 #    it is the whole point of this script.
 #    --allow=snapshot-rails matches unit-tests.yml, so this is the same bar and not a
 #    softer one invented here.
-if _sc_out=$(bash "$BUNDLE" selfcheck --allow=snapshot-rails --label=release-commit 2>&1); then
+if _sc_out=$(bash "$BUNDLE" selfcheck --allow=snapshot-rails,ship-ledger-liveness --label=release-commit 2>&1); then
   echo "$_sc_out"
   echo "grade-release-commit: selfcheck PASS on the released bundle"
 else

--- a/src/cmd_selfcheck.sh
+++ b/src/cmd_selfcheck.sh
@@ -67,6 +67,7 @@ SELFCHECK_PROBES=(
   bundle-integrity
   snapshot-rails
   scorecard-honesty
+  ship-ledger-liveness
 )
 
 _sc_title() {
@@ -80,6 +81,7 @@ _sc_title() {
     bundle-integrity)  echo "the installed bundle's sha256 matches the commit it claims" ;;
     snapshot-rails)    echo "the crontab snapshot committed what it says it saved" ;;
     scorecard-honesty) echo "a partial read renders as NO DATA, never as a number" ;;
+    ship-ledger-liveness) echo "the ship ledger's ZERO is a measurement, not an absence — a push crossed the rail post-arming and was captured" ;;
     *)                 echo "$1" ;;
   esac
 }
@@ -777,6 +779,269 @@ _sc_probe_scorecard_honesty() {
   else _sc_pass "over an empty store ${#rows[@]} metric rows: $nodata degraded to NO DATA and each names what was missed; every number declares its coverage [graded $self]"; fi
 }
 
+# --- probe: ship-ledger liveness (DIVE-2129) ----------------------------------
+# ZERO ROWS IS VACUOUS UNTIL A PUSH CROSSES THE RAIL POST-ARMING.
+#
+# DIVE-1923 built the ship ledger (`5dive push` -> ship_events) and its close said
+# "if no row appears after the fleet rolls and pushes, that is a real signal". It
+# was not, and the measurement is why this probe exists:
+#
+#   instrument armed (binary mtime): 2026-07-26 23:35:15Z
+#   last push through the rail:      2026-07-26 23:14:41Z
+#   pushes AFTER arming:             0
+#
+# An UNINSTALLED or UNEXERCISED instrument renders IDENTICALLY to a healthy one
+# with no events. So `ship_events` = 0 is three different facts wearing one face,
+# and this probe separates them — three verdicts, never two:
+#
+#   NOT-REACHED  zero pushes crossed the rail since the RUNNING bundle acquired
+#                the writer. Not a pass, not a fail. States the arming stamp and
+#                the last-push stamp so the reader can see the window is empty.
+#   LIVE (pass)  >=1 post-arming push AND >=1 post-arming ship_events row. The
+#                capture path is proven end to end, in production, on this box.
+#   BROKEN (fail) >=1 post-arming push and ZERO rows. The only alarming state.
+#
+# The DENOMINATOR — post-arming pushes — is the whole deliverable. Without it this
+# is a soak with no traffic that passes forever.
+#
+# FOUR CONSTRAINTS, each from a measurement, each load-bearing:
+#
+# 1. THE DENOMINATOR MUST NOT COME FROM ship_events. Counting pushes from the
+#    table whose emptiness is under test makes 0/0 self-certifying: a dead writer
+#    reports "no pushes, therefore fine" forever. It comes from OUTSIDE.
+#
+# 2. FILTER result=ok. 519 of 528 audit push rows on this host were `error`, one
+#    of them a refused push of DIVE-1923 itself. A refused push never reaches the
+#    writer, so counting it manufactures a FALSE BROKEN. `ok` is 9/528 here —
+#    the filter removes 98% of the source, which is the point, not an edge case.
+#
+# 3. BROKEN IS STICKY ACROSS ARMING EPOCHS. The window is anchored to the bundle,
+#    and the bundle's mtime moves on every install — so an alarm raised in one
+#    epoch would be silently forgotten by the next roll, which happens nightly.
+#    A BROKEN is written down and re-asserted until a LIVE at-or-after it clears
+#    it. The record is this probe's own; it is never the ledger (see below).
+#
+# 4. THE DENOMINATOR SOURCE MUST BE PROVEN RECORDING BEFORE AN EMPTY DENOMINATOR
+#    IS TRUSTED. This is constraint 1 one level out, and it is not hypothetical:
+#    probed live 2026-07-26 23:41:35Z, a refused `push` wrote NO audit row at all,
+#    though the AUDIT_CMD="push" dispatch site is byte-identical across 0.16.23,
+#    0.16.24 and the installed binary — and the sink was ALIVE (a `task set-body`
+#    3 seconds later by the same user on the same binary wrote one). So push
+#    events are recorded NON-UNIFORMLY and "no push rows since arming" means
+#    EITHER "no pushes" OR "pushes this sink did not record". A denominator that
+#    can be empty for reasons unrelated to traffic cannot establish non-vacuity
+#    by being empty.
+#
+#    Hence TWO WITNESSES, and they are genuinely two — different writers, different
+#    files: the agent audit log (5dive's own sink) and the systemd journal's sudo
+#    records of `5dive _push_do` (sudo's sink, which caught pushes the audit log
+#    missed). Two logs with ONE writer are one witness.
+#
+# HOW THE TWO WITNESSES COMBINE, stated because "combine two logs" hides a choice:
+#   * a POSITIVE from either is credible on its own — a recorded push happened,
+#     and neither sink invents rows. So non-vacuity is the UNION.
+#   * an EMPTY is credible only when BOTH are proven recording (each produced at
+#     least one row of ANY kind since arming) and BOTH agree it is empty.
+#   * when exactly one is empty and the other is not, and the ledger is ALSO
+#     empty, both readings are wrong: preferring the positive raises an alarm on
+#     one uncorroborated witness, preferring the empty asserts no-traffic against
+#     direct evidence of traffic. That is `witness-disagreement`, its own
+#     not-reached reason — never a silent preference for one of them.
+#
+# READS THE ARTIFACT, NOT A VERSION STRING. A version number is a claim; the
+# symbol is the thing. Arming is `^ship_ledger_record()` AND
+# `^_push_record_ship_ledger()` present in the running bundle — both anchored at
+# column 0 so this comment, and the grep that carries them, cannot match
+# themselves and arm the probe by existing.
+#
+# DOES NOT SEED THE LEDGER, EVER. A synthetic first row corrupts the exact number
+# DIVE-1923 exists to make honest; main and I both refused it deliberately. The
+# only thing this probe writes is its own sticky record, under STATE_DIR/selfcheck
+# and never inside ship_events.
+
+# The sticky record. Overridable for tests. NEVER the ledger.
+_sc_sll_state_file() {
+  printf '%s' "${SELFCHECK_SLL_STATE:-${STATE_DIR:-/var/lib/5dive}/selfcheck/ship-ledger-liveness.state}"
+}
+# Append-only, last-write-wins on read: the file is the probe's own history and a
+# rewrite would lose the epoch an alarm was first raised in.
+_sc_sll_get() {
+  local f; f="$(_sc_sll_state_file)"
+  [[ -r "$f" ]] || return 0
+  sed -n "s/^$1=//p" "$f" 2>/dev/null | tail -1
+}
+_sc_sll_put() {
+  local f d; f="$(_sc_sll_state_file)"; d="$(dirname -- "$f")"
+  mkdir -p "$d" 2>/dev/null || return 1
+  printf '%s=%s\n' "$1" "$2" >> "$f" 2>/dev/null || return 1
+}
+
+# The store the CLI itself resolves — NOT a guess. /var/lib/5dive/tasks.db exists
+# on this host as a 0-byte stray and answers `no such table: ship_events`, i.e. a
+# plausible wrong path returns a FALSE BROKEN. Resolve it the one way, or not at all.
+_sc_sll_db() { printf '%s' "${TASKS_DB:-${STATE_DIR:-/var/lib/5dive}/tasks/tasks.db}"; }
+
+# WITNESS A — 5dive's own audit sink. Emits "<ok_pushes>|<rows_any_cmd>|<status>".
+# rows_any_cmd is the proof-of-recording half of constraint 4: it is what lets an
+# empty push count mean "no pushes" rather than "this sink wrote nothing at all".
+_sc_sll_audit() {
+  local since_iso="$1" log="${AUDIT_LOG:-/var/log/5dive/agent-audit.log}"
+  [[ -r "$log" ]] || { printf '0|0|unreadable\n'; return; }
+  command -v jq >/dev/null 2>&1 || { printf '0|0|no-jq\n'; return; }
+  # -R + fromjson? so ONE malformed line cannot abort the stream and shrink the
+  # denominator to a number that then reads as "no traffic".
+  jq -rR 'fromjson? // empty
+          | [ (.ts // ""), (.cmd // ""), (.result // "") ] | @tsv' "$log" 2>/dev/null \
+  | awk -F'\t' -v s="$since_iso" '
+      { ts=$1
+        if (length(ts) < 19) next
+        # Offsets other than UTC would make the lexical compare below silently
+        # wrong, so they are counted and reported, never quietly included.
+        if (ts !~ /(\+00:00|Z)$/) { off++; next }
+        if (substr(ts,1,19) < s) next
+        any++
+        if ($2 == "push" && $3 == "ok") push++
+      }
+      END { printf "%d|%d|%s\n", push+0, any+0, (off+0 ? "mixed-offset" : "ok") }'
+}
+
+# WITNESS B — sudo's own journal, a DIFFERENT writer to a DIFFERENT sink. Emits
+# "<pushes>|<rows_any>|<status>". `5dive push` re-enters as root via
+# `sudo 5dive _push_do`, so every push leaves a sudo record even when 5dive's own
+# audit dispatch does not fire.
+_sc_sll_journal() {
+  local since_epoch="$1" out
+  command -v journalctl >/dev/null 2>&1 || { printf '0|0|no-journalctl\n'; return; }
+  out="$(journalctl -q --no-pager --since "@${since_epoch}" 2>/dev/null)" \
+    || { printf '0|0|unreadable\n'; return; }
+  [[ -n "$out" ]] || { printf '0|0|silent\n'; return; }
+  local any push
+  any=$(printf '%s\n' "$out" | grep -c . || true)
+  push=$(printf '%s\n' "$out" | grep -c 'COMMAND=[^ ]*5dive _push_do' || true)
+  printf '%d|%d|ok\n' "${push:-0}" "${any:-0}"
+}
+
+_sc_probe_ship_ledger_liveness() {
+  local bundle; bundle="${SELFCHECK_SLL_BUNDLE:-$(_sc_self 2>/dev/null || true)}"
+  if [[ -z "$bundle" || ! -r "$bundle" ]]; then
+    _sc_notreached "no-bundle" "could not resolve a readable running bundle to grade (looked at '${bundle:-<none>}'), so the arming epoch is unknowable"
+    return
+  fi
+  _sc_note "  bundle: $bundle"
+
+  # Arming reads the ARTIFACT. Both patterns anchored at column 0 — the writer's
+  # definition and the push call site — so neither this file's prose nor this very
+  # grep can satisfy them.
+  if ! grep -q '^ship_ledger_record()' "$bundle" 2>/dev/null \
+     || ! grep -q '^_push_record_ship_ledger()' "$bundle" 2>/dev/null; then
+    _sc_notreached "not-armed" "the running bundle ($bundle) carries no ship-ledger writer, so ship_events cannot fill and its emptiness says nothing about the capture path"
+    return
+  fi
+
+  local armed_epoch armed_iso now_iso
+  armed_epoch=$(stat -c %Y "$bundle" 2>/dev/null) || armed_epoch=""
+  [[ -n "$armed_epoch" ]] \
+    || { _sc_notreached "no-arming-stamp" "the running bundle ($bundle) is armed but its mtime is unreadable, so the observation window has no start"; return; }
+  armed_iso=$(date -u -d "@$armed_epoch" +%Y-%m-%dT%H:%M:%S 2>/dev/null)
+  now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local armed_sql; armed_sql=$(date -u -d "@$armed_epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null)
+
+  # --- the sticky record, read BEFORE this run's own verdict is computed -------
+  local sticky_broken sticky_live sticky_out=0 sticky_note="" persist_ok=1
+  sticky_broken="$(_sc_sll_get broken_at)"
+  sticky_live="$(_sc_sll_get live_at)"
+  if [[ -n "$sticky_broken" ]] && [[ -z "$sticky_live" || "$sticky_live" < "$sticky_broken" ]]; then
+    sticky_out=1
+  fi
+  _sc_sll_put armed_at "$armed_iso" || persist_ok=0
+  [[ -n "$(_sc_sll_get armed_first_seen)" ]] || _sc_sll_put armed_first_seen "$armed_iso" || true
+  if (( ! persist_ok )); then sticky_note=" [STICKY RECORD UNWRITABLE at $(_sc_sll_state_file) — a BROKEN observed here will not survive the next install, which is constraint 3 unmet on this box]"; fi
+
+  # --- the denominator: two witnesses, neither of them ship_events ------------
+  local a b a_push a_any a_st b_push b_any b_st
+  a="$(_sc_sll_audit "$armed_iso")"; b="$(_sc_sll_journal "$armed_epoch")"
+  IFS='|' read -r a_push a_any a_st <<<"$a"
+  IFS='|' read -r b_push b_any b_st <<<"$b"
+  _sc_note "  witnesses since $armed_iso: audit=${a_push} ok-push / ${a_any} rows ($a_st); journal=${b_push} _push_do / ${b_any} rows ($b_st)"
+
+  # Proven RECORDING, not merely readable: a sink that produced no row of any kind
+  # in this window cannot certify that the window had no pushes.
+  local a_live=0 b_live=0
+  if [[ "$a_st" == "ok" ]] && (( a_any > 0 )); then a_live=1; fi
+  if [[ "$b_st" == "ok" ]] && (( b_any > 0 )); then b_live=1; fi
+
+  local last_push="none recorded"
+  local lp; lp=$(command -v jq >/dev/null 2>&1 && [[ -r "${AUDIT_LOG:-/var/log/5dive/agent-audit.log}" ]] \
+        && jq -rR 'fromjson? // empty | select(.cmd=="push" and .result=="ok") | .ts' \
+             "${AUDIT_LOG:-/var/log/5dive/agent-audit.log}" 2>/dev/null | tail -1)
+  if [[ -n "$lp" ]]; then last_push="$lp"; fi
+
+  # --- the numerator: the ledger, resolved the way the CLI resolves it ---------
+  local db rows table
+  db="$(_sc_sll_db)"
+  if [[ ! -r "$db" ]] || ! command -v sqlite3 >/dev/null 2>&1; then
+    _sc_notreached "ledger-unreadable" "the ship ledger store ($db) is not readable from here (or sqlite3 is absent), so this run measured neither the numerator nor the denominator${sticky_note}"
+    return
+  fi
+  table=$(sqlite3 -cmd ".timeout 3000" "$db" \
+          "SELECT 1 FROM sqlite_master WHERE type='table' AND name='ship_events' LIMIT 1;" 2>/dev/null)
+  if [[ "$table" == "1" ]]; then
+    rows=$(sqlite3 -cmd ".timeout 3000" "$db" \
+           "SELECT COUNT(*) FROM ship_events WHERE ts >= '$armed_sql';" 2>/dev/null)
+    [[ "$rows" =~ ^[0-9]+$ ]] || rows=0
+  else
+    rows=0
+  fi
+  local tnote=""
+  if [[ "$table" != "1" ]]; then tnote=" (the ship_events table does not exist in $db — the migration never ran here)"; fi
+
+  local window="armed $armed_iso, now $now_iso; last recorded ok push $last_push; witnesses audit=$a_push/${a_any} ($a_st) journal=$b_push/${b_any} ($b_st); ship_events since arming = $rows$tnote"
+
+  # --- verdict ---------------------------------------------------------------
+  local pushes=$(( a_push > b_push ? a_push : b_push ))
+
+  if (( pushes > 0 )); then
+    if (( rows > 0 )); then
+      _sc_sll_put live_at "$now_iso" || persist_ok=0
+      local cleared=""
+      if (( sticky_out )); then cleared=" This LIVE clears the sticky BROKEN recorded at $sticky_broken."; fi
+      _sc_pass "LIVE — $pushes push(es) crossed the rail since the running bundle acquired the writer, and the ledger holds $rows row(s) in the same window, so the capture path is proven end to end here. Emptiness is no longer the only reading available.$cleared [$window]${sticky_note}"
+      return
+    fi
+    # Zero rows against a real denominator. Alarm — but only on a CORROBORATED
+    # denominator, or on a disagreement named as one.
+    if (( a_push > 0 && b_push > 0 )); then
+      if (( ! sticky_out )); then
+        _sc_sll_put broken_at "$now_iso" || persist_ok=0
+        _sc_sll_put broken_window "$window" || true
+      fi
+      _sc_fail "BROKEN — $pushes push(es) are recorded by BOTH independent witnesses since arming and the ledger holds ZERO rows in that window. This is the real signal DIVE-1923's close was reaching for: the capture path is armed, exercised, and not writing.$tnote [$window]${sticky_note}"
+      return
+    fi
+    if (( (a_push > 0 && b_live) || (b_push > 0 && a_live) )); then
+      _sc_notreached "witness-disagreement" "the ledger is empty since arming and the two witnesses disagree about whether any push happened (audit=$a_push, journal=$b_push) while BOTH are recording. Alarming would rest a BROKEN on one uncorroborated witness; claiming no-traffic would deny direct evidence of traffic. Neither is supported, so neither is asserted. [$window]${sticky_note}"
+      return
+    fi
+    # One witness saw traffic; the other is not proven to be recording at all, so
+    # it cannot corroborate OR contradict. An uncorroborated alarm on a rail whose
+    # sinks are known to be non-uniform is exactly the false BROKEN constraint 2
+    # exists to prevent.
+    _sc_notreached "uncorroborated-denominator" "the ledger is empty since arming and the only witness reporting traffic (audit=$a_push, journal=$b_push) has no live partner to corroborate it (audit recording=$a_live, journal recording=$b_live), so a BROKEN here would rest on a single sink already measured to record pushes non-uniformly. [$window]${sticky_note}"
+    return
+  fi
+
+  # --- denominator is empty: is it trustworthy? -------------------------------
+  if (( sticky_out )); then
+    _sc_fail "BROKEN (sticky) — no push has crossed the rail in the CURRENT arming epoch, but a BROKEN was recorded at $sticky_broken and no LIVE has been observed since. The bundle's mtime moved (nightly rolls do this) and the window reset; the alarm does not reset with it. Recorded window: $(_sc_sll_get broken_window). [$window]${sticky_note}"
+    return
+  fi
+  if (( ! a_live || ! b_live )); then
+    _sc_notreached "denominator-source-unproven" "ZERO post-arming pushes were counted, but that emptiness is not trustworthy: audit sink $( ((a_live)) && echo "is recording" || echo "produced NO row of any kind since arming (status=$a_st)"), journal sink $( ((b_live)) && echo "is recording" || echo "produced NO row of any kind since arming (status=$b_st)"). An empty count from a sink not proven to be writing means 'not observed', not 'no traffic'. [$window]${sticky_note}"
+    return
+  fi
+  _sc_notreached "no-post-arming-push" "NOT-REACHED, and this is the honest state, not a pass: both witnesses are proven to be recording and BOTH count ZERO pushes since the running bundle acquired the writer at $armed_iso. ship_events = $rows in that window says nothing about the capture path — an unexercised instrument renders identically to a healthy one. [$window]${sticky_note}"
+}
+
 _sc_dispatch() {
   case "$1" in
     lead-clear-seal)   _sc_probe_lead_clear_seal ;;
@@ -788,6 +1053,7 @@ _sc_dispatch() {
     bundle-integrity)  _sc_probe_bundle_integrity ;;
     snapshot-rails)    _sc_probe_snapshot_rails ;;
     scorecard-honesty) _sc_probe_scorecard_honesty ;;
+    ship-ledger-liveness) _sc_probe_ship_ledger_liveness ;;
     *)                 _sc_error "unknown probe: $1" ;;
   esac
 }

--- a/tests/ship_ledger_liveness_unit.sh
+++ b/tests/ship_ledger_liveness_unit.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# DIVE-2129 unit: the ship-ledger LIVENESS probe — 0 rows is VACUOUS until a push
+# crosses the rail post-arming.
+#
+# What this grades, and why each case exists. The probe's whole job is to refuse to
+# report a number it has not earned, so this harness is weighted toward the two
+# FALSE readings that motivated the ticket:
+#
+#   FALSE PASS   — an unexercised instrument renders identically to a healthy one.
+#                  DIVE-1923 closed saying "no row after the fleet rolls is a real
+#                  signal"; measured, there had been ZERO pushes since arming, so
+#                  the watch would have fired on nothing. Cases 2/3/9 are that.
+#   FALSE BROKEN — a refused push never reaches the writer. 519 of 528 audit push
+#                  rows on the origin host were `error`, one of them a refused push
+#                  of DIVE-1923 itself. Counting them alarms on a healthy rail.
+#                  Case 8 is that, and it is a NEGATIVE CONTROL, not a nicety.
+#
+# And the two structural properties that make the verdict mean anything:
+#
+#   THE DENOMINATOR NEVER COMES FROM ship_events (case 9). A check that counted
+#   pushes from the table under test would be 0/0 self-certifying forever.
+#   ARMING READS THE ARTIFACT, NOT A VERSION STRING (cases 1, 12). Case 12 is the
+#   self-match control: the probe's own source names the symbols it greps for, so
+#   a pattern that could match its own text would arm the probe by existing.
+#
+# Isolated: temp bundle, temp audit log, temp sqlite store, a stub `journalctl` on
+# PATH, temp sticky record. No prod DB, no root, no network, and it NEVER writes a
+# ship_events row — seeding the ledger is the one thing DIVE-1923 exists to prevent.
+#   bash tests/ship_ledger_liveness_unit.sh
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
+SRC=src
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh cmd_selfcheck.sh; do
+  source "$SRC/$f"
+done
+set +e
+
+PASS=0; FAIL=0
+ok_t()   { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+fail_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+command -v sqlite3 >/dev/null 2>&1 || { echo "SKIP: sqlite3 absent"; exit 0; }
+command -v jq      >/dev/null 2>&1 || { echo "SKIP: jq absent"; exit 0; }
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/sll-unit.XXXXXX") || exit 2
+mkdir -p "$TMP/bin"
+PATH="$TMP/bin:$PATH"
+
+# ── the stub journal ──────────────────────────────────────────────────────────
+# Witness B is sudo's own sink, a DIFFERENT writer to a DIFFERENT file. The stub is
+# driven by two knobs so "recording but saw no push" and "not recording at all" are
+# separable — which is the entire point of constraint 4 and cannot be tested with a
+# single on/off.
+cat > "$TMP/bin/journalctl" <<'STUB'
+#!/usr/bin/env bash
+[[ "${STUB_JOURNAL:-ok}" == "unreadable" ]] && exit 1
+i=0; while (( i < ${STUB_JOURNAL_NOISE:-0} )); do echo "Aug 09 20:00:00 box systemd[1]: noise $i"; i=$((i+1)); done
+i=0; while (( i < ${STUB_JOURNAL_PUSH:-0} )); do
+  echo "Aug 09 20:0$i:00 box sudo[1000]:     root : PWD=/x ; USER=root ; COMMAND=/usr/local/bin/5dive _push_do"; i=$((i+1)); done
+exit 0
+STUB
+chmod +x "$TMP/bin/journalctl"
+
+ARMED_EPOCH=1754700000                       # 2026-08-09 01:20:00Z, the arming stamp
+ARMED_SQL=$(date -u -d "@$ARMED_EPOCH" '+%Y-%m-%d %H:%M:%S')
+BEFORE_ISO=$(date -u -d "@$((ARMED_EPOCH-3600))" '+%Y-%m-%dT%H:%M:%S+00:00')
+AFTER_ISO=$(date -u -d "@$((ARMED_EPOCH+3600))" '+%Y-%m-%dT%H:%M:%S+00:00')
+AFTER_SQL=$(date -u -d "@$((ARMED_EPOCH+3600))" '+%Y-%m-%d %H:%M:%S')
+
+mk_bundle() { # mk_bundle <path> <armed:1|0> [epoch]
+  if [[ "$2" == 1 ]]; then
+    { echo '#!/usr/bin/env bash'
+      echo 'ship_ledger_record() { :; }'
+      echo '_push_record_ship_ledger() { :; }'; } > "$1"
+  else
+    # Names the symbols the way the PROBE'S OWN SOURCE does — indented, quoted,
+    # inside prose. An unanchored grep would arm on this. That is case 12.
+    { echo '#!/usr/bin/env bash'
+      echo "  # calls ship_ledger_record and _push_record_ship_ledger one day"
+      echo "  grep -q '^ship_ledger_record()' \"\$b\" && grep -q '^_push_record_ship_ledger()' \"\$b\""; } > "$1"
+  fi
+  touch -d "@${3:-$ARMED_EPOCH}" "$1"
+}
+
+mk_audit() { # mk_audit <path> <spec...>  spec = cmd:result:when(before|after)
+  : > "$1"
+  local s cmd res when ts
+  for s in "${@:2}"; do
+    IFS=: read -r cmd res when <<<"$s"
+    [[ "$when" == before ]] && ts="$BEFORE_ISO" || ts="$AFTER_ISO"
+    printf '{"ts":"%s","user":"agent-dev","cmd":"%s","result":"%s","code":0,"args":["DIVE-2129"]}\n' \
+      "$ts" "$cmd" "$res" >> "$1"
+  done
+}
+
+mk_db() { # mk_db <path> <ship_rows_after_arming> [--no-table]
+  rm -f "$1"
+  [[ "${3:-}" == "--no-table" ]] && { sqlite3 "$1" "CREATE TABLE other(x);" ; return; }
+  sqlite3 "$1" "CREATE TABLE ship_events (id INTEGER PRIMARY KEY, kind TEXT, actor TEXT, ident TEXT, repo TEXT, branch TEXT, sha TEXT, reverts TEXT, self INT, ts TEXT DEFAULT (datetime('now')));"
+  local i=0
+  while (( i < $2 )); do
+    sqlite3 "$1" "INSERT INTO ship_events (kind,sha,ts) VALUES ('ship','sha$i','$AFTER_SQL');"; i=$((i+1))
+  done
+}
+
+# run <name> — dispatch the probe under the current fixture env; sets V/R/D
+run() {
+  local line
+  line=$(SELFCHECK_SLL_BUNDLE="$BUNDLE" AUDIT_LOG="$AUDITLOG" TASKS_DB="$DB" \
+         SELFCHECK_SLL_STATE="$STATE" \
+         STUB_JOURNAL="${STUB_JOURNAL:-ok}" STUB_JOURNAL_PUSH="${STUB_JOURNAL_PUSH:-0}" \
+         STUB_JOURNAL_NOISE="${STUB_JOURNAL_NOISE:-0}" \
+         _sc_probe_ship_ledger_liveness 2>/dev/null | tail -1)
+  V="${line%%|*}"; local rest="${line#*|}"; R="${rest%%|*}"; D="${rest#*|}"
+}
+expect() { # expect <case> <verdict> <reason-or-empty>
+  if [[ "$V" == "$2" && ( -z "$3" || "$R" == "$3" ) ]]; then ok_t "$1"
+  else fail_t "$1 (wanted verdict='$2' reason='${3:-*}', got verdict='$V' reason='$R'; detail=$D)"; fi
+}
+
+BUNDLE="$TMP/5dive"; AUDITLOG="$TMP/audit.log"; DB="$TMP/tasks.db"; STATE="$TMP/sticky.state"
+
+# ── 1. an UNARMED bundle is not-reached, never a pass ─────────────────────────
+mk_bundle "$BUNDLE" 0; mk_audit "$AUDITLOG" push:ok:after; mk_db "$DB" 0
+STUB_JOURNAL_PUSH=1 STUB_JOURNAL_NOISE=5 run
+expect "an unarmed bundle -> not-reached(not-armed), NOT a pass over an empty ledger" not-reached not-armed
+
+# ── 12. the self-match control: prose naming the symbols must NOT arm ─────────
+grep -q 'ship_ledger_record' "$BUNDLE" \
+  && ok_t "the unarmed fixture DOES contain the symbol name (so case 1 proves anchoring, not absence)" \
+  || fail_t "the unarmed fixture lost the symbol name — case 1 no longer grades the anchor"
+
+# ── 2. armed, both witnesses recording, ZERO pushes -> the honest NOT-REACHED ──
+mk_bundle "$BUNDLE" 1; mk_audit "$AUDITLOG" task:ok:after push:ok:before; mk_db "$DB" 0
+STUB_JOURNAL_PUSH=0 STUB_JOURNAL_NOISE=5 run
+expect "no post-arming push, both sinks recording -> not-reached(no-post-arming-push)" not-reached no-post-arming-push
+grep -q 'NOT-REACHED' <<<"$D" && ok_t "the detail speaks the ticket's vocabulary (NOT-REACHED)" \
+                              || fail_t "detail does not say NOT-REACHED: $D"
+
+# ── 3. constraint 4: an EMPTY count from a sink with no rows at all is untrusted ─
+mk_audit "$AUDITLOG" task:ok:before; mk_db "$DB" 0
+STUB_JOURNAL_PUSH=0 STUB_JOURNAL_NOISE=5 run
+expect "audit sink silent since arming -> not-reached(denominator-source-unproven)" not-reached denominator-source-unproven
+mk_audit "$AUDITLOG" task:ok:after
+STUB_JOURNAL=unreadable STUB_JOURNAL_PUSH=0 STUB_JOURNAL_NOISE=0 run
+expect "journal sink unreadable -> not-reached(denominator-source-unproven)" not-reached denominator-source-unproven
+
+# ── 4. LIVE: post-arming pushes on BOTH witnesses + rows in the same window ────
+mk_audit "$AUDITLOG" push:ok:after task:ok:after; mk_db "$DB" 3
+STUB_JOURNAL_PUSH=1 STUB_JOURNAL_NOISE=5 run
+expect "post-arming push + rows -> pass" pass ""
+grep -q 'LIVE' <<<"$D" && ok_t "the pass names LIVE and is not silent about what it observed" \
+                       || fail_t "pass detail does not say LIVE: $D"
+
+# ── 5. BROKEN: corroborated pushes, ZERO rows. The only alarming state ────────
+rm -f "$STATE"; mk_db "$DB" 0
+STUB_JOURNAL_PUSH=1 STUB_JOURNAL_NOISE=5 run
+expect "corroborated post-arming push + zero rows -> fail" fail ""
+grep -q 'BROKEN' <<<"$D" && ok_t "the fail names BROKEN" || fail_t "fail detail does not say BROKEN: $D"
+grep -q '^broken_at=' "$STATE" && ok_t "the BROKEN is written down (constraint 3 prerequisite)" \
+                               || fail_t "no broken_at persisted: $(cat "$STATE" 2>/dev/null)"
+
+# ── 6. constraint 3: the alarm SURVIVES a new arming epoch ────────────────────
+# A nightly roll moves the bundle's mtime, so the window resets and this box sees
+# no traffic. Without stickiness that reads as a fresh, blameless not-reached.
+NEW_EPOCH=$(date -u +%s)
+mk_bundle "$BUNDLE" 1 "$NEW_EPOCH"; mk_audit "$AUDITLOG" task:ok:before; : > "$AUDITLOG"
+printf '{"ts":"%s","user":"u","cmd":"task","result":"ok","code":0,"args":[]}\n' \
+  "$(date -u -d "@$((NEW_EPOCH+1))" '+%Y-%m-%dT%H:%M:%S+00:00')" > "$AUDITLOG"
+STUB_JOURNAL_PUSH=0 STUB_JOURNAL_NOISE=5 run
+expect "a new arming epoch with no traffic still reports the earlier BROKEN" fail ""
+grep -q 'sticky' <<<"$D" && ok_t "the sticky fail says WHY it is still failing" \
+                         || fail_t "sticky fail does not name itself: $D"
+
+# ── 7. and a later LIVE clears it, so the alarm is not permanent ──────────────
+printf '{"ts":"%s","user":"u","cmd":"push","result":"ok","code":0,"args":[]}\n' \
+  "$(date -u -d "@$((NEW_EPOCH+2))" '+%Y-%m-%dT%H:%M:%S+00:00')" >> "$AUDITLOG"
+sqlite3 "$DB" "INSERT INTO ship_events (kind,sha,ts) VALUES ('ship','sX','$(date -u -d "@$((NEW_EPOCH+2))" '+%Y-%m-%d %H:%M:%S')');"
+STUB_JOURNAL_PUSH=1 STUB_JOURNAL_NOISE=5 run
+expect "a LIVE at-or-after the BROKEN clears the sticky alarm" pass ""
+grep -q 'clears the sticky' <<<"$D" && ok_t "the clearing pass says which alarm it cleared" \
+                                    || fail_t "pass did not name the cleared alarm: $D"
+: > "$AUDITLOG"
+printf '{"ts":"%s","user":"u","cmd":"task","result":"ok","code":0,"args":[]}\n' \
+  "$(date -u -d "@$((NEW_EPOCH+3))" '+%Y-%m-%dT%H:%M:%S+00:00')" > "$AUDITLOG"
+STUB_JOURNAL_PUSH=0 STUB_JOURNAL_NOISE=5 run
+expect "after clearing, a quiet window is not-reached again (the alarm is not permanent)" not-reached no-post-arming-push
+
+# ── 8. NEGATIVE CONTROL — constraint 2: a REFUSED push must not alarm ─────────
+rm -f "$STATE"; mk_bundle "$BUNDLE" 1; mk_db "$DB" 0
+mk_audit "$AUDITLOG" push:error:after push:error:after task:ok:after
+STUB_JOURNAL_PUSH=0 STUB_JOURNAL_NOISE=5 run
+expect "post-arming push rows that all FAILED do not manufacture a BROKEN" not-reached no-post-arming-push
+
+# ── 9. NEGATIVE CONTROL — constraint 1: the denominator is never ship_events ──
+mk_db "$DB" 9
+STUB_JOURNAL_PUSH=0 STUB_JOURNAL_NOISE=5 run
+expect "9 ledger rows and no witnessed push is STILL not-reached (rows cannot certify themselves)" not-reached no-post-arming-push
+
+# ── 10. disagreement is its own reason, never a silent preference ─────────────
+mk_db "$DB" 0; mk_audit "$AUDITLOG" push:ok:after task:ok:after
+STUB_JOURNAL_PUSH=0 STUB_JOURNAL_NOISE=5 run
+expect "one witness sees traffic, its recording partner sees none, ledger empty -> witness-disagreement" not-reached witness-disagreement
+
+# ── 11. and an UNCORROBORATED positive is not an alarm either ─────────────────
+STUB_JOURNAL=unreadable STUB_JOURNAL_PUSH=0 STUB_JOURNAL_NOISE=0 run
+expect "a lone positive with no live partner -> uncorroborated-denominator, not BROKEN" not-reached uncorroborated-denominator
+
+# ── 13. a missing ship_events table with real traffic is BROKEN, and says so ──
+mk_db "$DB" 0 --no-table; mk_audit "$AUDITLOG" push:ok:after task:ok:after
+STUB_JOURNAL_PUSH=1 STUB_JOURNAL_NOISE=5 run
+expect "traffic + no ship_events table -> fail" fail ""
+grep -q 'table does not exist' <<<"$D" && ok_t "the fail names the absent table rather than reporting a bare zero" \
+                                       || fail_t "fail does not name the missing table: $D"
+
+# ── 14. an unreadable ledger is not-reached, never a BROKEN ──────────────────
+# Fresh sticky record from here on: case 13 legitimately raised an alarm, and an
+# OUTSTANDING alarm correctly outranks everything below it (that is case 6). Reusing
+# the file would grade the sticky path a third time instead of what these cases say.
+rm -f "$STATE"
+mk_db "$DB" 0; DB_SAVE="$DB"; DB="$TMP/nope.db"
+STUB_JOURNAL_PUSH=1 STUB_JOURNAL_NOISE=5 run
+expect "an absent ledger store -> not-reached(ledger-unreadable), never an alarm" not-reached ledger-unreadable
+DB="$DB_SAVE"
+
+# ── 15. a non-UTC timestamp is reported, not silently lexically compared ──────
+rm -f "$STATE"; mk_db "$DB" 0; : > "$AUDITLOG"
+printf '{"ts":"%s","user":"u","cmd":"push","result":"ok","code":0,"args":[]}\n' \
+  "$(date -u -d "@$((ARMED_EPOCH+3600))" '+%Y-%m-%dT%H:%M:%S+05:30')" > "$AUDITLOG"
+STUB_JOURNAL_PUSH=0 STUB_JOURNAL_NOISE=5 run
+expect "a non-UTC audit ts leaves the audit witness unproven rather than lexically miscounted" not-reached denominator-source-unproven
+grep -q 'mixed-offset' <<<"$D" && ok_t "the unproven witness names mixed-offset as the cause" \
+                               || fail_t "cause not named: $D"
+
+# ── 16. a malformed line must not truncate the stream (and shrink the denominator) ─
+mk_audit "$AUDITLOG" push:ok:after
+sed -i '1i {"ts":"broken' "$AUDITLOG"
+printf '{"ts":"%s","user":"u","cmd":"task","result":"ok","code":0,"args":[]}\n' "$AFTER_ISO" >> "$AUDITLOG"
+mk_db "$DB" 2; STUB_JOURNAL_PUSH=1 STUB_JOURNAL_NOISE=5 run
+expect "one malformed audit line does not abort the count and hide the traffic" pass ""
+
+# ── 17. the probe is registered everywhere the runner reads ──────────────────
+printf '%s\n' "${SELFCHECK_PROBES[@]}" | grep -qx ship-ledger-liveness \
+  && ok_t "ship-ledger-liveness is in SELFCHECK_PROBES (so --list, the report header and the union all see it)" \
+  || fail_t "probe missing from SELFCHECK_PROBES"
+[[ "$(_sc_title ship-ledger-liveness)" != "ship-ledger-liveness" ]] \
+  && ok_t "the probe has a title, so a run says what it asserts" || fail_t "no title registered"
+d=$(_sc_dispatch ship-ledger-liveness 2>/dev/null | tail -1)
+[[ "$d" == error* ]] && fail_t "dispatch does not route ship-ledger-liveness ($d)" \
+                     || ok_t "the dispatcher routes ship-ledger-liveness"
+
+# ── 18. it NEVER writes to the ledger ────────────────────────────────────────
+before=$(sqlite3 "$DB" "SELECT COUNT(*) FROM ship_events;" 2>/dev/null)
+STUB_JOURNAL_PUSH=1 STUB_JOURNAL_NOISE=5 run
+after=$(sqlite3 "$DB" "SELECT COUNT(*) FROM ship_events;" 2>/dev/null)
+[[ "$before" == "$after" ]] && ok_t "the probe seeds nothing — ship_events is unchanged across a run ($before)" \
+                            || fail_t "the probe MUTATED the ledger ($before -> $after) — the exact corruption DIVE-1923 exists to prevent"
+
+printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Verified PASS by main2 (30/30 new harness + 5 touched harnesses green; runs LIVE on the control-plane host: 11 post-arming ok pushes vs 32 `ship_events` rows). Push-for-review gate answered `approve`; closure verified valid (`by: lead:standing:main`).

Branch was 15 commits behind main; merged current main in — **clean, no conflicts**. `ship_ledger_liveness_unit.sh` re-run on the merged tree: **30 passed, 0 failed**.

**On the `--allow` widening**, since an allowlist entry normally deserves a hard no: this one is structural, not convenience. The probe's denominator is pushes that crossed the production push rail since the running bundle acquired the ledger writer — an ephemeral CI runner has never crossed that rail and never will, so no number of extra jobs earns it. Compensating coverage is hermetic: the harness drives LIVE / BROKEN / all five not-reached reasons over fixture sinks and carries two negative controls (a refused push must not manufacture a BROKEN; ledger rows must not certify their own denominator).

**Verified from source rather than from the help text** that widening `--allow` cannot hide a failure: `allow` is read once at `cmd_selfcheck.sh:1075` and used only at `:1143`, where it is written into the report header. It is never consulted on the exit path. The union honours it for the never-probed requirement only — so this entry costs coverage of the probe's *wiring* on a real box, never of its verdict.
