### PR TITLE
fix(task): refuse a flag swallowed past '--' on task add instead of storing it as title text (DIVE-3107)

### DIFF
--- a/changelog.d/DIVE-3107.md
+++ b/changelog.d/DIVE-3107.md
@@ -1,0 +1,33 @@
+## Unreleased — fix(task): `task add` refuses a flag swallowed past `--` instead of storing it as title text (DIVE-3107)
+
+`5dive task add ... -- "<title>" --body="<text>"` puts `--body=` on the **wrong side** of the
+end-of-flags separator, so it never parses as a flag at all: it is appended to the positional
+title words. The add succeeded, silently. DIVE-3100 was filed that way — a **628-char title**
+whose text began `--body=MEASURED 2026-08-09…`, with the body column **empty**. Nobody saw it
+until a grader read the row days later, and by then delivered title/body are frozen, so the row
+could not be repaired in place.
+
+Add-time is the only moment the filer can still act on it, so it is now a refusal there. Two
+independent tells, either sufficient:
+
+- **A `--<word>=` token in the title.** The refusal names the leaked flag (`--body`, `--accept`, …),
+  says it landed after the `--`, and shows the title as parsed, so the swallow is visible in the
+  same breath rather than discovered later.
+- **A title over 200 characters.** No legitimate title is that long; this catches the same accident
+  when the swallowed text carries no `=` (a `--body-file` payload pasted inline, for instance).
+
+**A `--word` with no `=` is not a tell** — `"a title with -- a dash and --verbose"` still files.
+The refusal is on the equals form, which is unambiguously a flag name that crossed the separator.
+
+**`--materialized` is exempt from both tells**, and that is the narrow carve-out, not a general
+opt-out. The internal writers (`cmd_goal`, `cmd_loop`, `cmd_objective`, `cmd_proof`,
+`cmd_loop_pack`) build their argv programmatically with every flag already on the correct side of
+`--`, so the swallow this guards **cannot occur** on those paths — while their titles are user
+prose (`Goal: <outcome>`) that may legitimately run long, and a refusal mid-batch would abort a
+whole materialization over a cosmetic length. Unlike the DIVE-2681 filing cap, which is about what
+a title **means**, this guard is about how the command line was **typed**.
+
+`tests/task_add_flag_swallow_unit.sh` (new, core tier, 1.4s measured locally on the control plane):
+11 arms — the exact DIVE-3100 shape refused, no row written on refusal, a second leaked flag
+(`--accept=`), the length tell reporting its measured length, the correct invocation still filing
+with its body intact, the `--word`-without-`=` non-false-positive, and the `--materialized` exemption.

--- a/src/task/crud.sh
+++ b/src/task/crud.sh
@@ -80,6 +80,35 @@ cmd_task_add() {
   done
   local title="${words[*]:-}"
   [[ -n "$title" ]] || fail "$E_USAGE" "usage: 5dive task add <title...> [flags: 5dive task --help]"
+  # DIVE-3107: a flag written AFTER the `--` end-of-flags separator is not a flag
+  # at all — it is positional title text, and the parser above accepts it in
+  # silence. DIVE-3100 was filed with a 628-char title whose text began
+  # `--body=MEASURED 2026-08-09...` and an EMPTY body; nobody saw it until the
+  # grader read the row days later, by which point delivered title/body are
+  # frozen and the row could not be repaired in place. Add-time is the only
+  # moment the filer can still act on it, so refuse here rather than store it.
+  # Two independent tells, either sufficient:
+  #   1. a `--<word>=` token in the title — a flag name that leaked across `--`
+  #   2. a title over 200 chars — no legitimate title is that long
+  # Skipped for --materialized (the internal writers in cmd_goal/cmd_loop/
+  # cmd_objective/cmd_proof/cmd_loop_pack): they build the argv programmatically
+  # with every flag already on the correct side of `--`, so the swallow this
+  # guards cannot occur there, while their titles are user prose ("Goal: <outcome>")
+  # that may legitimately run long — and a refusal mid-batch aborts a whole
+  # materialization. Unlike the DIVE-2681 filing cap, which is about what a title
+  # MEANS, this one is about how the command line was TYPED.
+  if [[ -z "$materialized" ]]; then
+    local _w _leaked=""
+    for _w in "${words[@]}"; do
+      if [[ "$_w" =~ ^--[A-Za-z][A-Za-z0-9-]*= ]]; then _leaked="${_w%%=*}"; break; fi
+    done
+    if [[ -n "$_leaked" ]]; then
+      fail "$E_USAGE" "refusing: the title contains the flag token '${_leaked}=' — it was written AFTER the '--' end-of-flags separator, so it parsed as TITLE TEXT and '${_leaked}' was never applied (this is how DIVE-3100 got a 628-char title and an empty body). Move every flag BEFORE the '--': 5dive task add ${_leaked}=\"...\" -- \"<title>\". Title as parsed (${#title} chars): ${title:0:120}$([[ ${#title} -gt 120 ]] && printf '...')"
+    fi
+    if (( ${#title} > 200 )); then
+      fail "$E_USAGE" "refusing: the title is ${#title} chars (limit 200) — a title that long is almost always body text swallowed past the '--' end-of-flags separator, where flags parse as positional title words instead. Put the prose in --body=/--body-file= BEFORE the '--' and keep the title to one line. Title as parsed: ${title:0:120}..."
+    fi
+  fi
   valid_task_priority "$priority" || fail "$E_VALIDATION" "bad priority '$priority' (low|medium|high|urgent)"
   # DIVE-476: --max-iters is the maker→verifier loop cap; must be a positive int.
   [[ -z "$max_iters" || "$max_iters" =~ ^[1-9][0-9]*$ ]] \

--- a/tests/task_add_flag_swallow_unit.sh
+++ b/tests/task_add_flag_swallow_unit.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# DIVE-3107 unit harness: `task add` must REFUSE a title that carries a flag
+# swallowed past the `--` end-of-flags separator, and refuse an absurdly long
+# title, instead of silently storing either. Same isolation contract as the
+# other task harnesses: source src/ directly, point STATE_DIR at a throwaway
+# temp dir so the live shared tasks.db is NEVER touched.
+# Run: bash tests/task_add_flag_swallow_unit.sh   (no root, no network).
+set -uo pipefail
+
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/task-add-swallow-unit.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"
+TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"
+set +e   # header.sh enabled `set -e`; tests expect non-zero exits
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+run() { local verb="$1"; shift; ( "cmd_task_$verb" "$@" ) 2>"$TMP"/err; }
+jf()  { jq -r "$1" 2>/dev/null; }
+errof() { cat "$TMP"/err; }
+
+tasks_db_init
+
+longtext=$(printf 'x%.0s' $(seq 1 260))
+
+# --- T1: the exact DIVE-3100 shape — --body= written after `--` — is REFUSED
+out=$(run add --assignee=alice -- "real title" --body="MEASURED 2026-08-09 the body that got swallowed"); rc=$?
+[[ $rc -ne 0 ]] && ok_t "flag after -- exits non-zero" || bad_t "flag after -- exits non-zero" "rc=$rc out=$out"
+errof | grep -q -- '--body=' \
+  && ok_t "refusal names the leaked flag token" || bad_t "refusal names the leaked flag token" "$(errof)"
+errof | grep -qi 'end-of-flags' \
+  && ok_t "refusal explains the -- separator" || bad_t "refusal explains the -- separator" "$(errof)"
+[[ "$(db "SELECT COUNT(*) FROM tasks;")" == "0" ]] \
+  && ok_t "no row was written on refusal" || bad_t "no row was written on refusal" "count=$(db "SELECT COUNT(*) FROM tasks;")"
+
+# --- T2: any leaked flag, not just --body (e.g. --accept=)
+run add --assignee=alice -- "title" --accept="all tests green" >/dev/null; rc=$?
+[[ $rc -ne 0 ]] && ok_t "leaked --accept= is refused too" || bad_t "leaked --accept= is refused too" "rc=$rc"
+
+# --- T3: an over-long title is refused on the length tell alone
+run add --assignee=alice -- "$longtext" >/dev/null; rc=$?
+[[ $rc -ne 0 ]] && ok_t "260-char title is refused" || bad_t "260-char title is refused" "rc=$rc"
+errof | grep -q '260 chars' \
+  && ok_t "length refusal states the measured length" || bad_t "length refusal states the measured length" "$(errof)"
+
+# --- T4: the CORRECT invocation (flags before --) still works, body intact
+out=$(run add --assignee=alice --body="the real body" -- "a normal title")
+id=$(printf '%s' "$out" | jf '.data.id')
+[[ "$id" =~ ^[0-9]+$ ]] \
+  && ok_t "correct invocation still creates a row" || bad_t "correct invocation still creates a row" "$out"
+[[ "$(db "SELECT body FROM tasks WHERE id=$id;")" == "the real body" ]] \
+  && ok_t "correct invocation keeps the body" || bad_t "correct invocation keeps the body" "$(db "SELECT body FROM tasks WHERE id=$id;")"
+
+# --- T5: a title legitimately containing a lone dash or '--' word is NOT refused
+out=$(run add --assignee=alice -- "a title with -- a dash and --verbose but no equals")
+[[ "$(printf '%s' "$out" | jf '.data.id')" =~ ^[0-9]+$ ]] \
+  && ok_t "a '--word' with no '=' is not a false positive" || bad_t "a '--word' with no '=' is not a false positive" "$out"
+
+# --- T6: --materialized (the internal writers) is exempt from both tells
+out=$(run add --materialized --assignee=alice -- "$longtext")
+[[ "$(printf '%s' "$out" | jf '.data.id')" =~ ^[0-9]+$ ]] \
+  && ok_t "--materialized bypasses the length tell" || bad_t "--materialized bypasses the length tell" "$out"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
`task add ... -- "<title>" --body="<text>"` puts `--body=` after the `--` end-of-flags separator, so
it parses as positional title text instead of the body flag — silently. DIVE-3100 was filed with a
628-char title containing the literal string `--body=MEASURED 2026-08-09...` and an empty body. No
warning, no error, and the row could not be repaired in place afterwards because delivered
title/body are frozen.

Add-time is the only moment the filer can still act on it, so this refuses rather than accepts.
Two independent tells, either sufficient:

- a title over 200 chars
- a title containing a `--<word>=` token

The refusal names which tell fired and shows where the flag landed. `--materialized` is exempt.

Tests: `tests/task_add_flag_swallow_unit.sh` 11/11 core in 1.4s; all 10 materialized-caller
harnesses green. Two pre-existing failures reproduce identically on an `origin/main` control.

Row: DIVE-3107 (filed by quinn, fixed by main2, pushed by main — main2's seat holds no push grant).
