### PR TITLE
DO NOT MERGE — DIVE-3315 probe: fire the per-shard confirm rail

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,11 +37,49 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  # DIVE-3315: TWO INDEPENDENTLY-CAPPED SHARDS, not a bigger number. lodar's 300s
+  # stands; the core corpus does not fit under it any more. Measured on main
+  # 2026-08-11/12: 313s pristine against a 312s effective cap, with ~6% runner spread
+  # and the mutation-harness lever exhausted at ~7s available against ~13s needed
+  # (olivia's by-construction census, DIVE-3313). A cap breached by 1s on the draw of a
+  # runner presents as a flaky test and is not one.
+  #
+  # The cap is PER JOB (tests/lib/tier.sh), so two shards of ~157s each sit near 52% of
+  # the SAME 300s — the constraint is not relaxed, the corpus is split. Raising 300 to
+  # fit today's number would green the instrument instead of the thing it measures, and
+  # is explicitly out of scope on this row's parents.
+  #
+  # `${{ strategy.job-total }}` rather than a literal 2, for the reason full-sweep.yml
+  # gives: the shard count is the matrix length, spelled once, so adding a shard cannot
+  # leave the runner splitting the corpus a different number of ways than the matrix
+  # runs it. AGGREGATE capacity is now 2 x 300s and N is fixed here — adding a third
+  # shard is exactly as visible, and exactly as much a policy decision, as raising the
+  # number would have been.
+  #
+  # AND THE UN-SHARDED TOTAL IS STILL PRINTED, by `core-budget-report` below: sharding
+  # is the obvious way to lose the number this whole scheme exists to surface. Two jobs
+  # reporting 157s read as comfortable while the corpus still costs 313s. Per-shard is
+  # what the budget ENFORCES; the un-sharded total is what the trend is READ from, and
+  # it is deliberately wired to no failure — an enforced sum would put the corpus right
+  # back at 313 > 300 on day one and the split would have fixed nothing.
+  #
+  # WHY THIS JOB IS NO LONGER CALLED `test`. `test` is a REQUIRED status check on main
+  # (branch protection: test, test-installed-host, test-confirm,
+  # test-installed-host-confirm). A matrix job reports as `test (1)` / `test (2)`, so
+  # the context `test` would never report again and every PR would wait forever on a
+  # check that cannot arrive. So the required names survive as thin AGGREGATOR jobs that
+  # assert their shards' results, and the sharded work sits under new names. That also
+  # means a future shard-count change needs no branch-protection edit — the contract
+  # with the merge gate is the aggregator's name, not the corpus's shape.
+  # tests/corpus_tier_budget_unit.sh pins the four names against a rename.
+  core-pristine:
     runs-on: ubuntu-latest
-    outputs:
-      needs_confirm: ${{ steps.core.outputs.needs_confirm }}
-      runner_id: ${{ steps.core.outputs.runner_id }}
+    strategy:
+      # fail-fast: false — one shard over its cap must not cancel the other. The
+      # un-sharded total is re-summed from the shards' reports, and a cancelled shard
+      # is a hole in exactly the number this row exists to keep legible.
+      fail-fast: false
+      matrix: { shard: [1, 2] }
     steps:
       # DIVE-2229: fetch-depth is load-bearing, not hygiene. actions/checkout@v4
       # defaults to depth 1, and the harnesses below anchor "what this code did
@@ -91,34 +129,48 @@ jobs:
       # a second box does, and on GitHub-hosted runners every job is its own
       # ephemeral VM, so `needs:` + a fresh job IS a second box. One-sided: this can
       # only turn a 4 into a 6, never a green into a red.
-      - name: Run core harnesses (budgeted)
+      - name: Run core harnesses (budgeted, shard ${{ matrix.shard }})
         id: core
         run: |
-          rid="${GITHUB_JOB}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          echo "runner_id=$rid" >> "$GITHUB_OUTPUT"
+          # The runner id names a BOX. Both shards run under the same ${GITHUB_JOB}, so
+          # the shard index is part of the id or the two ids collide and a shard could
+          # "confirm" itself — the DIVE-2829 comparison is an equality test on this
+          # string and nothing else.
+          rid="${GITHUB_JOB}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-s${{ matrix.shard }}"
           set +e
-          bash scripts/run-harnesses.sh --tier=core --label=pristine \
-            --report=core-pristine.txt --cross-runner=required --runner-id="$rid"
+          bash scripts/run-harnesses.sh --tier=core \
+            --shard=${{ matrix.shard }}/${{ strategy.job-total }} \
+            --label=pristine --report=core-pristine-${{ matrix.shard }}.txt \
+            --cross-runner=required --runner-id="$rid"
           rc=$?
           set -e
           # HAND OFF ONLY THE CROSS-RUNNER 6, never the calibration one. Exit 6 has two
           # producers and they are not the same event: `undetermined=0` in the report
           # with rc 6 is this row's gate, and anything else keeps the red it always had.
-          if [ "$rc" = 6 ] && grep -q '^# undetermined=0' core-pristine.txt \
-             && ! grep -q '^# cross_runner_state=confirmed' core-pristine.txt; then
-            echo "needs_confirm=1" >> "$GITHUB_OUTPUT"
-            exit 0
+          #
+          # DIVE-3315: the hand-off travels as a FILE, not as a job output. Matrix legs
+          # share one `outputs` map and the last leg to finish wins it, so shard 2
+          # finishing green would silently erase shard 1's "I went over" — a budget red
+          # dropped by the machinery built to stop exactly that. `core-confirm-plan`
+          # reads these verdicts back and fails closed on a missing one.
+          nc=0
+          if [ "$rc" = 6 ] && grep -q '^# undetermined=0' core-pristine-${{ matrix.shard }}.txt \
+             && ! grep -q '^# cross_runner_state=confirmed' core-pristine-${{ matrix.shard }}.txt; then
+            nc=1
           fi
+          printf 'shard=%s\nshards=%s\nneeds_confirm=%s\nrunner_id=%s\n' \
+            '${{ matrix.shard }}' '${{ strategy.job-total }}' "$nc" "$rid" \
+            > core-verdict-pristine-${{ matrix.shard }}.txt
+          if [ "$nc" = 1 ]; then exit 0; fi
           exit "$rc"
       - uses: actions/upload-artifact@v4
         if: always()
-        with: { name: core-pristine, path: core-pristine.txt, if-no-files-found: warn }
-      # DIVE-3017: the bun step above is a DECLARATION and a succeeding declaration
-      # was already shown not to imply a graded harness. This reads the outcome back
-      # out of the report just written: rc=0 AND seconds-scale, which together are
-      # satisfied only by the ACP stdio scenarios having actually run.
-      - name: The ACP server must have been GRADED (pristine)
-        run: bash tests/meta/harness-graded-union.sh --harness=acp_stdio_unit.sh --min-ms=1000 core-pristine.txt
+        with:
+          name: "core-pristine-${{ matrix.shard }}"
+          path: |
+            core-pristine-${{ matrix.shard }}.txt
+            core-verdict-pristine-${{ matrix.shard }}.txt
+          if-no-files-found: warn
 
   # DIVE-1919: the bare runner above is a PRISTINE box — no /var/lib/5dive, no
   # installed plugins. That is NOT the environment any agent actually runs the
@@ -276,11 +328,18 @@ jobs:
         if: always()
         with: { name: selfcheck-pristine, path: selfcheck-pristine.txt, if-no-files-found: error }
 
-  test-installed-host:
+  # DIVE-3315: sharded on the same terms as `core-pristine` — see the comment there.
+  # This environment is the slower of the two (real sudo, seeded host state) and it is
+  # the one whose 313s reading forced this row, so it gets the same two independently
+  # capped jobs and the same 300s per job. The rails prover that used to live at the
+  # bottom of this job moved to `rails-installed-host`: it is not the corpus, it would
+  # have run once per shard for no gain, and two shards uploading one artifact name is
+  # a hard error in upload-artifact@v4.
+  core-installed-host:
     runs-on: ubuntu-latest
-    outputs:
-      needs_confirm: ${{ steps.core.outputs.needs_confirm }}
-      runner_id: ${{ steps.core.outputs.runner_id }}
+    strategy:
+      fail-fast: false
+      matrix: { shard: [1, 2] }
     steps:
       # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
@@ -318,28 +377,52 @@ jobs:
         uses: oven-sh/setup-bun@v2
       # DIVE-2829: see the pristine job. This is the job the 2026-08-05 pair was
       # measured on, and the one whose red froze release-cut.yml.
-      - name: Run core harnesses (installed host, budgeted)
+      - name: Run core harnesses (installed host, budgeted, shard ${{ matrix.shard }})
         id: core
         run: |
-          rid="${GITHUB_JOB}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          echo "runner_id=$rid" >> "$GITHUB_OUTPUT"
+          rid="${GITHUB_JOB}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-s${{ matrix.shard }}"
           set +e
-          bash scripts/run-harnesses.sh --tier=core --label=installed-host \
-            --report=core-installed.txt --cross-runner=required --runner-id="$rid"
+          bash scripts/run-harnesses.sh --tier=core \
+            --shard=${{ matrix.shard }}/${{ strategy.job-total }} \
+            --label=installed-host --report=core-installed-${{ matrix.shard }}.txt \
+            --cross-runner=required --runner-id="$rid"
           rc=$?
           set -e
-          if [ "$rc" = 6 ] && grep -q '^# undetermined=0' core-installed.txt \
-             && ! grep -q '^# cross_runner_state=confirmed' core-installed.txt; then
-            echo "needs_confirm=1" >> "$GITHUB_OUTPUT"
-            exit 0
+          # DIVE-3315: verdict as a FILE, never a matrix job output — see the pristine
+          # job for why a shared outputs map drops one shard's budget red on the floor.
+          nc=0
+          if [ "$rc" = 6 ] && grep -q '^# undetermined=0' core-installed-${{ matrix.shard }}.txt \
+             && ! grep -q '^# cross_runner_state=confirmed' core-installed-${{ matrix.shard }}.txt; then
+            nc=1
           fi
+          printf 'shard=%s\nshards=%s\nneeds_confirm=%s\nrunner_id=%s\n' \
+            '${{ matrix.shard }}' '${{ strategy.job-total }}' "$nc" "$rid" \
+            > core-verdict-installed-${{ matrix.shard }}.txt
+          if [ "$nc" = 1 ]; then exit 0; fi
           exit "$rc"
       - uses: actions/upload-artifact@v4
         if: always()
-        with: { name: core-installed, path: core-installed.txt, if-no-files-found: warn }
-      # DIVE-3017: same outcome assertion as the pristine job — see the comment there.
-      - name: The ACP server must have been GRADED (installed host)
-        run: bash tests/meta/harness-graded-union.sh --harness=acp_stdio_unit.sh --min-ms=1000 core-installed.txt
+        with:
+          name: "core-installed-${{ matrix.shard }}"
+          path: |
+            core-installed-${{ matrix.shard }}.txt
+            core-verdict-installed-${{ matrix.shard }}.txt
+          if-no-files-found: warn
+  # DIVE-3315: the rails prover, lifted OUT of the (now sharded) corpus job unchanged.
+  # It grades the shipped rails, not the corpus, so it has nothing to do with the budget
+  # and every reason not to run twice. It stays inside what the merge gate covers: the
+  # `test-installed-host` aggregator requires THIS job green as well as both shards, so
+  # moving these steps did not shrink the required check that used to contain them.
+  rails-installed-host:
+    runs-on: ubuntu-latest
+    steps:
+      # DIVE-2229: full history — pinned baselines must resolve here too.
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      # DIVE-2829: the same seeding script the corpus jobs use, for the same reason —
+      # two copies of a setup block are two environments as soon as one is edited.
+      - name: Simulate a box with 5dive installed
+        run: bash .github/scripts/simulate-installed-host.sh
       # DIVE-2039: TWICE, and that is the point. DIVE-1989 stayed invisible for as
       # long as the audit log was measured from one side — the same command wrote 0
       # rows as an agent and 1 row under sudo. `audit-root` is honestly NOT-REACHED
@@ -372,7 +455,7 @@ jobs:
   # exactly, which is why it is closed here on day one instead of after it bites.
   selfcheck-union:
     runs-on: ubuntu-latest
-    needs: [rails-pristine, test-installed-host]
+    needs: [rails-pristine, rails-installed-host]
     steps:
       # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
@@ -399,10 +482,22 @@ jobs:
   # --prior-over-runner, and the run exits 4 with the corpus finding restored. Inside
   # the cap here and the first sample was the runner, which is what happened on
   # 828c1ea: 416s then 245s, and only the 416s was ever acted on.
-  test-confirm:
-    needs: test
-    if: needs.test.outputs.needs_confirm == '1'
+  core-pristine-confirm:
+    needs: core-confirm-plan
+    # A shard confirms a shard. The plan job emits one entry per over-budget shard,
+    # carrying that shard's index, the divisor it was split by, and the runner id that
+    # went over — so the second box measures THE SAME SUBSET the first one did. An
+    # empty list means no shard went over and this job does not exist for that run.
+    # The plan's RESULT is tested as well as its output. A plan that failed closed on a
+    # missing verdict emits no output at all, and an empty string is not '[]' — without
+    # this, the reason no confirmation ran would surface as an empty-matrix YAML error
+    # instead of the refusal the plan job printed.
+    if: needs['core-confirm-plan'].result == 'success' && needs['core-confirm-plan'].outputs.pristine != '[]'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs['core-confirm-plan'].outputs.pristine) }}
     steps:
       # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
@@ -415,22 +510,35 @@ jobs:
         uses: oven-sh/setup-bun@v2
       - name: Confirm the budget red on a SECOND runner (DIVE-2829)
         run: |
-          bash scripts/run-harnesses.sh --tier=core --label=pristine-confirm \
-            --report=core-pristine-confirm.txt --cross-runner=required \
-            --runner-id="${GITHUB_JOB}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
-            --prior-over-runner="${{ needs.test.outputs.runner_id }}"
+          bash scripts/run-harnesses.sh --tier=core \
+            --shard=${{ matrix.shard }}/${{ matrix.shards }} \
+            --label=pristine-confirm \
+            --report=core-pristine-confirm-${{ matrix.shard }}.txt --cross-runner=required \
+            --runner-id="${GITHUB_JOB}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-s${{ matrix.shard }}" \
+            --prior-over-runner="${{ matrix.prior }}"
       - uses: actions/upload-artifact@v4
         if: always()
-        with: { name: core-pristine-confirm, path: core-pristine-confirm.txt, if-no-files-found: warn }
+        with:
+          name: "core-pristine-confirm-${{ matrix.shard }}"
+          path: "core-pristine-confirm-${{ matrix.shard }}.txt"
+          if-no-files-found: warn
 
   # DIVE-2829: the same second box for the installed-host tier. It seeds the
   # environment from the SAME script the first job used, which is the whole reason
   # that script exists — a confirmation taken in a different environment confirms a
   # different question.
-  test-installed-host-confirm:
-    needs: test-installed-host
-    if: needs.test-installed-host.outputs.needs_confirm == '1'
+  core-installed-host-confirm:
+    needs: core-confirm-plan
+    # The plan's RESULT is tested as well as its output. A plan that failed closed on a
+    # missing verdict emits no output at all, and an empty string is not '[]' — without
+    # this, the reason no confirmation ran would surface as an empty-matrix YAML error
+    # instead of the refusal the plan job printed.
+    if: needs['core-confirm-plan'].result == 'success' && needs['core-confirm-plan'].outputs.installed != '[]'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs['core-confirm-plan'].outputs.installed) }}
     steps:
       # DIVE-2229: full history — pinned baselines must resolve here too.
       - uses: actions/checkout@v4
@@ -445,10 +553,263 @@ jobs:
         uses: oven-sh/setup-bun@v2
       - name: Confirm the budget red on a SECOND runner (DIVE-2829)
         run: |
-          bash scripts/run-harnesses.sh --tier=core --label=installed-host-confirm \
-            --report=core-installed-confirm.txt --cross-runner=required \
-            --runner-id="${GITHUB_JOB}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
-            --prior-over-runner="${{ needs.test-installed-host.outputs.runner_id }}"
+          bash scripts/run-harnesses.sh --tier=core \
+            --shard=${{ matrix.shard }}/${{ matrix.shards }} \
+            --label=installed-host-confirm \
+            --report=core-installed-confirm-${{ matrix.shard }}.txt --cross-runner=required \
+            --runner-id="${GITHUB_JOB}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-s${{ matrix.shard }}" \
+            --prior-over-runner="${{ matrix.prior }}"
       - uses: actions/upload-artifact@v4
         if: always()
-        with: { name: core-installed-confirm, path: core-installed-confirm.txt, if-no-files-found: warn }
+        with:
+          name: "core-installed-confirm-${{ matrix.shard }}"
+          path: "core-installed-confirm-${{ matrix.shard }}.txt"
+          if-no-files-found: warn
+
+  # DIVE-3315: WHICH SHARD, IF ANY, NEEDS A SECOND BOX — decided from the verdict files
+  # the shards uploaded, because a matrix cannot hand this up any other way. Matrix legs
+  # share one `outputs` map and the last leg to finish wins it, so the obvious version of
+  # the DIVE-2829 rail loses shard 1's over-budget verdict whenever shard 2 finishes
+  # green: a budget red silently downgraded by the machinery built to stop that exact
+  # thing. Reading it back out of the artifact of record cannot be raced.
+  #
+  # IT FAILS CLOSED. A verdict file that is missing is not a shard that came in under its
+  # cap — it is a shard nobody has a reading for, and "nobody said they went over" must
+  # not resolve to "nobody went over". That refusal is the whole reason this job exists
+  # rather than the confirm jobs each grepping for their own marker.
+  core-confirm-plan:
+    runs-on: ubuntu-latest
+    needs: [core-pristine, core-installed-host]
+    # if: always() — a shard that reds on a FAILING harness (rc 1) still wrote a verdict,
+    # and the confirm rail has to be decided for the other shard regardless.
+    if: always()
+    outputs:
+      pristine: ${{ steps.plan.outputs.pristine }}
+      installed: ${{ steps.plan.outputs.installed }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { pattern: 'core-*', merge-multiple: true }
+      - name: Which shards went over their cap on their FIRST box?
+        id: plan
+        run: |
+          set -euo pipefail
+          plan() {   # <env> -> "<env>=[{shard,shards,prior}...]" into $GITHUB_OUTPUT
+            local env="$1" n i f rid joined="" ; local -a entries=()
+            # THE DIVISOR COMES FROM THE RUNNER'S OWN VERDICT, not from a second copy of
+            # the matrix length written here. A divisor spelled twice is a divisor that
+            # drifts, and this one decides which subset the confirming box measures — a
+            # confirmation of a different subset confirms a different question.
+            n="$(sed -n 's/^shards=//p' core-verdict-"$env"-*.txt 2>/dev/null | sort -rn | head -1 || true)"
+            if [[ -z "$n" ]]; then
+              printf 'core-confirm-plan: BLOCKED — not one %s shard left a verdict file. "Nobody reported going over" is not "nobody went over".\n' "$env" >&2
+              return 1
+            fi
+            for (( i = 1; i <= n; i++ )); do
+              f="core-verdict-$env-$i.txt"
+              if [[ ! -r "$f" ]]; then
+                printf 'core-confirm-plan: BLOCKED — %s is missing. A shard with no reading is not a shard inside its cap.\n' "$f" >&2
+                return 1
+              fi
+              if grep -qx 'needs_confirm=1' "$f"; then
+                rid="$(sed -n 's/^runner_id=//p' "$f" | head -1)"
+                entries+=("{\"shard\":$i,\"shards\":$n,\"prior\":\"$rid\"}")
+              fi
+            done
+            if (( ${#entries[@]} > 0 )); then joined="$(IFS=,; printf '%s' "${entries[*]}")"; fi
+            printf '%s=[%s]\n' "$env" "$joined" >> "$GITHUB_OUTPUT"
+            printf '%s (of %s shards): [%s]\n' "$env" "$n" "$joined"
+          }
+          plan pristine
+          plan installed
+
+  # DIVE-3017, one level out: the ACP grade is now a UNION OVER THE SHARDS, because
+  # acp_stdio_unit.sh lands in exactly one of them and the other shard's report cannot
+  # contain it. Per-shard, the assertion would red the shard that does not own the file —
+  # so the invariant moves to where the whole environment's rows are visible, exactly as
+  # full-sweep.yml does it.
+  #
+  # THE REPORTS ARE NAMED, NOT GLOBBED, and one job per environment: a shard that died
+  # has to red this rather than quietly reduce the union it is checked against, and a
+  # pass in one environment must not cover for the other going ungraded. A third shard
+  # added without extending this list reds it too (the file it owns would be absent from
+  # the union) — the fail-closed direction.
+  acp-graded-pristine:
+    runs-on: ubuntu-latest
+    needs: core-pristine
+    steps:
+      # DIVE-2229: full history, like every other checkout in this file.
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/download-artifact@v4
+        with: { pattern: 'core-pristine-*', merge-multiple: true }
+      - name: The ACP server must have been GRADED (pristine)
+        run: |
+          bash tests/meta/harness-graded-union.sh --harness=acp_stdio_unit.sh --min-ms=1000 \
+            core-pristine-1.txt core-pristine-2.txt
+
+  acp-graded-installed:
+    runs-on: ubuntu-latest
+    needs: core-installed-host
+    steps:
+      # DIVE-2229: full history, like every other checkout in this file.
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/download-artifact@v4
+        with: { pattern: 'core-installed-*', merge-multiple: true }
+      - name: The ACP server must have been GRADED (installed host)
+        run: |
+          bash tests/meta/harness-graded-union.sh --harness=acp_stdio_unit.sh --min-ms=1000 \
+            core-installed-1.txt core-installed-2.txt
+
+  # DIVE-3315: THE FOUR REQUIRED CHECKS, kept by NAME. `test`, `test-installed-host`,
+  # `test-confirm` and `test-installed-host-confirm` are required status checks on main.
+  # A matrix job reports as `test (1)` / `test (2)`, so sharding under the old names would
+  # leave the required context unable to ever report and every PR waiting on a check that
+  # cannot arrive. These four jobs keep the names and assert the sharded work instead, so
+  # the merge gate's contract is a NAME and not the corpus's shape — a future shard-count
+  # change needs no branch-protection edit.
+  #
+  # `if: always()` plus an EXPLICIT result comparison, never a bare `needs:`. A job whose
+  # dependency failed is SKIPPED, and GitHub treats a skipped required check as satisfied
+  # — so the obvious one-line version of these jobs passes the merge gate in precisely the
+  # case where the corpus went red. Anything that is not `success` fails here, `skipped`
+  # and `cancelled` included.
+  test:
+    needs: [core-pristine, acp-graded-pristine]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Both pristine shards, and the ACP grade over their union, must be green
+        run: |
+          rc=0
+          for d in "core-pristine=${{ needs['core-pristine'].result }}" \
+                   "acp-graded-pristine=${{ needs['acp-graded-pristine'].result }}"; do
+            printf '%s\n' "$d"
+            [ "${d#*=}" = success ] || rc=1
+          done
+          exit "$rc"
+
+  test-installed-host:
+    needs: [core-installed-host, rails-installed-host, acp-graded-installed]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # rails-installed-host is in here because those steps USED to be in the job this
+      # check is named after. Dropping it would have shrunk the required check silently,
+      # which is the same defect as sharding it away.
+      - name: Both installed-host shards, the rails prover and the ACP grade must be green
+        run: |
+          rc=0
+          for d in "core-installed-host=${{ needs['core-installed-host'].result }}" \
+                   "rails-installed-host=${{ needs['rails-installed-host'].result }}" \
+                   "acp-graded-installed=${{ needs['acp-graded-installed'].result }}"; do
+            printf '%s\n' "$d"
+            [ "${d#*=}" = success ] || rc=1
+          done
+          exit "$rc"
+
+  test-confirm:
+    needs: [core-confirm-plan, core-pristine-confirm]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: A second box's verdict, or a plan that proved none was needed
+        run: |
+          plan='${{ needs['core-confirm-plan'].result }}'
+          conf='${{ needs['core-pristine-confirm'].result }}'
+          printf 'core-confirm-plan=%s core-pristine-confirm=%s\n' "$plan" "$conf"
+          # The plan job is the thing that fails closed on a shard with no reading, so
+          # `skipped` here must not read as "no confirmation was needed".
+          [ "$plan" = success ] || exit 1
+          # `skipped` is the good case and the common one: no shard went over its cap, so
+          # no second box was spawned. Anything else is a confirmation that did not confirm.
+          case "$conf" in success|skipped) exit 0 ;; *) exit 1 ;; esac
+
+  test-installed-host-confirm:
+    needs: [core-confirm-plan, core-installed-host-confirm]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: A second box's verdict, or a plan that proved none was needed
+        run: |
+          plan='${{ needs['core-confirm-plan'].result }}'
+          conf='${{ needs['core-installed-host-confirm'].result }}'
+          printf 'core-confirm-plan=%s core-installed-host-confirm=%s\n' "$plan" "$conf"
+          [ "$plan" = success ] || exit 1
+          case "$conf" in success|skipped) exit 0 ;; *) exit 1 ;; esac
+
+  # DIVE-3315: THE UN-SHARDED TOTAL, PRINTED EVERY RUN AND WIRED TO NOTHING.
+  #
+  # This is the honesty condition of the split, and it is the half that is easy to
+  # implement backwards. Two shards reporting 157s each read as comfortable while the
+  # corpus still costs 313s: sharding is the obvious way to lose the number the whole
+  # tier scheme exists to surface. Per-shard is what the budget ENFORCES; the re-summed
+  # total is what the TREND is read from, and it belongs on the page either way.
+  #
+  # AND IT MUST NOT GATE. If the sum were held to the 300s per-job cap the corpus would
+  # read 313 > 300 on day one and the split would have fixed nothing — the number is an
+  # instrument, not a second budget. So this job exits 0 on every path, deliberately, and
+  # is required by nothing. The figure that does gate is per-shard, in the shards.
+  #
+  # DIVE-2592's legible form, not a raw ratio: the total in units of the POLICY DIAL, as
+  # the MINIMUM number of shards this corpus now needs. When that reaches the configured
+  # count, adding one is the decision on the table and it is exactly as visible as raising
+  # the ceiling would have been.
+  #
+  # if: always() — the run worth summarising most is the one that went over.
+  core-budget-report:
+    runs-on: ubuntu-latest
+    needs: [core-pristine, core-installed-host]
+    if: always()
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { pattern: 'core-*', merge-multiple: true }
+      - name: Re-sum the shards and print the UN-SHARDED core total
+        run: |
+          total_row() {   # <label> <glob>
+            local label="$1" pat="$2" n=0 s=0 b=0 shards=0 f need=0
+            for f in $pat; do
+              [[ -r "$f" ]] || continue
+              shards=$(( shards + 1 ))
+              n=$(( n + $(sed -n 's/^# harnesses=//p' "$f" | head -1) ))
+              s=$(( s + $(sed -n 's/^# wall_clock_s=//p' "$f" | head -1) ))
+              b=$(sed -n 's/^# budget_s=//p' "$f" | head -1)
+            done
+            # A missing shard is not a smaller corpus. Say the count, so a total assembled
+            # from one of two shards cannot read as a corpus that got faster.
+            (( ${b:-0} > 0 )) && need=$(( (s + b - 1) / b ))
+            printf '| %s | %d | %d | %ds | %ds per shard | %d |\n' \
+              "$label" "$shards" "$n" "$s" "${b:-0}" "$need"
+          }
+          {
+            echo "## Core tier wall-clock (DIVE-3315: two capped shards, one un-sharded total)"
+            echo
+            echo "| environment | shards reporting | harnesses | UN-SHARDED total | budget | shards NEEDED |"
+            echo "|---|---:|---:|---:|---:|---:|"
+            total_row pristine 'core-pristine-[0-9]*.txt'
+            total_row installed-host 'core-installed-[0-9]*.txt'
+            echo
+            echo "Per-shard (this is what the budget is enforced on):"
+            echo '```'
+            for f in core-pristine-[0-9]*.txt core-installed-[0-9]*.txt; do
+              [[ -r "$f" ]] || continue
+              printf '%-28s %4ss / %ss  (%s%%)\n' "$(sed -n 's/^# label=//p' "$f" | head -1)" \
+                "$(sed -n 's/^# wall_clock_s=//p' "$f" | head -1)" \
+                "$(sed -n 's/^# budget_s=//p' "$f" | head -1)" \
+                "$(sed -n 's/^# pct_of_budget=//p' "$f" | head -1)"
+            done
+            echo '```'
+            echo
+            echo "Slowest 15 harnesses across the pristine shards — the merge/retire shortlist:"
+            echo '```'
+            if compgen -G 'core-pristine-[0-9]*.txt' >/dev/null; then
+              grep -hv '^#' core-pristine-[0-9]*.txt | sort -rn | head -15 \
+                | awk -F'\t' '{printf "%7.1fs  %s\n", $1/1000, $3}'
+            else
+              echo "(no reports — no pristine shard finished)"
+            fi
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+          # WIRED TO NOTHING, on purpose. See the comment above this job: a total that
+          # can red is a second budget, and this one would red on day one.
+          exit 0

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -1330,5 +1330,114 @@ if [[ -f "$_wf" ]]; then
   else bad "unit-tests.yml arms the cross-runner gate on both core jobs" "armed=$_armed prior=$_prior"; fi
 else bad "unit-tests.yml is readable from the harness" "no file at $_wf"; fi
 
+# ---- 92-96 DIVE-3315: THE SPLIT, AND THE FOUR NAMES THE MERGE GATE KNOWS
+# core is TWO independently capped jobs per environment now. The corpus read 313s against
+# a 312s effective cap with ~6% runner spread, and the trimming levers were measured
+# exhausted (~7s available against ~13s needed, olivia's by-construction census on
+# DIVE-3313), so a cap breached by 1s on the draw of a runner was presenting as a flaky
+# test. The cap is PER JOB, so two shards of ~157s each hold the SAME 300s: the corpus is
+# split, the constraint is not relaxed.
+#
+# Four things have to stay true or the split is a capacity raise in disguise, a broken
+# merge gate, or both. All four are graded by PARSING the workflow, not by grepping it —
+# a `grep 'always()'` matches the comment that explains why it is there, which is the
+# vacuity this file keeps re-learning (see the jobs_missing_build arm above).
+#
+#   92  the four REQUIRED status-check names still exist as jobs. `test` is required on
+#       main; a matrix job reports as `test (1)`, so sharding under the old name leaves
+#       the required context unable to ever report and every PR waits on a check that
+#       cannot arrive. The names survive as aggregators over the shards.
+#   93  those aggregators FAIL CLOSED. A job skipped because its dependency failed
+#       reports SKIPPED, and GitHub counts a skipped required check as satisfied — so the
+#       one-line `needs:`-only version passes the merge gate exactly when the corpus went
+#       red. `if: always()` plus an explicit .result comparison, or it is not a gate.
+#   94  every core invocation is sharded, and the DIVISOR is the matrix length rather
+#       than a literal — a divisor spelled twice drifts, and the runner would then split
+#       the corpus a different number of ways than the matrix runs it.
+#   95  one job re-sums the shards and prints the UN-SHARDED total. Two shards reporting
+#       157s read as comfortable while the corpus still costs 313s; sharding is the
+#       obvious way to lose the number the whole tier scheme exists to surface.
+#   96  and that total is PRINTED, NEVER ENFORCED, and nothing gates on the job that
+#       prints it. Held to the 300s per-job cap the sum reads 313 > 300 on day one and
+#       the split fixes nothing — the number is an instrument, not a second budget.
+_wf3315="$(dirname "${BASH_SOURCE[0]}")/../.github/workflows/unit-tests.yml"
+if [[ -r "$_wf3315" ]]; then
+  while IFS=$'\t' read -r _v _name _detail; do
+    [[ -n "$_v" ]] || continue
+    if [[ "$_v" == ok ]]; then ok "$_name"; else bad "$_name" "$_detail"; fi
+  done < <(python3 - "$_wf3315" <<'PY' 2>&1
+import re, sys, yaml
+wf = sys.argv[1]
+d = yaml.safe_load(open(wf)) or {}
+jobs = d.get('jobs') or {}
+def chk(good, name, detail=''):
+    print('%s\t%s\t%s' % ('ok' if good else 'bad', name, detail.replace('\t', ' ')))
+def runs(job):
+    return [s.get('run') or '' for s in (job.get('steps') or []) if isinstance(s, dict)]
+
+# 92 — the names branch protection requires, pinned here so a rename is a red in the
+# repo rather than a queue of PRs blocked on a context that will never report.
+REQUIRED = ['test', 'test-installed-host', 'test-confirm', 'test-installed-host-confirm']
+missing = [c for c in REQUIRED if c not in jobs]
+chk(not missing,
+    'every REQUIRED status check on main is still a job NAME in unit-tests.yml (sharding must not rename the merge gate out from under branch protection)',
+    'missing: ' + ','.join(missing))
+
+# 93 — fail closed. Grades the aggregator's `if:` and the presence of a .result test.
+bad_agg = []
+for c in REQUIRED:
+    j = jobs.get(c) or {}
+    if str(j.get('if', '')).strip() != 'always()':
+        bad_agg.append('%s: if=%r, so a failed dependency SKIPS it and a skipped required check reads as satisfied' % (c, j.get('if')))
+        continue
+    if not any('.result' in r for r in runs(j)):
+        bad_agg.append('%s: runs always() but never compares a dependency .result — it is green by construction' % c)
+chk(not bad_agg,
+    'each required check RUNS on always() and asserts its dependencies\' .result (a bare needs: is satisfied by a skip, which is the merge gate passing precisely when the corpus went red)',
+    ' | '.join(bad_agg))
+
+# 94 — sharded, with the divisor taken from the matrix length.
+bad_shard, sharded = [], 0
+for jn, j in jobs.items():
+    for r in runs(j):
+        flat = re.sub(r'\\\n\s*', ' ', r)
+        for line in flat.splitlines():
+            if 'run-harnesses.sh' not in line or '--tier=core' not in line:
+                continue
+            # NOT \S+: the value is `${{ matrix.shard }}/${{ strategy.job-total }}`, which
+            # contains spaces, and splitting on the first one reads the divisor as `${{`.
+            m = re.search(r'--shard=(.+?)(?=\s+--|\s*$)', line)
+            if not m:
+                bad_shard.append('%s: a core invocation with no --shard=' % jn)
+                continue
+            sharded += 1
+            div = m.group(1).split('/')[-1]
+            if not re.search(r'strategy\.job-total|matrix\.shards', div):
+                bad_shard.append('%s: literal divisor %s — spelled twice, it drifts from the matrix' % (jn, div))
+chk(sharded >= 4 and not bad_shard,
+    'every core invocation in unit-tests.yml is SHARDED and takes its divisor from the matrix length, in both environments and in both confirm jobs (%d invocations)' % sharded,
+    ' | '.join(bad_shard) or 'sharded=%d' % sharded)
+
+# 95/96 — the un-sharded total: printed, and wired to nothing.
+summ = [jn for jn, j in jobs.items()
+        if any('wall_clock_s' in r and 'GITHUB_STEP_SUMMARY' in r for r in runs(j))]
+chk(len(summ) == 1,
+    'exactly one job re-sums the shards and prints the UN-SHARDED core total (per-shard is what the budget enforces; the total is what the trend is read from)',
+    'jobs printing a re-summed total: %s' % (summ or 'none'))
+if len(summ) == 1:
+    jn = summ[0]
+    body = '\n'.join(runs(jobs[jn]))
+    gated = re.findall(r'exit\s+[1-9]\b|\|\|\s*exit|exit\s+"\$\{?rc', body)
+    def needs_of(j):
+        n = j.get('needs')
+        return [n] if isinstance(n, str) else (n or [])
+    depended = [o for o, j in jobs.items() if jn in needs_of(j)]
+    chk(not gated and not depended,
+        'the un-sharded total is PRINTED, NEVER ENFORCED — the job that prints it exits 0 on every path and nothing gates on it (an enforced sum is 313 > 300 on day one and the split would fix nothing)',
+        'gating exits: %s; jobs depending on it: %s' % (gated or 'none', depended or 'none'))
+PY
+  )
+else bad "unit-tests.yml is readable from the harness (DIVE-3315 arms)" "no file at $_wf3315"; fi
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 (( fail == 0 ))

--- a/tests/lib/tier.sh
+++ b/tests/lib/tier.sh
@@ -57,7 +57,7 @@
 # re-installing the ratchet this row exists to remove. The run prints its
 # percentage-of-budget every time, so the trend is legible in the number rather than
 # only in the red.
-TIER_BUDGET_CORE=300
+TIER_BUDGET_CORE=1
 TIER_BUDGET_FULL=1320
 
 # DIVE-2728: A SECOND IS NOT A STABLE UNIT ON RENTED HARDWARE, so the cap above is


### PR DESCRIPTION
Throwaway. `TIER_BUDGET_CORE=1` so every core shard goes over its cap, to prove the rewired DIVE-2829 rail FIRES after sharding: verdict files -> `core-confirm-plan` emitting a non-empty list -> a dynamic confirm matrix expanding per over-budget shard -> exit 4 on the second box -> the `test-confirm` aggregator going RED. A red run here is the pass condition. Closed and deleted as soon as it is read; the real change is #622.