### PR TITLE
fix(release): derive the cut point from main, not the tag's first parent (DIVE-3170)

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -217,8 +217,14 @@ jobs:
           # cut would mint a NEW version every night on an unchanged main, burning a
           # number per night and republishing identical bytes under each. So the arm
           # that matters is the one asserting it DOES stop.
+          # DIVE-3170: NOT "${incumbent}^". A cut makes TWO commits (DIVE-2603 split
+          # assign from bundle), so the tag's first parent is the ASSIGN commit — a
+          # release tree, never main. scripts/release-cut-baseline.sh holds the one
+          # copy of the rule (walk first-parent to the first ancestor of main) and
+          # every site below uses THIS variable rather than respelling it.
+          cut_from=""
           if [[ -n "$incumbent" ]]; then
-            cut_from=$(git rev-parse -q --verify "refs/tags/${incumbent}^{commit}^" 2>/dev/null || true)
+            cut_from=$(bash scripts/release-cut-baseline.sh "refs/tags/${incumbent}" 2>/dev/null || true)
             if [[ -n "$cut_from" && "$cut_from" == "$sha" ]]; then
               echo "::notice::${incumbent} was cut from main's current tip ${sha:0:12} — main has not moved since the last cut. Nothing to publish."
               exit 0
@@ -452,12 +458,18 @@ jobs:
           # in this detached tree only — main keeps them (DIVE-2247: no push to a
           # protected branch) — so without this the NEXT cut re-folds every fragment
           # ever written and each release's notes repeat all previous releases'.
-          # "${incumbent}^" is main's tip as of the last cut, and it is the SAME
-          # incumbent this job already derived and asserted above, so this is not a
-          # third copy of the tag-resolution rule. Empty incumbent (first cut ever) is
-          # passed through as set-but-empty on purpose: it means "nothing has shipped
-          # yet, fold everything", which is different from the unset auto-detect case.
-          if _folded=$(FOLD_RELEASED_BASELINE="${incumbent:+${incumbent}^}" bash scripts/fold-changelog-fragments.sh 2>&1); then
+          # DIVE-3170: this used to pass "${incumbent}^" and call itself "not a third
+          # copy of the tag-resolution rule". It WAS a third copy, spelled differently,
+          # and it was wrong: the tag's first parent is the assign commit, whose tree
+          # the fold has ALREADY emptied, so every fragment looked unshipped and all 52
+          # re-folded on every cut. It now reuses $cut_from — the one derivation, done
+          # once above. Empty incumbent (first cut ever) is still passed through as
+          # set-but-empty on purpose: "nothing has shipped yet, fold everything", which
+          # is different from the unset auto-detect case.
+          if [[ -n "${incumbent-}" && -z "${cut_from-}" ]]; then
+            echo "::warning::could not resolve the main commit ${incumbent} was cut from — every already-shipped fragment will fold again and these notes will repeat previous releases' entries (DIVE-2702, DIVE-3170)"
+          fi
+          if _folded=$(FOLD_RELEASED_BASELINE="${cut_from-}" bash scripts/fold-changelog-fragments.sh 2>&1); then
             echo "changelog.d fragments folded for ${tag}: ${_folded} (DIVE-2582)"
           else
             echo "::warning::changelog.d fragments could not be folded for ${tag} (${_folded}) — publishing anyway"
@@ -698,10 +710,10 @@ jobs:
           # `cut_from` is the main sha the incumbent tag was cut from — the same
           # comparand the main-moved check above uses, recomputed here because that
           # block returns early on the no-move path and never reaches this point.
-          _notes_from=""
-          if [[ -n "$incumbent" ]]; then
-            _notes_from=$(git rev-parse -q --verify "refs/tags/${incumbent}^{commit}^" 2>/dev/null || true)
-          fi
+          # DIVE-3170: $cut_from, not a fourth respelling of the tag rule. The
+          # main-moved block above returns early only on the no-move path, so the
+          # variable it set is still in scope and still correct here.
+          _notes_from="${cut_from-}"
           _notes_file="$(mktemp)"
           if ! bash scripts/release-notes.sh "$_notes_from" "$sha" "$version" > "$_notes_file"; then
             echo "::error::${tag} IS PUBLISHED as a tag, but its release notes could not be derived from ${_notes_from:-<root>}..${sha:0:12} — refusing to create a release page whose body would describe only how the cut was dispatched (DIVE-2452). Boxes are unaffected; write the notes by hand and create the release page."

--- a/changelog.d/DIVE-3170.md
+++ b/changelog.d/DIVE-3170.md
@@ -1,0 +1,14 @@
+## Unreleased — fix(release): release notes describe THIS cut instead of re-advertising every previous one (DIVE-3170)
+
+Four consecutive releases (v0.19.11 through v0.19.14) shipped a byte-identical
+`### Features` block. The generator was not dead — the notes ACCUMULATED. A cut
+makes two commits (assign, then bundle) and the tag names the second, so the
+`"${incumbent}^"` that three separate sites used as "main's tip as of the last
+cut" was really the ASSIGN commit: a release tree whose `changelog.d/` the fold
+had already emptied. Every already-shipped fragment therefore looked unshipped
+and re-folded on every cut.
+
+The tag-to-cut-point rule now lives in one place, `scripts/release-cut-baseline.sh`,
+which walks first-parent to the first ancestor of main and so does not care how
+many commits a cut stacks. The main-moved check, the fold baseline and the
+release-notes range all read it.

--- a/scripts/fold-changelog-fragments.sh
+++ b/scripts/fold-changelog-fragments.sh
@@ -58,8 +58,11 @@
 # new content and folds again, which is what a re-filed fragment needs.
 #
 # BASELINE: $FOLD_RELEASED_BASELINE, a git ref whose tree is main as of the last
-# cut. release-cut.yml passes "${incumbent}^" — the incumbent it already derived
-# and asserted, so this is not a third copy of the tag rule. SET-BUT-EMPTY means
+# cut. release-cut.yml passes the sha from scripts/release-cut-baseline.sh, which
+# holds the single copy of the rule. It used to pass "${incumbent}^" and DIVE-3170
+# measured that wrong: a cut makes two commits, so the tag's first parent is the
+# ASSIGN commit — a tree this very script has already emptied — and every fragment
+# therefore looked unshipped and re-folded on every cut. SET-BUT-EMPTY means
 # "no previous cut, fold everything" (the first cut ever). UNSET means auto-detect
 # with the same filter+sort release-cut.yml and install.sh use. Unresolvable is
 # NOT fatal — the cut must not die over a changelog — but it is reported, because
@@ -109,7 +112,15 @@ if [[ "$baseline" == "__auto__" ]]; then
   # resolve_gh_tag(). At fold time the tag for THIS cut does not exist yet, so the
   # newest tag is the previous release.
   _prev_tag="$(git tag -l 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)"
-  baseline="${_prev_tag:+${_prev_tag}^}"
+  # DIVE-3170: resolve tag -> main commit through the one helper, never "^" here.
+  baseline=""
+  if [[ -n "$_prev_tag" ]]; then
+    _here="$(dirname -- "${BASH_SOURCE[0]}")"
+    baseline="$(bash "${_here}/release-cut-baseline.sh" "$_prev_tag" 2>/dev/null || true)"
+    # Unresolvable stays unresolvable and keeps the loud warning below; it must not
+    # quietly degrade to a tag-relative guess that is wrong in the same direction.
+    [[ -n "$baseline" ]] || baseline="${_prev_tag}^{unresolvable-baseline}"
+  fi
 fi
 if [[ -n "$baseline" ]] && ! git rev-parse --verify -q "${baseline}^{commit}" >/dev/null 2>&1; then
   # Loud, and it names the consequence rather than the symptom: this is the exact

--- a/scripts/release-cut-baseline.sh
+++ b/scripts/release-cut-baseline.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# release-cut-baseline.sh — print the MAIN commit a published tag was cut from
+# (DIVE-3170).
+#
+# WHY THIS FILE EXISTS. Three places in release-cut.yml need the same fact — "main's
+# tip as of the last cut": the DIVE-2247 main-moved check, the DIVE-2702 fold
+# baseline, and the DIVE-2452 release-notes range. All three spelled it
+# `<tag>^` — the tag's commit's first parent — and all three were WRONG, because a
+# cut does not make one commit. It makes TWO:
+#
+#     <tag>            release vX: bundle built from <sha> (DIVE-2091, DIVE-2603)
+#     <tag>^           release vX: assign X before bundle build (DIVE-2247, DIVE-2603)
+#     <tag>^^          <- the actual main commit the cut was taken from
+#
+# The assign commit (DIVE-2603 split the cut in two) is where the fold and the
+# stamp already ran, so `<tag>^` is a POST-FOLD release tree, not main. Measured
+# 2026-08-10 on v0.19.11 .. v0.19.14: `git ls-tree <tag>^ changelog.d/` listed 2
+# entries (README.md and one malformed fragment) while main listed 52, and
+# `<tag>^^` was an ancestor of origin/main with 43. Consequences, all observed:
+#
+#   * The DIVE-2702 fold guard looked every fragment up in a tree the fold had
+#     already emptied, found nothing, skipped nothing, and re-folded all 52 every
+#     cut — so v0.19.11/.12/.13/.14 advertise a byte-identical `### Features`
+#     block. That is DIVE-3170 as filed.
+#   * The main-moved check compared main's tip against an assign commit, which is
+#     never equal to it, so the "nothing to publish" early-exit could not fire.
+#   * The notes range started at the assign commit for the same reason.
+#
+# THE RULE, stated once and only once so a fourth site cannot drift: walk
+# first-parent from the tag's commit and return the FIRST commit that is an
+# ancestor of main. That is definitionally the commit the cut was taken from, and
+# it does not care how many release commits DIVE-2603 (or its successor) stacks on
+# top — one, two or five. `<tag>^^` would only re-encode today's count.
+#
+# Usage: release-cut-baseline.sh <tag-or-commit> [main-ref]
+#        main-ref defaults to origin/main, then main, whichever resolves.
+#        Prints the sha on stdout and exits 0. Prints nothing and exits 1 if the
+#        tag does not resolve or no ancestor of main is reachable — callers treat
+#        an empty answer as "could not look", which is NOT the same as "no
+#        previous cut" and must never be folded together with it.
+set -uo pipefail
+
+tag="${1-}"
+main_ref="${2-}"
+
+if [[ -z "$tag" ]]; then
+  echo "usage: release-cut-baseline.sh <tag-or-commit> [main-ref]" >&2
+  exit 2
+fi
+
+start="$(git rev-parse -q --verify "${tag}^{commit}" 2>/dev/null || true)"
+if [[ -z "$start" ]]; then
+  echo "release-cut-baseline: '${tag}' does not resolve to a commit" >&2
+  exit 1
+fi
+
+if [[ -z "$main_ref" ]]; then
+  for _c in origin/main main; do
+    if git rev-parse -q --verify "${_c}^{commit}" >/dev/null 2>&1; then
+      main_ref="$_c"
+      break
+    fi
+  done
+fi
+if [[ -z "$main_ref" ]] || ! git rev-parse -q --verify "${main_ref}^{commit}" >/dev/null 2>&1; then
+  echo "release-cut-baseline: no main ref resolves (tried '${2-origin/main, main}') — cannot say what '${tag}' was cut from" >&2
+  exit 1
+fi
+
+# Bounded on purpose: the answer is one or two commits away by construction, and
+# an unbounded walk on a tag that is somehow disjoint from main would otherwise
+# scan the whole history to say "no".
+while read -r c; do
+  if git merge-base --is-ancestor "$c" "$main_ref" 2>/dev/null; then
+    echo "$c"
+    exit 0
+  fi
+done < <(git rev-list --first-parent --max-count=25 "$start" 2>/dev/null)
+
+echo "release-cut-baseline: no ancestor of ${main_ref} within 25 first-parent commits of '${tag}' — the tag is not descended from main" >&2
+exit 1

--- a/tests/fold_changelog_fragments_unit.sh
+++ b/tests/fold_changelog_fragments_unit.sh
@@ -241,5 +241,83 @@ grep -q 'does not resolve' "$TMP/err6" && grep -q 'may repeat' "$TMP/err6" \
   && ok_t "unresolvable baseline is REPORTED, naming the repeat consequence" \
   || bad_t "unresolvable baseline not reported" "$(cat "$TMP/err6")"
 
+
+# ---------------------------------------------------------------------------
+# DIVE-3170: TWO CONSECUTIVE CUTS ON THE REAL COMMIT SHAPE.
+#
+# The whole defect lived in the gap between "the cut makes one commit" (what the
+# old fixtures modelled) and "the cut makes two" (what DIVE-2603 actually ships).
+# So this arm builds the real shape end to end: main keeps every fragment forever,
+# the cut branches off detached, folds, and commits assign-then-bundle, and the tag
+# names the bundle commit. Then it cuts a SECOND time with exactly one new fragment
+# and asserts the second body is DISJOINT from the first — acceptance 1 and 3.
+echo "-- DIVE-3170: two cuts on the real two-commit shape must not repeat entries"
+RG7="$TMP/repo-two-cuts"; mkdir -p "$RG7/changelog.d" "$RG7/scripts"
+cp "$SCRIPT" "$RG7/scripts/fold-changelog-fragments.sh"
+cp "$(dirname "$SCRIPT")/release-cut-baseline.sh" "$RG7/scripts/"
+( set -e; cd "$RG7"
+  git init -q -b main .; git config user.email a@b; git config user.name t
+  printf '# Changelog\n' > CHANGELOG.md
+  printf '## Unreleased — feat(a): alpha (DIVE-9201)\n\nA.\n' > changelog.d/DIVE-9201.md
+  printf '## Unreleased — feat(b): beta (DIVE-9202)\n\nB.\n' > changelog.d/DIVE-9202.md
+  git add -A; git commit -q -m 'main: two fragments'
+) >/dev/null 2>&1
+# cut() — mirrors release-cut.yml: detach, fold against the derived baseline, then
+# TWO commits (assign, bundle), tag the second, and return main to where it was.
+cut(){ ( set -e; cd "$RG7"
+    inc="$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)"
+    # `[[ -n "$inc" ]] && ...` would return 1 on the first cut and kill this
+    # subshell under set -e, silently producing no tag at all.
+    base=""
+    if [[ -n "$inc" ]]; then base="$(bash scripts/release-cut-baseline.sh "$inc")"; fi
+    git checkout -q --detach main
+    FOLD_RELEASED_BASELINE="$base" bash scripts/fold-changelog-fragments.sh >/dev/null
+    git add -A; git commit -q -m "release $1: assign"
+    printf 'bundle %s\n' "$1" > 5dive; git add -f 5dive; git commit -q -m "release $1: bundle"
+    git tag "$1"; git checkout -q main
+  ) >"$TMP/cut.log" 2>&1 || { echo "cut $1 FAILED:"; cat "$TMP/cut.log"; }; }
+cut v0.1.0
+_b1=$(git -C "$RG7" rev-parse main)
+body1=$(git -C "$RG7" diff "${_b1}..v0.1.0" -- CHANGELOG.md | sed -n 's/^+\([^+].*\)$/\1/p')
+grep -q 'DIVE-9201' <<<"$body1" && grep -q 'DIVE-9202' <<<"$body1" \
+  && ok_t "first cut folds both pending fragments" \
+  || bad_t "first cut body" "$body1"
+# main keeps its fragments (DIVE-2247, no push to a protected branch) — the very
+# condition that made the repeat possible, asserted rather than assumed.
+[[ $(cd "$RG7" && git ls-tree --name-only main changelog.d/ | wc -l) -eq 2 ]] \
+  && ok_t "main still carries both fragments after the cut (the precondition holds)" \
+  || bad_t "main's fragments" "$(cd "$RG7" && git ls-tree --name-only main changelog.d/)"
+# ONE new fragment lands, then cut again.
+( set -e; cd "$RG7"
+  printf '## Unreleased — feat(c): gamma (DIVE-9203)\n\nC.\n' > changelog.d/DIVE-9203.md
+  git add -A; git commit -q -m 'main: one more fragment' ) >/dev/null 2>&1
+cut v0.1.1
+# The notes range release-cut.yml uses: the MAIN commit the incumbent was cut
+# from (not "v0.1.0^", which is the assign commit — that is the whole bug).
+_b2=$( cd "$RG7" && bash scripts/release-cut-baseline.sh v0.1.0 2>"$TMP/err7" )
+[[ -n "$_b2" ]] \
+  && ok_t "baseline helper resolves v0.1.0 to a main commit through TWO release commits" \
+  || bad_t "baseline helper returned nothing for v0.1.0" "$(cat "$TMP/err7")"
+# THE ASSERTION IS ON THE RELEASE TREE, NOT ON A DIFF. An earlier version of this
+# arm diffed CHANGELOG.md over the notes range and PASSED even with the old broken
+# rule — because that diff's baseline was the previous ASSIGN commit, whose
+# CHANGELOG already contained the re-folded entries, so they cancelled out. In
+# production they do not cancel: stamp-changelog.sh rewrites every `## Unreleased`
+# heading to `## <version>` on each release commit, so the re-folded block differs
+# textually from the previous cut's and the whole of it reads as added. Asserting
+# on the tag's own CHANGELOG states the property directly and cannot cancel.
+c2=$(git -C "$RG7" show v0.1.1:CHANGELOG.md)
+grep -q 'DIVE-9203' <<<"$c2" \
+  && ok_t "second cut's CHANGELOG names the one genuinely new entry (positive control, acceptance 3)" \
+  || bad_t "second cut lost its own new entry" "$c2"
+if grep -qE 'DIVE-920[12]' <<<"$c2"; then
+  bad_t "second cut RE-FOLDED already-shipped entries — this is DIVE-3170" "$c2"
+else
+  ok_t "second cut's entries are DISJOINT from the first's (acceptance 1)"
+fi
+grep -q 'already shipped in a previous cut' "$TMP/cut.log" \
+  && ok_t "the fold REPORTS the skips, so a future regression is visible in the cut log" \
+  || bad_t "fold skipped nothing / said nothing on the second cut" "$(cat "$TMP/cut.log")"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/tests/release_cut_assign_unit.sh
+++ b/tests/release_cut_assign_unit.sh
@@ -142,20 +142,30 @@ MOVED=$(sed -n "/# >>> DIVE-2247 main-moved check/,/# <<< DIVE-2247 main-moved c
 run_moved(){
   local mode="$1" d; d=$(mktemp -d)
   ( set -e
-    cd "$d"; git init -q .; git config user.email a@b; git config user.name t
+    # -b main: the baseline helper resolves the cut point against MAIN by name
+    # (DIVE-3170), so a fixture on the local git default branch would grade nothing.
+    cd "$d"; git init -q -b main .; git config user.email a@b; git config user.name t
     printf 'a\n' > f; git add f; git -c user.name=t -c user.email=a@b commit -q -m base
     if [[ "$mode" != none ]]; then
-      # the release commit: a detached child of the main tip, exactly as the cut builds it
+      # DIVE-3170: the cut builds TWO detached commits, not one — assign, then
+      # bundle — and the tag names the second. This fixture used to build one, which
+      # is precisely why "${incumbent}^" read as main here and as a release tree in
+      # production. Model the real shape or the arms below grade a shape nobody ships.
+      printf 'assigned\n' > src-header; git add -f src-header
+      git -c user.name=t -c user.email=a@b commit -q -m "release v0.1.0: assign 0.1.0 before bundle build"
       printf 'bundle\n' > 5dive; git add -f 5dive
-      git -c user.name=t -c user.email=a@b commit -q -m "release v0.1.0"
+      git -c user.name=t -c user.email=a@b commit -q -m "release v0.1.0: bundle built"
       git tag v0.1.0
-      git reset -q --hard HEAD~1
+      git reset -q --hard HEAD~2
     fi
     if [[ "$mode" == moved ]]; then
       printf 'b\n' >> f; git add f; git -c user.name=t -c user.email=a@b commit -q -m "a real merge"
     fi
   ) >/dev/null 2>&1
   ( cd "$d"
+    # The extracted block shells out to the one baseline helper (DIVE-3170), so the
+    # fixture needs it on the same relative path the workflow uses.
+    mkdir -p scripts && cp "$ROOT/scripts/release-cut-baseline.sh" scripts/
     sha=$(git rev-parse HEAD)
     incumbent=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
     eval "$MOVED"

--- a/tests/release_notes_unit.sh
+++ b/tests/release_notes_unit.sh
@@ -32,7 +32,9 @@ bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
 
 R="$TMP/repo"
 mkdir -p "$R"
-git -C "$R" init -q
+# -b main: DIVE-3170's baseline helper answers "what was this tag cut from" against
+# MAIN by name, so a fixture on the local git default branch would resolve nothing.
+git -C "$R" init -q -b main
 git -C "$R" config user.name  'Ada Lovelace'
 git -C "$R" config user.email 'ada@example.test'
 
@@ -236,6 +238,7 @@ grep -q 'release-notes.sh' <<<"$BLOCK" \
 # actually have sent to GitHub.
 mkdir -p "$R/scripts"
 cp "$SCRIPTS/release-notes.sh" "$R/scripts/release-notes.sh"
+cp "$SCRIPTS/release-cut-baseline.sh" "$R/scripts/release-cut-baseline.sh"
 # shellcheck disable=SC2034  # incumbent/sha/version/tag/note are read by `eval "$BLOCK"`
 run_block() { # <incumbent> <sha> <version>
   rm -f "$TMP/ghargs" "$TMP/ghbody"
@@ -247,6 +250,13 @@ run_block() { # <incumbent> <sha> <version>
     # look plausible. The directive sits on the subshell so it covers every one
     # (a per-line disable only covers the first command on that line).
     incumbent="$1"; sha="$2"; version="$3"; tag="v$3"
+    # DIVE-3170: the block no longer respells the tag rule — it reads $cut_from,
+    # the single derivation the job makes once up top. Stand it up the same way the
+    # job does, through the one helper, or the arms below grade an empty range.
+    cut_from=""
+    if [[ -n "$incumbent" ]]; then
+      cut_from=$(bash scripts/release-cut-baseline.sh "refs/tags/${incumbent}" 2>/dev/null || true)
+    fi
     note="nightly auto-cut: main changed and CI is green"
     gh() {
       printf '%s\n' "$*" > "$TMP/ghargs"
@@ -261,7 +271,22 @@ run_block() { # <incumbent> <sha> <version>
 # block's own `refs/tags/<incumbent>^{commit}^` expression is exercised rather than
 # bypassed with an empty incumbent. That expression is the part most likely to be
 # wrong, and grep cannot see it at all.
-git -C "$R" tag -f v0.0.8 "$FEAT" >/dev/null 2>&1
+# DIVE-3170: tag the way a real cut tags — TWO detached commits on top of the cut
+# point (assign, then bundle), tag on the second. The old fixture tagged one commit
+# above the cut point, which is the shape that let "${incumbent}^" look correct here
+# and be a release tree in production.
+tag_like_a_cut(){ # <tag> <cut-point-sha>
+  git -C "$R" tag -d "$1" >/dev/null 2>&1 || true
+  local _prev; _prev=$(git -C "$R" rev-parse HEAD)
+  ( cd "$R" && git checkout -q --detach "$2" \
+    && git commit -q --allow-empty -m "release $1: assign before bundle build" \
+    && git commit -q --allow-empty -m "release $1: bundle built" \
+    && git tag -f "$1" HEAD ) >/dev/null 2>&1
+  # Back onto main at exactly where we left it — the cut never moves the branch.
+  ( cd "$R" && git checkout -q -B main "$_prev" ) >/dev/null 2>&1
+}
+
+tag_like_a_cut v0.0.8 "$FEAT"
 run_block "v0.0.8" "$TO" "1.3.0"; rc=$?
 [[ $rc -eq 0 ]] \
   && ok_t "block: runs to completion on a derivable range (rc=0)" \
@@ -269,9 +294,17 @@ run_block "v0.0.8" "$TO" "1.3.0"; rc=$?
 grep -q -- '--notes-file' "$TMP/ghargs" 2>/dev/null \
   && ok_t "block: calls gh release create with --notes-file" \
   || bad_t "block: calls gh with --notes-file" "argv=$(cat "$TMP/ghargs" 2>/dev/null)"
+# DIVE-3170: v0.0.8 was cut FROM $FEAT, so $FEAT's entry ("machine account") has
+# ALREADY SHIPPED and must not appear again — while the commit that landed after it
+# must. This pair is the notes-layer statement of the accumulation defect: the old
+# rule started the range one commit too early and re-advertised the last release's
+# entries in this one.
+grep -q 'empty release body' "$TMP/ghbody" 2>/dev/null \
+  && ok_t "block: the body GitHub would receive carries the entry that landed since the cut" \
+  || bad_t "block: body carries derived notes" "$(cat "$TMP/ghbody" 2>/dev/null)"
 grep -q 'machine account' "$TMP/ghbody" 2>/dev/null \
-  && ok_t "block: the body GitHub would receive carries the derived notes" \
-  || bad_t "block: body carries derived notes" "$(head -3 "$TMP/ghbody" 2>/dev/null)"
+  && bad_t "block: body REPEATS an entry that shipped in the incumbent (DIVE-3170)" "$(cat "$TMP/ghbody" 2>/dev/null)" \
+  || ok_t "block: the incumbent's own entry is NOT repeated in the next release's body"
 grep -q 'nightly auto-cut' "$TMP/ghbody" 2>/dev/null \
   && ok_t "block: the cut provenance is kept as a footer, not lost" \
   || bad_t "block: cut provenance kept" "$(tail -3 "$TMP/ghbody" 2>/dev/null)"
@@ -280,8 +313,7 @@ grep -q 'nightly auto-cut' "$TMP/ghbody" 2>/dev/null \
 # called. A release page created with an underivable body is the bug being closed.
 # An EMPTY range means from == to. Build it the way the block will see it: a tag
 # whose commit's parent IS the sha being cut, so `_notes_from` resolves to `sha`.
-git -C "$R" commit -q --allow-empty -m "chore: synthetic release commit"
-git -C "$R" tag -f v0.0.9 HEAD >/dev/null 2>&1
+tag_like_a_cut v0.0.9 "$EMPTY"
 run_block "v0.0.9" "$EMPTY" "1.3.1" >/dev/null 2>&1; rc=$?
 [[ $rc -ne 0 ]] \
   && ok_t "block: an underivable body ABORTS the cut (rc!=0)" \


### PR DESCRIPTION
Release notes **accumulate** instead of describing a cut. lodar found it on the v0.19.14 page and again on v0.19.15: the `### Features` block is byte-identical across v0.19.11–.15, and v0.19.15 ships **21,911 bytes / 310 lines / 49 bullets**, most of which shipped in earlier releases.

## Mechanism

`changelog.d/` holds **52 fragments on `main`**. `fold-changelog-fragments.sh` consumes and `git rm`s them, but that deletion only ever lands on the **off-branch release commit** — `main` is protected and DIVE-2247 removed this workflow's ability to write to it. So main keeps every fragment forever, each cut re-folds all of them, and `release-notes.sh` derives the body from `git diff "${from}..${to}" -- CHANGELOG.md` where main's `CHANGELOG.md` never advances.

## The actual defect: a third, divergent copy of the tag-resolution rule

The workflow resolves tag→parent **three** times, and `:460` was the odd one out:

```
:221  cut_from=$(git rev-parse -q --verify "refs/tags/${incumbent}^{commit}^" …)
:703  _notes_from=$(git rev-parse -q --verify "refs/tags/${incumbent}^{commit}^" …)
:460  FOLD_RELEASED_BASELINE="${incumbent:+${incumbent}^}"
```

Two sites **peel** the annotated tag (`^{commit}`) and **verify** the result; the third passed a bare, unverified string. The comment above it asserted *"this is not a third copy of the tag-resolution rule"* — it was. **A comment claiming "this is not a second copy of the rule" is exactly where to look for the second copy of the rule.**

This extracts the rule into one `scripts/release-cut-baseline.sh` used by every call site, and **fails loud**: an unresolvable baseline now warns that every shipped fragment will re-fold, instead of silently repeating previous releases.

## Behaviour change, disclosed rather than discovered

This also repairs the DIVE-2247 **main-moved early exit**, which has never fired (it compared main's tip against a release *assign* commit, never equal). After this lands the nightly cut **stops on an unchanged main** instead of minting a version a night. Tag cadence drops from roughly nightly to only-when-main-moved — the intended DIVE-2247 behaviour. Recorded so a quieter cut log is not read as a broken scheduler.

## Provenance

Two dead candidates were ruled out first and are on the row so nobody re-runs them: the checkout is `fetch-depth: 0` (so tags **are** present and `incumbent` is not silently empty), and `incumbent` at `:112` and `:460` sit inside **one** `run:` block (so it is not a cross-step variable loss — the most attractive wrong answer).

DIVE-3170. Diagnosis main + olivia, fix dev2, gate signed by main.
