### PR TITLE
fix(usage): the middle wildcard is a read too — usage_collect + activity_collect (DIVE-3419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased — fix(usage): the middle wildcard is a read too (DIVE-3419)
+
+Both transcript readers in `cmd_usage.sh` used `projects/*/*.jsonl`. `usage_collect` was guarded at the
+**top** (`probe_readable` on `projects/`) and the **bottom** (per-file `except OSError`) of a *three*-level
+path; the middle `*` is a directory listing that `glob.glob()` performs itself and swallows every `OSError`
+from. So a project subdir the caller could not read dropped out of the agent's total with no exception and
+no reason, leaving the agent in the READABLE set with **a fraction of its burn and `coverage.complete` still
+true** — and every "⚠ N NOT checked — burn is unknown (not 0)" banner built on that flag stayed quiet on it.
+
+- **A guard at the top and the bottom of a path does not cover a glob's MIDDLE wildcards**, and no third
+  probe can fix it — there is no exception to catch. Each level is now enumerated with `os.listdir`, which
+  may raise. `ENOENT` (a session rolling over) and `ENOTDIR` (a stray file in `projects/`) stay silent: both
+  mean "nothing unread here", and flagging them would disable coverage in the other direction.
+- **`activity_collect` had no readability contract at any level** and still resolved `home` through the
+  guessed `/home/agent-<name>` fallback DIVE-3345 deleted from its sibling. It now gets a **reporting**
+  contract, not the fail-closed NOT-REACHED one the spend scanner owes: nothing persists this trail over
+  durable state, so it emits the trail and NAMES what is missing from it (`.partial`, printed above the
+  counts). An unresolvable agent exits non-zero with empty stdout and a named cause instead of rendering a
+  clean "did nothing".
+- Replacing `glob` **widens** coverage: `glob` hid dot-prefixed names at both levels, and a dot-prefixed
+  session file is still burn.
+- `tests/usage_middle_wildcard_unit.sh` — 23 arms, unprivileged, anchor-first, paired sick/healed, an
+  ANY-UID arm (`ELOOP`, which root cannot resolve either) so a uid-0 CI run cannot be a vacuous green, and
+  over-fire controls. **9/14 pre-fix, 23/0 after.**
+
 ## Unreleased — fix(task): `assignee` / `verifier` / `created_by` must name a real agent (DIVE-3344)
 
 Nothing validated these columns. The work-picker dispatches on `assignee`, so a row on a name that is

--- a/src/cmd_usage.sh
+++ b/src/cmd_usage.sh
@@ -35,7 +35,7 @@ usage_collect() {
   local since="$1" db
   db="${TASKS_DB:-${STATE_DIR}/tasks/tasks.db}"
   REGISTRY="$REGISTRY" TASK_DB="$db" USAGE_SINCE="$since" python3 - <<'PY'
-import os, sys, json, glob, time, re, sqlite3, errno, datetime as dt
+import os, sys, json, time, re, sqlite3, errno, datetime as dt   # no glob: DIVE-3419
 
 since = int(os.environ["USAGE_SINCE"])
 now   = int(time.time())
@@ -155,6 +155,67 @@ def probe_readable(home, projects):
         return False, "home unreadable: %s" % (e.strerror or e.errno)
     return True, None              # home readable, no transcript dir: idle
 
+# DIVE-3419 — probe_readable() above covers `projects/`, and the per-file
+# `except OSError` below covers each `*.jsonl`. Those are the TOP and the BOTTOM
+# of a THREE-level path. The middle `*` of `projects/*/*.jsonl` is a directory
+# listing too, and `glob.glob()` performs it by SWALLOWING every OSError and
+# yielding nothing for that entry — so a project subdir this uid cannot read
+# dropped out of the agent's total with no exception, no reason, and the agent
+# still counted as READ with `coverage.complete` true. Milder than DIVE-3417's
+# clobber (nothing here persists over durable state) but the same defect: every
+# surface built on that flag — `usage.sh`'s "cannot read" and "⚠ N NOT checked —
+# burn is unknown (not 0)" banners — stays quiet on a number short of the truth,
+# and `5dive usage` is what a human reads when deciding whether a seat is
+# burning.
+#
+# The generalisable rule, and why one more probe could not fix it: a guard at the
+# top and the bottom of a path does not cover a glob's MIDDLE wildcards. Every
+# wildcard is a directory read that can fail, glob cannot report what it skipped,
+# so the level is enumerated explicitly here with os.listdir, which may raise.
+# Same shape as `list_sessions()` in cmd_loop.sh (DIVE-3417); the VERDICT differs
+# and that divergence is the point — there an unread level is NOT-REACHED (rc 2,
+# no number at all, because _loop_refresh_spend would persist a short one); here
+# it moves the agent into `coverage.unreadable`, which is exactly where an
+# unreadable FILE already puts it.
+def list_sessions(projects):
+    """-> (paths, reason). reason is not None => this agent was not fully read.
+
+    Enumerates `projects/*/*.jsonl` one level at a time. Two skips are kept
+    deliberately, because both mean "there is nothing unread here" rather than
+    "we failed to read it", and both match what the glob did:
+      * ENOENT  — the entry vanished between the listing and the read (sessions
+                  and their dirs roll over under a live agent).
+      * ENOTDIR — a regular FILE sitting directly in projects/. It cannot
+                  contain <it>/*.jsonl, so no transcript is being missed.
+    Anything else (EACCES on a 700 subdir, ELOOP on a self-referential symlink,
+    EIO) is a read we could not perform, and is reported.
+
+    One deliberate WIDENING over glob.glob: glob hides dot-prefixed names at
+    both levels. A dot-prefixed session file is still burn, and silently not
+    counting it is the very shape this function exists to refuse.
+    """
+    out = []
+    try:
+        entries = sorted(os.listdir(projects))
+    except OSError as e:
+        # ENOENT here is the state probe_readable JUST classified as genuinely
+        # idle: a readable home with no transcript dir yet. Flagging it would
+        # over-fire on every agent that has never run, which corrupts coverage
+        # as thoroughly as the fail-open did, in the other direction.
+        if e.errno == errno.ENOENT:
+            return [], None
+        return [], "transcript dir %s became unreadable mid-scan: %s" % (projects, e.strerror or e.errno)
+    for d in entries:
+        sub = os.path.join(projects, d)
+        try:
+            names = sorted(os.listdir(sub))
+        except OSError as e:
+            if e.errno in (errno.ENOENT, errno.ENOTDIR):
+                continue
+            return [], "project dir %s unreadable: %s" % (sub, e.strerror or e.errno)
+        out.extend(os.path.join(sub, n) for n in names if n.endswith(".jsonl"))
+    return out, None
+
 # --- scan transcripts: per agent per model token sums + per-turn timeline ---
 # turns[name] = list of (epoch, out_tokens, total_tokens) for task attribution.
 agent_rows = []
@@ -180,8 +241,14 @@ for name, meta in agents.items():
     turns = []
     pins = set()
     denied = None
-    pat = os.path.join(projects, "*", "*.jsonl")
-    for path in glob.glob(pat):
+    # DIVE-3419: a middle level we could not read makes this agent a blind spot,
+    # not a low scorer. Same destination as an unreadable home or file — never a
+    # silent short total sitting inside coverage.complete=true.
+    sessions, why = list_sessions(projects)
+    if why is not None:
+        unreadable.append({"name": name, "reason": why})
+        continue
+    for path in sessions:
         try:
             if os.path.getmtime(path) < since:   # whole file predates window
                 continue
@@ -1034,7 +1101,7 @@ cmd_cost() {
 activity_collect() {
   local agent="$1" since="$2" tstart="$3" tend="$4"
   A_AGENT="$agent" A_SINCE="$since" A_TSTART="$tstart" A_TEND="$tend" python3 - <<'PY'
-import os, json, glob, time, pwd, datetime as dt
+import os, json, time, pwd, errno, sys, datetime as dt   # no glob: DIVE-3419
 
 agent = os.environ["A_AGENT"]
 since = int(os.environ["A_SINCE"])
@@ -1055,10 +1122,19 @@ def to_epoch(s):
     except Exception:
         return None
 
-try:
-    home = pwd.getpwnam("agent-" + agent).pw_dir
-except KeyError:
-    home = "/home/agent-" + agent
+# DIVE-3419 acceptance 4 — the guessed `/home/agent-<name>` fallback is gone,
+# for the reason DIVE-3345 deleted it from the sibling spend scanner: a name with
+# no account on this host has no transcript root, and inventing a path that then
+# reads empty does not produce an empty activity trail, it produces an UNREAD one
+# and renders it as "this agent did nothing".
+_root = os.environ.get("A_HOME_ROOT") or ""      # test seam; unset in production
+if _root:
+    home = os.path.join(_root, "agent-" + agent)
+else:
+    try:
+        home = pwd.getpwnam("agent-" + agent).pw_dir
+    except KeyError:
+        sys.exit("activity: no agent-%s account on this host — transcript root unresolvable" % agent)
 
 files = {}      # mutated path -> {"edits":n, "last":ts}
 reads = {}      # read path -> count
@@ -1069,16 +1145,62 @@ tot = out = 0
 lo = since if tstart is None else max(since, tstart)
 hi = now   if tend   is None else tend
 
-pat = os.path.join(home, ".claude", "projects", "*", "*.jsonl")
-for path in glob.glob(pat):
+# DIVE-3419 acceptance 4, the DECISION and its reason, recorded here because the
+# next reader will otherwise re-derive it: an activity log DOES owe a readability
+# contract, but a REPORTING one, not the fail-closed NOT-REACHED contract its
+# spend-scanning sibling owes. `_spend_scan_task_ids` must emit NO number when it
+# is blind, because its caller PERSISTS what it returns over durable state and a
+# short total silently becomes the record. Nothing consumes this trail that way —
+# it is read by one human, about one agent, next to the trail itself. Refusing to
+# render 40 commands because one project dir is mode 000 would destroy the whole
+# surface to protect a token count that `5dive usage` reports properly anyway.
+# So: emit the trail, and NAME what is missing from it. `partial` is non-empty
+# exactly when this trail is short of the truth, and cmd_activity prints it above
+# the numbers. What is refused is the old behaviour — a bare `continue` at every
+# level, which made "unreadable" and "did nothing" the same rendering.
+partial = []
+
+def list_sessions(projects):
+    """-> paths, appending a named reason to `partial` for each unread level.
+
+    Same enumeration as usage_collect's (DIVE-3417/3419): os.listdir per level,
+    because glob.glob() swallows the middle wildcard's OSError and cannot report
+    what it skipped. ENOENT (rolled over mid-scan) and ENOTDIR (a regular file in
+    projects/, which cannot hold <it>/*.jsonl) are real absences and stay silent.
+    Dot-prefixed names are included, which glob hid at both levels.
+    """
+    out = []
+    try:
+        entries = sorted(os.listdir(projects))
+    except OSError as e:
+        # ENOENT = this agent has never run. Genuinely empty, not unread.
+        if e.errno != errno.ENOENT:
+            partial.append("transcript dir %s unreadable: %s" % (projects, e.strerror or e.errno))
+        return out
+    for d in entries:
+        sub = os.path.join(projects, d)
+        try:
+            names = sorted(os.listdir(sub))
+        except OSError as e:
+            if e.errno not in (errno.ENOENT, errno.ENOTDIR):
+                partial.append("project dir %s unreadable: %s" % (sub, e.strerror or e.errno))
+            continue
+        out.extend(os.path.join(sub, n) for n in names if n.endswith(".jsonl"))
+    return out
+
+for path in list_sessions(os.path.join(home, ".claude", "projects")):
     try:
         if os.path.getmtime(path) < lo:  # whole file predates window
             continue
-    except OSError:
+    except OSError as e:
+        if e.errno != errno.ENOENT:      # vanished mid-scan is fine; denied is not
+            partial.append("transcript %s unreadable: %s" % (path, e.strerror or e.errno))
         continue
     try:
         f = open(path, "r", errors="ignore")
-    except OSError:
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            partial.append("transcript %s unreadable: %s" % (path, e.strerror or e.errno))
         continue
     pending_cold = []   # DIVE-1026: skill fires in THIS session awaiting a follow-on tool
     with f:
@@ -1146,6 +1268,7 @@ print(json.dumps({
     "window": {"since": lo, "now": hi},
     "files": file_rows, "reads": read_rows, "commands": commands, "skills": skill_rows,
     "counts": counts, "tokens": {"total": tot, "output": out},
+    "partial": partial,          # DIVE-3419: non-empty => this trail is SHORT
 }))
 PY
 }
@@ -1201,6 +1324,13 @@ cmd_activity() {
   local label; [[ "$win_flag" == "7d" ]] && label="last 7d" || label="last 24h"
   [[ -n "$task" ]] && label="$twin_label"
   echo "ACTIVITY — ${agent}  (${label})"
+  # DIVE-3419: an unread level rides WITH the numbers it shortened, above them,
+  # so the trail can never be mistaken for a complete one.
+  local _pn; _pn=$(jq -r '(.partial // [])|length' <<<"$data")
+  if [[ "$_pn" =~ ^[0-9]+$ && "$_pn" -gt 0 ]]; then
+    printf '  ⚠ PARTIAL — %s level(s) could not be read; the counts below are SHORT of the truth, not low:\n' "$_pn"
+    jq -r '(.partial // [])[] | "      " + .' <<<"$data"
+  fi
   jq -r "$USAGE_JQ_HELPERS"'
     ((.counts.edit + .counts.write + .counts.multiedit + .counts.notebook)) as $ops |
     "  files touched: " + ((.files|length)|tostring) + " (" + ($ops|tostring) + " edits)"

--- a/tests/usage_middle_wildcard_unit.sh
+++ b/tests/usage_middle_wildcard_unit.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# DIVE-3419 unit: the MIDDLE wildcard of `projects/*/*.jsonl` in BOTH transcript
+# readers in cmd_usage.sh — `usage_collect` (guarded top and bottom, unguarded in
+# the middle) and `activity_collect` (unguarded at every level).
+#
+# The defect: glob.glob() performs the middle directory listing itself and
+# SWALLOWS every OSError, yielding nothing for the entry. So a project subdir
+# this uid cannot read left the agent in the READABLE set with a total that is a
+# FRACTION of the truth and `coverage.complete` still true — every "⚠ NOT checked
+# — burn is unknown (not 0)" surface built on that flag stayed quiet.
+#
+# WHY THE ARMS ARE BUILT THIS WAY (DIVE-3345/3417 rules, applied):
+#  * ANCHOR FIRST. A healthy arm asserting a specific NON-ZERO total, on the same
+#    code path. Every refusal arm below is VACUOUS while the anchor is red: a
+#    zero from an empty fixture is indistinguishable from a zero from a clean
+#    check, which is the bug being fixed.
+#  * PAIRED SICK/HEALED. Each sick fixture is re-run healed, and the heal arm
+#    must recompute the real non-zero total THROUGH THE SAME CODE — proving the
+#    sick arm reported blindness and not emptiness.
+#  * ANY-UID ARM. EACCES is only expressible unprivileged, so a uid-0 CI run
+#    would skip the point. ENOTDIR does not work at THIS level (it is a
+#    legitimate skip here), so the any-uid vehicle is ELOOP: a self-referential
+#    symlink where a project dir belongs, which root cannot resolve either.
+#  * OVER-FIRE CONTROLS. A fix that flags idle agents disables coverage exactly
+#    as thoroughly as the fail-open did. Legitimate-zero arms are not padding.
+#
+#   bash tests/usage_middle_wildcard_unit.sh
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; chmod -R u+rwX "${TMP:-}" 2>/dev/null; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+
+TMP="$(mktemp -d /tmp/usage-midwild.XXXXXX)"
+
+# Extract each collector's python. usage_collect is the FIRST heredoc in the
+# file; activity_collect's is taken from inside its own function body, because
+# grabbing "the first PY block" would silently grade the wrong subject.
+awk "/python3 - <<'PY'/{f=1;next} f&&/^PY\$/{exit} f" src/cmd_usage.sh > "$TMP/collect.py"
+awk '/^activity_collect\(\) \{/{g=1} g&&/python3 - <<.PY./{f=1;next} f&&/^PY$/{exit} f' \
+  src/cmd_usage.sh > "$TMP/activity.py"
+[[ -s "$TMP/collect.py"  ]] || { echo "FAIL - could not extract usage_collect python";  exit 1; }
+[[ -s "$TMP/activity.py" ]] || { echo "FAIL - could not extract activity_collect python"; exit 1; }
+grep -q 'A_AGENT' "$TMP/activity.py" || { echo "FAIL - extracted the wrong python for activity_collect"; exit 1; }
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+NOW="$(date +%s)"; TS="$(date -u -d @"$NOW" +%Y-%m-%dT%H:%M:%SZ)"
+printf '{"agents":{"alpha":{"type":"claude"}}}' > "$TMP/reg.json"
+
+# one project subdir worth exactly 30000 total tokens (in+out+cache-write), and
+# one Bash tool_use so the activity trail has something to be short OF.
+mk_proj() { # mk_proj <home> <projname> [<sessionfilename>]
+  local d="$1/.claude/projects/$2"; mkdir -p "$d"
+  printf '%s\n' "{\"type\":\"assistant\",\"timestamp\":\"$TS\",\"message\":{\"model\":\"m\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"input\":{\"command\":\"echo $2\",\"description\":\"d\"}}],\"usage\":{\"input_tokens\":20000,\"output_tokens\":10000}}}" \
+    > "$d/${3:-session.jsonl}"
+}
+collect()  { REGISTRY="$TMP/reg.json" TASK_DB="$TMP/none.db" USAGE_SINCE="$((NOW-3600))" \
+             USAGE_HOME_ROOT="$1" python3 "$TMP/collect.py" 2>/dev/null; }
+activity() { A_AGENT=alpha A_SINCE="$((NOW-3600))" A_TSTART=- A_TEND=- A_HOME_ROOT="$1" \
+             python3 "$TMP/activity.py" 2>"$TMP/act.err"; }
+
+# ============ ANCHOR — two readable project dirs, 60000, complete. ============
+A="$TMP/anchor"; H="$A/agent-alpha"; mk_proj "$H" p1; mk_proj "$H" p2
+OA="$(collect "$A")"
+[[ "$(jq -r '[.agents[].total]|add' <<<"$OA")" == "60000" ]] \
+  && ok_t "ANCHOR usage_collect sums BOTH project dirs (60000) — refusal arms below are vacuous while this is red" \
+  || bad_t "ANCHOR usage total" "$(jq -c '.agents' <<<"$OA")"
+[[ "$(jq -r '.coverage.complete' <<<"$OA")" == "true" ]] \
+  && ok_t "ANCHOR a fully readable agent is coverage.complete=true" || bad_t "ANCHOR complete" "$(jq -c .coverage <<<"$OA")"
+AA="$(activity "$A")"
+[[ "$(jq -r '.tokens.total' <<<"$AA")" == "60000" && "$(jq -r '.counts.bash' <<<"$AA")" == "2" ]] \
+  && ok_t "ANCHOR activity_collect sees both dirs (60000 tok, 2 commands)" || bad_t "ANCHOR activity" "$AA"
+[[ "$(jq -r '(.partial//[])|length' <<<"$AA")" == "0" ]] \
+  && ok_t "ANCHOR a complete activity trail carries an EMPTY partial list" || bad_t "ANCHOR partial" "$AA"
+
+# ==== CORE (EACCES) — one of two project dirs chmod 000. Unprivileged only. ====
+if [[ "$(id -u)" -eq 0 ]]; then
+  printf 'skip - EACCES arms not runnable as root (the ELOOP arms below cover any uid) — NOT faked\n'
+else
+  E="$TMP/eacces"; H="$E/agent-alpha"; mk_proj "$H" p1; mk_proj "$H" p2
+  chmod 000 "$H/.claude/projects/p2"
+  OE="$(collect "$E")"
+  [[ "$(jq -r '.coverage.complete' <<<"$OE")" == "false" ]] \
+    && ok_t "EACCES an unreadable project SUBDIR makes coverage INCOMPLETE (was: true, with a half total)" \
+    || bad_t "EACCES complete" "$(jq -c .coverage <<<"$OE")"
+  [[ "$(jq -r '.coverage.unreadable[0].name' <<<"$OE")" == "alpha" ]] \
+    && ok_t "EACCES the agent is NAMED in coverage.unreadable, not left in the READABLE set" \
+    || bad_t "EACCES named" "$(jq -c .coverage <<<"$OE")"
+  [[ "$(jq -r '.coverage.unreadable[0].reason' <<<"$OE")" == *"p2"* ]] \
+    && ok_t "EACCES the reason names the exact subdir that could not be read" \
+    || bad_t "EACCES reason" "$(jq -c .coverage <<<"$OE")"
+  [[ "$(jq -r '[.agents[].total]|add // 0' <<<"$OE")" != "30000" ]] \
+    && ok_t "EACCES no agent row carries the 30000 HALF-TOTAL as if it were a measurement" \
+    || bad_t "EACCES half total still emitted as complete" "$(jq -c '.agents' <<<"$OE")"
+  AE="$(activity "$E")"
+  [[ "$(jq -r '(.partial//[])|length' <<<"$AE")" -ge 1 && "$(jq -r '(.partial//[])|join(" ")' <<<"$AE")" == *"p2"* ]] \
+    && ok_t "EACCES activity_collect NAMES the unread level in .partial (was: bare continue)" \
+    || bad_t "EACCES activity partial" "$AE"
+  [[ "$(jq -r '.counts.bash' <<<"$AE")" == "1" ]] \
+    && ok_t "EACCES the activity trail is still RENDERED (1 cmd) — reported short, not refused" \
+    || bad_t "EACCES activity trail" "$AE"
+  # --- HEALED: same fixture, permission restored, through the same code. ---
+  chmod 755 "$H/.claude/projects/p2"
+  OH="$(collect "$E")"; AH="$(activity "$E")"
+  [[ "$(jq -r '[.agents[].total]|add' <<<"$OH")" == "60000" && "$(jq -r '.coverage.complete' <<<"$OH")" == "true" ]] \
+    && ok_t "HEALED the same fixture recomputes the full 60000 and complete=true (so the sick arm read blindness, not emptiness)" \
+    || bad_t "HEALED usage" "$(jq -c '{c:.coverage.complete,t:[.agents[].total]}' <<<"$OH")"
+  [[ "$(jq -r '(.partial//[])|length' <<<"$AH")" == "0" && "$(jq -r '.tokens.total' <<<"$AH")" == "60000" ]] \
+    && ok_t "HEALED activity partial empties and the trail recomputes 60000" || bad_t "HEALED activity" "$AH"
+fi
+
+# ==== ANY-UID (ELOOP) — root can read every bit and still cannot resolve a
+#      self-referential symlink. ENOTDIR is NOT usable at this level: a regular
+#      file in projects/ is a legitimate skip here (see the over-fire arm below).
+L="$TMP/eloop"; H="$L/agent-alpha"; mk_proj "$H" p1
+ln -s p2 "$H/.claude/projects/p2"
+OL="$(collect "$L")"
+[[ "$(jq -r '.coverage.complete' <<<"$OL")" == "false" \
+   && "$(jq -r '.coverage.unreadable[0].name' <<<"$OL")" == "alpha" ]] \
+  && ok_t "ANY-UID a project dir that cannot be listed for a non-permission reason (ELOOP) is reported — a uid-0 run cannot be a vacuous green" \
+  || bad_t "ANY-UID eloop" "$(jq -c .coverage <<<"$OL")"
+AL="$(activity "$L")"
+[[ "$(jq -r '(.partial//[])|join(" ")' <<<"$AL")" == *"p2"* ]] \
+  && ok_t "ANY-UID activity_collect names the ELOOP level too" || bad_t "ANY-UID activity" "$AL"
+rm -f "$H/.claude/projects/p2"
+OLH="$(collect "$L")"
+[[ "$(jq -r '.coverage.complete' <<<"$OLH")" == "true" && "$(jq -r '[.agents[].total]|add' <<<"$OLH")" == "30000" ]] \
+  && ok_t "ANY-UID HEALED removing the loop restores complete=true and a real 30000" || bad_t "ANY-UID healed" "$OLH"
+
+# ==== OVER-FIRE CONTROLS — the legitimate zeros. A fix that flags these has
+#      disabled coverage in the other direction and will look green in every arm above.
+Z="$TMP/idle"; mkdir -p "$Z/agent-alpha"          # home exists, never ran: ENOENT on projects/
+OZ="$(collect "$Z")"
+[[ "$(jq -r '.coverage.complete' <<<"$OZ")" == "true" ]] \
+  && ok_t "OVER-FIRE an agent that has never run stays READ (ENOENT on projects/ is idle, not blind)" \
+  || bad_t "OVER-FIRE idle slandered" "$(jq -c .coverage <<<"$OZ")"
+[[ "$(jq -r '(.partial//[])|length' <<<"$(activity "$Z")")" == "0" ]] \
+  && ok_t "OVER-FIRE an idle agent's activity trail is empty, NOT partial" || bad_t "OVER-FIRE idle activity" "$(activity "$Z")"
+N="$TMP/notdir"; H="$N/agent-alpha"; mk_proj "$H" p1
+printf 'stray' > "$H/.claude/projects/README"     # a regular FILE in projects/: ENOTDIR
+ON="$(collect "$N")"
+[[ "$(jq -r '.coverage.complete' <<<"$ON")" == "true" && "$(jq -r '[.agents[].total]|add' <<<"$ON")" == "30000" ]] \
+  && ok_t "OVER-FIRE a regular file in projects/ (ENOTDIR) is a real skip — it cannot hold <it>/*.jsonl" \
+  || bad_t "OVER-FIRE notdir" "$(jq -c '{c:.coverage.complete,t:[.agents[].total]}' <<<"$ON")"
+[[ "$(jq -r '(.partial//[])|length' <<<"$(activity "$N")")" == "0" ]] \
+  && ok_t "OVER-FIRE activity_collect does not flag the ENOTDIR skip either" || bad_t "OVER-FIRE notdir activity" "$(activity "$N")"
+
+# ==== WIDENING — glob hid dot-prefixed names at BOTH levels; listdir does not. ====
+D="$TMP/dot"; H="$D/agent-alpha"; mk_proj "$H" p1; mk_proj "$H" .hidden ".s.jsonl"
+OD="$(collect "$D")"
+[[ "$(jq -r '[.agents[].total]|add' <<<"$OD")" == "60000" ]] \
+  && ok_t "WIDENING a dot-prefixed project dir AND a dot-prefixed session file are counted (glob hid both)" \
+  || bad_t "WIDENING dotfiles" "$(jq -c '.agents' <<<"$OD")"
+[[ "$(jq -r '.tokens.total' <<<"$(activity "$D")")" == "60000" ]] \
+  && ok_t "WIDENING activity_collect counts them too" || bad_t "WIDENING activity dotfiles" "$(activity "$D")"
+
+# ==== ACCEPTANCE 4 — the GUESSED /home/agent-<name> fallback is gone. =========
+# Without A_HOME_ROOT and with no such account, the old code invented a path,
+# read nothing, and rendered "did nothing". It must now refuse and say why.
+if A_AGENT="nosuchagent-dive3419" A_SINCE=0 A_TSTART=- A_TEND=- python3 "$TMP/activity.py" >"$TMP/g.out" 2>"$TMP/g.err"; then
+  bad_t "GUESSED-HOME an unresolvable agent must NOT return a clean empty trail" "$(cat "$TMP/g.out")"
+else
+  [[ ! -s "$TMP/g.out" ]] && grep -qi "unresolvable" "$TMP/g.err" \
+    && ok_t "GUESSED-HOME an agent with no account on this host: non-zero rc, EMPTY stdout, named cause on stderr" \
+    || bad_t "GUESSED-HOME all three halves" "out=$(cat "$TMP/g.out") err=$(cat "$TMP/g.err")"
+fi
+grep -q '"/home/agent-" + agent' "$TMP/activity.py" \
+  && bad_t "GUESSED-HOME the literal /home/agent-<name> guess is still in activity_collect" \
+  || ok_t "GUESSED-HOME the literal guessed-path fallback is absent from the source"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Both transcript readers in `cmd_usage.sh` read `projects/*/*.jsonl`. Found by dev3 while fixing DIVE-3417 (the same shape in `_spend_scan_task_ids`).

## usage_collect — guarded top and bottom, of a THREE-level path

`probe_readable` covers `projects/`; the per-file `except OSError` covers each `*.jsonl`. Between them sat a third read nothing covered: the middle `*` is a directory listing that **`glob.glob()` performs itself and swallows every `OSError` from**, yielding nothing for that entry. An unreadable project subdir therefore left the agent in the READABLE set with a total that is a *fraction* of the truth and `coverage.complete` still `true` — so `usage.sh`'s "cannot read" and "⚠ N NOT checked — burn is unknown (not 0)" surfaces stayed quiet on a short number. `5dive usage` is what a human reads when deciding whether a seat is burning.

Milder than DIVE-3417 (nothing here persists over durable state) but the same defect. **No third probe could fix it — there is no exception to catch.** Each level is enumerated with `os.listdir`, which may raise. The agent now lands in `coverage.unreadable` with a named cause, exactly where an unreadable FILE already put it.

`ENOENT` and `ENOTDIR` skips are kept deliberately — both mean "nothing unread here", and re-reporting them as blindness over-fires on every idle agent, which disables coverage as thoroughly as the fail-open did.

## activity_collect — the decision acceptance 4 asked for, recorded at the site

It had **no** readability contract at any level (bare `except OSError: continue` throughout) and still resolved `home` through the guessed `/home/agent-<name>` fallback DIVE-3345 deleted from the sibling.

**Decision: it owes a contract, but a REPORTING one, not the fail-closed NOT-REACHED one `_spend_scan_task_ids` owes.** That function must emit *no number* when blind because its caller PERSISTS what it returns over durable state and a short total silently becomes the record. Nothing consumes this trail that way — one human, one agent, read next to the trail itself. Refusing to render 40 commands because one project dir is mode 000 destroys the surface to protect a token count `5dive usage` reports properly anyway. So: emit the trail, and **name what is missing from it** (`.partial`, printed above the counts by `cmd_activity`). What is refused is the old rendering, where "unreadable" and "did nothing" were the same output. The guessed path is gone — an unresolvable agent exits non-zero, empty stdout, named cause.

## Widening

`glob` hid dot-prefixed names at **both** levels. A dot-prefixed session file is still burn; not counting it silently is the shape being refused.

## Grade — `tests/usage_middle_wildcard_unit.sh`, uid 1011, unprivileged, same harness both sides

**9 passed / 14 failed pre-fix (`78b6a6a`) · 23 / 0 after.**

Headline red, which is dev3's reported shape reproduced exactly:

```
FAIL - EACCES half total still emitted as complete
   [{"name":"alpha","total":30000,...}]          <- expected 60000
   {"agentsExpected":1,"agentsRead":1,"unreadable":[],"complete":true}
```

Arms, built to DIVE-3345/3417's rules: **anchor first** (a healthy non-zero total on the same path — every refusal arm is vacuous while it is red); **paired sick/healed** (each sick fixture re-run healed must recompute the real 60000 through the same code, proving the arm read blindness and not emptiness); an **ANY-UID arm** — `ENOTDIR` does *not* work at this level (it is a legitimate skip here), so the vehicle is **`ELOOP`**, a self-referential symlink where a project dir belongs, which root cannot resolve either, so a uid-0 CI run cannot be a vacuous green; and **over-fire controls** (never-run agent, stray file in `projects/`).

*Honest caveat on the pre-fix reds:* the `activity_collect` arms are red pre-fix partly because `A_HOME_ROOT` (the test seam) does not exist there, so those fixtures resolved nowhere. That is itself acceptance 4's defect firing — pre-fix `activity_collect` guessed `/home/agent-alpha`, read nothing, and returned a well-formed **empty trail with rc 0** — but it conflates two defects. The unambiguous middle-wildcard reproduction is the `usage_collect` block above, which uses `USAGE_HOME_ROOT` and exists on both trees.

Siblings unmoved on the fixed tree: `usage_coverage` 11/0 · `usage_dispatch_flag` 15/0 · `usage_enumeration_completeness` 9/0 · `usage_presenter_coverage` 26/0 · `heartbeat_usage_heal` 27/0 · `loop_spend_not_reached` 17/0 · `loop_ceiling_enforce` 5/0 · `task_budget_enforce` 41/0.

## Not in scope, named so nobody re-derives it

The shell globs in `cmd_memory.sh` / `cmd_doctor.sh` share the unguarded middle wildcard but fail **LOUD** ("no memory stores found") rather than producing a number. A skipped level that cannot be mistaken for a measurement is not this defect.

`5dive-cli` does not auto-deploy (deliberate `release-cut`), so merge is not a ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
