### PR TITLE
fix(test): refuse sudo when PAM restores FIVE env (DIVE-3096)

### DIFF
--- a/changelog.d/DIVE-3096.md
+++ b/changelog.d/DIVE-3096.md
@@ -1,0 +1,15 @@
+## Unreleased — fix(test): refuse sudo when PAM restores host `FIVE_*` policy (DIVE-3096)
+
+`tests/lib/env_isolation.sh` cleared inherited `FIVE_*` variables in the harness shell, but
+`sudo` opened a PAM session that read `/etc/environment` and restored them before privileged
+code ran. A harness could therefore announce that it was isolated while grading host policy.
+
+The shared isolation seam now detects the exact configuration pair — a host `FIVE_*` entry
+plus an active sudo `pam_env` rule that reads `/etc/environment` — and refuses the sudo call
+before privileged code executes. It does not edit host policy or sweep customer boxes
+(DIVE-3092), and it does not rewrite sudo argv, which would break exact-path sudoers grants.
+
+`env_isolation_sudo_unit.sh` carries both positive controls: a clean environment with active
+`pam_env` forwards the original argv byte-for-byte, and a host knob with PAM pointed at a
+different file also passes. Only the conjunction refuses. Disabling the real guard installation
+turns the two DIVE-3096 arms red while both controls stay green.

--- a/tests/env_isolation_sudo_unit.sh
+++ b/tests/env_isolation_sudo_unit.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# TIER: core — DIVE-3096's sudo/PAM boundary, no root or network.
+#
+# env_isolation.sh clears caller FIVE_* values, but sudo opens a PAM session
+# after that clearing.  When sudo's pam_env rule reads /etc/environment, a host
+# FIVE_* value comes back.  This harness grades the conjunction, not either
+# input alone, and carries both green-side controls so "refuse every sudo" cannot
+# pass.  It also pins exact argv forwarding on the clean side: inserting `env -u`
+# would change the command matched by exact-path sudoers grants.
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${tmp:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+LIB="tests/lib/env_isolation.sh"
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+tmp=$(mktemp -d /tmp/env-iso-sudo.XXXXXX)
+mkdir -p "$tmp/bin"
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "$SUDO_LOG"\n' > "$tmp/bin/sudo"
+chmod +x "$tmp/bin/sudo"
+printf 'session required pam_env.so readenv=1 user_readenv=0\n' > "$tmp/pam-active"
+printf 'session required pam_env.so readenv=1 envfile=/etc/default/locale\n' > "$tmp/pam-other"
+printf 'FIVE_TEST_HOST_POLICY=1\n' > "$tmp/environment-dirty"
+: > "$tmp/environment-clean"
+
+# Each arm gets a fresh shell because installing the guard deliberately defines
+# `sudo` for the remainder of that harness process.
+SUDO_LOG="$tmp/clean.log" PATH="$tmp/bin:$PATH" \
+  bash -c '. '"$LIB"'; unset -f sudo 2>/dev/null || true; _five_env_sudo_guard_install '"$tmp"'/environment-clean '"$tmp"'/pam-active; sudo -n /usr/local/bin/5dive whoami --json' \
+  >/dev/null 2>"$tmp/clean.err"; rc=$?
+[[ $rc -eq 0 && "$(cat "$tmp/clean.log")" == '-n /usr/local/bin/5dive whoami --json' ]] \
+  && ok_t 'T1 CONTROL: active pam_env plus a CLEAN environment forwards exact sudo argv' \
+  || bad_t 'T1 clean side did not reach sudo unchanged' "rc=$rc log=$(cat "$tmp/clean.log" 2>/dev/null) err=$(cat "$tmp/clean.err")"
+
+SUDO_LOG="$tmp/other.log" PATH="$tmp/bin:$PATH" \
+  bash -c '. '"$LIB"'; unset -f sudo 2>/dev/null || true; _five_env_sudo_guard_install '"$tmp"'/environment-dirty '"$tmp"'/pam-other; sudo -n true' \
+  >/dev/null 2>"$tmp/other.err"; rc=$?
+[[ $rc -eq 0 && "$(cat "$tmp/other.log")" == '-n true' ]] \
+  && ok_t 'T2 CONTROL: a host knob is not blamed when sudo PAM reads a DIFFERENT file' \
+  || bad_t 'T2 inactive predicate was refused' "rc=$rc log=$(cat "$tmp/other.log" 2>/dev/null) err=$(cat "$tmp/other.err")"
+
+SUDO_LOG="$tmp/dirty.log" PATH="$tmp/bin:$PATH" \
+  bash -c '. '"$LIB"'; unset -f sudo 2>/dev/null || true; _five_env_sudo_guard_install '"$tmp"'/environment-dirty '"$tmp"'/pam-active; sudo -n true' \
+  >/dev/null 2>"$tmp/dirty.err"; rc=$?
+[[ $rc -eq 125 && ! -s "$tmp/dirty.log" ]] \
+  && ok_t 'T3 ARM: pam_env plus a host FIVE_* knob refuses before privileged code runs' \
+  || bad_t 'T3 sudo boundary stayed reachable' "rc=$rc log=$(cat "$tmp/dirty.log" 2>/dev/null) err=$(cat "$tmp/dirty.err")"
+err=$(cat "$tmp/dirty.err")
+[[ "$err" == *'REFUSED sudo'* && "$err" == *'FIVE_TEST_HOST_POLICY'* \
+   && "$err" == *'after this harness cleared FIVE_'* && "$err" == *'DIVE-3092'* ]] \
+  && ok_t 'T4 refusal names the restored knob, the boundary, and the no-sweep decision' \
+  || bad_t 'T4 refusal does not explain the actual predicate' "err=$err"
+
+grep -qx '_five_env_sudo_guard_install' "$LIB" \
+  && ok_t 'T5 SEAM: sourcing env_isolation installs the sudo boundary guard' \
+  || bad_t 'T5 guard helper exists but is not installed at the shared seam'
+
+# A shell function cannot intercept an explicitly bypassed lookup. The shared
+# seam covers the current sudo corpus because no harness uses command sudo,
+# env sudo, or an absolute sudo path; pin that condition rather than assuming it.
+bypass=$(grep -RInE --include='*.sh' \
+  '(^|[;&|()][[:space:]]*)(command[[:space:]]+sudo|/usr(/local)?/bin/sudo|/bin/sudo|env([[:space:]]+-[^[:space:]]+)*[[:space:]]+sudo)([[:space:]]|$)' \
+  tests 2>/dev/null || true)
+[[ -z "$bypass" ]] \
+  && ok_t 'T6 SCOPE: no harness bypasses function-resolved sudo' \
+  || bad_t 'T6 a sudo caller bypasses the shared isolation guard' "$bypass"
+
+echo '-----'
+printf 'env_isolation_sudo_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/lib/env_isolation.sh
+++ b/tests/lib/env_isolation.sh
@@ -101,3 +101,59 @@ _five_env_isolate() {
   return 0
 }
 _five_env_isolate
+
+# DIVE-3096: `unset` above only governs THIS shell.  sudo opens a PAM session,
+# and an active pam_env rule reads /etc/environment after that unset; a host
+# FIVE_* knob therefore comes back in the privileged command.  Do not "fix" the
+# host by sweeping or editing /etc/environment (DIVE-3092 forbids that fleet
+# shape).  Until sudo can carry an unset through an exact-path sudoers grant,
+# fail at the harness boundary instead: a test must not silently grade policy
+# restored on the other side of privilege escalation.
+_five_env_file_knobs() {
+  local file="$1" line name names=""
+  [[ -r "$file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    if [[ "$line" =~ ^[[:space:]]*(FIVE_[A-Za-z0-9_]*)[[:space:]]*= ]]; then
+      name="${BASH_REMATCH[1]}"
+      case " $names " in *" $name "*) ;; *) names="${names:+$names }$name" ;; esac
+    fi
+  done < "$file"
+  printf '%s' "$names"
+}
+
+_five_env_sudo_pam_reads_etc_environment() {
+  local file="$1" line
+  [[ -r "$file" ]] || return 1
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%%#*}"
+    [[ "$line" =~ ^[[:space:]]*session[[:space:]].*pam_env\.so([[:space:]]|$) ]] || continue
+    [[ "$line" =~ (^|[[:space:]])readenv=0([[:space:]]|$) ]] && continue
+    # pam_env's default file is /etc/environment.  An explicit different
+    # envfile does not prove that this file is read; an explicit default does.
+    if [[ "$line" != *"envfile="* || "$line" =~ envfile=[\"\']?/etc/environment([\"\']?|[[:space:]]) ]]; then
+      return 0
+    fi
+  done < "$file"
+  return 1
+}
+
+_five_env_sudo_guard_install() {
+  local env_file="${1:-/etc/environment}" pam_file="${2:-/etc/pam.d/sudo}" knobs
+  type -P sudo >/dev/null 2>&1 || return 0
+  knobs=$(_five_env_file_knobs "$env_file")
+  [[ -n "$knobs" ]] || return 0
+  _five_env_sudo_pam_reads_etc_environment "$pam_file" || return 0
+
+  # Global by necessity: shell functions have dynamic rather than lexical
+  # scope, and the wrapper runs after this installer returns.
+  _5D_ENV_ISOLATION_SUDO_RESTORED="$knobs"
+  sudo() {
+    printf 'env isolation: REFUSED sudo because PAM restores host knob(s) %s from /etc/environment after this harness cleared FIVE_* (DIVE-3096). Host policy was NOT changed (DIVE-3092); run on a clean test host or neutralise the knob after the PAM boundary with an independently guarded arm.\n' \
+      "${_5D_ENV_ISOLATION_SUDO_RESTORED:-unknown FIVE_* knob}" >&2
+    return 125
+  }
+  return 0
+}
+
+_five_env_sudo_guard_install


### PR DESCRIPTION
Relayed push: authored by codex, pushed by main because that seat has no direct HTTPS route. Immutable SHA `d63891d614b2a576f8f61b31f0457d5bd9e3f0aa`, based on `origin/main@3d34cf8`.

## The defect

`_five_env_isolate` unsets `FIVE_*` for the harness shell. `sudo` then opens a PAM session, and an active `pam_env` rule reads `/etc/environment` **after** that unset — so a host knob comes back inside the privileged command. A test can therefore grade policy that was restored on the other side of the privilege boundary, and report green.

Live instance on this host: `/etc/environment` carries `FIVE_GROK_UNFREEZE_VERIFIED=1` (DIVE-2910), and root `doctor` sees it.

## Why it fails closed instead of fixing the host

DIVE-3092 forbids the fleet-wide env sweep, so the host is not touched. The guard installs **only** on the exact conjunction — a `FIVE_*` knob present in the env file **and** a `pam_env` line that reads that file — and then shadows `sudo` with a function returning **rc 125** and a message naming the restored knob. Scoped to `tests/`; no source and no host policy changes.

`readenv=0` and an explicit non-default `envfile=` are both handled: an explicit different envfile does not prove the default file is read, so it does not arm.

## Evidence

- new core harness **6/0**
- disabling the real guard install gives **4/2**, with both positive controls still green — the arms grade the guard, not their own scaffolding
- 3 files, +145 lines, all under `tests/` and `changelog.d/`

## Review note from the relay

I read the diff before pushing. The one thing worth a reviewer's attention is that the `sudo` shadow is a **global shell function** — deliberately, since it must outlive the installer that defines it, and the alternative is silently grading restored policy. It only exists in a harness process where the conjunction was detected.

Merge gate stays with main. codex explicitly did not merge.
