### PR TITLE
feat(task): set-parent, and the bare-number parent guard on task add (DIVE-3275)

### DIFF
--- a/changelog.d/DIVE-3275.md
+++ b/changelog.d/DIVE-3275.md
@@ -1,0 +1,104 @@
+## Unreleased — feat(task): `set-parent`, and the bare-number parent guard on `task add` (DIVE-3275)
+
+`parent_id` was **INSERT-only**: `task add --parent=` was the sole moment a parent
+edge could ever be written, so a row filed without it could never be attached
+afterwards and the relationship survived only as prose in a body.
+
+That already cost a verification. `DIVE-3138` was split out of `DIVE-2895` with the
+words *"split out of DIVE-2895 items (1) and (2)"* but filed unparented, so
+`task show DIVE-2895` rendered no edge to it and the maker closing `DIVE-2895`
+asserted an item was blocked on work `DIVE-3138` had finished 2h36m earlier. The
+fix list said *"set parent_id on DIVE-3138"* — and no verb could.
+
+```
+5dive task set-parent <id|DIVE-N> <DIVE-N|none>      # 'none' detaches
+```
+
+### A CLOSED row CAN be re-parented — deliberately not `set-title`'s refusal
+
+A close freezes the record of what was **asserted** — body and result, the text a
+later reader quotes back. `parent_id` is not an assertion by the closer; it is a
+navigation edge, and its **absence** is the entire defect: `DIVE-3138` was already
+closed when its missing edge produced the false premise. A blanket closed-row
+refusal would have shipped a verb that cannot fix the case that motivated it.
+
+Audited like `set-title` (prior parent + new parent + actor), and it does not
+reopen the row, touch `done_at`, or bump `updated_at` — the write is to the graph,
+and nothing about the closed record's own timeline changes.
+
+### The bare-number guard, which `task add --parent` does not have
+
+`resolve_task_id()` branches on argument **shape**: `^[0-9]+$` is the global row
+`id`, `^[A-Za-z]+-[0-9]+$` is the `ident`. The two number spaces have diverged —
+measured on the live store: **`DIVE-2895` is row id 3082, and row id 2895 is
+`DIVE-2708`**, a cancelled row from another month. A bare number is therefore a
+valid id naming the wrong row with no error at all, which is exactly how
+`DIVE-3273` was filed under the wrong parent.
+
+So a bare number whose row carries a **different** ident number is refused, naming
+both the row it resolved to and the one the caller probably meant:
+
+```
+$ 5dive task set-parent DIVE-3138 2895
+error: '2895' as the parent is the global row id, which resolves to DIVE-2708
+("Daily lodar personal-X take …") — not to an ident numbered 2895. … re-run
+naming the row you mean: … DIVE-2708 (or DIVE-2895 if that is what you meant).
+```
+
+An *agreeing* bare number is accepted with a loud warning; the ident form is the
+quiet path, so the warning never becomes background noise. Applied to **both**
+arguments — a mis-resolved child re-parents the wrong row, the identical failure.
+
+The previous remedy for this was a written rule (*"always `--parent=DIVE-####`"*),
+and a rule is not a guard.
+
+**The same guard is now on `task add --parent`, the surface that actually
+misfired** — folded into this row rather than filed separately (main's call): it
+is one function away on the same surface, and a separate ident would have bought
+a second review of the same code. `task add --parent=2895` now refuses instead of
+silently filing under `DIVE-2708`, and refuses **before the INSERT**, since a row
+created under the wrong parent is the damage. The guard itself lives in
+`src/lib/tasks_db.sh` beside `resolve_task_id()`, because it is a statement about
+that function's two number spaces rather than about any one verb — so its refusal
+names the argument (`--parent`, `the parent`, `the task to re-parent`) instead of
+naming a verb. Both help lines now read `--parent=<DIVE-N>`; `--parent=<id>` is
+what made the bare form look intended.
+
+### The receipt prints the parent's child list
+
+A parent edge is verified by the **reader's** view, not by the writer's exit code.
+`set-parent` therefore prints the parent's resulting subtask list, so the command
+is self-verifying and the follow-up `task show <parent>` that everyone forgets is
+gone. On a detach it prints the **former** parent's list — that is where the
+absence has to be visible.
+
+### Also refused
+
+`parent_id INTEGER REFERENCES tasks(id) ON DELETE CASCADE`, so a wrong parent does
+not merely mis-render, it arms the child's deletion. Refused: self-parenting; a
+cycle (the target's ancestor chain is walked, **bounded at 64 hops**, so a
+pre-existing cycle in the store refuses rather than hangs); a nonexistent parent;
+and a recurring **template**, which is top-level by construction — the same thing
+`task add` already says when it refuses `--recurring` with `--parent`.
+
+### Tests
+
+New `tests/task_set_parent_unit.sh` — 57 arms, no root, no network, core tier.
+The arms grade the decisions rather than the `UPDATE`: **A1** re-parents a row that
+is already `done` and asserts it did not reopen; **C5** plants a pre-existing cycle
+by raw sqlite write and asserts the walk refuses instead of spinning; **D1/D2**
+reproduce the id/ident divergence with explicit row ids and assert the refusal on
+both arguments; **D3** asserts an agreeing bare number still warns while **D4**
+asserts the ident form warns about nothing; **F1** grades the acceptance shape —
+`task show <parent>` renders the edge — because that view is the whole point; and
+**G1d** asserts the refused `task add` created **no row at all**.
+
+Four mutation controls, all killed: copying `set-title`'s closed-row refusal reds
+section A; neutering the shared bare-number guard reds **both** section D
+(`set-parent`) and section G (`task add`), which is what proves it is one guard and
+not two; removing the cycle walk reds section C; and reverting the add path to a
+bare `resolve_task_id` reds section G alone.
+
+Knowledge compiled into the page this row came from:
+`community/wiki/a-split-out-row-with-no-parent-link-is-invisible-to-the-row-it-came-from.md`
+(Delta 2026-08-12), plus an index line in its new reader's words.

--- a/src/lib/tasks_db.sh
+++ b/src/lib/tasks_db.sh
@@ -2154,6 +2154,44 @@ resolve_task_id() {
   RESOLVED_TASK_IDENT=$(db "SELECT ident FROM tasks WHERE id=${found};")
 }
 
+# Resolve a task ref for a PARENT EDGE, refusing a bare number whose row carries
+# a different ident number. DIVE-3275. Lives beside resolve_task_id() because it
+# is a statement about that function's two number spaces, not about any one verb.
+#
+# resolve_task_id() branches on argument SHAPE: `^[0-9]+$` is the global row id,
+# `^[A-Za-z]+-[0-9]+$` is the ident. THE TWO SPACES HAVE DIVERGED — measured on
+# the live store 2026-08-12: DIVE-2895 is row id 3082, and row id 2895 is
+# DIVE-2708, a cancelled row from another month. So a bare number is a VALID id
+# naming the WRONG row, with no error: that is how DIVE-3273 was filed under
+# DIVE-2708, and `task add`'s own `--parent=<id>` help text is what made the bare
+# form look intended.
+#
+# Why this guard is stricter than the rest of the CLI's ref handling, rather than
+# resolve_task_id() itself being tightened: a wrong ref elsewhere shows you the
+# wrong row and you notice. A wrong PARENT is invisible (the edge renders on a
+# row nobody is looking at) and `parent_id INTEGER REFERENCES tasks(id) ON DELETE
+# CASCADE` silently arms the child's deletion with it. Tightening every caller of
+# resolve_task_id() would be a much larger behaviour change for cases that are
+# self-revealing.
+#
+# <role> names the argument in the refusal ("the parent", "the task to re-parent")
+# so a two-argument verb says WHICH one was wrong.
+_task_resolve_ref_strict() {
+  local ref="$1" role="$2"
+  resolve_task_id "$ref"
+  [[ "$ref" =~ ^[0-9]+$ ]] || return 0   # the ident form is the quiet path
+  local title; title=$(db "SELECT COALESCE(title,'') FROM tasks WHERE id=${RESOLVED_TASK_ID};")
+  local ident_number="${RESOLVED_TASK_IDENT##*-}"
+  if [[ "$ident_number" != "$ref" ]]; then
+    fail "$E_VALIDATION" "'$ref' as $role is the global row id, which resolves to ${RESOLVED_TASK_IDENT} (\"${title}\") — not to an ident numbered $ref. The two number spaces diverged; name the row you mean by IDENT: ${RESOLVED_TASK_IDENT} (or DIVE-${ref}, if that is what you meant)."
+  fi
+  # It agrees TODAY. That is a coincidence of this row's history, not a property
+  # of the argument form, so it still warns — and the ident form warns about
+  # nothing, which is what keeps this warning worth reading.
+  warn "$role was given as the bare number $ref, which resolved to ${RESOLVED_TASK_IDENT} (\"${title}\"). Prefer the ident form — a bare number is a global row id, not an ident."
+  return 0
+}
+
 # Resolve a known numeric row id to its display ident (DIVE-484). Used by call
 # sites that already hold the numeric id (params, subqueries) and must render a
 # user-facing label without assuming the DIVE-<id> shortcut.

--- a/src/task/crud.sh
+++ b/src/task/crud.sh
@@ -142,7 +142,15 @@ cmd_task_add() {
   fi
   local parent_sql="NULL"
   if [[ -n "$parent" ]]; then
-    resolve_task_id "$parent"; parent_sql="$RESOLVED_TASK_ID"
+    # DIVE-3275: the SAME guard `task set-parent` carries, on the surface that
+    # actually misfired. `--parent=2895` filed DIVE-3273 under DIVE-2708 with no
+    # error at all — a valid global row id naming a row from another month —
+    # because the id and ident number spaces have diverged and this line took the
+    # number on faith. The remedy shipped at the time was a written rule ("always
+    # --parent=DIVE-####"); a rule is not a guard, and the wrong-row edge is
+    # invisible by construction, since it renders on a row nobody is looking at.
+    # See _task_resolve_ref_strict (src/lib/tasks_db.sh) for the measurement.
+    _task_resolve_ref_strict "$parent" "--parent"; parent_sql="$RESOLVED_TASK_ID"
   fi
   # DIVE-2449: an explicit --parent is the graph edge, so it suppresses this
   # advisory regardless of prose. Without one, measure the narrow numbered

--- a/src/task/dispatch.sh
+++ b/src/task/dispatch.sh
@@ -15,7 +15,7 @@ _task_usage() {
 5dive task — shared task queue (sqlite at ${STATE_DIR}/tasks/tasks.db)
 
   init                                          one-time root bootstrap of the store
-  add <title...> [--body=<text>|--body-file=<path>] [--from=<who>] [--parent=<id>]
+  add <title...> [--body=<text>|--body-file=<path>] [--from=<who>] [--parent=<DIVE-N>]
       [--priority=low|medium|high|urgent] [--branch=<name>]
       [--assignee=<agent|role:<r>|charter:<kw>>]
       [--recurring="<5-field cron>"] [--accept=<criteria>|--accept-file=<path>] [--verify=<cmd>]
@@ -28,6 +28,10 @@ _task_usage() {
   set-body <id> <text...>|--file=<path> [--append]   replace the body, or append to it
   set-title <id> <text...>                      overwrite the title (audited; refused once closed)
   set-branch <id> <branch>                      bind the row to a git branch
+  set-parent <id> <DIVE-N|none>                 attach the row to its parent (audited; works on a
+                                                closed row; 'none' detaches). Name the parent by
+                                                IDENT — a bare number is the global row id, which
+                                                is NOT the ident number
   wip-cap-install [--relane=<lane>]             snapshot each lane's actionable count as its
                                                 frozen WIP ceiling (deliberate, once)
   set-budget <id> <tokens|\$cost|none>           raise/lower the token budget, or 'none' to exempt
@@ -223,6 +227,7 @@ cmd_task() {
     set-branch)      cmd_task_set_branch "$@" ;;
     set-body)        cmd_task_set_body "$@" ;;
     set-title)       cmd_task_set_title "$@" ;;
+    set-parent)      cmd_task_set_parent "$@" ;;   # DIVE-3275 re-parent a filed row
     set-budget)      cmd_task_set_budget "$@" ;;
     set-overlap)     cmd_task_set_overlap "$@" ;;
     wip-cap-install) cmd_task_wip_cap_install "$@" ;;
@@ -598,6 +603,144 @@ cmd_task_set_title() {
   ok "$ident retitled: \"$prior\" -> \"$text\"" \
      '{ident:$id, changed:true, prior_title:$p, title:$t}' \
      --arg id "$ident" --arg p "$prior" --arg t "$text"
+}
+
+# ---------------------------------------------------------------------------
+# `5dive task set-parent <id|DIVE-N> <DIVE-N|id|none>` — DIVE-3275.
+#
+# `parent_id` was INSERT-only: `task add --parent=<id>` was the sole moment a
+# parent edge could ever be written, so a row split out of another one and filed
+# without `--parent` could never be attached afterwards. The relationship then
+# survives only as prose in a body, and `task show <parent>` renders no edge to
+# it. That already cost a real verification: DIVE-3138 was split out of DIVE-2895
+# in words but filed unparented, so the maker closing DIVE-2895 asserted an item
+# was blocked on work DIVE-3138 had finished 2h36m earlier. The fix list said
+# "set parent_id on DIVE-3138" and there was no verb that could.
+# (community/wiki/a-split-out-row-with-no-parent-link-is-invisible-to-the-row-it-came-from.md)
+#
+# A CLOSED ROW CAN BE RE-PARENTED — deliberately NOT set-title's refusal (spec
+# decided by olivia, 2026-08-12). Closing freezes the record of what was
+# ASSERTED — body and result, the text a later reader quotes back. `parent_id` is
+# not an assertion by the closer; it is a navigation edge, and its ABSENCE is the
+# entire defect: DIVE-3138 was already closed when its missing edge produced the
+# false premise. A blanket closed-row refusal would ship a verb that cannot fix
+# the case that motivated it. So: audited like set-title, and it does not reopen
+# the row, touch `done_at`, or bump `updated_at` — the write is to the graph, and
+# nothing about the closed record's own timeline changes.
+cmd_task_set_parent() {
+  tasks_db_init
+  local task="" parent="" parent_from_flag=0
+  local -a positional=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --parent=*)  parent="${1#*=}"; parent_from_flag=1 ;;
+      --)          shift; positional+=("$@"); break ;;
+      -*)          fail "$E_USAGE" "unknown flag: $1" ;;
+      *)           positional+=("$1") ;;
+    esac
+    shift
+  done
+  task="${positional[0]:-}"
+  if (( parent_from_flag )); then
+    [[ ${#positional[@]} -le 1 ]] \
+      || fail "$E_USAGE" "--parent conflicts with the positional parent — name the parent exactly once"
+  else
+    parent="${positional[1]:-}"
+  fi
+  [[ -n "$task" && -n "$parent" ]] \
+    || fail "$E_USAGE" "usage: 5dive task set-parent <id|DIVE-N> <DIVE-N|none>   (none detaches)"
+  [[ ${#positional[@]} -le 2 ]] \
+    || fail "$E_USAGE" "usage: 5dive task set-parent <id|DIVE-N> <DIVE-N|none>   (got ${#positional[@]} positional arguments)"
+
+  _task_resolve_ref_strict "$task" "the task to re-parent"
+  local id="$RESOLVED_TASK_ID" ident="$RESOLVED_TASK_IDENT"
+
+  # A recurring TEMPLATE has no parent by construction — `task add` already
+  # refuses `--recurring` with `--parent` because instances are top-level. Say
+  # the same thing here rather than letting the graph disagree with the filer.
+  local kind; kind=$(db "SELECT COALESCE(kind,'standard') FROM tasks WHERE id=${id};")
+  [[ "$kind" != "recurring" ]] \
+    || fail "$E_VALIDATION" "$ident is a recurring TEMPLATE — templates are top-level by construction (task add refuses --recurring with --parent for the same reason)"
+
+  local prior_pid prior_ident
+  prior_pid=$(db "SELECT COALESCE(parent_id,'') FROM tasks WHERE id=${id};")
+  prior_ident="none"; [[ -n "$prior_pid" ]] && prior_ident=$(ident_of "$prior_pid")
+
+  local new_pid="" new_ident="none"
+  if [[ "${parent,,}" != "none" ]]; then
+    _task_resolve_ref_strict "$parent" "the parent"
+    new_pid="$RESOLVED_TASK_ID"; new_ident="$RESOLVED_TASK_IDENT"
+    # `parent_id INTEGER REFERENCES tasks(id) ON DELETE CASCADE` — a row that is
+    # its own parent is not merely odd, it is a cycle of length one, and every
+    # tree walker here assumes acyclicity.
+    [[ "$new_pid" != "$id" ]] \
+      || fail "$E_VALIDATION" "$ident cannot be its own parent"
+    _task_parent_cycle_check "$id" "$new_pid" "$ident" "$new_ident"
+  fi
+
+  if [[ "${prior_pid:-}" == "${new_pid:-}" ]]; then
+    _task_print_children "${new_pid:-$prior_pid}" "$new_ident"
+    ok "$ident parent unchanged (already $new_ident)" \
+       '{ident:$id, changed:false, parent:$p, children:($c|split(",")|map(select(length>0)))}' \
+       --arg id "$ident" --arg p "$new_ident" --arg c "$_TASK_CHILDREN_CSV"
+    return 0
+  fi
+
+  local set_sql="NULL"; [[ -n "$new_pid" ]] && set_sql="$new_pid"
+  db "UPDATE tasks SET parent_id=${set_sql} WHERE id=${id};"
+  # The PRIOR parent is the payload: without it the audit row records that a
+  # re-parent happened and destroys the only copy of the edge it replaced.
+  _task_store_audit_log "task set-parent" "ok" 0 -- \
+    "task=$ident" "actor=$(task_actor)" "prior=$prior_ident" "new=$new_ident" || true
+
+  # A parent edge is verified by the READER's view, not by the writer's exit code
+  # — that is the whole lesson of the wiki page above. Printing the parent's
+  # resulting child list makes the command self-verifying and removes the
+  # follow-up `task show <parent>` everyone forgets. On a detach we print the
+  # FORMER parent's list, which is where the absence has to be visible.
+  local shown_pid="$new_pid" shown_ident="$new_ident"
+  [[ -n "$shown_pid" ]] || { shown_pid="$prior_pid"; shown_ident="$prior_ident"; }
+  _task_print_children "$shown_pid" "$shown_ident"
+  ok "$ident parent $prior_ident -> $new_ident" \
+     '{ident:$id, changed:true, prior_parent:$pp, parent:$p, children:($c|split(",")|map(select(length>0)))}' \
+     --arg id "$ident" --arg pp "$prior_ident" --arg p "$new_ident" \
+     --arg c "$_TASK_CHILDREN_CSV"
+}
+
+# Refuse a cycle: walk the prospective parent's ancestor chain and refuse if the
+# child appears in it. The walk is BOUNDED — a pre-existing cycle in the store
+# (from a raw sqlite write, say) must make this command refuse, never hang.
+_task_parent_cycle_check() {
+  local child_id="$1" walk="$2" child_ident="$3" parent_ident="$4"
+  local hops=0 seen=""
+  while [[ -n "$walk" ]]; do
+    if (( ++hops > 64 )); then
+      fail "$E_VALIDATION" "ancestor chain above $parent_ident is deeper than 64 rows or already cyclic — refusing rather than walking it further (chain seen: ${seen#,})"
+    fi
+    seen+=",$(ident_of "$walk")"
+    walk=$(db "SELECT COALESCE(parent_id,'') FROM tasks WHERE id=${walk};")
+    [[ "$walk" != "$child_id" ]] \
+      || fail "$E_VALIDATION" "that would make a cycle: $child_ident is already an ancestor of $parent_ident (chain: ${seen#,})"
+  done
+  return 0
+}
+
+# Render the parent's children, and expose them as a CSV for the --json arm.
+_TASK_CHILDREN_CSV=""
+_task_print_children() {
+  local pid="$1" pident="$2" rows=""
+  _TASK_CHILDREN_CSV=""
+  [[ -n "$pid" ]] || return 0
+  rows=$(db "SELECT ident||'  ['||status||']  '||title FROM tasks WHERE parent_id=${pid} ORDER BY id;")
+  _TASK_CHILDREN_CSV=$(db "SELECT group_concat(ident, ',') FROM (SELECT ident FROM tasks WHERE parent_id=${pid} ORDER BY id);")
+  (( JSON_MODE )) && return 0
+  echo "subtasks of ${pident} now:"
+  if [[ -n "$rows" ]]; then
+    printf '%s\n' "$rows" | indent2
+  else
+    printf '%s\n' "(none)" | indent2
+  fi
+  return 0
 }
 
 cmd_task_init() {

--- a/tests/task_set_parent_unit.sh
+++ b/tests/task_set_parent_unit.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# TIER: core
+# DIVE-3275 — `task set-parent`.
+#
+# `parent_id` was INSERT-only: `task add --parent=` was the only moment a parent
+# edge could ever be written, so a row split out of another and filed without it
+# could never be attached. DIVE-3138 was split out of DIVE-2895 in prose, filed
+# unparented, and `task show DIVE-2895` therefore rendered no edge — so the maker
+# closing DIVE-2895 asserted an item was blocked on work DIVE-3138 had finished
+# 2h36m earlier. The fix list said "set parent_id on DIVE-3138" and no verb could.
+#
+# Run: bash tests/task_set_parent_unit.sh   (no root, no network)
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/task-set-parent.XXXXXX)"
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_agent.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=0
+mkdir -p "$TASKS_DIR"; set +e
+tasks_db_init; _tasks_db_migrate
+cmd_send() { return 0; }; audit_log() { return 0; }
+AUDIT_ROWS="$TMP/audit_rows"; : >"$AUDIT_ROWS"
+_task_store_audit_log() { printf '%s\n' "$*" >>"$AUDIT_ROWS"; return 0; }
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+eq_t()  { if [[ "$2" == "$3" ]]; then ok_t "$1"; else bad_t "$1" "want [$3] got [$2]"; fi; }
+has_t() { if [[ "$2" == *"$3"* ]]; then ok_t "$1"; else bad_t "$1" "[$2] lacks [$3]"; fi; }
+no_t()  { if [[ "$2" != *"$3"* ]]; then ok_t "$1"; else bad_t "$1" "[$2] unexpectedly contains [$3]"; fi; }
+# The parent edge, read back as the PARENT's ident — the reader's view, which is
+# the only view that mattered on DIVE-2895.
+parent_of() { db "SELECT COALESCE((SELECT p.ident FROM tasks p WHERE p.id=c.parent_id),'∅')
+                  FROM tasks c WHERE c.ident='$1';"; }
+rowid()  { db "SELECT id FROM tasks WHERE ident='$1';"; }
+# Seed with an explicit row id so the id/ident divergence this verb guards
+# against can be reproduced exactly.
+seed()   { db "INSERT INTO tasks (id,ident,title,priority,assignee,created_by,kind,status)
+                VALUES (${4:-NULL},'$1','${2:-a row}','medium','dev','main','standard','${3:-todo}');"; }
+
+# ── A. the motivating case: attach a row that is ALREADY CLOSED ───────────────
+# Deliberately not set-title's refusal. A close freezes what was ASSERTED (body,
+# result); parent_id is a navigation edge, and its ABSENCE is the defect — the
+# row that needed this verb was closed when its missing edge produced the false
+# premise. A blanket closed-row refusal would ship a verb that cannot fix the
+# case that motivated it.
+seed T-100 "the epic"                  todo
+seed T-101 "split out of T-100, closed" done
+OUT=$( (cmd_task_set_parent T-101 T-100) 2>&1 ); RC=$?
+eq_t "A1: a CLOSED row can be re-parented (rc 0)" "$RC" "0"
+eq_t "A1b: ... and the edge really landed" "$(parent_of T-101)" "T-100"
+eq_t "A1c: ... without reopening it" "$(db "SELECT status FROM tasks WHERE ident='T-101';")" "done"
+# Self-verifying: the writer's exit code is not evidence of a parent edge; the
+# reader's view is. That is the wiki lesson this verb is built from.
+has_t "A2: the receipt PRINTS the parent's resulting child list" "$OUT" "subtasks of T-100 now:"
+has_t "A2b: ... and the child is in it" "$OUT" "T-101"
+has_t "A3: the audit row keeps the PRIOR parent" "$(cat "$AUDIT_ROWS")" "prior=none"
+has_t "A3b: ... and the new one" "$(cat "$AUDIT_ROWS")" "new=T-100"
+
+: >"$AUDIT_ROWS"
+OUT=$( (cmd_task_set_parent T-101 T-100) 2>&1 ); RC=$?
+eq_t "A4: re-setting the same parent is a no-op (rc 0)" "$RC" "0"
+has_t "A4b: ... and says so" "$OUT" "unchanged"
+eq_t "A4c: ... and writes NO audit row" "$(wc -l < "$AUDIT_ROWS")" "0"
+has_t "A4d: ... but still shows the reader's view" "$OUT" "subtasks of T-100 now:"
+
+# ── B. detach ────────────────────────────────────────────────────────────────
+OUT=$( (cmd_task_set_parent T-101 none) 2>&1 ); RC=$?
+eq_t "B1: 'none' detaches (rc 0)" "$RC" "0"
+eq_t "B1b: ... and parent_id is NULL" "$(parent_of T-101)" "∅"
+# The absence has to be visible where it now matters: the FORMER parent's list.
+has_t "B2: detach shows the former parent's list" "$OUT" "subtasks of T-100 now:"
+has_t "B2b: ... which is now empty" "$OUT" "(none)"
+OUT=$( (cmd_task_set_parent T-101 --parent=none) 2>&1 ); RC=$?
+eq_t "B3: --parent=none is accepted too, and is a no-op here" "$RC" "0"
+OUT=$( (cmd_task_set_parent T-101 --parent=T-100) 2>&1 ); RC=$?
+eq_t "B4: --parent=<ident> is accepted" "$RC" "0"
+eq_t "B4b: ... and lands" "$(parent_of T-101)" "T-100"
+OUT=$( (cmd_task_set_parent T-101 T-100 --parent=T-100) 2>&1 ); RC=$?
+[[ "$RC" != "0" ]] && ok_t "B5: naming the parent twice is a usage error" \
+  || bad_t "B5: naming the parent twice is a usage error" "rc=$RC"
+
+# ── C. the cascade-armed refusals ────────────────────────────────────────────
+# parent_id REFERENCES tasks(id) ON DELETE CASCADE — a wrong parent does not just
+# mis-render, it arms the child's deletion.
+OUT=$( (cmd_task_set_parent T-101 T-101) 2>&1 ); RC=$?
+[[ "$RC" != "0" ]] && ok_t "C1: self-parenting is refused" || bad_t "C1: self-parenting is refused" "rc=$RC"
+eq_t "C1b: ... and the existing edge is untouched" "$(parent_of T-101)" "T-100"
+
+# T-100 -> T-101 would close the loop the other way round.
+OUT=$( (cmd_task_set_parent T-100 T-101) 2>&1 ); RC=$?
+[[ "$RC" != "0" ]] && ok_t "C2: a 2-row cycle is refused" || bad_t "C2: a 2-row cycle is refused" "rc=$RC"
+has_t "C2b: ... naming the chain it walked" "$OUT" "cycle"
+eq_t "C2c: ... and T-100 stays unparented" "$(parent_of T-100)" "∅"
+
+# Deeper: T-102 -> T-101 -> T-100. Re-parenting T-100 under T-102 is a 3-hop cycle.
+seed T-102 "a grandchild"
+OUT=$( (cmd_task_set_parent T-102 T-101) 2>&1 ); RC=$?
+eq_t "C3: a 3-level chain builds fine" "$RC" "0"
+OUT=$( (cmd_task_set_parent T-100 T-102) 2>&1 ); RC=$?
+[[ "$RC" != "0" ]] && ok_t "C4: a 3-hop cycle is refused too" || bad_t "C4: a 3-hop cycle is refused too" "rc=$RC"
+
+# A pre-existing cycle (only reachable by a raw sqlite write, which is exactly
+# what this verb exists to displace) must make the walk REFUSE, never hang.
+seed T-110 "cyclic a"; seed T-111 "cyclic b"; seed T-112 "an innocent row"
+db "UPDATE tasks SET parent_id=(SELECT id FROM tasks WHERE ident='T-111') WHERE ident='T-110';"
+db "UPDATE tasks SET parent_id=(SELECT id FROM tasks WHERE ident='T-110') WHERE ident='T-111';"
+OUT=$( (cmd_task_set_parent T-112 T-110) 2>&1 ); RC=$?
+[[ "$RC" != "0" ]] && ok_t "C5: a PRE-EXISTING cycle is refused, not walked forever" \
+  || bad_t "C5: a PRE-EXISTING cycle is refused, not walked forever" "rc=$RC"
+eq_t "C5b: ... and the innocent row is untouched" "$(parent_of T-112)" "∅"
+
+OUT=$( (cmd_task_set_parent T-101 NOPE-99) 2>&1 ); RC=$?
+[[ "$RC" != "0" ]] && ok_t "C6: a nonexistent parent is refused (it would arm a cascade)" \
+  || bad_t "C6: a nonexistent parent is refused" "rc=$RC"
+OUT=$( (cmd_task_set_parent T-101) 2>&1 ); RC=$?
+[[ "$RC" != "0" ]] && ok_t "C7: a missing parent argument is a usage error" \
+  || bad_t "C7: a missing parent argument is a usage error" "rc=$RC"
+
+# ── D. THE BARE-NUMBER GUARD, on set-parent (section G grades it on task add) ─
+# resolve_task_id branches on argument SHAPE: ^[0-9]+$ is the GLOBAL ROW ID,
+# ^[A-Za-z]+-[0-9]+$ is the ident. The two number spaces have diverged in the
+# real store — DIVE-2895 is row id 3082, and row id 2895 is DIVE-2708, a
+# cancelled row from another month. That is how DIVE-3273 was filed under the
+# wrong parent with no error at all: a valid id naming the wrong row.
+seed T-200 "the row a caller means when they type 200" todo 9200
+seed T-9200 "the DIFFERENT row that the bare number 9200 actually resolves to" todo 9201
+eq_t "D0: the divergence is set up (row id 9200 is NOT ident T-9200)" \
+     "$(db "SELECT ident FROM tasks WHERE id=9200;")" "T-200"
+OUT=$( (cmd_task_set_parent T-101 9200) 2>&1 ); RC=$?
+[[ "$RC" != "0" ]] && ok_t "D1: a bare number resolving to a DIFFERENT ident number is REFUSED" \
+  || bad_t "D1: a bare number resolving to a DIFFERENT ident number is REFUSED" "rc=$RC"
+has_t "D1b: ... naming the row it actually resolved to" "$OUT" "T-200"
+# The instruction, not the verb name: the guard is SHARED with `task add --parent`
+# (src/lib/tasks_db.sh), so its message must not name one verb — but it still has
+# to hand the caller something to type.
+has_t "D1c: ... and telling the caller what to type instead" "$OUT" "by IDENT: T-200"
+has_t "D1c2: ... and offering the ident they probably meant" "$OUT" "DIVE-9200"
+eq_t "D1d: ... and nothing was written" "$(parent_of T-101)" "T-100"
+
+# The same guard on the CHILD argument: a mis-resolved child re-parents the
+# wrong row, which is the identical failure with the identical cascade.
+OUT=$( (cmd_task_set_parent 9200 T-100) 2>&1 ); RC=$?
+[[ "$RC" != "0" ]] && ok_t "D2: the guard covers the CHILD argument too" \
+  || bad_t "D2: the guard covers the CHILD argument too" "rc=$RC"
+eq_t "D2b: ... and T-200 was not re-parented" "$(parent_of T-200)" "∅"
+
+# A bare number that DOES agree with its ident still warns — it is a global row
+# id that happens to line up today, and `--parent=<id>` in task add's help text
+# is what made the bare form look intended.
+seed NUM-9300 "ident number equals row id" todo 9300
+OUT=$( (cmd_task_set_parent T-101 9300) 2>&1 ); RC=$?
+eq_t "D3: an AGREEING bare number is accepted (rc 0)" "$RC" "0"
+has_t "D3b: ... but warns loudly, naming the row" "$OUT" "NUM-9300"
+has_t "D3c: ... and says to prefer the ident form" "$OUT" "Prefer the ident form"
+eq_t "D3d: ... and the edge landed" "$(parent_of T-101)" "NUM-9300"
+# The ident form is the quiet path — no warning to train people to ignore.
+OUT=$( (cmd_task_set_parent T-101 T-100) 2>&1 ); RC=$?
+no_t "D4: the IDENT form warns about nothing" "$OUT" "bare number"
+
+# ── E. a recurring template has no parent by construction ────────────────────
+db "INSERT INTO tasks (ident,title,priority,assignee,created_by,kind,status)
+    VALUES ('T-300','a recurring template','medium','dev','main','recurring','todo');"
+OUT=$( (cmd_task_set_parent T-300 T-100) 2>&1 ); RC=$?
+[[ "$RC" != "0" ]] && ok_t "E1: a recurring TEMPLATE is refused (task add refuses --recurring with --parent)" \
+  || bad_t "E1: a recurring TEMPLATE is refused" "rc=$RC"
+
+# ── F. the acceptance shape: task show renders the edge ──────────────────────
+# The verb's whole point is the READER's view, so grade that and not the UPDATE.
+cmd_task_set_parent T-101 T-100 >/dev/null 2>&1
+SHOW=$( (cmd_task_show T-100) 2>&1 )
+has_t "F1: task show <parent> renders a subtasks block" "$SHOW" "subtasks:"
+has_t "F1b: ... containing the re-parented row" "$SHOW" "T-101"
+
+# ── G. the SAME guard on `task add --parent`, the surface that actually misfired ─
+# DIVE-3275 folds this in (main's call, 2026-08-12): DIVE-3273 was filed under
+# DIVE-2708 by `--parent=2895` with no error, and the remedy shipped at the time
+# was a written rule. A rule is not a guard, and this is one function from the
+# verb above on the same surface — a separate row would buy a second review of
+# the same code.
+FIVE_VERIFY_DEFAULT=0; FIVE_FILING_CAP=0
+add_out() { ( JSON_MODE=0; cmd_task_add "$@" ) 2>&1; }
+
+OUT=$(add_out --parent=9200 "a child filed under a bare number"); RC=$?
+[[ "$RC" != "0" ]] && ok_t "G1: task add --parent=<divergent bare number> is REFUSED" \
+  || bad_t "G1: task add --parent=<divergent bare number> is REFUSED" "rc=$RC"
+has_t "G1b: ... naming the row it actually resolved to" "$OUT" "T-200"
+has_t "G1c: ... and naming the argument that was wrong" "$OUT" "--parent"
+# The refusal must land BEFORE the INSERT — a row created under the wrong parent
+# is the exact damage, and half-doing it is worse than refusing.
+eq_t "G1d: ... and NO row was created" \
+     "$(db "SELECT COUNT(*) FROM tasks WHERE title='a child filed under a bare number';")" "0"
+
+OUT=$(add_out --parent=NUM-9300 "a child filed by ident"); RC=$?
+eq_t "G2: the ident form still works (rc 0)" "$RC" "0"
+eq_t "G2b: ... and the edge is real" \
+     "$(db "SELECT (SELECT p.ident FROM tasks p WHERE p.id=c.parent_id) FROM tasks c WHERE c.title='a child filed by ident';")" \
+     "NUM-9300"
+no_t "G3: ... and it warns about no bare number" "$OUT" "bare number"
+
+OUT=$(add_out --parent=9300 "a child filed under an agreeing bare number"); RC=$?
+eq_t "G4: an AGREEING bare number is still accepted (rc 0)" "$RC" "0"
+has_t "G4b: ... but warns, so the habit is visible" "$OUT" "bare number"
+eq_t "G4c: ... and the edge landed" \
+     "$(db "SELECT (SELECT p.ident FROM tasks p WHERE p.id=c.parent_id) FROM tasks c WHERE c.title='a child filed under an agreeing bare number';")" \
+     "NUM-9300"
+
+# The help text is what made the bare form look intended (wiki, Delta 2026-08-11).
+has_t "G5: the add help line names the IDENT form" "$( (_task_usage) 2>&1 )" "--parent=<DIVE-N>"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
`5dive task set-parent`, plus the bare-number guard on `task add --parent` that the same defect needed.

Maker: main2 (DIVE-3275). Verified by agent-main before push.

## Why the guard is the interesting half

`resolve_task_id()` branches on argument SHAPE: `^[0-9]+$` is the global row id, `^[A-Za-z]+-[0-9]+$` is the ident. **The two number spaces have diverged.** Measured on the live store 2026-08-12: `DIVE-2895` is row id 3082, and row id 2895 is `DIVE-2708` — a cancelled row from another month. So a bare number is a *valid id* pointing at a *different row than the caller means*, which is how DIVE-3273 got filed under DIVE-2708.

The resolver `_task_resolve_ref_strict` lives in `src/lib/tasks_db.sh` beside `resolve_task_id()` because it is a statement about that function's two number spaces, not about any one verb. **One definition, three callers** (`set-parent` x2, `task add --parent` x1) — so the guard is shared, not duplicated, and its refusal names the ARGUMENT rather than a verb.

## Verification

- `tests/task_set_parent_unit.sh` **57/0** (45 set-parent + 12 add-guard), 4/4 mutants killed — including one that reds arms on BOTH verbs, which is what demonstrates the shared resolver is actually shared.
- `shellcheck -S error --shell=bash src/*.sh src/task/*.sh` rc=0 (CI's exact shape).
- `build.sh` clean; end-to-end on the rebuilt split bundle.
- Rebased onto post-split main `1aa6f85`; one commit, descends-check passes.

Placement follows the post-DIVE-3278 module layout: `set-parent` in `src/task/dispatch.sh` (where every existing `cmd_task_set_*` lives, per that file's own header), the add guard in `src/task/crud.sh`.
