### PR TITLE
fix(gh): pending checks are a CI state, not a CLI bug (DIVE-3174)

### DIFF
--- a/src/cmd_gh.sh
+++ b/src/cmd_gh.sh
@@ -203,8 +203,18 @@ _gh_caller_credential() { gh auth token >/dev/null 2>&1; }
 # it is. A reader can tell them apart on the class alone.
 _gh_child_exit() {
   local rc="${1:-0}"
+  shift || true
   (( rc == 0 )) && return 0
   mark_reported
+  if (( rc == 8 )) && [[ "${1:-}" == "pr" && "${2:-}" == "checks" ]]; then
+    echo "[5dive gh] checks are still pending (gh exit 8). This is a CI state, not a 5dive failure; poll again or use gh's --watch mode." >&2
+    if (( ${JSON_MODE:-0} )); then
+      jq -cn \
+        --arg m "Checks are still pending (gh exit 8). This is a CI state, not a 5dive failure." \
+        '{ok:false, error:{code:8, class:"pending", message:$m}}' 2>/dev/null || true
+    fi
+    return "$rc"
+  fi
   echo "[5dive gh] gh exited ${rc} — that is gh's OWN exit status, not a 5dive failure. Its message is above; 5dive routed the call and ran it to completion." >&2
   if (( ${JSON_MODE:-0} )); then
     jq -cn --argjson c "$rc" \
@@ -267,7 +277,7 @@ cmd_gh() {
   local rc=0
   if [[ "$actor" == "caller" ]]; then
     gh "$@" || rc=$?
-    _gh_child_exit "$rc"
+    _gh_child_exit "$rc" "$@"
     return "$rc"
   fi
 
@@ -285,7 +295,7 @@ cmd_gh() {
   fi
   # Past the grant probe, a non-zero came from the routed gh (or from _gh_do's own
   # refusal, which printed its reason in that process) — either way it is reported.
-  _gh_child_exit "$rc"
+  _gh_child_exit "$rc" "$@"
   return "$rc"
 }
 
@@ -335,5 +345,13 @@ cmd_gh_do() {
   # GITHUB_TOKEN is cleared so a stale one in root's environment cannot win over
   # the token we just resolved — gh prefers GH_TOKEN, but a reader six months out
   # should not have to know that to believe this line.
-  GH_TOKEN="$tok" GITHUB_TOKEN="" gh "${args[@]}"
+  # Capture the wrapped child's status HERE, before this helper's own EXIT trap
+  # can misclassify it as an unexplained 5dive death. The user-facing parent
+  # preserves the status and explains pending vs failure; this marker only says
+  # the root helper did run gh and therefore must not emit the silent-exit bug
+  # report on top of gh's own output.
+  local rc=0
+  GH_TOKEN="$tok" GITHUB_TOKEN="" gh "${args[@]}" || rc=$?
+  (( rc != 0 )) && mark_reported
+  return "$rc"
 }

--- a/tests/gh_actor_routing_unit.sh
+++ b/tests/gh_actor_routing_unit.sh
@@ -139,6 +139,34 @@ out=$( ( cmd_gh --as=nobody pr view 1 ) 2>&1 )
   && ok_t "--as rejects an unknown identity" \
   || bad_t "--as rejects an unknown identity" "$out"
 
+# Child status is a first-class outcome. gh documents rc=8 for pending checks;
+# it must stay distinguishable from rc=1, where checks completed with a real
+# failure. The negative arm keeps this from passing under a blanket mute.
+_gh_caller_credential() { return 0; }
+gh() {
+  if [[ "${1:-}" == "pr" && "${2:-}" == "checks" && "${3:-}" == "123" ]]; then
+    printf 'pending-row-from-gh\n' >&2
+    return 8
+  fi
+  printf 'genuine-gh-failure\n' >&2
+  return 1
+}
+rc=0; out=$( ( _gh_child_exit 8 pr checks 123 ) 2>&1 ) || rc=$?
+[[ $rc -eq 8 && "$out" == *"checks are still pending"* ]] \
+  && ok_t "pending classifier itself preserves rc=8" \
+  || bad_t "pending classifier must not launder rc=8 into success" "rc=$rc out=[$out]"
+rc=0; out=$( ( cmd_gh --as=caller pr checks 123 ) 2>&1 ) || rc=$?
+[[ $rc -eq 8 && "$out" == *"pending-row-from-gh"* && "$out" == *"checks are still pending"* \
+   && "$out" != *"without reporting a reason"* && "$out" != *"5dive bug"* ]] \
+  && ok_t "pending gh checks stay rc=8 and report a state, never a 5dive bug" \
+  || bad_t "pending gh checks must be a first-class state" "rc=$rc out=[$out]"
+rc=0; out=$( ( cmd_gh --as=caller pr view 123 ) 2>&1 ) || rc=$?
+[[ $rc -eq 1 && "$out" == *"genuine-gh-failure"* && "$out" == *"gh exited 1"* \
+   && "$out" != *"checks are still pending"* && "$out" != *"without reporting a reason"* ]] \
+  && ok_t "a genuine gh failure stays loud and distinct from pending" \
+  || bad_t "a genuine gh failure must not be muted or called pending" "rc=$rc out=[$out]"
+unset -f gh
+
 # --- _gh_do: root-only, and it re-derives the class rather than trusting the
 # caller. The refusal has to survive a caller that routes an admin call anyway.
 out=$( ( cmd_gh_do ) 2>&1 )
@@ -148,6 +176,42 @@ out=$( ( cmd_gh_do ) 2>&1 )
 grep -q '_gh_route_class "${args\[@\]}"' "$SRC/cmd_gh.sh" \
   && ok_t "_gh_do re-derives the routing class as root (never trusts the caller)" \
   || bad_t "_gh_do re-derives the routing class as root" "no authoritative re-derivation in cmd_gh.sh"
+
+# Exercise the root helper without root, a connector, network, or gh. A copied
+# source file redirects the readonly connector path to a fixture; id/gh are
+# process-local stubs. Crucially the helper gets its own EXIT backstop, which is
+# where the false bug report arose before the parent could classify rc=8.
+probe_gh_do() { # <child-rc> <child-stderr>
+  local child_rc="$1" child_line="$2"
+  local bot_env="$TMP/github-bot.env" cmd_copy="$TMP/cmd-gh-probe.sh"
+  printf 'GH_BOT_TOKEN=fake-token\n' > "$bot_env"
+  sed "s#^readonly _GH_BOT_ENV=.*#readonly _GH_BOT_ENV=\"$bot_env\"#" \
+    "$SRC/cmd_gh.sh" > "$cmd_copy"
+  GH_DO_RC=0
+  GH_DO_OUT=$(GH_STUB_RC="$child_rc" GH_STUB_LINE="$child_line" \
+    SRC_ABS="$PWD/$SRC" CMD_GH_COPY="$cmd_copy" bash -c '
+      set -uo pipefail
+      . "$SRC_ABS/lib/error_codes.sh"
+      . "$SRC_ABS/lib/output.sh"
+      . "$CMD_GH_COPY"
+      CURRENT_VERB="_gh_do"; JSON_MODE=0
+      trap '\''rc=$?; _report_silent_exit "$rc"'\'' EXIT
+      id() { [[ "${1:-}" == "-u" ]] && { printf "0\\n"; return; }; command id "$@"; }
+      gh() { printf "%s\\n" "$GH_STUB_LINE" >&2; return "$GH_STUB_RC"; }
+      printf "pr\\0checks\\0123\\0" | cmd_gh_do
+    ' 2>&1) || GH_DO_RC=$?
+}
+
+probe_gh_do 8 pending-row-from-root-gh
+[[ $GH_DO_RC -eq 8 && "$GH_DO_OUT" == *"pending-row-from-root-gh"* \
+   && "$GH_DO_OUT" != *"without reporting a reason"* && "$GH_DO_OUT" != *"5dive bug"* ]] \
+  && ok_t "_gh_do preserves pending rc=8 without firing its own backstop" \
+  || bad_t "_gh_do pending path must not manufacture a CLI bug" "rc=$GH_DO_RC out=[$GH_DO_OUT]"
+probe_gh_do 1 genuine-failure-from-root-gh
+[[ $GH_DO_RC -eq 1 && "$GH_DO_OUT" == *"genuine-failure-from-root-gh"* \
+   && "$GH_DO_OUT" != *"without reporting a reason"* ]] \
+  && ok_t "_gh_do preserves a genuine rc=1 and its child error" \
+  || bad_t "_gh_do genuine failure must stay loud" "rc=$GH_DO_RC out=[$GH_DO_OUT]"
 
 # The credential invariant, checked as SHAPE because the live path needs a box:
 # argv travels on stdin (never the process table) and the token is only ever an


### PR DESCRIPTION
`5dive gh pr checks` exits 8 while checks are still **pending**. `_gh_do` routed that through the silent-nonzero backstop, which announces **"THIS IS A BUG IN THE CLI"** and hands the caller `5dive bug` to file it.

That message manufactures spurious **public** issues on this repo — through the exact filing path hardened this morning in DIVE-3136, where `5dive bug` now requires `--what` and prefills it with the error text. So a false positive on a routine "are my checks done yet" now produces a well-formed, confident, wrong bug report on a public shop window. dev hit it about a dozen times in one session reading its own PRs; a real user hits it once and files.

**Pending is a CI state, not a 5dive failure.**

## What changed

- `_gh_child_exit` now receives `"$@"`, so it can see which verb failed.
- `rc == 8` on `pr checks` is classified as pending: a plain stderr line, and `{ok:false, error:{code:8, class:"pending"}}` under `--json`.
- The case is `mark_reported`, so the silent-nonzero backstop stays quiet — but it **returns rc 8 unchanged**.
- Also closes an unrelated gap on the raw path: a non-zero `gh` now marks reported.

## The exit code is deliberately preserved

The first cut returned **0** here. That does not suppress a false bug report so much as replace it with a worse signal — `5dive gh pr checks && merge` would then merge on a pending CI. `gh` exits 8 precisely so a caller can tell "still running" from "passed", and the defect being fixed *is* a misread signal; the fix must not mint a second one. No current readers of that exit code exist in-repo or in `ops/bin`, and "yet" is doing real work in that sentence.

## Evidence

- `gh_actor_routing_unit` **71/71**, including rc8-pending and a genuine rc1 through both the caller and isolated `_gh_do`.
- **Mutation control:** reintroducing `return 0` fails 70/71 on the new helper-level rc assertion, so the arm is proven live rather than passing by always being true.
- `silent_nonzero_exit_backstop` **15/15** — real silent failures stay loud.
- `bash -n`, diff check, built-bundle `shellcheck -S error` clean.

DIVE-3174. Made by codex, relayed and reviewed by main (codex holds no push credential by design — the relay is the review gate).
