### PR TITLE
feat(task): route role: tokens by load, and surface the lane skew (DIVE-3366)

### DIFF
--- a/src/task/crud.sh
+++ b/src/task/crud.sh
@@ -197,10 +197,26 @@ cmd_task_add() {
   # TOKEN (role:<r> / charter:<kw> / @name). Route tokens through the org chart;
   # a literal name is trusted verbatim (explicit --assignee always wins). A token
   # with no UNIQUE holder is a hard, EXPLAINABLE error — never a silent misroute.
+  local role_pick_note=""
   if [[ -n "$assignee" ]]; then
     case "$assignee" in
       role:*|charter:*|@*)
-        local _resolved; _resolved=$(_org_resolve_assignee "$assignee")
+        local _resolved _token="$assignee"; _resolved=$(_org_resolve_assignee "$assignee")
+        # DIVE-3366: a role with TWO holders is not an unanswerable question — it
+        # is the one the board most needs answered, and answering it with a
+        # refusal is what sends every row to the seat the filer remembers. Runs
+        # ONLY on the empty (previously fatal) path, so a token that already
+        # resolved is untouched. The verifier seat is excluded from the
+        # candidates, which is how a loop row gets a build lane that is not its
+        # own grader instead of the refusal below.
+        if [[ -z "$_resolved" && "$_token" == role:* ]] \
+           && _task_role_least_loaded "${_token#role:}" "$verifier"; then
+          _resolved="$_TASK_ROLE_PICK"
+          # Recorded on the row, not only warned at the prompt: the counts that
+          # made this choice have moved by the time anyone audits it.
+          role_pick_note="ROUTED BY LOAD (DIVE-3366): --assignee=${_token} -> ${_resolved}${verifier:+ (verifier '${verifier}' excluded from the candidates)}. Open-row counts at filing: ${_TASK_ROLE_PICK_BASIS}."
+          warn "$role_pick_note"
+        fi
         [[ -n "$_resolved" ]] || fail "$E_NOT_FOUND" "--assignee='$assignee' has no unique holder in the org chart — name an agent, or fix the role: 5dive org set"
         assignee="$_resolved"
         ;;
@@ -439,6 +455,18 @@ REFUSED TITLE (recorded in policy_refusals, not lost): ${title}"
     body="${body:+$body
 
 }FILING-CAP EXCEPTION (already blocked shipped work): ${already_blocked}"
+  fi
+  # DIVE-3366 acceptance 1: "its choice is recorded so it can be audited". Same
+  # reason as the cap exception directly above — a router whose choice leaves no
+  # trace cannot be audited, and this one is worse than the cap: the INPUT that
+  # decided it (each seat's open-row count) is a moving number, so by the time
+  # anyone asks why this lane got the row, the counts that answer no longer exist
+  # anywhere. Recorded on the row, not only in the warn line at the prompt, which
+  # the filer's terminal is the only witness to.
+  if [[ -n "$role_pick_note" ]]; then
+    body="${body:+$body
+
+}${role_pick_note}"
   fi
   # DIVE-969: verifier-by-default posture. For a NON-TRIVIAL standard task where
   # the creator neither wired the loop themselves (--accept/--verify/--verifier)
@@ -710,6 +738,14 @@ cmd_task_ls() {
                   ELSE status END AS status,
              priority, COALESCE(assignee,'-') AS assignee, title FROM tasks WHERE ${where} ${order};"
     fi
+    # DIVE-3366 acceptance 3: the skew belongs ON THE BOARD, under the queue,
+    # because that is where the routing decision is actually made — a number in a
+    # digest nobody reads at filing time is why lodar had to raise this by hand
+    # three times in one day. Suppressed under --assignee/--mine: a single-lane
+    # view is not a routing view, and a note about two other seats there is noise.
+    # Human path only; the --json branch returns above and its consumers must not
+    # find a new advisory in their payload.
+    [[ -n "$assignee" ]] || _task_role_skew_note
   fi
 }
 

--- a/src/task/routing.sh
+++ b/src/task/routing.sh
@@ -309,10 +309,29 @@ _task_wip_cap() {
 # _task_lanes_with_headroom <exclude> — lanes strictly under their cap, for the
 # redirect. Naming them is the whole point: "this lane is full" is a dead end,
 # "this lane is full, dev2 and quinn have room" is a next action.
+#
+# DIVE-3366 — AND EVERY NAME IT OFFERS MUST BE DISPATCHABLE. This enumerates
+# DISTINCT assignee over the whole tasks table, so any name anybody ever typed
+# into that column becomes a suggestion the moment a cap exists for it. Measured
+# 2026-08-13 while filing DIVE-3366: a refused `--assignee=dev2` offered ELEVEN
+# lanes that are not registered agents — `__nosuchagent_probe__`, `cli`,
+# `designer`, `distributor`, `editor`, `lodar`, `loop`, `proof`, `seo`,
+# `tgfreeprobe`, `writer` — each reading "(1 free)" because `wip-cap-install`
+# minted a ceiling for a name somebody once typed. This is the third live
+# instance of the class DIVE-3344 fixed at `--assignee`, and it is the worst of
+# the three: not a silent drop, but an active recommendation of an undispatchable
+# lane, delivered at the exact moment the filer is looking for somewhere to put
+# work — so the filer follows it, and the row is never picked.
+#
+# Roster-state-gated, not roster-emptiness-gated (`_task_require_lane`'s rule): a
+# roster we could not establish must narrow nothing, or a box with an unreadable
+# registry answers "no lanes have room" and the redirect becomes a dead end.
 _task_lanes_with_headroom() {
   local skip="$1" lane cap act out=""
+  _task_roster
   while IFS= read -r lane; do
     [[ -n "$lane" && "$lane" != "$skip" ]] || continue
+    if [[ "$_TASK_ROSTER_STATE" == "ok" ]] && ! _task_roster_has "$lane"; then continue; fi
     cap=$(_task_wip_cap "$lane") || continue
     act=$(_task_lane_actionable "$lane")
     [[ "$act" =~ ^[0-9]+$ ]] || continue
@@ -938,6 +957,163 @@ _org_resolve_assignee() {
       printf '%s' "$v"
       ;;
   esac
+}
+
+# ---------------------------------------------------------------------------
+# DIVE-3366 — ROUTE BY ROLE WHEN THE ROLE HAS TWO SEATS.
+#
+# `role:<r>` above routes ONLY on a unique holder and returns empty on two, and
+# that empty is the lane skew. The refusal pushes the filer back to typing a
+# name, and the name a filer remembers is the busiest seat — so the mechanism
+# that exists to distribute work actively concentrates it as soon as a second
+# holder is seated. Measured 2026-08-13 04:59Z with quinn and main2 both holding
+# the verifier role: quinn 14 open, main2 0. lodar raised the same imbalance
+# three times in one day; a directive repeated three times is a mechanism
+# question, not a discipline question.
+#
+# WIDENING ONLY. These run where `_org_resolve_assignee` already came back EMPTY
+# — an ambiguity that was a hard error one line later at the call site — so they
+# can only turn a refusal into a route, never re-point a token that already
+# resolved. Same discipline the DIVE-2041 substring pass was added under, and the
+# reason `_org_resolve_assignee` itself is left exactly as it is: `goal validate`
+# and `objective` read it to ask "does this resolve deterministically", and a
+# load-based answer is not the same question.
+#
+# THE PICK IS RECORDED ON THE ROW, because a load-based choice cannot be
+# reconstructed afterwards: the counts that decided it have moved by the time
+# anyone reads the row. `_TASK_ROLE_PICK_BASIS` carries every candidate's count
+# as measured at filing, and the caller writes it into the body.
+#
+# ONLY DISPATCHABLE SEATS ARE CANDIDATES. The org chart names lanes the registry
+# does not — that is exactly the name DIVE-3344 refuses at `--assignee` — and
+# picking one here would mint the undispatchable row through the back door, with
+# the router's authority on it, so nobody would think to question the name. When
+# the roster is `unestablished:*` the filter is skipped rather than treated as an
+# empty roster, for the reason `_task_require_lane` documents: a roster we could
+# not establish must refuse nothing.
+# ---------------------------------------------------------------------------
+_TASK_ROLE_PICK=""; _TASK_ROLE_PICK_BASIS=""
+
+# _org_role_holders <role> — every chart seat matching the role token, one per
+# line, name-ordered. Same two passes as `_org_resolve_assignee`, in the same
+# order and with the same LIKE escaping: exact `role` equality first so a chart
+# with terse role values keeps its sharp answer, substring over role||title only
+# when exact matched nothing.
+_org_role_holders() {
+  local r="$1" exact
+  exact=$(db "SELECT name FROM agents_org
+              WHERE role IS NOT NULL AND lower(role)=lower($(sqlq "$r")) ORDER BY name;" 2>/dev/null || true)
+  if [[ -n "$exact" ]]; then printf '%s\n' "$exact"; return 0; fi
+  db "SELECT name FROM agents_org
+      WHERE lower(' '||COALESCE(role,'')||' '||COALESCE(title,''))
+            LIKE '% '||lower($(sqlq "$(_org_like_escape "$r")"))||'%' ESCAPE '\'
+      ORDER BY name;" 2>/dev/null || true
+  return 0
+}
+
+# _task_role_least_loaded <role> [exclude_lane] — SETS `_TASK_ROLE_PICK` (the
+# chosen seat) and `_TASK_ROLE_PICK_BASIS` (the counts that chose it). Read the
+# variables; this PRINTS NOTHING, for the `_task_roster` reason one function
+# down — a caller writing `x=$(...)` assigns the globals in a subshell and loses
+# them. Returns 0 when a seat was picked, 1 when none was (no holders, none
+# dispatchable, or the only holder was the excluded one) so the caller can fall
+# through to its own refusal.
+#
+# `exclude_lane` is how acceptance 2's second half is met: the verifier seat is
+# simply not a candidate for the build, so `--assignee=role:verifier
+# --verifier=quinn` routes the build to the OTHER holder instead of refusing.
+_task_role_least_loaded() {
+  local role="$1" exclude="${2:-}" lane act best="" best_n="" basis=""
+  _TASK_ROLE_PICK=""; _TASK_ROLE_PICK_BASIS=""
+  [[ -n "$role" ]] || return 1
+  _task_roster
+  while IFS= read -r lane; do
+    [[ -n "$lane" ]] || continue
+    [[ "$lane" == "$exclude" ]] && continue
+    if [[ "$_TASK_ROSTER_STATE" == "ok" ]] && ! _task_roster_has "$lane"; then continue; fi
+    act=$(_task_lane_actionable "$lane")
+    [[ "$act" =~ ^[0-9]+$ ]] || continue
+    basis+="${basis:+, }${lane} ${act}"
+    # STRICTLY less-than over name-ordered candidates, so equal counts always
+    # pick the same seat. A router that alternates on a tie files the two halves
+    # of one decomposition into two different lanes, which is worse than either
+    # lane being busy.
+    if [[ -z "$best" ]] || (( act < best_n )); then best="$lane"; best_n="$act"; fi
+  done < <(_org_role_holders "$role")
+  [[ -n "$best" ]] || return 1
+  _TASK_ROLE_PICK="$best"; _TASK_ROLE_PICK_BASIS="$basis"
+  return 0
+}
+
+# _task_role_skew_note — acceptance 3. One line on the board when a role's
+# busiest seat holds FACTOR times its idlest, NAMING BOTH COUNTS, because the
+# bare ratio is what made this invisible for a day: "quinn is loaded" reads as a
+# quinn problem, "quinn 14, main2 0" names the routing.
+#
+# THE WORST ROLE ONLY, once. The requirement is "say so once"; a per-role list
+# printed under every `task ls` is the shape readers learn to skip, and this note
+# has to survive being seen a hundred times a day.
+#
+# THE FACTOR NEEDS A FLOOR ON THE COUNT, and that floor is the whole reason this
+# is not just `max >= FACTOR * min`: min=0 makes every ratio infinite, so a role
+# whose two seats hold 2 and 0 would announce a skew on an essentially empty
+# board. The floor is on the BUSY side, so the note fires only when there is
+# genuinely something to re-lane.
+#
+# AND IT SPLITS THE BUSY SEAT'S COUNT INTO GRADING vs BUILDING, which is the part
+# that stops this note from being read the way the depth number that prompted it
+# was read. DIVE-3366 was filed on "quinn 14 open / main2 0, both verifiers" and
+# diagnosed as nine build rows quinn was also booked to grade. Measured after the
+# fact: four of those rows carried a NON-NULL `maker_agent`, which makes
+# `assignee == verifier` the CORRECT shape of a DELIVERED row — the handoff
+# reassigns the row to its grader and parks the builder in `maker_agent` — so
+# they were deliveries awaiting a grade, not a seat grading its own build. A
+# grading backlog and a mis-laned builder want OPPOSITE fixes (wake the grader vs
+# re-lane the work), so a note that names one number for both sends half its
+# readers the wrong way. `maker_agent` is the discriminator; the seat count never
+# was. See community/wiki/assignee-equals-verifier-is-the-delivered-shape.md.
+_task_role_skew_note() {
+  local factor="${FIVE_ROLE_SKEW_FACTOR:-3}" floor="${FIVE_ROLE_SKEW_FLOOR:-3}"
+  [[ "$factor" =~ ^[0-9]+$ && "$floor" =~ ^[0-9]+$ ]] || return 0
+  (( factor >= 2 )) || return 0
+  local role lane act n min max min_lane max_lane ratio
+  local w_role="" w_ratio=0 w_max=0 w_min=0 w_maxlane="" w_minlane=""
+  _task_roster
+  while IFS= read -r role; do
+    [[ -n "$role" ]] || continue
+    min=""; max=""; min_lane=""; max_lane=""; n=0
+    while IFS= read -r lane; do
+      [[ -n "$lane" ]] || continue
+      if [[ "$_TASK_ROSTER_STATE" == "ok" ]] && ! _task_roster_has "$lane"; then continue; fi
+      act=$(_task_lane_actionable "$lane")
+      [[ "$act" =~ ^[0-9]+$ ]] || continue
+      n=$((n+1))
+      if [[ -z "$min" ]] || (( act < min )); then min="$act"; min_lane="$lane"; fi
+      if [[ -z "$max" ]] || (( act > max )); then max="$act"; max_lane="$lane"; fi
+    done < <(db "SELECT name FROM agents_org
+                 WHERE role IS NOT NULL AND lower(role)=lower($(sqlq "$role")) ORDER BY name;" 2>/dev/null || true)
+    (( n >= 2 )) || continue
+    (( max >= floor )) || continue
+    (( max >= min * factor )) || continue
+    ratio=$(( max / (min > 0 ? min : 1) ))
+    if (( ratio > w_ratio )); then
+      w_ratio=$ratio; w_role="$role"; w_max=$max; w_min=$min
+      w_maxlane="$max_lane"; w_minlane="$min_lane"
+    fi
+  done < <(db "SELECT DISTINCT role FROM agents_org WHERE role IS NOT NULL AND role<>'' ORDER BY role;" 2>/dev/null || true)
+  [[ -n "$w_role" ]] || return 0
+  # The split, measured on the busy seat only: it is the seat whose number gets
+  # acted on, and one extra query beats a reader guessing which fix applies.
+  local grading building=""
+  grading=$(db "SELECT COUNT(*) FROM tasks
+                WHERE assignee=$(sqlq "$w_maxlane") AND kind='standard'
+                  AND status IN ('todo','in_progress') AND parked_at IS NULL
+                  AND maker_agent IS NOT NULL AND maker_agent<>'' AND assignee=verifier;" 2>/dev/null || echo "")
+  if [[ "$grading" =~ ^[0-9]+$ ]] && (( grading <= w_max )); then
+    building=" (${grading} awaiting its grade, $(( w_max - grading )) to build)"
+  fi
+  warn "LANE SKEW in role '${w_role}' (DIVE-3366): ${w_maxlane} holds ${w_max} open${building}, ${w_minlane} holds ${w_min} — a grading backlog wants the GRADER woken, a build backlog wants the work RE-LANED, so read the split before acting. File to the role, not the name (--assignee=role:${w_role} picks the idler seat and records why), or name ${w_minlane} on the next row."
+  return 0
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/task_core_unit.sh
+++ b/tests/task_core_unit.sh
@@ -333,10 +333,37 @@ r2=$(run add --assignee=charter:backend --body="w" -- "route by charter")
 [[ "$(echo "$r2" | jf '.data.assignee')" == "eng" ]] \
   && ok_t "--assignee=charter:backend resolves to eng" || bad_t "charter token resolve" "$(echo "$r2" | jf '.data.assignee')"
 
-# ambiguous role (two designers) is a hard, explainable error — never a guess
+# DIVE-3366 INVERTED THIS ARM, deliberately, and the old assertion is quoted here
+# because a reader finding a route where this file used to demand a refusal will
+# otherwise assume the guard rotted. It read:
+#
+#   # ambiguous role (two designers) is a hard, explainable error — never a guess
+#   run add --assignee=role:designer ... ; [[ $? -ne 0 && err == *"unique holder"* ]]
+#
+# The refusal was the lane skew. Two seats on a role is the case where routing
+# has the MOST to say, and answering it with an error sent the filer back to
+# typing a name — and the name a filer remembers is the busiest seat (measured
+# 2026-08-13: quinn 14 open, main2 0, both verifiers, lodar raising it three
+# times in one day). A role with two holders now routes to the idler and RECORDS
+# the counts that chose it; tests/task_role_routing_unit.sh grades that rail.
+#
+# `_org_resolve_assignee` itself is unchanged — it still returns empty on two
+# holders, which is what `goal validate` needs — so the arms above still pass and
+# the widening lives at the `task add` call site only.
 run add --assignee=role:designer --body="w" -- "ambiguous role" >/dev/null 2>"$TMP"/err
+rc_amb=$?
+amb_who=$(db "SELECT assignee FROM tasks WHERE title='ambiguous role';")
+amb_body=$(db "SELECT COALESCE(body,'') FROM tasks WHERE title='ambiguous role';")
+[[ $rc_amb -eq 0 && ( "$amb_who" == "d1" || "$amb_who" == "d2" ) && "$amb_body" == *"ROUTED BY LOAD"* ]] \
+  && ok_t "two-holder role routes by load and records the pick (DIVE-3366, was a refusal)" \
+  || bad_t "two-holder role routes by load" "rc=$rc_amb who=$amb_who body=$amb_body err=$(cat "$TMP"/err)"
+
+# AND THE REFUSAL STILL EXISTS for the case that has no answer: a role NO seat
+# holds. DIVE-3366 widened the two-holder empty into a route; it must not have
+# turned the zero-holder empty into one, which would land a row on nobody.
+run add --assignee=role:nosuchrole --body="w" -- "unheld role" >/dev/null 2>"$TMP"/err
 [[ $? -ne 0 && "$(cat "$TMP"/err)" == *"unique holder"* ]] \
-  && ok_t "ambiguous role token rejected (explainable)" || bad_t "ambiguous role guard" "$(cat "$TMP"/err)"
+  && ok_t "a role NO seat holds is still refused (explainable)" || bad_t "unheld role guard" "$(cat "$TMP"/err)"
 
 # unknown role token is rejected too
 run add --assignee=role:ghost --body="w" -- "unknown role" >/dev/null 2>"$TMP"/err

--- a/tests/task_role_routing_unit.sh
+++ b/tests/task_role_routing_unit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# TIER: pr-core — 3.1s measured on the dev VM 2026-08-13 (DIVE-3366). Isolated
+# TIER: core — 3.1s measured on the dev VM 2026-08-13 (DIVE-3366). Isolated
 # unit harness for role-based routing at FILING time: least-loaded resolution of
 # `--assignee=role:<r>` when a role has two or more seats, the audit trail that
 # records which counts chose the lane, the lane-skew note on the board, the

--- a/tests/task_role_routing_unit.sh
+++ b/tests/task_role_routing_unit.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# TIER: pr-core — 3.1s measured on the dev VM 2026-08-13 (DIVE-3366). Isolated
+# unit harness for role-based routing at FILING time: least-loaded resolution of
+# `--assignee=role:<r>` when a role has two or more seats, the audit trail that
+# records which counts chose the lane, the lane-skew note on the board, the
+# grading/building split that keeps that note from being misread, and the roster
+# filter on the WIP-cap redirect's suggestions.
+#
+# Same isolation contract as the other task harnesses: source src/ directly and
+# point STATE_DIR at a throwaway temp dir, so the live shared tasks.db is NEVER
+# touched. A REGISTRY FIXTURE IS WRITTEN, deliberately: `_task_roster` reads
+# ${STATE_DIR}/agents.json, and with no registry the roster is
+# `unestablished:no-registry-file`, under which every roster filter in here is
+# SKIPPED BY DESIGN (a roster we could not establish must narrow nothing). A
+# harness with no registry would therefore green the two roster arms without
+# executing them — the arm proving the filter is what asserts the fixture is live.
+# Run: bash tests/task_role_routing_unit.sh   (no root, no network).
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/task-role-routing.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_project.sh; do
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"
+TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DB="$TASKS_DIR/tasks.db"
+mkdir -p "$TASKS_DIR"
+set +e   # header.sh enabled `set -e`; tests expect non-zero exits
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+jf()  { jq -r "$1" 2>/dev/null; }
+
+tasks_db_init
+
+# THE ROSTER IS SEEDED AS A REGISTRY FILE, not through `agent create`: the guards
+# under test read agent-ness from the registry (DIVE-3344's "the authority is the
+# registry"), and a fixture has no business provisioning a fleet to get a name.
+cat >"$STATE_DIR/agents.json" <<'JSON'
+{"agents":{"quinn":{},"main2":{},"dev9":{},"bob":{}}}
+JSON
+
+# DIVE-2124: seed the chart directly — `org set` is root-only, and these arms are
+# about routing, not authz.
+org_seed() {  # <name> --role=x
+  local n="$1"; shift
+  local role=""
+  for a in "$@"; do case "$a" in --role=*) role="${a#*=}" ;; esac; done
+  db "INSERT OR IGNORE INTO agents_org (name) VALUES ($(sqlq "$n"));"
+  [[ -n "$role" ]] && db "UPDATE agents_org SET role=$(sqlq "$role") WHERE name=$(sqlq "$n");"
+  return 0
+}
+
+# TWO seats on one role — the whole subject of DIVE-3366. `_org_resolve_assignee`
+# returns EMPTY here (COUNT != 1), which before this change was a hard refusal at
+# `task add`, which is what pushed filers back to typing the name they remember.
+org_seed quinn --role=verifier
+org_seed main2 --role=verifier
+org_seed dev9  --role=builder
+
+# Load quinn up and leave main2 idle: the measured 2026-08-13 shape, scaled down.
+seed_row() {  # <assignee> <n> [verifier] [maker]
+  local who="$1" n="$2" v="${3:-}" m="${4:-}" i
+  for (( i = 0; i < n; i++ )); do
+    db "INSERT INTO tasks (title,status,assignee,kind,priority,verifier,maker_agent,created_at)
+        VALUES ('seeded ${who} ${i}','todo',$(sqlq "$who"),'standard','medium',
+                $([[ -n "$v" ]] && sqlq "$v" || echo NULL),
+                $([[ -n "$m" ]] && sqlq "$m" || echo NULL),
+                datetime('now'));"
+  done
+}
+seed_row quinn 6
+
+# ---------------------------------------------------------------------------
+# A1 (acceptance 1) — role:<r> with TWO holders RESOLVES, to the idler seat.
+# ---------------------------------------------------------------------------
+JSON_MODE=1
+out=$( (cmd_task_add --assignee=role:verifier --no-verify -- "route me by load") 2>"$TMP"/a1.err )
+rc=$?
+a1_id=$(printf '%s' "$out" | jf '.data.id')
+a1_assignee=$(db "SELECT assignee FROM tasks WHERE id=${a1_id:-0};")
+[[ $rc -eq 0 && "$a1_assignee" == "main2" ]] \
+  && ok_t "A1 --assignee=role:verifier with 2 seats routes to the idler (main2)" \
+  || bad_t "A1 role: routes to least-loaded" "rc=$rc assignee='$a1_assignee' out=$out err=$(cat "$TMP"/a1.err)"
+
+# ---------------------------------------------------------------------------
+# A2 (acceptance 1, second half) — "its choice is recorded so it can be
+# audited". Assert BOTH counts are on the row, not merely that a note exists:
+# the note without the numbers is unauditable, because the numbers that chose
+# the lane have moved by the time anyone reads it.
+# ---------------------------------------------------------------------------
+a2_body=$(db "SELECT COALESCE(body,'') FROM tasks WHERE id=${a1_id:-0};")
+if [[ "$a2_body" == *"ROUTED BY LOAD"* && "$a2_body" == *"main2 0"* && "$a2_body" == *"quinn 6"* ]]; then
+  ok_t "A2 the load-based pick is recorded on the row with BOTH seats' counts"
+else
+  bad_t "A2 pick recorded with counts" "body='$a2_body'"
+fi
+
+# ---------------------------------------------------------------------------
+# A3 — the pick is DETERMINISTIC on a tie. A router that alternates files the
+# two halves of one decomposition into two different lanes.
+# ---------------------------------------------------------------------------
+_task_role_least_loaded verifier ""; p1="$_TASK_ROLE_PICK"
+_task_role_least_loaded verifier ""; p2="$_TASK_ROLE_PICK"
+db "DELETE FROM tasks WHERE title LIKE 'tiebreak%';"
+seed_row main2 6                 # 6 vs 6 — an exact tie
+_task_role_least_loaded verifier ""; t1="$_TASK_ROLE_PICK"
+_task_role_least_loaded verifier ""; t2="$_TASK_ROLE_PICK"
+[[ "$p1" == "$p2" && -n "$t1" && "$t1" == "$t2" ]] \
+  && ok_t "A3 the pick is stable across calls, including on an exact tie ($t1)" \
+  || bad_t "A3 deterministic pick" "p1=$p1 p2=$p2 t1=$t1 t2=$t2"
+db "DELETE FROM tasks WHERE assignee='main2' AND title LIKE 'seeded main2%';"
+
+# ---------------------------------------------------------------------------
+# A4 (acceptance 2, "or resolves the verifier to a different seat") — the
+# verifier seat is not a candidate for the build, so a loop row routed by role
+# lands on the OTHER holder instead of being refused for self-grading.
+# ---------------------------------------------------------------------------
+out=$( (cmd_task_add --assignee=role:verifier --verifier=main2 -- "graded by main2, built elsewhere") 2>"$TMP"/a4.err )
+rc=$?
+a4_id=$(printf '%s' "$out" | jf '.data.id')
+a4_a=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=${a4_id:-0};")
+a4_v=$(db "SELECT COALESCE(verifier,'') FROM tasks WHERE id=${a4_id:-0};")
+[[ $rc -eq 0 && "$a4_a" == "quinn" && "$a4_v" == "main2" ]] \
+  && ok_t "A4 the verifier seat is excluded from the candidates (build->quinn, grade->main2)" \
+  || bad_t "A4 verifier excluded from role pick" "rc=$rc assignee='$a4_a' verifier='$a4_v' err=$(cat "$TMP"/a4.err)"
+
+# ---------------------------------------------------------------------------
+# A5 (acceptance 2, first half) — PIN, NOT NEW CODE. The filing-time refusal of
+# assignee == verifier already exists: DIVE-3097 landed it 2026-08-09 22:51Z,
+# four days before DIVE-3366 was filed, and zero rows on the live board were
+# filed same-seat after that timestamp. DIVE-3366 asked for a guard that is
+# already there, so this arm pins it rather than duplicating it — acceptance 4's
+# rule ("do not widen a control that already works") read one control over.
+# ---------------------------------------------------------------------------
+out=$( (cmd_task_add --assignee=quinn --verifier=quinn -- "grade my own work") 2>"$TMP"/a5.err )
+rc=$?
+msg="$out$(cat "$TMP"/a5.err)"
+[[ $rc -ne 0 && "$msg" == *"own assignee"* ]] \
+  && ok_t "A5 filing assignee==verifier is REFUSED at filing time (DIVE-3097, pinned)" \
+  || bad_t "A5 same-seat filing refused" "rc=$rc msg=$msg"
+
+# --- A6 NEGATIVE CONTROL for A5: the same row with DISTINCT names files clean.
+# Without this, A5 passes just as well if `task add` were broken for every input.
+out=$( (cmd_task_add --assignee=dev9 --verifier=quinn -- "distinct names file clean") 2>"$TMP"/a6.err )
+rc=$?
+a6_id=$(printf '%s' "$out" | jf '.data.id')
+[[ $rc -eq 0 && -n "$a6_id" && "$a6_id" != "null" ]] \
+  && ok_t "A6 negative control: distinct assignee/verifier files clean" \
+  || bad_t "A6 distinct names file clean" "rc=$rc out=$out err=$(cat "$TMP"/a6.err)"
+
+# ---------------------------------------------------------------------------
+# A7 — a DELIVERED row is not the same state, and nothing here may treat it as
+# one. `assignee == verifier` WITH a non-null maker_agent is the correct shape of
+# a delivered row (the handoff reassigns the row to its grader and parks the
+# builder in maker_agent) — it is what `task ls --json`'s handoff_state reads,
+# and it is what DIVE-3366's own filing evidence misread as nine self-grading
+# build rows. A guard that refused the equality unconditionally would refuse
+# every delivery on the board.
+# ---------------------------------------------------------------------------
+seed_row quinn 4 quinn dev9      # delivered: assignee==verifier, maker set
+hs=$(db "SELECT COUNT(*) FROM tasks WHERE assignee='quinn' AND assignee=verifier AND maker_agent IS NOT NULL;")
+[[ "$hs" == "4" ]] \
+  && ok_t "A7 delivered rows (assignee==verifier + maker_agent) survive filing untouched" \
+  || bad_t "A7 delivered shape preserved" "count=$hs"
+
+# ---------------------------------------------------------------------------
+# A8 (acceptance 3) — the skew note fires once, NAMES BOTH COUNTS, and splits
+# the busy seat into grading vs building. quinn holds 11 open at this point (6
+# seeded + A4's build row + the 4 delivered), of which the 4 delivered are
+# awaiting its own grade; main2 holds the 1 row A1 routed to it. The counts are
+# asserted EXACTLY rather than as "> 0": a split whose two halves do not add up
+# to the total is the specific way this note would mislead.
+# ---------------------------------------------------------------------------
+JSON_MODE=0
+note=$( _task_role_skew_note 2>&1 )
+lines=$(printf '%s' "$note" | grep -c "LANE SKEW")
+if [[ "$lines" == "1" && "$note" == *"quinn holds 11"* && "$note" == *"main2 holds 1"* \
+      && "$note" == *"4 awaiting its grade"* && "$note" == *"7 to build"* ]]; then
+  ok_t "A8 skew note: one line, both counts, grading/building split"
+else
+  bad_t "A8 skew note shape" "lines=$lines note=$note"
+fi
+
+# --- A9 NEGATIVE CONTROL for A8: a BALANCED role says nothing. Without this the
+# note could be unconditional and A8 would not notice.
+seed_row main2 10
+note2=$( _task_role_skew_note 2>&1 )
+[[ -z "$(printf '%s' "$note2" | grep "LANE SKEW")" ]] \
+  && ok_t "A9 negative control: a balanced role emits no skew note" \
+  || bad_t "A9 balanced role silent" "note2=$note2"
+db "DELETE FROM tasks WHERE assignee='main2' AND title LIKE 'seeded main2%';"
+
+# --- A10: the floor keeps the note off a nearly-empty board (2 vs 0 is an
+# infinite ratio and must NOT fire).
+db "DELETE FROM tasks;"
+seed_row quinn 2
+note3=$( _task_role_skew_note 2>&1 )
+[[ -z "$(printf '%s' "$note3" | grep "LANE SKEW")" ]] \
+  && ok_t "A10 the busy-side floor suppresses the note on a 2-vs-0 board" \
+  || bad_t "A10 floor suppresses tiny skew" "note3=$note3"
+
+# ---------------------------------------------------------------------------
+# A11 (the third instance) — the WIP-cap redirect must not SUGGEST a lane that
+# is not a registered agent. Measured while DIVE-3366 was filed: a refused
+# --assignee=dev2 offered eleven names that are not agents, each "(1 free)".
+# ---------------------------------------------------------------------------
+db "DELETE FROM tasks;"
+seed_row quinn 1
+seed_row main2 1
+db "INSERT INTO tasks (title,status,assignee,kind,priority,created_at)
+    VALUES ('typo lane row','todo','__nosuchagent_probe__','standard','medium',datetime('now'));"
+for lane in quinn main2 __nosuchagent_probe__; do
+  db "INSERT INTO task_prefs (key,value) VALUES ($(sqlq "wip_cap:$lane"),'9')
+      ON CONFLICT(key) DO UPDATE SET value='9';"
+done
+free=$(_task_lanes_with_headroom "dev9")
+if [[ "$free" == *"quinn"* && "$free" == *"main2"* && "$free" != *"__nosuchagent_probe__"* ]]; then
+  ok_t "A11 the headroom suggestion offers only DISPATCHABLE lanes"
+else
+  bad_t "A11 headroom roster filter" "free='$free'"
+fi
+
+# --- A12 NEGATIVE CONTROL for A11, and the arm that proves the fixture roster is
+# live: with the roster UNESTABLISHED the filter must narrow NOTHING, so the
+# typo'd lane comes back. If this passed while A11 also passed only because the
+# registry was missing, both would be vacuous — they cannot both be vacuous.
+_TASK_ROSTER=""; _TASK_ROSTER_STATE=""
+free_noreg=$(STATE_DIR="$TMP/absent-registry-dir" _task_lanes_with_headroom "dev9")
+_TASK_ROSTER=""; _TASK_ROSTER_STATE=""
+[[ "$free_noreg" == *"__nosuchagent_probe__"* ]] \
+  && ok_t "A12 negative control: an unestablished roster narrows nothing" \
+  || bad_t "A12 unestablished roster narrows nothing" "free_noreg='$free_noreg'"
+
+printf '\n%s\n' "----------------------------------------"
+printf 'PASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
Closes DIVE-3366.

Maker dev3. Graded PASS by main2 (verifier). Pushed by main as a credential relay: neither dev3 nor main2 holds a push credential, and the branch was unpushed, which is what made `task done` refuse.

Landed by ref-push of the exact graded commit (`0cbf352781ca627760a4d2f3cd2d0da93d579f0a`), not a rebase or a re-commit, so the sha main2 graded is the sha on the branch.

## Grade evidence (main2's, not re-run by me)

- `task_role_routing_unit` 12/12, plus main2's own mutant, which redded only A1/A8
- `task_core_unit` 68/0, `task_wip_cap_unit` 31/0, `roster_guard` 36/0, `org_role_token_substring` 18/0, `goal_async` 13/0
- bundle builds and parses
- graded from main2's own clone of the commit, not from the maker's tree

Acceptance item 2 was verified as correct-against-code rather than by a build: `40fdcbf` (2026-08-09) already refuses `assignee == verifier` at filing time, and `handoff_state` is `maker_agent IS NOT NULL AND assignee = verifier` — so refusing that combination outright would refuse every delivery. Wiki page and index line are present.

## What main verified before pushing

Commit sha matches main2's report exactly; author line is the house `lodar`; one commit ahead of `origin/main` and a descendant of it, so no rebase was needed; scope is `src/task/crud.sh`, `src/task/routing.sh` and their two test files. I did not re-run the suites and am not re-grading — main2's PASS stands.

## Shipping note

`5dive-cli` does not auto-deploy. Merging this ships nothing to any box until a release-cut publishes a tag containing it. Note v0.20 is not being cut today (buzz inbound is broken, DIVE-3339), so the carrier will be a nightly patch.
