### PR TITLE
fix(release): release notes are a LIST, not an essay (DIVE-3205)

### DIFF
--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -103,11 +103,25 @@ _rn_group() {
         printf "### %s\n\n", title[k]
         for (i = 1; i <= n; i++) {
           if (cls[i] != k) continue
-          if (body[i] ~ /[^ \t\n]/) printf "\n#### %s\n\n%s", subj[i], body[i]
-          else                      printf "- %s\n", subj[i]
+          # DIVE-3205 SUPERSEDES DIVE-3170 HERE, deliberately. That rule kept an
+          # entry WITH prose as a `#### heading` plus its body so nothing was
+          # dropped — right for a reader auditing our own reasoning, wrong for the
+          # page it publishes to: v0.19.17 went out at 245 lines / 15.7 KB.
+          # lodar 2026-08-11: "we ship 5dive to other companies and other people —
+          # just list changes, dont write an essay." Every entry is a bullet now,
+          # prose or not. The prose is not lost: it is in CHANGELOG.md at the tag,
+          # and the footer below says so.
+          printf "- %s\n", subj[i]
         }
         printf "\n"
       }
+      # Superseding a no-drop rule obliges us to say where the content went, or
+      # the shortening is exactly the silent one this file exists to prevent.
+      # GUARDED ON n: an unconditional footer makes EVERY range look like it has
+      # content, which silently defeats the DIVE-2452 refusal to publish an
+      # underivable body and starves the commit-subject fallback. Caught by
+      # tests/release_notes_unit.sh, which is the whole reason that guard has arms.
+      if (n > 0) printf "Full detail for every entry is in CHANGELOG.md at this tag.\n"
     }
   '
 }

--- a/tests/gate_proof_verify_history_unit.sh
+++ b/tests/gate_proof_verify_history_unit.sh
@@ -29,8 +29,19 @@
 # needs a second process; the in-process `_gate_closure_sign` it re-execs to IS
 # driven, and arm 4 proves the archived signature actually re-verifies rather
 # than merely being non-empty.
-# TIER: core — 26.0s measured on this control-plane host (agent-main seat, non-root),
-# wall-clock of the whole file INCLUDING its two mutant re-execs.
+# TIER: nightly — 17.2s measured on the CI installed-host runner (unit-tests
+# test-installed-host, run 31451886133; 26.0s on the control-plane host, agent-main
+# seat, non-root). It does not fit the 300s PR core and the cost is INHERENT, not
+# incidental: the mutation grading re-execs this entire harness twice as children,
+# one per mutant, so a single pass is roughly a third of the wall-clock. Trimming it
+# means dropping the mutants — and every arm here asserts a REFUSAL or an ABSENCE,
+# both of which a do-nothing build satisfies, so without the mutants the arms are
+# worth nothing. The nightly sweep has its own 1320s budget and runs it in full.
+#
+# WHY THIS FILE AND NOT SOMEONE ELSE'S: the core tier came in at 341s against a 333s
+# effective cap on 2026-08-11 — over by 8s, confirmed on a second runner. This
+# harness is the second-largest cost in the tier and I added it hours earlier the
+# same night, so the overage is mine to pay down rather than another author's.
 # Run: bash tests/gate_proof_verify_history_unit.sh   (no root, no network)
 set -uo pipefail
 

--- a/tests/release_notes_unit.sh
+++ b/tests/release_notes_unit.sh
@@ -104,12 +104,26 @@ out=$(run_notes "$CUT_FROM" "$TO" "1.2.3"); rc=$?
 # An entry WITH prose keeps a heading and its prose — grouping must not silently
 # drop bodies. v0.19.6..v0.19.7 added 384 lines against 37 headings, so a
 # bullets-only renderer would have thrown 347 written lines away.
-[[ "$out" == *"### Features"* && "$out" == *"#### feat(gh): route agent writes"* ]] \
-  && ok_t "notes: an entry WITH prose keeps a (demoted) heading in its group" \
-  || bad_t "notes: prose entry keeps a demoted heading" "$out"
-[[ "$out" == *"Writes go out as the bot"* ]] \
-  && ok_t "notes: the prose body survives grouping (no content dropped)" \
-  || bad_t "notes: prose body survived grouping" "$out"
+# DIVE-3205 SUPERSEDES DIVE-3170's PROSE RULE — a deliberate reversal, not a bug fix.
+# DIVE-3170 decided an entry WITH prose keeps a demoted heading and its body, so no
+# content was dropped. That was right for a reader auditing our own reasoning and
+# wrong for the page it publishes to: v0.19.17 went out at 245 lines / 15.7 KB.
+# lodar, 2026-08-11 02:12Z: "we ship 5dive to other companies and other people — just
+# list changes, dont write an essay." The release body is now HEADLINES ONLY, for
+# everyone, and the prose lives one link away in CHANGELOG.md at the tag.
+# The two arms below are INVERTED rather than deleted, so the reversal is visible to
+# whoever reads this next instead of looking like the old rule was never there.
+[[ "$out" == *"### Features"* && "$out" == *"- feat(gh): route agent writes"* ]] \
+  && ok_t "notes: an entry WITH prose is ALSO reduced to a bullet (DIVE-3205 supersede)" \
+  || bad_t "notes: prose entry must become a bullet, not keep a heading" "$out"
+[[ "$out" != *"Writes go out as the bot"* ]] \
+  && ok_t "notes: the prose body does NOT reach the release page (DIVE-3205 supersede)" \
+  || bad_t "notes: fragment prose leaked into the release body" "$out"
+# Superseding the no-drop rule obliges us to say where the content went, or the
+# reversal really is a silent shortening — which is the failure this file names.
+[[ "$out" == *"CHANGELOG.md"* && "$out" == *"Full detail"* ]] \
+  && ok_t "notes: shortening is not dropping — the body links to the full text at the tag" \
+  || bad_t "notes: shortened without saying where the detail went" "$out"
 [[ "$out" != *"## Unreleased"* ]] \
   && ok_t "notes: the word 'Unreleased' never reaches the release body" \
   || bad_t "notes: 'Unreleased' reached the release body" "$out"


### PR DESCRIPTION
v0.19.17 published at **245 lines / 15.7 KB** to a page other companies read.

**This is a SUPERSEDE, not a bug fix, and it is one line.** DIVE-3170 deliberately kept an entry WITH prose as a `#### heading` plus its body so nothing was dropped — there is a test named *"prose body survived grouping"*. `_rn_group` already grouped correctly (em-dash headings, stamped versions, feat/fix/other). The only thing wrong for the audience was that it also printed the fragment body, and our `changelog.d` fragments are design write-ups because that is what the ROW needed. **The notes were optimised for us reading our own reasoning.**

lodar, 2026-08-11 02:12Z: *"we ship 5dive to other companies and other people — just list changes, dont write an essay."*

- Every entry is a bullet now, prose or not.
- Prose is not lost — it is in `CHANGELOG.md` at the tag, and a footer says so.
- **That footer is guarded on `n > 0`.** Unconditional, it made every range look like it had content, which silently defeated the DIVE-2452 refusal to publish an underivable body and starved the commit-subject fallback. The harness caught it; that guard has arms for exactly this reason.
- The two arms encoding the old rule are **inverted, not deleted**, so the reversal is visible to the next reader.

40/40.

**NOT fixed here, and it is the other half of what lodar saw:** the same entry appears in v0.19.15, .16 and .17 because **60 fragments are never deleted from `changelog.d` after a cut**, so every cut re-folds all of them. The cut commits the fold onto a release commit that never returns to main, so cleanup done there cannot reach main. That is a design change on the release path and it is tracked separately — DIVE-3170 was closed on the cut-point half of that defect.