### PR TITLE
feat(doctor): re-grade openclaw model pins against the installed catalog (DIVE-3457)

### DIFF
--- a/changelog.d/DIVE-3457.md
+++ b/changelog.d/DIVE-3457.md
@@ -1,0 +1,68 @@
+## Unreleased — feat(doctor): re-grade openclaw model pins against the installed catalog (DIVE-3457)
+
+An `OPENCLAW_PROVIDER_MODEL` row is graded against
+`openclaw models list --provider <native> --plain` **at the moment the row is
+written** — that is the rule in `header.sh`, and DIVE-3184 is a worked example of
+following it. Nothing re-checked it afterwards. The installed openclaw then
+upgrades underneath the row, and the pin already written into a seat's
+`openclaw.json` is never rewritten: `_apply_byo_openclaw` validates at *write*
+time and the write already happened, the boot seed re-syncs whatever is there,
+and DIVE-3442's push is a faithful copy of an already-graded value (correct
+behaviour, for a copier).
+
+So a pin that has stopped resolving is a **dated observation gone stale, not a
+bad write** — and at the file level it is byte-identical to one that still
+resolves, dying in the same place with the same 401. See
+`community/wiki/an-unconfigured-model-authenticates-against-the-wrong-provider.md`:
+the error names auth and hides provider selection.
+
+**Correction to the ticket's premise, measured before building anything.** The
+catalog *rows* were already re-checked: `/home/agent-dev3/byo-model-drift-check.sh`
+has run nightly on `poke-two` (cron `23 5 * * *`) since 2026-08-03, reads the pins
+from `git show origin/main:src/header.sh`, and files a task row on drift
+(DIVE-2626). Its 2026-08-16 05:23 run reported `pins=27 graded=13 skipped=0
+excluded=14 unaccounted=0 drift=0`. What it does **not** do is read a single
+already-written pin — `grep -cE 'openclaw\.json|agents\.defaults'` over that
+script is **0**. And nothing in this repo does either: `models list` appears in
+`origin/main` only inside comments and one error string, never on a code path.
+So the uncovered half is the pin **on disk**, not the pin in the table.
+
+`5dive doctor --category=models` now re-grades, against the **installed**
+catalog:
+
+* every `OPENCLAW_PROVIDER_MODEL` row — a second, host-local instrument that
+  agrees with the nightly cron rather than replacing it (it grades against the
+  openclaw installed *here*, which the cron's control-plane view cannot see), and
+* every already-written pin on the box — the shared
+  `/home/claude/.openclaw/openclaw.json`, each auth profile's
+  `<profile>/openclaw/.openclaw/openclaw.json`, and each seat's
+  `/home/agent-*/.openclaw/openclaw.json`.
+
+A stale pin is an `error` naming the exact re-grade command (rows) or the file
+to repair (written pins). A provider that enumerates **nothing** is a `warn`
+NO-ORACLE, never an error: an unenumerated namespace is not a proof of
+unroutability (DIVE-3130/3184), and grading it as an error would tell an
+operator to delete a good row.
+
+**Two controls run before any verdict, and their failure suppresses the sweep
+rather than colouring it.** On the version the rows were graded against every
+pin resolves, so an all-green run proves only that the probe returned:
+
+* *non-vacuity* — the control provider's list must be non-empty. `models list`
+  prints `No models found.` at **exit 0** both for a provider it does not
+  enumerate and for one spelled wrong (DIVE-3184 measured those byte-identical),
+  so an openclaw answering nothing for everything would otherwise report every
+  pin stale: the false alarm, mirror of the false green.
+* *discrimination* — a sentinel known **absent** must miss. `openai/gpt-4o` is
+  the sentinel because it is live on models.dev and absent here (openai starts
+  at gpt-5.3 on 2026.7.1-2, DIVE-2631). A hit means the matcher is looser than
+  an exact id comparison and every green below it is worthless.
+
+**Opt-in on purpose — a bare `doctor` does not run it.** Each provider costs a
+full openclaw process (5.8s measured), so the seven rows are ~36s, and the
+dashboard polls `doctor --json`. It is likewise not a create-time probe in
+`selfcheck_cred_reached_agent`: that rail re-runs continuously and the answer
+cannot change between runs on a fixed build (dev2 + quinn, DIVE-3442). The
+trigger is instead the one event that can invalidate a pin without touching a
+byte of it — `5dive agent install openclaw --upgrade` now prints the re-grade
+command when the version actually moves.

--- a/src/cmd_auth.sh
+++ b/src/cmd_auth.sh
@@ -475,6 +475,17 @@ cmd_install() {
     local verb="installed" ujson=false
     [[ $upgrade -eq 1 ]] && ujson=true
     [[ $existed -eq 1 && $upgrade -eq 1 ]] && verb="upgraded"
+    # DIVE-3457: an openclaw UPGRADE is the one event that can invalidate an
+    # OPENCLAW_PROVIDER_MODEL row or an already-written seat pin without
+    # touching a byte of either. Both were graded against the catalog of the
+    # build that just got replaced, and nothing downstream re-reads them:
+    # `_apply_byo_openclaw` validates at write time and the write already
+    # happened. A pin that has stopped resolving is byte-identical to one that
+    # still does and dies on the same 401. Say so here, where the version
+    # actually moved — this is a NUDGE, not the check: the re-grade shells to
+    # openclaw once per provider (~36s) and is not run inline for that reason.
+    [[ "$type" == "openclaw" && $verb == "upgraded" ]] \
+      && step "openclaw version changed — model pins were graded against the OLD catalog and nothing re-reads them. Re-grade: sudo 5dive doctor --category=models"
     ok "$type $verb at $bin" \
        '{type:$t, bin:$b, installed:true, alreadyInstalled:false, upgraded:$u}' \
        --arg t "$type" --arg b "$bin" --argjson u "$ujson"

--- a/src/cmd_doctor.sh
+++ b/src/cmd_doctor.sh
@@ -576,6 +576,175 @@ doctor_build_caps() {
   return 0
 }
 
+# ── openclaw model-pin re-grade (DIVE-3457) ────────────────────────────────
+#
+# WHY THIS EXISTS. An OPENCLAW_PROVIDER_MODEL row is graded against
+# `openclaw models list --provider <native> --plain` AT THE MOMENT THE ROW IS
+# WRITTEN (that is the rule in the header; DIVE-3184 is a worked example of
+# following it). Nothing re-checks it afterwards. The installed openclaw then
+# upgrades underneath the row, and the already-written pin in a seat's
+# openclaw.json is never rewritten. So a pin that has stopped resolving is a
+# DATED OBSERVATION GONE STALE, not a bad write — and it is BYTE-IDENTICAL at
+# the file level to one that still resolves, dying at the same place with the
+# same 401 (community/wiki/an-unconfigured-model-authenticates-against-the-
+# wrong-provider.md: the error names auth and hides provider selection).
+#
+# WHY IT IS NOT IN THE DEFAULT SWEEP, and why it is not a create-time probe.
+# Each provider costs a full openclaw process: measured 5.8s for one
+# `--provider minimax --plain` on this host, so the seven catalog rows are ~40s.
+# The dashboard polls `doctor --json`, and `selfcheck_cred_reached_agent` re-runs
+# continuously on the agent-list health rail — paying 40s there buys nothing,
+# because the answer cannot change between runs on a fixed openclaw build
+# (dev2 + quinn, DIVE-3442). So this is its OWN opt-in category: it runs from
+# `doctor --category=models`, on a schedule or right after an openclaw upgrade,
+# and never from a bare `doctor`.
+#
+# WHY THE CONTROLS ARE PART OF THE CHECK AND NOT PART OF THE TEST. On the
+# version the rows were graded against, every row resolves — so an all-green run
+# proves only that the probe RETURNED. Two controls run first, every time, and
+# their failure SUPPRESSES the verdict rather than colouring it:
+#
+#   non-vacuity  the control provider's list must be non-empty. `models list`
+#                prints "No models found." at EXIT 0 for a provider it does not
+#                enumerate AND for a provider spelled wrong (DIVE-3184 measured
+#                those two byte-identical), so an openclaw that answers nothing
+#                for everything would otherwise report all seven pins STALE —
+#                the false ALARM, the mirror of the false green.
+#   discrimination  a sentinel id known ABSENT must MISS. openai carries no
+#                gpt-4 family at all on 2026.7.1-2 (20 ids, starting at gpt-5.3
+#                — DIVE-2631), while models.dev still lists gpt-4o as present,
+#                which is exactly why it is the sentinel: it is a live id
+#                somewhere else and absent HERE. If it hits, the matcher is
+#                looser than an exact id comparison and every green below is
+#                worthless.
+#
+# The oracle is one-sided in the other direction too, and this check inherits
+# that: a HIT is authoritative, a MISS on a provider whose whole list is empty
+# says nothing (DIVE-3130/3184 — zai, qwen and huggingface enumerate nothing and
+# are deliberately unpinned). A pin under an EMPTY list is therefore reported
+# `warn` NO-ORACLE, never `error` stale.
+
+OPENCLAW_PIN_CONTROL_PROVIDER="openai"
+OPENCLAW_PIN_CONTROL_ABSENT="openai/gpt-4o"
+
+# openclaw_catalog_ids <native> — the provider's `--plain` id list on stdout.
+# rc 1 when the runtime is missing (caller must not read that as an empty
+# catalog). "No models found." is filtered out here rather than at the call
+# sites: it is prose on stdout at exit 0, and leaving it in makes an empty
+# catalog look like a one-id catalog.
+openclaw_catalog_ids() {
+  local native="$1"
+  local node="/home/claude/.local/bin/node" bin="${TYPE_BIN[openclaw]:-}"
+  [[ -n "$bin" && -x "$node" && -x "$bin" ]] || return 1
+  sudo -u claude -H env HOME=/home/claude PATH=/home/claude/.local/bin:/usr/bin:/bin \
+    "$node" "$bin" models list --provider "$native" --plain 2>/dev/null \
+    | grep -vxF 'No models found.' | grep . || true
+}
+
+# openclaw_written_pins — every ALREADY-WRITTEN model pin on this box, one
+# `<path>\t<pin>` row per line. These are the rows the catalog table cannot
+# speak for: `_apply_byo_openclaw` validates at WRITE time and the write already
+# happened, DIVE-3442's push is a faithful copy of an already-graded value, and
+# the boot seed re-syncs whatever is there. Three shapes hold one:
+#   shared   /home/claude/.openclaw/openclaw.json
+#   profile  <auth-profiles>/<name>/openclaw/.openclaw/openclaw.json  (HOME redirect)
+#   seat     /home/agent-*/.openclaw/openclaw.json  (start-time sync target)
+openclaw_written_pins() {
+  local f pin
+  for f in /home/claude/.openclaw/openclaw.json \
+           "${AUTH_PROFILES_DIR}"/*/openclaw/.openclaw/openclaw.json \
+           /home/agent-*/.openclaw/openclaw.json; do
+    [[ -f "$f" ]] || continue
+    pin=$(jq -r '.agents.defaults.model.primary // empty' "$f" 2>/dev/null) || continue
+    [[ -n "$pin" ]] || continue
+    printf '%s\t%s\n' "$f" "$pin"
+  done
+}
+
+# doctor_check_openclaw_model_pins — re-grade catalog rows AND written pins
+# against the INSTALLED catalog. Adds its own checks via doctor_add.
+doctor_check_openclaw_model_pins() {
+  local bin="${TYPE_BIN[openclaw]:-}"
+  local node="/home/claude/.local/bin/node"
+  if [[ -z "$bin" || ! -x "$node" || ! -x "$bin" ]]; then
+    doctor_add models openclaw-runtime warn \
+      "openclaw is not installed here, so no pin was graded — this is a NOT-MEASURED, not a clean bill of health (install: 5dive agent install openclaw --upgrade)"
+    return 0
+  fi
+
+  local version
+  version=$(sudo -u claude -H env HOME=/home/claude PATH=/home/claude/.local/bin:/usr/bin:/bin \
+    "$node" "$bin" --version 2>/dev/null | head -1)
+  [[ -n "$version" ]] || version="unknown"
+
+  # ── controls, before any verdict ────────────────────────────────────────
+  local ctl_ids ctl_n
+  ctl_ids=$(openclaw_catalog_ids "$OPENCLAW_PIN_CONTROL_PROVIDER")
+  ctl_n=$(grep -c . <<<"${ctl_ids}" 2>/dev/null || printf 0)
+  [[ -n "$ctl_ids" ]] || ctl_n=0
+  if (( ctl_n == 0 )); then
+    doctor_add models openclaw-pin-control error \
+      "non-vacuity control FAILED: '$OPENCLAW_PIN_CONTROL_PROVIDER' enumerates 0 ids on $version, so the probe cannot tell a stale pin from a silent catalog — NO pin was graded this run (a verdict here would have called every pin stale)"
+    return 0
+  fi
+  if grep -qxF "$OPENCLAW_PIN_CONTROL_ABSENT" <<<"$ctl_ids"; then
+    doctor_add models openclaw-pin-control error \
+      "discrimination control FAILED: sentinel '$OPENCLAW_PIN_CONTROL_ABSENT' is supposed to be ABSENT from '$OPENCLAW_PIN_CONTROL_PROVIDER' on this build and it MATCHED — the matcher is looser than an exact id comparison, so NO pin was graded this run"
+    return 0
+  fi
+  doctor_add models openclaw-pin-control ok \
+    "controls passed on $version: '$OPENCLAW_PIN_CONTROL_PROVIDER' enumerates $ctl_n ids (non-vacuity) and absent sentinel '$OPENCLAW_PIN_CONTROL_ABSENT' did not match (discrimination)"
+
+  # ── catalog rows ────────────────────────────────────────────────────────
+  local canonical native pin ids n stale=0 noracle=0 graded=0
+  for canonical in $(printf '%s\n' "${!OPENCLAW_PROVIDER_MODEL[@]}" | sort); do
+    pin="${OPENCLAW_PROVIDER_MODEL[$canonical]}"
+    native="${OPENCLAW_PROVIDER_ID[$canonical]:-$canonical}"
+    ids=$(openclaw_catalog_ids "$native")
+    n=$(grep -c . <<<"${ids}" 2>/dev/null || printf 0)
+    [[ -n "$ids" ]] || n=0
+    if (( n == 0 )); then
+      noracle=$((noracle + 1))
+      doctor_add models "openclaw-row-${canonical}" warn \
+        "NO ORACLE: '$native' enumerates nothing on $version, so pin '$pin' is neither confirmed nor refuted — an unenumerated namespace is not a proof of unroutability (DIVE-3130/3184). Do not delete the row on this."
+    elif grep -qxF "$pin" <<<"$ids"; then
+      graded=$((graded + 1))
+      doctor_add models "openclaw-row-${canonical}" ok \
+        "pin '$pin' still resolves on $version ($n ids in '$native')"
+    else
+      stale=$((stale + 1))
+      doctor_add models "openclaw-row-${canonical}" error \
+        "STALE PIN: '$pin' is ABSENT from '$native' on $version ($n ids). Every new openclaw seat on provider '$canonical' will be created with an id this build cannot resolve, report AUTH ok, and 401. Re-grade and edit OPENCLAW_PROVIDER_MODEL[$canonical] in src/header.sh: openclaw models list --provider $native --plain"
+    fi
+  done
+
+  # ── already-written pins ────────────────────────────────────────────────
+  local line path wpin wnative wids wn wrote=0
+  while IFS=$'\t' read -r path wpin; do
+    [[ -n "$path" ]] || continue
+    wrote=$((wrote + 1))
+    wnative="${wpin%%/*}"
+    wids=$(openclaw_catalog_ids "$wnative")
+    wn=$(grep -c . <<<"${wids}" 2>/dev/null || printf 0)
+    [[ -n "$wids" ]] || wn=0
+    if (( wn == 0 )); then
+      doctor_add models "openclaw-written-${wrote}" warn \
+        "NO ORACLE for written pin '$wpin' in $path: provider '$wnative' enumerates nothing on $version"
+    elif grep -qxF "$wpin" <<<"$wids"; then
+      doctor_add models "openclaw-written-${wrote}" ok \
+        "written pin '$wpin' still resolves on $version ($path)"
+    else
+      doctor_add models "openclaw-written-${wrote}" error \
+        "STALE WRITTEN PIN: '$wpin' in $path is ABSENT from '$wnative' on $version ($wn ids). This seat is already on disk — nothing rewrites it, so it will 401 on every message while reporting AUTH ok. Repair: sudo -u claude -H env HOME=$(dirname "$(dirname "$path")") PATH=/home/claude/.local/bin:/usr/bin:/bin $node $bin config set agents.defaults.model.primary <graded-id>"
+    fi
+  done < <(openclaw_written_pins)
+
+  doctor_add models openclaw-pin-summary \
+    "$( (( stale > 0 )) && printf error || printf ok )" \
+    "graded ${graded}/${#OPENCLAW_PROVIDER_MODEL[@]} catalog rows + ${wrote} written pin(s) against installed openclaw $version — ${stale} stale, ${noracle} no-oracle"
+  return 0
+}
+
 cmd_doctor() {
   require_root
   local filter="" want_fix=0 dry=0
@@ -606,12 +775,17 @@ cmd_doctor() {
     # `--category=policy` failed usage for every caller who read the error message
     # and did what it said. Pre-existing; fixed here because this change lands its
     # surface under that category and would otherwise be unreachable by filter.
-    ""|deps|types|auth|creds|registry|shelld|channels|host|memory|policy|plugins|caps) ;;
-    *) fail "$E_USAGE" "unknown --category (deps|types|auth|creds|registry|shelld|channels|host|memory|policy|plugins|caps)" ;;
+    ""|deps|types|auth|creds|registry|shelld|channels|host|memory|policy|plugins|caps|models) ;;
+    *) fail "$E_USAGE" "unknown --category (deps|types|auth|creds|registry|shelld|channels|host|memory|policy|plugins|caps|models)" ;;
   esac
 
   local run_deps=0 run_types=0 run_auth=0 run_creds=0 run_registry=0 run_shelld=0 run_channels=0 run_host=0 run_memory=0 run_policy=0
   local run_plugins=0 run_caps=0
+  # DIVE-3457: `models` is the ONE category a bare `doctor` does NOT run. It
+  # shells to openclaw once per provider (5.8s measured), and the dashboard
+  # polls `doctor --json`. Opt-in keeps the poll cheap; the schedule and the
+  # post-upgrade run ask for it by name.
+  local run_models=0
   [[ -z "$filter" || "$filter" == "deps"     ]] && run_deps=1
   [[ -z "$filter" || "$filter" == "types"    ]] && run_types=1
   [[ -z "$filter" || "$filter" == "auth"     ]] && run_auth=1
@@ -624,6 +798,7 @@ cmd_doctor() {
   [[ -z "$filter" || "$filter" == "policy"   ]] && run_policy=1
   [[ -z "$filter" || "$filter" == "plugins"  ]] && run_plugins=1
   [[ -z "$filter" || "$filter" == "caps"     ]] && run_caps=1
+  [[ "$filter" == "models" ]] && run_models=1
 
   # --- deps ---
   if (( run_deps )); then
@@ -1375,6 +1550,10 @@ cmd_doctor() {
   if (( run_caps )); then
     doctor_build_caps
     [[ -n "$DOCTOR_CAPS" ]] || DOCTOR_CAPS='{"seat":"unknown","sudoGrant":"unknown","runas":"unknown","github:read":{"state":"UNKNOWN","detail":"the capability probe itself failed to run — this is NOT a NO; nothing was measured"},"github:write":{"state":"NO","detail":"push identity is per-seat; the claude-uid borrow is RETIRED for the push class (DIVE-3017)."}}'
+  fi
+
+  if (( run_models )); then
+    doctor_check_openclaw_model_pins
   fi
 
   # --- summary + output ---

--- a/src/cmd_doctor.sh
+++ b/src/cmd_doctor.sh
@@ -627,6 +627,17 @@ doctor_build_caps() {
 OPENCLAW_PIN_CONTROL_PROVIDER="openai"
 OPENCLAW_PIN_CONTROL_ABSENT="openai/gpt-4o"
 
+# The node the openclaw shim is executed under. A VARIABLE and not a literal,
+# and that is a fix, not a refactor: with the path hardcoded, the runtime guard
+# below is a THIRD live seam the offline harness could not stub, so on any box
+# without openclaw installed the check emitted one warn and returned at its
+# first line. Every arm of tests/openclaw_pin_regrade_unit.sh then observed an
+# empty tree — including the two arms that assert a verdict is ABSENT, which
+# passed on that emptiness and reported the suppression working. An
+# absence-assertion arm passes on empty output; the seam it depends on has to
+# be injectable or the positive control cannot be written.
+OPENCLAW_PIN_NODE_BIN="${OPENCLAW_PIN_NODE_BIN:-/home/claude/.local/bin/node}"
+
 # openclaw_catalog_ids <native> — the provider's `--plain` id list on stdout.
 # rc 1 when the runtime is missing (caller must not read that as an empty
 # catalog). "No models found." is filtered out here rather than at the call
@@ -634,7 +645,7 @@ OPENCLAW_PIN_CONTROL_ABSENT="openai/gpt-4o"
 # catalog look like a one-id catalog.
 openclaw_catalog_ids() {
   local native="$1"
-  local node="/home/claude/.local/bin/node" bin="${TYPE_BIN[openclaw]:-}"
+  local node="$OPENCLAW_PIN_NODE_BIN" bin="${TYPE_BIN[openclaw]:-}"
   [[ -n "$bin" && -x "$node" && -x "$bin" ]] || return 1
   sudo -u claude -H env HOME=/home/claude PATH=/home/claude/.local/bin:/usr/bin:/bin \
     "$node" "$bin" models list --provider "$native" --plain 2>/dev/null \
@@ -665,7 +676,7 @@ openclaw_written_pins() {
 # against the INSTALLED catalog. Adds its own checks via doctor_add.
 doctor_check_openclaw_model_pins() {
   local bin="${TYPE_BIN[openclaw]:-}"
-  local node="/home/claude/.local/bin/node"
+  local node="$OPENCLAW_PIN_NODE_BIN"
   if [[ -z "$bin" || ! -x "$node" || ! -x "$bin" ]]; then
     doctor_add models openclaw-runtime warn \
       "openclaw is not installed here, so no pin was graded — this is a NOT-MEASURED, not a clean bill of health (install: 5dive agent install openclaw --upgrade)"
@@ -696,8 +707,16 @@ doctor_check_openclaw_model_pins() {
     "controls passed on $version: '$OPENCLAW_PIN_CONTROL_PROVIDER' enumerates $ctl_n ids (non-vacuity) and absent sentinel '$OPENCLAW_PIN_CONTROL_ABSENT' did not match (discrimination)"
 
   # ── catalog rows ────────────────────────────────────────────────────────
-  local canonical native pin ids n stale=0 noracle=0 graded=0
+  # `rows` is counted in the loop rather than read as ${#OPENCLAW_PROVIDER_MODEL[@]}
+  # in the summary line. Not cosmetic: tests/local_array_unbound_default_unit.sh
+  # arm G resolves every such read against a creation earlier in the SAME
+  # function, so a file-scope `declare -A` in src/header.sh can never satisfy it
+  # and the read reds a guard that is green on main. Widening that guard to
+  # accept file-scope globals is a change to the guard's own non-vacuity and
+  # does not belong in this diff (DIVE-3457, quinn iteration 1).
+  local canonical native pin ids n stale=0 noracle=0 graded=0 rows=0
   for canonical in $(printf '%s\n' "${!OPENCLAW_PROVIDER_MODEL[@]}" | sort); do
+    rows=$((rows + 1))
     pin="${OPENCLAW_PROVIDER_MODEL[$canonical]}"
     native="${OPENCLAW_PROVIDER_ID[$canonical]:-$canonical}"
     ids=$(openclaw_catalog_ids "$native")
@@ -741,7 +760,7 @@ doctor_check_openclaw_model_pins() {
 
   doctor_add models openclaw-pin-summary \
     "$( (( stale > 0 )) && printf error || printf ok )" \
-    "graded ${graded}/${#OPENCLAW_PROVIDER_MODEL[@]} catalog rows + ${wrote} written pin(s) against installed openclaw $version — ${stale} stale, ${noracle} no-oracle"
+    "graded ${graded}/${rows} catalog rows + ${wrote} written pin(s) against installed openclaw $version — ${stale} stale, ${noracle} no-oracle"
   return 0
 }
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -375,7 +375,7 @@ Health:
     or an editor). Needs root for the mutating and journal/cron verbs — an admin
     agent reaches them through its existing \`/usr/local/bin/5dive *\` grant.
 
-  5dive doctor [--fix] [--dry-run] [--caps] [--category=deps|types|auth|creds|registry|shelld|channels|host|memory|policy|plugins|caps]
+  5dive doctor [--fix] [--dry-run] [--caps] [--category=deps|types|auth|creds|registry|shelld|channels|host|memory|policy|plugins|caps|models]
     Walks deps (tmux/jq/bun/python3/nvm/node/npm), type bins, live auth
     probes, stale shadow-credential heal (creds), registry integrity, channel
     health (allowlist + dead inbound telegram poller), host safety (needrestart

--- a/tests/openclaw_pin_regrade_unit.sh
+++ b/tests/openclaw_pin_regrade_unit.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# DIVE-3457: `doctor --category=models` re-grades every OPENCLAW_PROVIDER_MODEL
+# row AND every already-written seat pin against the INSTALLED openclaw catalog.
+#
+# WHY THIS HARNESS MUTATES INSTEAD OF LOOKING AT THE LIVE RUN. On the version the
+# rows were graded against, every pin resolves, so the live run is all-green and
+# proves only that the probe RETURNED (task body, dev2). Every arm below is a
+# DEFECT the check must SEE — the green arm is the control, not the evidence.
+#
+# Offline: openclaw_catalog_ids is stubbed at its ONE seam, so no openclaw
+# process, no network, no sudo and no seat config is touched by the run. The
+# module under test still calls the real doctor_add/jq (see
+# tests/lib/grading_tree.sh and the least-injected-seam rule).
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+
+SRC=src
+for f in header.sh lib/error_codes.sh lib/output.sh cmd_doctor.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f" 2>/dev/null || { echo "source FAIL: $f"; exit 7; }
+done
+
+FAILED=0
+bad() { echo "FAIL: $1"; echo "      $2"; FAILED=1; }
+ok()  { echo "ok: $1"; }
+
+# TYPE_BIN/node gate: the check refuses early when the runtime is absent. Point
+# both at things that exist so the arms below reach the graded code, and stub
+# the probe itself.
+TYPE_BIN[openclaw]="/bin/sh"
+CATALOG=""            # newline-separated ids the stub returns for ANY provider
+CATALOG_openai=""     # per-provider override for the control provider
+openclaw_catalog_ids() {
+  local p="$1"
+  # The control provider ALWAYS reads its own fixture — never falling back to
+  # $CATALOG. An earlier cut fell back when CATALOG_openai was empty, which is
+  # precisely the state ARM 4 sets, so ARM 4 silently graded a NON-vacuous
+  # control and passed on the green path. The stub, not the check, was wrong;
+  # a fixture that cannot express the defect is not a control arm.
+  if [[ "$p" == "$OPENCLAW_PIN_CONTROL_PROVIDER" ]]; then
+    printf '%s\n' "$CATALOG_openai" | grep . || true
+    return 0
+  fi
+  printf '%s\n' "$CATALOG" | grep . || true
+}
+# The written-pin sweep reads real files; stub the enumerator so the harness
+# never depends on this box having a seat.
+WRITTEN=""
+openclaw_written_pins() { [[ -n "$WRITTEN" ]] && printf '%s\n' "$WRITTEN"; return 0; }
+# --version is shelled through sudo; neutralise it (the version string is only
+# ever interpolated into messages).
+sudo() { printf 'OpenClaw test-build\n'; }
+
+run_arm() {
+  DOCTOR_CHECKS='[]'
+  doctor_check_openclaw_model_pins >/dev/null 2>&1
+}
+sev_of() { jq -r --arg n "$1" '.[] | select(.name==$n) | .severity' <<<"$DOCTOR_CHECKS"; }
+msg_of() { jq -r --arg n "$1" '.[] | select(.name==$n) | .message' <<<"$DOCTOR_CHECKS"; }
+count_sev() { jq -r --arg s "$1" '[.[] | select(.severity==$s)] | length' <<<"$DOCTOR_CHECKS"; }
+
+# A single-row table keeps each arm's expectation readable. The real table is
+# graded live by `doctor --category=models`, not here.
+unset OPENCLAW_PROVIDER_MODEL OPENCLAW_PROVIDER_ID
+declare -A OPENCLAW_PROVIDER_MODEL=( [deepseek]="deepseek/deepseek-chat" )
+declare -A OPENCLAW_PROVIDER_ID=( [deepseek]="deepseek" )
+
+# ── ARM 1 (control arm): pin present in the catalog → ok, no error ──────────
+CATALOG_openai=$'openai/gpt-5.6\nopenai/gpt-5.3'
+CATALOG=$'deepseek/deepseek-chat\ndeepseek/deepseek-reasoner'
+WRITTEN=""
+run_arm
+[[ "$(sev_of openclaw-row-deepseek)" == "ok" ]] \
+  && ok "green arm: a resolving pin reports ok" \
+  || bad "green arm" "got '$(sev_of openclaw-row-deepseek)'"
+[[ "$(count_sev error)" == "0" ]] \
+  && ok "green arm: no error raised" \
+  || bad "green arm errors" "$(count_sev error) error(s)"
+
+# ── ARM 2 (MUTATION): the id disappears from the catalog under the row ──────
+# This is the whole ticket: the row is unchanged and byte-identical, the
+# INSTALLED catalog moved. Must be error, and must name the re-grade command.
+CATALOG=$'deepseek/deepseek-v5-chat\ndeepseek/deepseek-reasoner'
+run_arm
+[[ "$(sev_of openclaw-row-deepseek)" == "error" ]] \
+  && ok "MUTATION stale row: reports error" \
+  || bad "MUTATION stale row" "expected error, got '$(sev_of openclaw-row-deepseek)'"
+grep -q 'models list --provider deepseek --plain' <<<"$(msg_of openclaw-row-deepseek)" \
+  && ok "MUTATION stale row: message names the re-grade command" \
+  || bad "stale message" "no re-grade command in: $(msg_of openclaw-row-deepseek)"
+[[ "$(sev_of openclaw-pin-summary)" == "error" ]] \
+  && ok "MUTATION stale row: summary escalates to error" \
+  || bad "summary severity" "got '$(sev_of openclaw-pin-summary)'"
+
+# ── ARM 3 (MUTATION): provider enumerates NOTHING → warn NO-ORACLE, not error ─
+# An unenumerated namespace is not a proof of unroutability (DIVE-3130/3184).
+# Grading this as `error` would tell an operator to delete a good row.
+CATALOG=""
+run_arm
+[[ "$(sev_of openclaw-row-deepseek)" == "warn" ]] \
+  && ok "MUTATION empty catalog: NO-ORACLE is warn, not error" \
+  || bad "no-oracle severity" "expected warn, got '$(sev_of openclaw-row-deepseek)'"
+
+# ── ARM 4 (MUTATION): non-vacuity control fails → NO verdict at all ─────────
+# openclaw answering nothing for everything would otherwise mark every pin
+# stale — the false ALARM. The control must SUPPRESS the sweep, not colour it.
+CATALOG_openai=""
+CATALOG=$'deepseek/deepseek-chat'
+run_arm
+[[ "$(sev_of openclaw-pin-control)" == "error" ]] \
+  && ok "MUTATION vacuous control: control reports error" \
+  || bad "vacuous control" "got '$(sev_of openclaw-pin-control)'"
+[[ -z "$(sev_of openclaw-row-deepseek)" ]] \
+  && ok "MUTATION vacuous control: no row verdict was emitted" \
+  || bad "vacuous control leaked a verdict" "row severity '$(sev_of openclaw-row-deepseek)'"
+
+# ── ARM 5 (MUTATION): discrimination control fails → NO verdict at all ──────
+# Sentinel present means the matcher is looser than an exact id compare, so
+# every green below it is worthless and must not be printed.
+CATALOG_openai=$'openai/gpt-5.6\nopenai/gpt-4o'
+run_arm
+[[ "$(sev_of openclaw-pin-control)" == "error" ]] \
+  && ok "MUTATION loose matcher: control reports error" \
+  || bad "loose-matcher control" "got '$(sev_of openclaw-pin-control)'"
+[[ -z "$(sev_of openclaw-row-deepseek)" ]] \
+  && ok "MUTATION loose matcher: no row verdict was emitted" \
+  || bad "loose matcher leaked a verdict" "row severity '$(sev_of openclaw-row-deepseek)'"
+
+# ── ARM 6 (MUTATION): an ALREADY-WRITTEN seat pin has gone stale ────────────
+# The row table can be perfect and a seat still dead: _apply_byo_openclaw
+# validates at WRITE time and the write already happened.
+CATALOG_openai=$'openai/gpt-5.6'
+CATALOG=$'deepseek/deepseek-chat'
+WRITTEN=$'/home/agent-x/.openclaw/openclaw.json\tdeepseek/deepseek-v4-pro'
+run_arm
+[[ "$(sev_of openclaw-written-1)" == "error" ]] \
+  && ok "MUTATION stale written pin: reports error" \
+  || bad "stale written pin" "expected error, got '$(sev_of openclaw-written-1)'"
+grep -q '/home/agent-x/.openclaw/openclaw.json' <<<"$(msg_of openclaw-written-1)" \
+  && ok "MUTATION stale written pin: message names the file to repair" \
+  || bad "written-pin message" "$(msg_of openclaw-written-1)"
+
+# ── ARM 7 (static): `models` must NOT run in the bare-doctor sweep ──────────
+# 35.8s of openclaw subprocesses behind a dashboard poll. If someone adds
+# `-z "$filter"` to the run_models line, this arm goes red.
+if grep -qE '^\s*\[\[ "\$filter" == "models" \]\] && run_models=1' "$SRC/cmd_doctor.sh" \
+   && ! grep -qE 'run_models=1' <<<"$(grep -E '\-z "\$filter"' "$SRC/cmd_doctor.sh")"; then
+  ok "static: models is opt-in — bare \`doctor\` does not run it"
+else
+  bad "models is no longer opt-in" "a bare \`doctor --json\` poll now pays ~36s of openclaw subprocesses"
+fi
+# And it must still be reachable by filter (the DIVE-2327 shape: dispatched but
+# rejected by the allow-list is a category nobody can run).
+grep -q 'policy|plugins|caps|models) ;;' "$SRC/cmd_doctor.sh" \
+  && ok "static: --category=models passes the allow-list" \
+  || bad "allow-list" "--category=models is dispatched but not allowed"
+
+echo
+(( FAILED )) && { echo "RESULT: FAIL"; exit 1; }
+echo "RESULT: PASS"
+exit 0

--- a/tests/openclaw_pin_regrade_unit.sh
+++ b/tests/openclaw_pin_regrade_unit.sh
@@ -207,6 +207,12 @@ grep -q 'NOT-MEASURED' <<<"$(msg_of openclaw-runtime)" \
 OPENCLAW_PIN_NODE_BIN="/bin/sh"
 
 echo
-(( FAILED )) && { echo "RESULT: FAIL"; exit 1; }
-echo "RESULT: PASS"
-exit 0
+(( FAILED )) && echo "RESULT: FAIL" || echo "RESULT: PASS"
+# Verdict LAST, and in a shape tests/meta/harness-verdict-probe.sh can read.
+# The earlier `(( FAILED )) && { …; exit 1; }` / `exit 0` pair was correctly
+# wired and still UNPROBEABLE — the probe identifies the verdict VARIABLE from
+# the last executable line, and `exit 0` names none, so it could not inject its
+# mutation and refused to count this harness clean. That refusal is the point of
+# DIVE-2013: an unprobeable harness and a harness whose exit status is not wired
+# to its assertions are indistinguishable from outside.
+exit $(( FAILED > 0 ))

--- a/tests/openclaw_pin_regrade_unit.sh
+++ b/tests/openclaw_pin_regrade_unit.sh
@@ -30,7 +30,17 @@ ok()  { echo "ok: $1"; }
 # TYPE_BIN/node gate: the check refuses early when the runtime is absent. Point
 # both at things that exist so the arms below reach the graded code, and stub
 # the probe itself.
+#
+# THE NODE PATH IS THE THIRD SEAM, and leaving it live is what failed CI on
+# iteration 1. openclaw_catalog_ids and openclaw_written_pins were stubbed; the
+# runtime guard inside doctor_check_openclaw_model_pins was not, and it tests a
+# path that exists only on a box with openclaw installed. On a clean runner the
+# check emitted ONE warn and returned before grading anything, so every arm saw
+# an empty tree — and the two arms that assert "no row verdict was emitted"
+# stayed GREEN on that emptiness. ARM 0 below is the positive control that makes
+# those two arms mean something.
 TYPE_BIN[openclaw]="/bin/sh"
+OPENCLAW_PIN_NODE_BIN="/bin/sh"
 CATALOG=""            # newline-separated ids the stub returns for ANY provider
 CATALOG_openai=""     # per-provider override for the control provider
 openclaw_catalog_ids() {
@@ -67,6 +77,23 @@ count_sev() { jq -r --arg s "$1" '[.[] | select(.severity==$s)] | length' <<<"$D
 unset OPENCLAW_PROVIDER_MODEL OPENCLAW_PROVIDER_ID
 declare -A OPENCLAW_PROVIDER_MODEL=( [deepseek]="deepseek/deepseek-chat" )
 declare -A OPENCLAW_PROVIDER_ID=( [deepseek]="deepseek" )
+
+# ── ARM 0 (POSITIVE CONTROL): the graded path is actually REACHED ───────────
+# Load-bearing for arms 4 and 5. Those assert a verdict is ABSENT, and an
+# absence assertion passes on empty output — so unless something proves the run
+# got PAST the runtime guard, "suppressed by a failing control" and "the check
+# returned at line 1 because this box has no openclaw" are the same observation.
+# This arm is that proof, and its mutation (ARM 8) shows it can fail.
+CATALOG_openai=$'openai/gpt-5.6\nopenai/gpt-5.3'
+CATALOG=$'deepseek/deepseek-chat'
+WRITTEN=""
+run_arm
+[[ -z "$(sev_of openclaw-runtime)" ]] \
+  && ok "REACH control: the runtime guard did not fire (openclaw seam is stubbed)" \
+  || bad "runtime guard fired" "openclaw-runtime='$(sev_of openclaw-runtime)' — every arm below would grade an empty tree"
+[[ -n "$(sev_of openclaw-row-deepseek)" ]] \
+  && ok "REACH control: a row verdict was emitted, so the sweep ran" \
+  || bad "sweep did not run" "no openclaw-row-deepseek verdict; the arms asserting ABSENCE are vacuous"
 
 # ── ARM 1 (control arm): pin present in the catalog → ok, no error ──────────
 CATALOG_openai=$'openai/gpt-5.6\nopenai/gpt-5.3'
@@ -113,9 +140,9 @@ run_arm
 [[ "$(sev_of openclaw-pin-control)" == "error" ]] \
   && ok "MUTATION vacuous control: control reports error" \
   || bad "vacuous control" "got '$(sev_of openclaw-pin-control)'"
-[[ -z "$(sev_of openclaw-row-deepseek)" ]] \
-  && ok "MUTATION vacuous control: no row verdict was emitted" \
-  || bad "vacuous control leaked a verdict" "row severity '$(sev_of openclaw-row-deepseek)'"
+[[ -z "$(sev_of openclaw-row-deepseek)" && -z "$(sev_of openclaw-runtime)" ]] \
+  && ok "MUTATION vacuous control: no row verdict was emitted (and the run REACHED the sweep)" \
+  || bad "vacuous control leaked a verdict" "row='$(sev_of openclaw-row-deepseek)' runtime='$(sev_of openclaw-runtime)'"
 
 # ── ARM 5 (MUTATION): discrimination control fails → NO verdict at all ──────
 # Sentinel present means the matcher is looser than an exact id compare, so
@@ -125,9 +152,9 @@ run_arm
 [[ "$(sev_of openclaw-pin-control)" == "error" ]] \
   && ok "MUTATION loose matcher: control reports error" \
   || bad "loose-matcher control" "got '$(sev_of openclaw-pin-control)'"
-[[ -z "$(sev_of openclaw-row-deepseek)" ]] \
-  && ok "MUTATION loose matcher: no row verdict was emitted" \
-  || bad "loose matcher leaked a verdict" "row severity '$(sev_of openclaw-row-deepseek)'"
+[[ -z "$(sev_of openclaw-row-deepseek)" && -z "$(sev_of openclaw-runtime)" ]] \
+  && ok "MUTATION loose matcher: no row verdict was emitted (and the run REACHED the sweep)" \
+  || bad "loose matcher leaked a verdict" "row='$(sev_of openclaw-row-deepseek)' runtime='$(sev_of openclaw-runtime)'"
 
 # ── ARM 6 (MUTATION): an ALREADY-WRITTEN seat pin has gone stale ────────────
 # The row table can be perfect and a seat still dead: _apply_byo_openclaw
@@ -157,6 +184,27 @@ fi
 grep -q 'policy|plugins|caps|models) ;;' "$SRC/cmd_doctor.sh" \
   && ok "static: --category=models passes the allow-list" \
   || bad "allow-list" "--category=models is dispatched but not allowed"
+
+# ── ARM 8 (MUTATION of ARM 0): the runtime is absent → NOT-MEASURED, no verdict ─
+# Point the node seam at nothing and the check must say so LOUDLY and grade
+# nothing. This reproduces iteration 1's CI signature on purpose: it is the only
+# arm that can distinguish "the controls suppressed the sweep" from "this box
+# never had openclaw", and without it ARM 0 is an unfalsifiable green.
+OPENCLAW_PIN_NODE_BIN="/nonexistent/node"
+CATALOG_openai=$'openai/gpt-5.6'
+CATALOG=$'deepseek/deepseek-chat'
+WRITTEN=""
+run_arm
+[[ "$(sev_of openclaw-runtime)" == "warn" ]] \
+  && ok "MUTATION absent runtime: reports NOT-MEASURED as warn" \
+  || bad "absent runtime" "expected warn, got '$(sev_of openclaw-runtime)'"
+[[ -z "$(sev_of openclaw-row-deepseek)" && -z "$(sev_of openclaw-pin-control)" && -z "$(sev_of openclaw-pin-summary)" ]] \
+  && ok "MUTATION absent runtime: nothing was graded (no row, no control, no summary)" \
+  || bad "absent runtime graded anyway" "row='$(sev_of openclaw-row-deepseek)' ctl='$(sev_of openclaw-pin-control)' sum='$(sev_of openclaw-pin-summary)'"
+grep -q 'NOT-MEASURED' <<<"$(msg_of openclaw-runtime)" \
+  && ok "MUTATION absent runtime: message says NOT-MEASURED, not a clean bill of health" \
+  || bad "absent-runtime message" "$(msg_of openclaw-runtime)"
+OPENCLAW_PIN_NODE_BIN="/bin/sh"
 
 echo
 (( FAILED )) && { echo "RESULT: FAIL"; exit 1; }


### PR DESCRIPTION
## What

`5dive doctor --category=models` re-grades openclaw model pins against the **installed** catalog, and `5dive agent install openclaw --upgrade` prints the re-grade command when the version actually moves.

## The premise, corrected before building

The ticket says *nothing in the chain re-checks a pin*. Measured first — half of that was already false:

- **The catalog ROWS are covered.** `/home/agent-dev3/byo-model-drift-check.sh` has run nightly on `poke-two` (cron `23 5 * * *`) since 2026-08-03 (DIVE-2626), reads pins from `git show origin/main:src/header.sh`, and files a task row on drift. Its **2026-08-16 05:23** run logged `pins=27 graded=13 skipped=0 excluded=14 unaccounted=0 drift=0` — live, twelve hours before this branch.
- **The WRITTEN pins are not.** `grep -cE 'openclaw\.json|agents\.defaults'` over that script → **0**. And nothing in this repo grades one either: `git grep 'models list' origin/main` matches only comments and one error string, never a code path.

So the uncovered artifact is the pin **on disk**. `_apply_byo_openclaw` validates at *write* time and the write already happened; the boot seed re-syncs whatever is there; DIVE-3442's push is a faithful copy of an already-graded value.

## What it grades

- every `OPENCLAW_PROVIDER_MODEL` row — a second, **host-local** instrument (the cron's control-plane view cannot see the openclaw installed here), and
- every written pin: shared `/home/claude/.openclaw/openclaw.json`, each `<profile>/openclaw/.openclaw/openclaw.json`, each `/home/agent-*/.openclaw/openclaw.json`.

Stale row → `error` naming the re-grade command. Stale written pin → `error` naming the file and the repair. Provider enumerating nothing → `warn` NO-ORACLE, never error (DIVE-3130/3184 — an `error` there tells an operator to delete a good row).

## Two controls, inside the check, every run

On the build the rows were graded against **every pin resolves**, so an all-green run proves only that the probe returned. Control failure **suppresses** the verdict rather than colouring it:

- **non-vacuity** — `models list` prints `No models found.` at **exit 0** both for an uncarried provider and a misspelled one (byte-identical, DIVE-3184). A silent openclaw would otherwise mark every pin stale: the false ALARM.
- **discrimination** — `openai/gpt-4o` must MISS. It is live on models.dev and absent here (openai starts at gpt-5.3 on 2026.7.1-2, DIVE-2631). A hit means the matcher is looser than an exact id compare.

## Evidence

**Live run** (`sudo ./5dive doctor --category=models`, poke-two, openclaw 2026.7.1-2 `0790d9f`), 35.8s:

```
[ok] openclaw-pin-control: controls passed … 'openai' enumerates 20 ids (non-vacuity)
     and absent sentinel 'openai/gpt-4o' did not match (discrimination)
[ok] openclaw-row-{anthropic,deepseek,google,minimax,moonshot,openai,openrouter}
[ok] openclaw-written-1: 'openrouter/auto' still resolves (/home/claude/.openclaw/openclaw.json)
[ok] openclaw-pin-summary: graded 7/7 catalog rows + 1 written pin(s) — 0 stale, 0 no-oracle
summary: 10 checks, 10 ok, 0 warn, 0 error
```

That green is the control, not the evidence. **`tests/openclaw_pin_regrade_unit.sh` (14/14, 0.41s, core tier)** carries the mutation arms — every one a defect the check must SEE: stale row → error + names the re-grade command + summary escalates; empty catalog → warn not error; vacuous control → error **and no row verdict emitted**; loose matcher → same; stale written pin → error + names the file. Plus a static arm that the category stays opt-in, **mutation-graded**: adding `-z "$filter"` to the `run_models` line turns it red, restoring it turns it green.

The harness's own stub was graded too: the first cut fell back to the shared fixture when the control fixture was empty — exactly the state the vacuous-control arm sets — so that arm silently graded a *non*-vacuous control and passed. Fixed at the seam; a fixture that cannot express the defect is not a control arm.

## Why it is opt-in and not on a hot path

**5.8s measured for one `models list --provider <p> --plain`** — a full openclaw process per provider, ~36s for seven rows. So: not `selfcheck_cred_reached_agent` (that rail re-runs continuously and the answer cannot change on a fixed build — dev2 + quinn, DIVE-3442), not the bare `doctor` sweep (the dashboard polls `doctor --json`), not create time (`_apply_byo_openclaw` already grades the id it is about to write). A bare `doctor` does **not** run it.

## Not covered

`HERMES_PROVIDER_MODEL` and the `CLAUDE_PROVIDER_*` tables — the nightly cron grades those rows, and their written-pin equivalents are a separate shape (hermes prefers a live fetch; DIVE-2626 trap 3). Not widened here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
