### PR TITLE
DIVE-3250: the audit-leak guard must measure what I wrote, not what the file did

### DIFF
--- a/tests/gate_answer_audit_unit.sh
+++ b/tests/gate_answer_audit_unit.sh
@@ -81,9 +81,21 @@ for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
   source "$SRC/$f"
 done
 
-# Suite guard: remember the REAL log's length up front, so the check at the
-# bottom fails if THIS run grew it (same shape as
-# tests/audit_task_store_fence_unit.sh).
+# Suite guard: remember where the REAL log ended before this run, so the check at
+# the bottom can read ONLY the bytes appended during it.
+#
+# DIVE-3250: this used to compare the offset before/after and fail if it MOVED.
+# That measured "did the file grow", not "did I grow it" — and every agent on this
+# box appends to it continuously, so on a live host it was a false red BY
+# CONSTRUCTION (measured: two full gate-corpus sweeps red on a frozen clean tree,
+# 6/6 green standalone on a quiet box; one unrelated line appended mid-run
+# reproduces it exactly). Do NOT restore the byte-equality arm here, and do not
+# copy it from tests/audit_task_store_fence_unit.sh / audit_nonroot_unit.sh /
+# audit_exit_trap_row_unit.sh — they still carry the defective shape (DIVE-3251).
+# The property this suite actually wants is "no row from THIS suite reached the
+# real log", which is an identity filter, not an offset. Same shape as the arm
+# already proven on main in tests/gate_evidence_form_unit.sh, which fences the
+# identical command surface.
 REALLOG=/var/log/5dive/agent-audit.log
 REALLOG_OFFSET=0
 [[ -r "$REALLOG" ]] && REALLOG_OFFSET=$(wc -c <"$REALLOG" 2>/dev/null || echo 0)
@@ -201,14 +213,34 @@ else
   bad_t "a silent fence is the same fail-open shape as no fence" "$(cat "$TMP/off.err")"
 fi
 
-# --- 5. suite guard: the real fleet log must be untouched --------------------
-NOW_OFFSET=0
-[[ -r "$REALLOG" ]] && NOW_OFFSET=$(wc -c <"$REALLOG" 2>/dev/null || echo 0)
-if [[ "$NOW_OFFSET" == "$REALLOG_OFFSET" ]]; then
-  ok_t "this suite wrote nothing to the real fleet audit log"
-else
-  bad_t "suite grew the REAL audit log" "$REALLOG_OFFSET -> $NOW_OFFSET"
+# --- 5. suite guard: no row from THIS suite reached the real fleet log -------
+# Read only the bytes appended since we started, then keep only rows bearing this
+# run's identity (our user + the command surface this suite exercises). Rows from
+# the other agents writing to this box concurrently are EXPECTED and must not red.
+LEAKED=""
+PROBED=0
+if [[ -r "$REALLOG" ]]; then
+  PROBED=1
+  LEAKED=$(tail -c "+$((REALLOG_OFFSET + 1))" "$REALLOG" 2>/dev/null \
+    | jq -rc --arg me "$(id -un 2>/dev/null)" \
+        'select(.user == $me)
+         | select(.cmd | startswith("task answer") or startswith("task need"))
+         | .cmd + " " + ((.args // []) | join(" "))' \
+        2>/dev/null | head -5)
 fi
+if [[ "$PROBED" -eq 0 ]]; then
+  # An unreadable log is not a pass — it is an UNPROBED guard, and it says so
+  # rather than scoring green (same reasoning as gate_lead_clear_stamp_unit.sh).
+  printf 'skip - real fleet log not readable here; leak guard UNPROBED (not a pass)\n'
+elif [[ -z "$LEAKED" ]]; then
+  ok_t "no row from THIS suite reached the real fleet audit log"
+else
+  bad_t "this suite LEAKED fixture rows into the REAL audit log" "$LEAKED"
+fi
+# Report the offset delta as CONTEXT so no reader mistakes this for a proof that
+# the file never moved. It moves; other agents write to it.
+[[ -r "$REALLOG" ]] && printf '# note: real log grew %s bytes during this run (concurrent agents; expected)\n' \
+  "$(( $(wc -c <"$REALLOG" 2>/dev/null || echo 0) - REALLOG_OFFSET ))"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## The defect

`tests/gate_answer_audit_unit.sh` section 5 compared **byte offsets** of the shared
`/var/log/5dive/agent-audit.log` before and after its own run. That file is written
continuously by every agent on this box, so the arm measured *"did the file grow"*,
not *"did I grow it"* — a **false red by construction** on a live multi-agent host.

Reported red in two independent full sweeps of the gate corpus on a frozen clean
tree, while passing 6/6 standalone on a quiet box. That combination is what makes it
read as a flake forever and get re-run rather than fixed.

## The fix

Ported the identity filter **already proven on `main`** in
`tests/gate_evidence_form_unit.sh`, which fences the *identical* command surface:
read only bytes appended since the run started, then keep only rows bearing this
run's user **and** this suite's commands (`task answer` / `task need`).

Note the task body pointed at `tests/gate_card_model_unit.sh` as the reference shape —
that file is **not on `main`** (it lands with DIVE-3228), so `gate_evidence_form_unit.sh`
is the correct in-repo exemplar.

## Grading — 2x3, against a REDIRECTED copy (production telemetry untouched)

| arm | OLD (`main`) | FIXED |
|---|---|---|
| quiet host | pass | pass |
| **unrelated concurrent write** | **FAIL** | **pass** |
| **real fixture leak** | FAIL | **FAIL** |

Row 2 reproduces the defect and shows it cured. **Row 3 is the one that matters**: an
identity filter matching nothing would pass everything, so this is only worth its bytes
because `FIXED/LEAK` still reds.

An unreadable log now prints `UNPROBED` and scores **11 passed**, not a silent 12th green.

## Scope found beyond the task

The task asked me to check one sibling. Scanning all 10 harnesses that reference the
real log, **four** carried the defective offset shape and **two** already used the correct
identity shape:

- defective: `gate_answer_audit_unit` (this PR), `audit_task_store_fence_unit`,
  `audit_nonroot_unit`, `audit_exit_trap_row_unit`
- already correct: `gate_evidence_form_unit`, `gate_lead_clear_stamp_unit`

The other three are filed as **DIVE-3251** rather than bundled here — they need the same
per-suite command-surface judgement and their own mutation grading, which is not mechanical.

## Risk

Test-only. `5dive-cli` does not auto-deploy. `changed-harnesses` CI will run this harness
because the diff touches it.
