### PR TITLE
DIVE-3188: wire the declared-cost drift verdict to a rail

### DIFF
--- a/.github/workflows/header-drift-window.yml
+++ b/.github/workflows/header-drift-window.yml
@@ -1,0 +1,165 @@
+name: Header-drift window
+
+# DIVE-3188 — THE RAIL. Without this file, items 1-4 of that row are a correct
+# instrument nobody runs, which is the state DIVE-3163's merge left behind: the
+# facts land in every CI log and every report artifact, and NOTHING READS THEM.
+#
+# WHY A SCHEDULED WORKFLOW AND NOT A PER-PR CHECK. The question is "did a DIFFERENT
+# BOX see this same file drift", and it is unanswerable from inside any one job by
+# construction — that is the whole finding of DIVE-3163, where a per-job `exit 5`
+# fired on stale headers and on runner variance alike with nothing to tell them
+# apart. A cross-job read needs a window of jobs, so it runs where a window exists:
+# after the fact, over harvested logs.
+#
+# WHY IT NEVER GOES RED ON A FINDING, and this is the load-bearing constraint on the
+# whole design rather than caution. release-cut.yml grades EVERY check-run on main's
+# tip and refuses to cut on ANY red without reading which red it is. A scheduled
+# workflow run creates a check-run on main's tip. So a job that reddened on a stale
+# header would freeze release cuts on a stopwatch disagreement — which is EXACTLY the
+# harm DIVE-3163 measured and removed (the v0.19.14 cut, frozen ~40 minutes, PR #565
+# and PR #554 held, three agents charged a differential each). Re-creating it through
+# a scheduled door instead of a per-PR one would be the same defect with a new
+# address. `--drift-strict` therefore exists in the script and is NOT passed here.
+#
+# SO WHERE THE VERDICT LANDS: a step summary, an uploaded artifact carrying the
+# harvested reports the verdict was computed from, and a single long-lived GitHub
+# issue that is rewritten every run. The issue is the durable half — and it is also
+# this rail's own liveness signal, on the DIVE-1924 badge-staleness principle: the
+# body carries the date it was written, so a rail that dies leaves an issue visibly
+# frozen rather than a silence indistinguishable from "nothing recurred".
+
+on:
+  schedule:
+    # 04:47 UTC. AFTER full-sweep.yml's 03:17 so the night's shards are harvestable,
+    # and off the hour because the hour is where every other fleet cron already is.
+    - cron: '47 4 * * *'
+  workflow_dispatch:
+    inputs:
+      last:
+        description: 'How many runs of each workflow to harvest'
+        required: false
+        default: '20'
+      drift_min_jobs:
+        description: 'Distinct jobs a file must be WRONG on to be a stale claim'
+        required: false
+        default: '2'
+
+permissions:
+  contents: read
+  actions: read          # gh run view --log, which is what the harvester reads
+  issues: write          # the landing place for the verdict
+
+concurrency:
+  group: header-drift-window
+  cancel-in-progress: false
+
+jobs:
+  window:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Harvest the window from CI logs
+        id: harvest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LAST: ${{ github.event.inputs.last || '20' }}
+        run: |
+          set -uo pipefail
+          mkdir -p tier-cal-window
+          # BOTH workflows, because the drift signal is not confined to one. All three
+          # DIVE-3163 samples fired on full-sweep's full-pristine shards, and
+          # unit-tests.yml is where the core corpus is graded — a window over one of
+          # them would answer "does it recur" from half the boxes that could have seen
+          # it, and a recurrence missed reads exactly like a recurrence absent.
+          for wf in full-sweep.yml unit-tests.yml; do
+            echo "::group::harvest $wf"
+            scripts/tier-cal-harvest.sh --last="$LAST" --branch=main \
+              --workflow="$wf" --out=tier-cal-window || true
+            echo "::endgroup::"
+          done
+          n="$(find tier-cal-window -name '*.report' -type f | wc -l | tr -d ' ')"
+          echo "reports=$n" >> "$GITHUB_OUTPUT"
+          echo "harvested $n report(s)"
+
+      - name: Read the window
+        id: window
+        env:
+          MIN_JOBS: ${{ github.event.inputs.drift_min_jobs || '2' }}
+        run: |
+          set -uo pipefail
+          # NOT --drift-strict, and NOT by omission: see the header. A finding here must
+          # never be able to freeze a release cut.
+          if [ "${{ steps.harvest.outputs.reports }}" = "0" ]; then
+            {
+              echo "tier-cal-window: NO REPORTS HARVESTED."
+              echo "An empty window is not a window and must not be read as 'nothing recurred'."
+              echo "Check log retention and the workflow names above."
+            } | tee window.txt
+          else
+            scripts/tier-cal-window.sh tier-cal-window/*.report \
+              --drift-min-jobs="$MIN_JOBS" > window.txt 2>&1 || true
+            cat window.txt
+          fi
+          # The whole verdict, not a grep of it: a summary that quotes only the line it
+          # expected cannot show a reader the case it did not expect.
+          {
+            echo "## Header-drift window (DIVE-3188)"
+            echo
+            echo '```'
+            cat window.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the harvested window
+        uses: actions/upload-artifact@v4
+        with:
+          name: header-drift-window
+          # The REPORTS travel with the verdict. A verdict whose inputs did not survive
+          # cannot be re-read by the person it accuses, and this one accuses a named file.
+          path: |
+            window.txt
+            tier-cal-window/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Land the verdict on its issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          TITLE='Header-drift window (DIVE-3188)'
+          MARKER='<!-- dive-3188-header-drift-window -->'
+          STAMP="$(date -u '+%Y-%m-%d %H:%M UTC')"
+          {
+            echo "$MARKER"
+            echo "Rewritten by [\`header-drift-window.yml\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) at **${STAMP}**."
+            echo
+            echo "A STALE CLAIM below means one named file overran its own \`# TIER:\` header by the"
+            echo "FAIL margin on two or more DISTINCT jobs — distinct ephemeral boxes, so the"
+            echo "slow-runner explanation does not cover it. Re-measure the header and widen it with"
+            echo "its environment and date; the replacement line is printed in the run log."
+            echo
+            echo "A single-box \`WRONG\` is NOT a stale claim and is listed as a stopwatch"
+            echo "disagreement, because that reading was measured false three times on 2026-08-10"
+            echo "(DIVE-3163) including a green re-run at the same sha."
+            echo
+            echo '```'
+            cat window.txt
+            echo '```'
+            echo
+            echo "_This body is rewritten every run. If the timestamp above is stale, the RAIL is"
+            echo "dead — that is a different failure from 'nothing recurred', and it looks the same"
+            echo "from anywhere else (DIVE-1924)._"
+          } > issue-body.md
+
+          num="$(gh issue list --state open --limit 50 --json number,title \
+                   --jq ".[] | select(.title == \"$TITLE\") | .number" | head -1)"
+          if [ -n "${num:-}" ]; then
+            gh issue edit "$num" --body-file issue-body.md
+            echo "updated issue #$num"
+          else
+            gh issue create --title "$TITLE" --body-file issue-body.md
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,15 @@ decision to add one is ever wrong on its own merits. See
     `--no-cal-post` skips it. Across runs: `scripts/tier-cal-window.sh <reports…>`
     (normalises wall-clock to µs/harness first, or deleting a harness reads as
     anti-correlation).
+  - **A stale `# TIER:` header is a CROSS-JOB verdict, not a per-job exit** (DIVE-3163
+    → DIVE-3188). One box cannot separate a stale claim from a slow runner, so
+    `run-harnesses.sh` only warns. The verdict lives in `tier-cal-window.sh`: the same
+    named file `WRONG` on **>=2 distinct jobs** is a STALE CLAIM; one job is a stopwatch
+    disagreement. Identity is `harvest_run_id`/`harvest_job` (every GitHub job is its own
+    VM), never `--runner-id` — full-sweep passes none. `header-drift-window.yml` runs it
+    nightly and lands the verdict on an issue; it **never reds**, because `release-cut.yml`
+    refuses to cut on any red on main's tip. `--drift-strict` and `--drift-fatal=required`
+    exist for humans and no workflow may pass either (`tests/header_drift_window_unit.sh`).
   - `--no-calibrate` grades against the raw cap (useful with no built bundle). The
     clamp floor is 1.0, so that is the **strictest** this gate gets, never a
     relaxation. `--cal-us=` / `--cal-baseline-us=` / `--cal-cli=` are harness seams;

--- a/changelog.d/DIVE-3188.md
+++ b/changelog.d/DIVE-3188.md
@@ -1,0 +1,16 @@
+- **The declared-cost drift verdict now runs on a rail (DIVE-3188).** DIVE-3163 removed the
+  per-job `exit 5` from the harness header-drift check, correctly — one box cannot separate a
+  stale `# TIER:` header from a slow runner, measured false three times on 2026-08-10. What it
+  left behind was the quiet half: `header_drift_wrong` sat in every report and nothing read it.
+  `run-harnesses.sh` now prints the drift facts on a parseable `harness-budget[...]` line on
+  EVERY run (a clean run prints `wrong 0`, so absent and zero stay different things);
+  `tier-cal-harvest.sh` parses those lines back out of CI logs into per-file rows, emitting the
+  fields only when the log carried them; and `tier-cal-window.sh` grades the cross-job question
+  the exit code never could — the same named file marked `WRONG` on two or more DISTINCT jobs is
+  a STALE CLAIM, one job is a stopwatch disagreement. Identity is `harvest_run_id`/`harvest_job`,
+  because on GitHub-hosted runners every job is its own ephemeral VM; two reports from one job
+  count once. `--drift-strict` (exit 8) is off by default. A new scheduled workflow,
+  `header-drift-window.yml`, runs harvest and window nightly and lands the verdict in a step
+  summary, an artifact and a long-lived issue — and never reds, because `release-cut.yml` refuses
+  to cut on any red on main's tip and a scheduled red would re-create the harm DIVE-3163 removed.
+  `--drift-fatal=required` is kept as a local re-arm and is now watched: no workflow may pass it.

--- a/scripts/run-harnesses.sh
+++ b/scripts/run-harnesses.sh
@@ -32,6 +32,13 @@
 #      stale header from a slow runner — measured false three times on 2026-08-10 —
 #      so by default that finding PRINTS as a stale-claim warning and does not red
 #      the run. See the block beside the drift print at the end of this file.
+#      DIVE-3188 DECIDED THIS FLAG'S FUTURE rather than leaving it standing beside a
+#      new verdict: it is KEPT, as a local re-arm for a caller reproducing the old
+#      behaviour by hand, and it is now WATCHED — tests/header_drift_window_unit.sh
+#      refuses any workflow that passes it. "Wired to no caller" was the honest state
+#      but not a safe one, because nothing would have noticed a caller appearing. The
+#      cross-job verdict lives in scripts/tier-cal-window.sh and is the enforcement
+#      path; this exit is deliberately NOT a second one.
 #   6  UNDETERMINED (DIVE-2728). The budget could not be GRADED: the calibration
 #      probe could not run, the runner drew so far outside its clamp that the
 #      scaled cap would license an arbitrarily larger corpus, or (DIVE-2829, under
@@ -957,6 +964,45 @@ if (( ${#drift[@]} )); then
     fi
   fi
 fi
+
+# DIVE-3188. THE CROSS-JOB CARRIER, AND IT IS A LOG LINE RATHER THAN A REPORT FIELD.
+#
+# DIVE-3163 left the count in the report and named the reader it needed: something that
+# can compare the same file ACROSS runners. The report file cannot be that carrier, and
+# the reason is mechanical rather than stylistic — a `--report=` file lives only inside
+# the run that wrote it. scripts/tier-cal-harvest.sh exists BECAUSE of that: it rebuilds
+# reports for the cross-run window by parsing `harness-budget[...]` lines back out of the
+# CI log, which is the one store that already outlives the run. A field written only to
+# the report is a field the window never sees, so the cross-job question would stay
+# unanswerable with the number sitting right there.
+#
+# So the facts go on a line the harvester's contract already matches. The prose block
+# above is unchanged and stays the thing a human reads; this is the same facts in a shape
+# a parser can key on, which is the difference between "the data is in the log" (it
+# already was) and "something reads it" (it did not).
+#
+# PRINTED ON EVERY RUN, INCLUDING A CLEAN ONE, and that is the load-bearing detail. The
+# window counts RECURRENCES ACROSS HISTORY, so a missing field defaulted to zero would
+# manufacture a majority of clean historical samples inside the very instrument built to
+# count them — poisoning the exact statistic, in the direction of "nothing recurs", and
+# looking like a healthy corpus while it did it. An unconditional line makes
+# `header_drift_wrong=0` a GRADED zero and leaves every pre-DIVE-3188 log with no field
+# at all, which is what lets the window exclude those samples instead of scoring them
+# clean. Absent must stay absent; that is only possible if present is unconditional.
+printf '\nharness-budget[%s/%s]: HEADER DRIFT (DIVE-3188) files %d, wrong %d, policy %s\n' \
+  "$TIER" "$LABEL" "${#drift[@]}" "$drift_wrong" "$DRIFT_FATAL"
+for d in "${drift[@]}"; do
+  IFS=$'\t' read -r _dsev _dnm _dclaim _dms <<<"$d"
+  _dclaim_ms=$(awk -v c="$_dclaim" 'BEGIN{printf "%d", c*1000 + 0.5}')
+  # The per-FILE rows are what make the verdict per-file. A summary count cannot answer
+  # "did a DIFFERENT job see THIS SAME file drift" — two jobs each reporting one wrong
+  # file is indistinguishable from one file wrong twice, and only the second is a stale
+  # claim. The name is the key the window joins on.
+  printf 'harness-budget[%s/%s]: HEADER DRIFT FILE %s %s claim %ss measured %ss over %d%%\n' \
+    "$TIER" "$LABEL" "$_dsev" "$_dnm" "$_dclaim" \
+    "$(awk -v m="$_dms" 'BEGIN{printf "%.1f", m/1000}')" \
+    "$(( (_dms - _dclaim_ms) * 100 / _dclaim_ms ))"
+done
 
 if (( ${#failed[@]} )); then
   printf '\n%d harness(es) FAILED:\n' "${#failed[@]}"

--- a/scripts/tier-cal-harvest.sh
+++ b/scripts/tier-cal-harvest.sh
@@ -153,6 +153,24 @@ parse_log() {
       post_delta="$(printf '%s' "$brk" | sed -E 's/.*\(([-+][0-9]+)%\)$/\1/')"
     fi
 
+    # DIVE-3188: "harness-budget[full/pristine]: HEADER DRIFT (DIVE-3188) files 3, wrong 1, policy off"
+    # and one "HEADER DRIFT FILE <sev> <name> claim <n>s measured <n>s over <n>%" per
+    # drifting file. These are the cross-job carrier for the stale-claim verdict; see the
+    # block beside the drift print in scripts/run-harnesses.sh for why the report FIELD
+    # could not be it.
+    # Declared local so a job that `continue`d above cannot leak its values into the next
+    # one — a harvested field belonging to a different job is worse than a missing field.
+    local hdsum hdfiles hd_all hd_wrong hd_policy
+    hdsum="$(printf '%s\n' "$blk" | grep -aoE 'HEADER DRIFT \(DIVE-3188\) files [0-9]+, wrong [0-9]+, policy [a-z]+' | tail -1)"
+    if [[ -n "$hdsum" ]]; then
+      hd_all="$(printf '%s' "$hdsum"    | sed -E 's/.*files ([0-9]+),.*/\1/')"
+      hd_wrong="$(printf '%s' "$hdsum"  | sed -E 's/.*wrong ([0-9]+),.*/\1/')"
+      hd_policy="$(printf '%s' "$hdsum" | sed -E 's/.*policy ([a-z]+)$/\1/')"
+      # Only meaningful when the summary line was there. A per-file row harvested without
+      # its summary would be a count with no denominator.
+      hdfiles="$(printf '%s\n' "$blk" | grep -aoE 'HEADER DRIFT FILE (WRONG|stale) [^ ]+ claim [0-9.]+s measured [0-9.]+s over [0-9]+%' | sort -u)"
+    fi
+
     local f="$OUT/${run}-${job}.report"
     {
       printf '# run-harnesses report (HARVESTED from CI log by scripts/tier-cal-harvest.sh)\n'
@@ -175,10 +193,27 @@ parse_log() {
         printf '# cal_post_status=measured\n# cal_post_us_per_iter=%s\n# cal_post_delta_pct=%s\n' \
           "$post_us" "${post_delta#+}"
       fi
+      # DIVE-3188, and the absence rule above is the whole point on THIS field. A log from
+      # before DIVE-3188 carries no HEADER DRIFT line, so these keys are simply not written
+      # — never `header_drift_wrong=0`. The window counts recurrences across history, so a
+      # zero-fill here would manufacture a majority of clean historical samples inside the
+      # instrument built to count them, and it would look like a healthy corpus.
+      if [[ -n "${hd_wrong:-}" ]]; then
+        printf '# header_drift=%s\n# header_drift_wrong=%s\n# drift_fatal_policy=%s\n' \
+          "${hd_all}" "$hd_wrong" "$hd_policy"
+        # One row per drifting file, tab-separated: sev, name, claim_s, measured_s, over_pct.
+        # A repeated key, which every existing reader tolerates — tier-cal-window.sh's
+        # field() is `grep -m1`, so the scalar fields above are unaffected.
+        if [[ -n "${hdfiles:-}" ]]; then
+          printf '%s\n' "$hdfiles" | sed -E \
+            's/^HEADER DRIFT FILE (WRONG|stale) (.*) claim (.*)s measured (.*)s over ([0-9]+)%$/# header_drift_file=\1\t\2\t\3\t\4\t\5/'
+        fi
+      fi
     } > "$f"
     printf '%s\n' "$f"
     n=$((n+1))
     unset cal_status cal_us cal_base scale_raw scale_app eff_cap eff_pct post_us post_delta
+    unset hd_all hd_wrong hd_policy hdsum hdfiles
   done <<< "$jobs"
   return "$(( n > 0 ? 0 : 1 ))"
 }

--- a/scripts/tier-cal-window.sh
+++ b/scripts/tier-cal-window.sh
@@ -51,17 +51,29 @@
 # anti-correlation, do not bake it into a constant).
 #
 #   scripts/tier-cal-window.sh report1.txt report2.txt ...   [--strict] [--min-runs=N]
+#                                                            [--drift-strict] [--drift-min-jobs=N]
+#
+# DIVE-3188 ADDED A SECOND, INDEPENDENT VERDICT to the same window: the per-FILE
+# stale-claim read (see its block below). It shares the inputs and nothing else — it
+# needs no calibration probe, it is graded per named file rather than per run, and it
+# prints and gates separately. Read them as two instruments in one housing.
 #
 # Exit: 0 read and reported | 2 could not read a window | 7 --strict and the window
-# FAILS the correlation assertion (discordant outnumber concordant).
+# FAILS the correlation assertion (discordant outnumber concordant) | 8 --drift-strict
+# and at least one file was marked WRONG on >= --drift-min-jobs DISTINCT jobs.
 set -uo pipefail
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 2
 # shellcheck source=tests/lib/tier.sh
 . tests/lib/tier.sh
 
-STRICT=0; MIN_RUNS=3; FILES=()
+STRICT=0; MIN_RUNS=3; FILES=(); DRIFT_STRICT=0; DRIFT_MIN_JOBS=2
 for a in "$@"; do case "$a" in
   --strict) STRICT=1 ;;
+  # DIVE-3188: OFF BY DEFAULT, for the same reason --strict is. The verdict below is the
+  # first instrument that can separate a stale header from a slow box, and an instrument
+  # whose first act is to gate is one whose first false positive is somebody's red.
+  --drift-strict) DRIFT_STRICT=1 ;;
+  --drift-min-jobs=*) DRIFT_MIN_JOBS="${a#--drift-min-jobs=}" ;;
   # A window of two has no interior and its median is one of its own endpoints, so
   # "which side of typical" is not a question it can answer. Refusing under three is
   # the same fail-closed call the runner makes on an empty corpus: a verdict computed
@@ -73,13 +85,115 @@ esac; done
 
 [[ "$MIN_RUNS" =~ ^[0-9]+$ ]] && (( MIN_RUNS >= 3 )) || {
   printf 'tier-cal-window: --min-runs must be an integer >= 3, got %s\n' "$MIN_RUNS" >&2; exit 2; }
+# A recurrence needs two occurrences. One is the thing this verdict exists to NOT call a
+# stale claim, so 1 is not a tightening of the control, it is its removal — refuse it here
+# rather than let a caller silently reinstate the one-box assertion DIVE-3163 removed.
+[[ "$DRIFT_MIN_JOBS" =~ ^[0-9]+$ ]] && (( DRIFT_MIN_JOBS >= 2 )) || {
+  printf 'tier-cal-window: --drift-min-jobs must be an integer >= 2, got %s\n' "$DRIFT_MIN_JOBS" >&2; exit 2; }
 (( ${#FILES[@]} )) || {
-  printf 'usage: tier-cal-window.sh <run-harnesses report>... [--strict] [--min-runs=N]\n' >&2; exit 2; }
+  printf 'usage: tier-cal-window.sh <run-harnesses report>... [--strict] [--min-runs=N]\n' >&2
+  printf '                          [--drift-strict] [--drift-min-jobs=N]\n' >&2; exit 2; }
 
 field() { # field <file> <key> -> value, empty if absent
   local v; v="$(grep -m1 "^# $2=" "$1" 2>/dev/null)" || true
   printf '%s\n' "${v#*=}"
 }
+
+# ---------------------------------------------------------------------------
+# DIVE-3188. THE STALE-CLAIM VERDICT: a per-FILE `WRONG` recurring across DISTINCT JOBS.
+#
+# WHAT THIS ANSWERS AND WHY NOTHING ELSE COULD. DIVE-3163 removed `exit 5` from the
+# per-harness declared-cost drift check because a single job cannot separate "this
+# header is stale" from "this box drew slow" — measured false three times on 2026-08-10,
+# including a green re-run at the same sha with no code change. That is not a threshold
+# problem and raising TIER_CLAIM_DRIFT_FAIL_PCT would hide it rather than settle it. The
+# separating instrument is a SECOND BOX, and this is the only place in the toolchain that
+# can hold two of them at once.
+#
+# IDENTITY IS THE JOB, NOT THE RUNNER ID AND NOT THE REPORT. `--runner-id` is `-` on
+# exactly the jobs this is about: full-sweep.yml passes --tier/--shard/--label/--report
+# and no runner id, and all three DIVE-3163 samples came off full-pristine shards. It is
+# also unnecessary — on GitHub-hosted runners every JOB gets its own ephemeral VM, so
+# distinct `harvest_run_id/harvest_job` pairs ARE distinct boxes. Reports are counted
+# never: two attempts on one box are one box, and a re-run that re-reports the same file
+# would otherwise convict it on its own second opinion.
+#
+# ABSENT IS EXCLUDED, NOT SCORED CLEAN, and this is the arithmetic the whole verdict
+# rests on. A run harvested from a pre-DIVE-3188 log carries NO header_drift_wrong field
+# — the summary line did not exist to parse. Defaulting that to 0 would manufacture a
+# majority of clean historical samples inside the very instrument built to count
+# recurrences across history: it would not add noise, it would poison the exact statistic,
+# in the direction of "nothing recurs", and the output would look like a healthy corpus.
+# So a sample without the field leaves the DENOMINATOR, by name, and is reported as
+# skipped. The boundary is DIVE-3188's carrier, not #577's merge: report FILES have
+# carried header_drift_wrong since #577, but the window reads HARVESTED reports and those
+# do not carry it until the log line ships.
+#
+# WHY --drift-min-jobs=2 AND NOT MORE. Two independent boxes agreeing that one named file
+# overran its own header by the FAIL margin is the smallest evidence that excludes the
+# runner, and it is exactly the evidence the removed exit 5 never had. Raising it to 3
+# would be defensible and is a flag, not a constant, for that reason.
+# ---------------------------------------------------------------------------
+declare -A DRIFT_JOBS=() DRIFT_SEEN=() DRIFT_GRADED=()
+dskipped=0; dskipnames=""
+for f in "${FILES[@]}"; do
+  [[ -r "$f" ]] || continue           # already named as a skip by the cal pass below
+  _rid="$(field "$f" harvest_run_id)"; _job="$(field "$f" harvest_job)"
+  _hw="$(field "$f" header_drift_wrong)"
+  if [[ -z "$_hw" ]]; then
+    dskipped=$((dskipped+1)); dskipnames="$dskipnames $(basename "$f")(no header_drift_wrong)"; continue
+  fi
+  if [[ -z "$_rid" || -z "$_job" ]]; then
+    # No provable job identity, so this sample cannot be shown to be a SECOND box — and
+    # counting it as one is the precise error the verdict exists to avoid.
+    dskipped=$((dskipped+1)); dskipnames="$dskipnames $(basename "$f")(no harvest_run_id/harvest_job)"; continue
+  fi
+  _jid="$_rid/$_job"
+  DRIFT_GRADED["$_jid"]=1
+  while IFS=$'\t' read -r _sev _nm _rest; do
+    [[ -n "$_nm" ]] || continue
+    # Only WRONG is counted. `stale` is the WARN band, below the FAIL margin the removed
+    # exit 5 used, and folding it in would make the verdict answer a different question
+    # than the one it is named for.
+    [[ "$_sev" == "WRONG" ]] || continue
+    [[ -n "${DRIFT_SEEN["$_nm|$_jid"]:-}" ]] && continue
+    DRIFT_SEEN["$_nm|$_jid"]=1
+    DRIFT_JOBS["$_nm"]="${DRIFT_JOBS["$_nm"]:-}$_jid "
+  done < <(grep -a '^# header_drift_file=' "$f" 2>/dev/null | sed 's/^# header_drift_file=//')
+done
+
+DRIFT_CONFIRMED=0
+ngraded=${#DRIFT_GRADED[@]}
+printf 'tier-cal-window: stale-claim verdict (DIVE-3188) — %d job(s) carried a graded drift count' "$ngraded"
+(( dskipped )) && printf ', %d excluded:%s' "$dskipped" "$dskipnames"
+printf '\n'
+if (( ngraded < MIN_RUNS )); then
+  # The same fail-closed call the cal window makes, for the same reason: a verdict
+  # computed from too little reads exactly like a verdict computed from enough.
+  printf 'tier-cal-window: DRIFT UNDETERMINED — need %d graded job(s), have %d. This is not\n' "$MIN_RUNS" "$ngraded"
+  printf '  "no stale headers": nothing here says a file recurs and nothing says it does not.\n'
+elif (( ${#DRIFT_JOBS[@]} == 0 )); then
+  printf 'tier-cal-window: no file was marked WRONG on any of the %d graded job(s).\n' "$ngraded"
+else
+  printf '\n%-52s %5s  %s\n' FILE JOBS VERDICT
+  for _nm in "${!DRIFT_JOBS[@]}"; do
+    read -r -a _js <<<"${DRIFT_JOBS[$_nm]}"
+    if (( ${#_js[@]} >= DRIFT_MIN_JOBS )); then
+      _v="STALE CLAIM"; DRIFT_CONFIRMED=$((DRIFT_CONFIRMED+1))
+    else
+      _v="stopwatch disagreement (1 box)"
+    fi
+    printf '%-52s %5d  %s\n' "$_nm" "${#_js[@]}" "$_v"
+    printf '%*s  on: %s\n' 52 '' "${DRIFT_JOBS[$_nm]}"
+  done
+  printf '\nSTALE CLAIM = the same named file overran its own header by the FAIL margin on >=%d\n' "$DRIFT_MIN_JOBS"
+  printf 'DISTINCT jobs, which on GitHub-hosted runners are distinct ephemeral boxes. That is the\n'
+  printf 'one reading the slow-runner explanation does not cover, so re-measure the header and\n'
+  printf 'widen it with its environment and date (run-harnesses.sh prints the replacement line).\n'
+  printf 'A single-box WRONG is left as a stopwatch disagreement ON PURPOSE — DIVE-3163 measured\n'
+  printf 'that reading false three times in one day, including a green re-run at the same sha.\n'
+fi
+printf '\n'
 
 declare -a LBL=() CAL=() LOAD=() POST=() DELTA=() HN=() WALL=()
 skipped=0; skipnames=""
@@ -109,6 +223,12 @@ if (( n < MIN_RUNS )); then
   (( skipped )) && printf 'tier-cal-window: skipped%s\n' "$skipnames" >&2
   printf 'A window this short cannot say which side of typical a run sat on. This is exit 2,\n' >&2
   printf 'not a pass: nothing here says the probe tracks the corpus, and nothing says it does not.\n' >&2
+  # DIVE-3188: the two verdicts are independent, and a caller that asked to gate on drift
+  # gets its answer even when the CALIBRATION window is unreadable. The drift verdict is
+  # counted per named file across jobs and needs no probe at all, so letting exit 2
+  # swallow a CONFIRMED stale claim would lose a determined finding to an undetermined
+  # neighbour — the same shape as reading a control's silence as a pass.
+  (( DRIFT_STRICT && DRIFT_CONFIRMED )) && exit 8
   exit 2
 fi
 
@@ -162,5 +282,15 @@ if (( STRICT )); then
     exit 7
   fi
   printf '\ntier-cal-window: PASS (--strict) — %d concordant against %d discordant.\n' "$conc" "$disc"
+fi
+if (( DRIFT_STRICT )); then
+  if (( DRIFT_CONFIRMED )); then
+    printf '\ntier-cal-window: FAIL (--drift-strict) — %d file(s) marked WRONG on >=%d distinct\n' \
+      "$DRIFT_CONFIRMED" "$DRIFT_MIN_JOBS"
+    printf 'jobs. Two ephemeral boxes agreeing is the reading the slow-runner explanation does not\n'
+    printf 'cover, so these headers are stale rather than unlucky. Exit 8.\n'
+    exit 8
+  fi
+  printf '\ntier-cal-window: PASS (--drift-strict) — no file recurred on %d or more distinct jobs.\n' "$DRIFT_MIN_JOBS"
 fi
 exit 0

--- a/tests/header_drift_window_unit.sh
+++ b/tests/header_drift_window_unit.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# DIVE-3188 — THE CROSS-JOB STALE-CLAIM RAIL, GRADED END TO END.
+#
+# TIER: nightly — 5.0s measured (5dive host, agent-dev seat, 2026-08-10): four of those
+# five seconds are one `sleep 4`, and core has no room for them.
+#
+# THE DEMOTION IS ARGUED FROM A CI NUMBER, not a local one, because a local reading on
+# the contended control plane runs ~45% high and a demotion argued on an unverified
+# figure is the second budget the tier system exists to prevent. Read off unit-tests.yml
+# run 31437553333 on main, 2026-08-10:
+#     core/pristine        279 harnesses, 306s wall-clock, budget 300s (102%)
+#     core/installed-host  279 harnesses, 385s (128%), confirm re-time 251s (83%)
+# Core is AT its cap on that sample. CLAUDE.md ranks merge and retire ahead of demotion
+# and neither applies — this harness has no sibling to fold into and the mechanism it
+# guards is brand new — but adding 5s of recurring cost to a tier already at 102% would
+# red somebody else's PR on content they did not change, which is the exact harm the
+# budget exists to price.
+#
+# THE COST CANNOT BE ENGINEERED AWAY, which is what makes this a tier question rather
+# than an optimisation. WRONG is `>=50% AND >=3s` over the claim, so a fixture that
+# provokes one must actually burn three wall-clock seconds; there is no faster way to
+# make a real drift verdict happen. That same fact makes this figure unusually STABLE
+# across runners — a sleep costs the same on a slow box, so almost none of the 5s is
+# platform draw, and this header should not itself go stale.
+#
+# THE LATENCY IS ACCEPTABLE HERE FOR A REASON SPECIFIC TO WHAT THIS GUARDS: the rail it
+# grades (header-drift-window.yml) is ITSELF nightly, so a 24h detection window on the
+# guard matches the cadence of the thing guarded. And `changed-harnesses` runs a touched
+# harness at introduction whatever its tier, so anyone editing this chain still pays for
+# it on their own PR — the tier only sets the RECURRING cost. Decision: dev, 2026-08-10.
+#
+# WHAT THIS EXISTS TO CATCH. DIVE-3163 removed a per-job `exit 5` because one box
+# cannot separate a stale header from a slow runner, and left the count in the report
+# with the reader it needed unwritten. DIVE-3188 writes that reader as a chain of
+# three files, and a chain is exactly the shape where every link can be individually
+# green while the thing itself does nothing: the runner can print a line no harvester
+# matches, the harvester can emit a field no window reads, and the window can score a
+# verdict off samples that never carried the field. So the arms below follow ONE fact
+# from the runner's stdout, through a harvested report, to a verdict — and the
+# negative arms are the load-bearing half.
+#
+# THE ARMS:
+#   1-4   CARRIER. The runner prints a parseable summary line on EVERY run including a
+#         clean one (so `wrong 0` is a GRADED zero), plus one row per drifting file
+#         carrying its severity and name. Shaped `harness-budget[...]` because that is
+#         the harvester's contract; an arm on the shape, since a prettier line that
+#         does not match is the silent break.
+#   5-9   HARVEST. The lines parse back into report fields and per-file rows — and a
+#         PRE-DIVE-3188 log yields NO header_drift_wrong at all, never a zero. That
+#         negative arm is the one that protects the statistic: the window counts
+#         recurrences across history, so a missing-means-zero default would
+#         manufacture a majority of clean historical samples inside the instrument
+#         built to count them.
+#  10-16  VERDICT. WRONG on one job is a stopwatch disagreement; on two DISTINCT jobs
+#         it is a STALE CLAIM. Two reports from the SAME job count once (a re-run must
+#         not convict a file on its own second opinion). `stale` never counts (it is
+#         the WARN band, below the margin the removed exit 5 used). Samples with no job
+#         identity leave the denominator by name. Under three graded jobs the verdict
+#         is UNDETERMINED, not clean. `--drift-strict` exits 8; the default does not.
+#  17-18  ITEM 4's WATCH. `--drift-fatal=required` survives as a local re-arm and NO
+#         workflow may pass it — an unwatched second enforcement path beside a new
+#         verdict is the thing DIVE-3188 refused to leave standing. And the scheduled
+#         rail must not pass `--drift-strict` either: release-cut.yml refuses to cut on
+#         ANY red on main's tip, so a workflow that reddened on a stale header would
+#         re-create the exact harm DIVE-3163 measured, through a scheduled door.
+set -uo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 2
+ROOT="$PWD"
+RUNNER="$ROOT/scripts/run-harnesses.sh"
+HARVEST="$ROOT/scripts/tier-cal-harvest.sh"
+WINDOW="$ROOT/scripts/tier-cal-window.sh"
+
+TMP="$(mktemp -d /tmp/header-drift-window.XXXXXX)" || exit 2
+trap 'rm -rf "$TMP"' EXIT
+CORPUS="$TMP/corpus"; mkdir -p "$CORPUS" "$TMP/reports"
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s\n     %s\n' "$1" "${2:-}"; }
+want() { if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1" "expected [$2] got [$3]"; fi; }
+has() { # has <name> <haystack> <needle>
+  if [[ "$2" == *"$3"* ]]; then ok "$1"; else bad "$1" "missing [$3] in: $2"; fi; }
+hasnt() {
+  if [[ "$2" != *"$3"* ]]; then ok "$1"; else bad "$1" "unexpectedly found [$3] in: $2"; fi; }
+
+mk() { printf '%s\n' "$2" > "$CORPUS/$1"; chmod +x "$CORPUS/$1"; }
+run() { OUT="$(bash "$RUNNER" --no-calibrate --corpus-dir="$CORPUS" "$@" 2>&1)"; RC=$?; }
+
+# --- 1-4: the carrier -------------------------------------------------------
+mk truthful.sh '#!/usr/bin/env bash
+# TIER: nightly — 10.0s measured (DIVE-3188 fixture): headroom to spare.
+exit 0'
+run --tier=full --budget=600 --label=t
+want "a clean corpus still exits 0" "0" "$RC"
+# THE ARM THAT MAKES ABSENT MEAN ABSENT. If this line only printed when something
+# drifted, then "no drift" and "this build predates DIVE-3188" would be the same bytes
+# in the log, and the window could not tell a graded zero from a missing field.
+has "a CLEAN run still prints the drift summary line (wrong 0 is a graded zero)" \
+  "$OUT" "HEADER DRIFT (DIVE-3188) files 0, wrong 0, policy off"
+has "the summary line carries the harness-budget[] prefix the harvester keys on" \
+  "$OUT" "harness-budget[full/t]: HEADER DRIFT (DIVE-3188)"
+
+mk wrong_claim.sh '#!/usr/bin/env bash
+# TIER: nightly — 0.5s measured (DIVE-3188 fixture): claims half a second, draws four.
+sleep 4
+exit 0'
+run --tier=full --budget=600 --label=t
+want "a WRONG header is still only a warning on one box (DIVE-3163 stands)" "0" "$RC"
+has "the summary line counts the wrong file" \
+  "$OUT" "HEADER DRIFT (DIVE-3188) files 1, wrong 1, policy off"
+if [[ "$OUT" =~ harness-budget\[full/t\]:\ HEADER\ DRIFT\ FILE\ WRONG\ [^[:space:]]*wrong_claim\.sh\ claim\ 0\.5s\ measured\ [0-9.]+s\ over\ [0-9]+% ]]; then
+  ok "one parseable per-FILE row, carrying severity, name, claim and measurement"
+else bad "one parseable per-FILE row, carrying severity, name, claim and measurement" "$OUT"; fi
+
+# --- 5-9: harvest -----------------------------------------------------------
+# `gh run view --log` prefixes every line with "<job>\t<step>\t<timestamp> ". The
+# harvester splits on the job column FIRST, so the fixture must too — a log built
+# without the prefix would grade a parser nobody runs.
+mklog() { # mklog <file> <job> <wrong-count> <extra drift rows...>
+  local f="$1" job="$2" wrongn="$3"; shift 3
+  {
+    printf '%s\tRun\t2026-08-10T04:00:00Z harness-budget[full/pristine]: 120 harnesses, 500s wall-clock, budget 1320s (37%% of budget)\n' "$job"
+    # The harness-budget[] prefix is not decoration on THIS line either: the harvester
+    # narrows to a block with `grep harness-budget|runner; applied|EFFECTIVE cap` before
+    # it parses anything, so a CALIBRATION line without it is invisible to the parser.
+    printf '%s\tRun\t2026-08-10T04:00:00Z harness-budget[full/pristine]: CALIBRATION (measured) 119385us/iter vs baseline 119000us/iter = 100%%\n' "$job"
+    printf '%s\tRun\t2026-08-10T04:00:00Z of a normal runner; applied 100%% (clamp 100-150%%) -> effective cap 1320s\n' "$job"
+    printf '%s\tRun\t2026-08-10T04:00:00Z harness-budget[full/pristine]: HEADER DRIFT (DIVE-3188) files %d, wrong %s, policy off\n' "$job" "$#" "$wrongn"
+    local r; for r in "$@"; do
+      printf '%s\tRun\t2026-08-10T04:00:00Z harness-budget[full/pristine]: HEADER DRIFT FILE %s\n' "$job" "$r"
+    done
+  } > "$f"
+}
+DROW='WRONG tests/slow_unit.sh claim 41.4s measured 62.1s over 50%'
+SROW='stale tests/mild_unit.sh claim 10.0s measured 12.0s over 20%'
+
+mklog "$TMP/log-a" "full-pristine (1)" 1 "$DROW" "$SROW"
+"$HARVEST" --from-log="$TMP/log-a" --run=111 --sha=abc --out="$TMP/reports" >/dev/null 2>&1
+RA="$TMP/reports/111-full-pristine (1).report"
+if [[ -r "$RA" ]]; then ok "harvest wrote a report for the job"; else bad "harvest wrote a report for the job" "$(ls "$TMP/reports")"; fi
+BODY="$(cat "$RA" 2>/dev/null)"
+has "harvested report carries header_drift_wrong"  "$BODY" "# header_drift_wrong=1"
+has "harvested report carries the drift denominator" "$BODY" "# header_drift=2"
+has "harvested report carries the policy that governed the run" "$BODY" "# drift_fatal_policy=off"
+if [[ "$BODY" == *"# header_drift_file=WRONG"$'\t'"tests/slow_unit.sh"$'\t'"41.4"$'\t'"62.1"$'\t'"50"* ]]; then
+  ok "the per-file row survives harvest as a tab-separated repeated key"
+else bad "the per-file row survives harvest as a tab-separated repeated key" "$BODY"; fi
+has "the existing cal fields are untouched by the new parsing" "$BODY" "# cal_us_per_iter=119385"
+
+# THE NEGATIVE ARM THIS WHOLE ROW TURNS ON. A log from before the carrier shipped must
+# yield NO field — not a zero. See the block in tier-cal-harvest.sh.
+{ printf 'old-job\tRun\t2026-08-09T04:00:00Z harness-budget[full/pristine]: 120 harnesses, 500s wall-clock, budget 1320s (37%% of budget)\n'; } > "$TMP/log-old"
+"$HARVEST" --from-log="$TMP/log-old" --run=222 --out="$TMP/old" >/dev/null 2>&1
+OLDBODY="$(cat "$TMP/old/222-old-job.report" 2>/dev/null)"
+hasnt "a PRE-DIVE-3188 log harvests with NO header_drift_wrong — absent, never 0" \
+  "$OLDBODY" "header_drift_wrong"
+
+# --- 10-16: the verdict -----------------------------------------------------
+W="$TMP/w"; mkdir -p "$W"
+mkreport() { # mkreport <file> <run> <job> <wrong> [rows...]
+  local f="$1" run="$2" job="$3" wrong="$4"; shift 4
+  {
+    printf '# run-harnesses report (HARVESTED from CI log by scripts/tier-cal-harvest.sh)\n'
+    printf '# harvest_source=ci-log\n# harvest_run_id=%s\n# harvest_job=%s\n' "$run" "$job"
+    printf '# tier=full\n# label=pristine\n# harnesses=120\n# wall_clock_s=500\n# budget_s=1320\n# pct_of_budget=37\n'
+    printf '# cal_status=measured\n# cal_us_per_iter=119385\n'
+    printf '# header_drift_wrong=%s\n# drift_fatal_policy=off\n' "$wrong"
+    local r; for r in "$@"; do printf '# header_drift_file=%s\n' "$r"; done
+  } > "$W/$f"
+}
+FROW=$'WRONG\ttests/slow_unit.sh\t41.4\t62.1\t50'
+FROW2=$'WRONG\ttests/other_unit.sh\t10.0\t20.0\t100'
+FSTALE=$'stale\ttests/mild_unit.sh\t10.0\t12.0\t20'
+
+# Three graded jobs, so the verdict is answerable at all. slow_unit is WRONG on ONE.
+mkreport a.report 111 "job-a" 1 "$FROW"
+mkreport b.report 222 "job-b" 0
+mkreport c.report 333 "job-c" 0 "$FSTALE"
+WOUT="$("$WINDOW" "$W"/*.report 2>&1)"; WRC=$?
+has "one box's WRONG is a stopwatch disagreement, not a stale claim" \
+  "$WOUT" "stopwatch disagreement (1 box)"
+hasnt "and it is NOT called a stale claim" "$WOUT" "STALE CLAIM  "
+hasnt "a 'stale' severity row never enters the verdict (WARN band, not the FAIL margin)" \
+  "$WOUT" "mild_unit.sh"
+want "the default is not a gate — a finding does not change the exit code" "0" "$WRC"
+
+# A SECOND, DISTINCT job sees the SAME file. This is the reading the slow-runner
+# explanation does not cover, and the only one the removed exit 5 never had.
+mkreport b.report 222 "job-b" 1 "$FROW"
+WOUT="$("$WINDOW" "$W"/*.report 2>&1)"
+has "the same file WRONG on two distinct jobs is a STALE CLAIM" "$WOUT" "STALE CLAIM"
+has "and the verdict names the jobs it rests on" "$WOUT" "111/job-a"
+
+# TWO REPORTS, ONE JOB. Distinct reports are not distinct boxes — two attempts on one
+# ephemeral VM are one box, and counting them twice would convict a file on its own
+# second opinion, which is precisely the one-box assertion DIVE-3163 removed.
+rm -f "$W/b.report"
+mkreport a2.report 111 "job-a" 1 "$FROW"
+mkreport d.report 444 "job-d" 0
+WOUT="$("$WINDOW" "$W"/*.report 2>&1)"
+has "two reports from the SAME job count as one box" "$WOUT" "stopwatch disagreement (1 box)"
+
+# --drift-strict, on a confirmed recurrence.
+mkreport b.report 222 "job-b" 1 "$FROW" "$FROW2"
+WOUT="$("$WINDOW" "$W"/*.report --drift-strict 2>&1)"; WRC=$?
+want "--drift-strict exits 8 on a confirmed stale claim" "8" "$WRC"
+has "the other_unit row, WRONG on only one job, stays a disagreement" "$WOUT" "stopwatch disagreement (1 box)"
+
+# ABSENT IS EXCLUDED, NOT SCORED CLEAN — and the exclusion is NAMED. A window of
+# pre-carrier samples must refuse, not report a healthy corpus.
+OLD="$TMP/oldw"; mkdir -p "$OLD"
+for i in 1 2 3 4; do
+  { printf '# run-harnesses report\n# harvest_run_id=9%s\n# harvest_job=job-%s\n' "$i" "$i"
+    printf '# tier=full\n# label=pristine\n# harnesses=120\n# wall_clock_s=500\n'
+    printf '# cal_status=measured\n# cal_us_per_iter=119385\n'; } > "$OLD/o$i.report"
+done
+OOUT="$("$OLD"/../../dev/null 2>/dev/null; "$WINDOW" "$OLD"/*.report --drift-strict 2>&1)"; ORC=$?
+has "a window of pre-carrier samples is UNDETERMINED, never 'nothing recurred'" \
+  "$OOUT" "DRIFT UNDETERMINED"
+has "and every excluded sample is named, with why" "$OOUT" "(no header_drift_wrong)"
+if (( ORC != 8 )); then ok "--drift-strict does not gate on an undetermined drift window"
+else bad "--drift-strict does not gate on an undetermined drift window" "exit $ORC"; fi
+
+# --- 17-18: item 4's watch --------------------------------------------------
+# The disarmed arm survives as a local re-arm, so it must stay unreachable from CI.
+# `git grep` would read the checkout's branch; this reads the tree as it will ship.
+# COMMENT LINES ARE STRIPPED FIRST, and the first version of these arms did not: it
+# read its own explanation of why the flag is absent as the flag being present. A grep
+# over raw text cannot tell a MENTION from a USE, and the careful author who writes down
+# why a control is off is exactly the person it then accuses.
+uses_flag() { # uses_flag <flag> -> prints the offending lines, empty if only mentioned
+  grep -rn -- "$1" "$ROOT/.github/workflows/" 2>/dev/null | grep -v ':[[:space:]]*#'
+}
+for _f in --drift-fatal=required --drift-strict; do
+  case "$_f" in
+    --drift-fatal=required) _why="the verdict is the window, not a per-job exit" ;;
+    *)                      _why="release-cut refuses on ANY red on main's tip" ;;
+  esac
+  _hit="$(uses_flag "$_f")"
+  if [[ -n "$_hit" ]]; then bad "no workflow passes $_f — $_why" "$_hit"
+  else ok "no workflow passes $_f — $_why"; fi
+done
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+(( fail == 0 )) || exit 1
+exit 0

--- a/tests/header_drift_window_unit.sh
+++ b/tests/header_drift_window_unit.sh
@@ -65,6 +65,18 @@
 #         re-create the exact harm DIVE-3163 measured, through a scheduled door.
 set -uo pipefail
 
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+# DIVE-2692: the corpus RC contract. Registered HERE, above the `cd ... || exit 2`
+# below, because that is an early exit and a trap set after it would not cover it.
+# The TMP cleanup is FOLDED IN rather than left as a second `trap ... EXIT` — bash
+# keeps only the LAST registration per signal, so a second one silently replaces the
+# first and the temp dir would leak with nothing to notice. `${TMP:-}` because TMP is
+# not created until further down and this trap is live before it exists.
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 2
 ROOT="$PWD"
 RUNNER="$ROOT/scripts/run-harnesses.sh"
@@ -72,7 +84,6 @@ HARVEST="$ROOT/scripts/tier-cal-harvest.sh"
 WINDOW="$ROOT/scripts/tier-cal-window.sh"
 
 TMP="$(mktemp -d /tmp/header-drift-window.XXXXXX)" || exit 2
-trap 'rm -rf "$TMP"' EXIT
 CORPUS="$TMP/corpus"; mkdir -p "$CORPUS" "$TMP/reports"
 
 pass=0; fail=0


### PR DESCRIPTION
## DIVE-3188: wire the declared-cost drift verdict to a rail

DIVE-3163 (#577) removed the per-job `exit 5` from the harness header-drift check, correctly — one
box cannot separate a stale `# TIER:` header from a slow runner, measured false three times on
2026-08-10 including a green re-run at the same sha. It left `header_drift_wrong` in the report and
named the reader it needed. **This is that reader.** Filed before #577 merged, as main's condition
for it; #577 has since landed as `062f04ce`, so the gap is live now.

| item | file |
|---|---|
| 1. carrier | `scripts/run-harnesses.sh` — a parseable `harness-budget[...]` drift line |
| 2. identity | `scripts/tier-cal-harvest.sh` — per-file rows keyed by `harvest_run_id`/`harvest_job` |
| 3. verdict | `scripts/tier-cal-window.sh` — `WRONG` on >=2 distinct jobs is a STALE CLAIM |
| 4. `--drift-fatal` | kept as a local re-arm, now **watched** |
| 5. rail | `.github/workflows/header-drift-window.yml`, nightly |

### Three decisions that are not the obvious ones

**A report FIELD cannot be the cross-run carrier.** A `--report=` file lives only inside the run
that wrote it — which is why `tier-cal-harvest.sh` exists at all, rebuilding reports from the CI
log because stdout is the one store GitHub already retains. A field the harvester does not parse is
a field the window never sees. So the facts go on a line shaped like the contract the harvester
already keys on; the prose block a human reads is unchanged beside it.

**The carrier line prints on EVERY run, including a clean one.** This is the load-bearing detail
and it is one layer up from where olivia found the same hazard. If the line only printed when
something drifted, then *"nothing drifted"* and *"this build predates the carrier"* would be the
same bytes in the log, permanently — and a missing-means-zero default in the window would
manufacture a majority of clean historical samples inside the very instrument built to count
recurrences across history. Not noise: it poisons the exact statistic, in the direction of "nothing
recurs", and looks like a healthy corpus doing it. A clean run prints `files 0, wrong 0`, so a
graded zero and a missing field stay different things, and the window **excludes** ungradeable
samples by name rather than scoring them clean.

**The rail must never go red.** `release-cut.yml` grades every check-run on main's tip and refuses
to cut on ANY red without reading which red it is. A scheduled workflow run *is* a check-run on
main's tip — so a nightly job reddening on a stale header would re-create the exact v0.19.14 freeze
DIVE-3163 removed, through a new door. `--drift-strict` (exit 8) exists in the script, the workflow
does **not** pass it, and a test arm holds that absence. The verdict lands on a step summary, an
artifact carrying the reports it was computed from, and a long-lived issue rewritten every run —
whose timestamp doubles as the rail's own liveness signal (DIVE-1924 principle: a dead rail leaves
a visibly frozen issue rather than a silence indistinguishable from "nothing recurred").

### Identity is the JOB

`--runner-id` is `-` on exactly the jobs this is about — `full-sweep.yml` passes
`--tier/--shard/--label/--report` and no runner id, and all three DIVE-3163 samples fired on
full-pristine shards. Reports are counted never: two attempts on one box are one box, and counting
them would let a re-run convict a file on its own second opinion. On GitHub-hosted runners every job
gets its own ephemeral VM, so `harvest_run_id`/`harvest_job` **is** the box identity, already
stamped by the harvester.

### Item 4, decided rather than left standing

`--drift-fatal=required` is **kept** as a local re-arm for reproducing the old behaviour by hand,
and it is now **watched**: no workflow may pass it, nor `--drift-strict`. "Wired to no caller" was
the honest state but not a safe one — nothing would have noticed a caller appearing, and an
unwatched second enforcement path beside a new verdict is how two controls start disagreeing.

### Evidence

- `tests/header_drift_window_unit.sh` — **27 arms, 0 failed, 5.0s.** Follows one fact from the
  runner's stdout through a harvested report to a verdict; the negative arms are the load-bearing
  half (a pre-carrier log harvests with NO field, two reports from one job count once, `stale` never
  enters the verdict, under three graded jobs is UNDETERMINED not clean).
- `tests/corpus_tier_budget_unit.sh` — **135 passed, 0 failed**, unchanged by the new prints.
- `shellcheck -S warning` and `actionlint` clean on every changed file.
- **End-to-end against a real 23,560-line CI log** (run `31437553333`): 3 real jobs harvested with
  their real cal fields; all 3 correctly excluded as `(no header_drift_wrong)`; verdict
  `DRIFT UNDETERMINED`. The absence rule is verified against genuine pre-carrier data, not only a
  fixture.

### The new harness is nightly, argued from CI

Read off run `31437553333` on main rather than from a local run (a contended control-plane reading
runs ~45% high):

```
core/pristine        279 harnesses, 306s wall-clock, budget 300s (102%)
core/installed-host  279 harnesses, 385s (128%), confirm re-time 251s (83%)
```

Core is at its cap. CLAUDE.md ranks merge and retire ahead of demotion and neither applies — no
sibling to fold into, and the mechanism is new — but 5s of recurring cost on a tier at 102% would
red somebody else's PR on content they did not change. The cost cannot be engineered away: `WRONG`
is `>=50% AND >=3s` over the claim, so a fixture that provokes one must burn three wall-clock
seconds. That also makes the figure unusually stable across runners. `changed-harnesses` still runs
it at introduction whatever its tier.

### Not verified, stated plainly

The workflow has never executed, so the `gh issue` upsert step and the schedule trigger are unrun.
That is also why the rail lands on an artifact and an issue rather than gating anything.

**Follow-up, raised by main on the gate and deliberately not in this diff:** the verdict lands
durably and a dead rail is visibly dated, but nothing *requires* a human to look. If the existing
digest can pick the issue up, the rail acquires a reader for almost nothing and "durable" becomes
"seen".

Wiki: `community/wiki/the-carrier-for-a-cross-job-verdict-is-the-log-line-not-the-report-field.md`.


---

## The unconditional-print property, OBSERVED IN REAL CI rather than argued from a fixture

Added after the fact, and it is the strongest evidence the second decision above has — it arrived
by accident, out of a failure.

The first CI run of this branch went red for an unrelated reason (two corpus-contract violations in
the new harness, fixed in `0eacc974`). Its log carries this line:

```
harness-budget[core/pristine]: HEADER DRIFT (DIVE-3188) files 0, wrong 0, policy off
```

**That is a clean drift report printed on a run that failed.** Every property the design argument
rests on is visible in one line from a real GitHub-hosted runner rather than from
`tests/header_drift_window_unit.sh`:

- it printed with **zero** drifting files, so `wrong 0` is a GRADED zero and not an absence;
- it printed on a run that **exited non-zero**, so the carrier does not ride on the success path —
  which matters because a stale header is exactly as stale on a run that went red for something
  else (the DIVE-2555 rule the prose block beside it already follows);
- it is byte-shaped the way `tier-cal-harvest.sh` keys on, in the store the harvester actually
  reads.

A fixture can only ever show that the emitter *can* produce the line. This shows the line surviving
a real job, on a real runner, on the unhappy path.

## Correction to the evidence list above, since it names a set I got wrong

The first push of this branch went red on `tests/names_the_tree_contract_unit.sh` and
`tests/harness_rc_corpus_contract_unit.sh` — **four red checks from one root cause**, both against
the harness this PR adds, neither reached by the touched-harness search that found
`corpus_tier_budget_unit.sh`.

The reason generalises and is not "I skipped a step": a search for the touched set finds harnesses
that **reference** what you changed, while corpus-contract harnesses **name no diff and reference
nothing** — they enumerate `tests/` and assert a property of each member. So a diff that ADDS a
harness has two disjoint touched sets and only one is derivable from the diff.

`0eacc974` sources `tests/lib/grading_tree.sh` (DIVE-2211) and carries the `HARNESS-RC` EXIT trap
(DIVE-2692), folded into the existing tempdir cleanup rather than registered beside it — bash keeps
only the LAST trap per signal, so a second registration would have silently replaced the cleanup and
leaked a tempdir per run. **That variant would have passed both contracts**, which is why the form
here is byte-identical to the one 208 harnesses in the corpus already use.

Now verified: `header_drift_window` 27/27, both contracts, plus `harness_tree_guard`,
`harness_graded_union`, `harness_verdict_union`, `pack_cross_harness`, `type_map_registration`, and
`corpus_tier_budget` 135/135.
