### PR TITLE
feat(a2a): refuse an agent send that hands work back to a row's owner (DIVE-3499)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased — feat(a2a): handing work back is a ROW, not a message — refused, not advised (DIVE-3499)
+
+`5dive agent send` now **refuses** a message when the recipient is the assignee of an **open** row
+the message names — by ident, by a `/pull/<n>` URL, or by the `#<n>` bound to that row — and points
+the sender at `task reject --feedback=` / `task set-body` / `task assign` instead.
+
+The rule was a line in an auto-loaded file, read ~1100 times a day and enforced by nothing. The
+maker wakes **fresh**, so a ping about work they already own does not cost a message, it costs a
+full reload of a PR they had closed out.
+
+- **This one may refuse where the round cap only warns**, and the split is deliberate. A control may
+  only refuse what it can identify — "the recipient owns this open row" is a database fact, not a
+  read on tone — and a refusal is cheap only when it names a channel carrying the same text to the
+  same agent. The round cap has no such channel; this one is a redirect, not a loss.
+- **Carve-outs, all chosen:** a body containing `?` sends (a2a is for a decision you need from a
+  named seat *now*, and that is asked, not asserted); a sender with no derivable identity (a human
+  or root relay) sends; the notification rails (`_5DIVE_A2A_NOTIFY=1`) stay exempt; done/cancelled
+  rows and rows the recipient does not own are untouched. `blocked` counts as open — a row parked on
+  a gate is the most likely thing to get pinged about.
+- **Fails OPEN when the board is unreachable.** A control that silenced the fleet because its own
+  store did not answer is worse than the traffic it removes.
+- A refused send is **not** recorded as a round, the same treatment the acknowledgement refusal gets.
+- Graded by `tests/a2a_handback_guard_unit.sh` against a real sqlite board (0.9s, core tier).
+
 ## Unreleased — fix(council): `authority.gate_clear_leads` can actually be set (DIVE-3493)
 
 The constitution validator and the authority reader accepted **disjoint** subsets of YAML, so the

--- a/src/lib/a2a_rounds.sh
+++ b/src/lib/a2a_rounds.sh
@@ -10,7 +10,7 @@
 # answered with twenty tool calls. That is also why "be concise" does not work —
 # concision does not reduce the digging a message provokes.
 #
-# Two controls, and they are DELIBERATELY NOT THE SAME STRENGTH. The dividing
+# Three controls, and they are DELIBERATELY NOT THE SAME STRENGTH. The dividing
 # principle, and the reason this file reads the way it does:
 #
 #   **A control may only refuse what it can actually identify.**
@@ -21,6 +21,11 @@
 #      nothing. Refused regardless of round count, and never recorded.
 #   2. ROUND CAP — a WARNING. A counter cannot tell agreement from a CORRECTION,
 #      and the correction is the expensive one to lose.
+#   3. HANDBACK REFUSAL (DIVE-3499) — a REFUSAL. "This recipient is the assignee
+#      of an OPEN row this message names" is a database fact, not a read on tone,
+#      and the remedy (`task reject --feedback=` / `set-body` / `assign`) puts
+#      the SAME text in front of the SAME agent. Refusing what you can identify
+#      AND redirect costs nothing; see the block above a2a_handback_refusal.
 #
 # The row as filed said "Refuse, not warn" for both. That was overturned on the
 # gate (main, 2026-08-12 06:36Z) by a day of evidence, and the evidence is the
@@ -219,6 +224,136 @@ a2a_round_warning_msg() {
     "$from" "$(( n + 1 ))" "$to" "$where" "$A2A_ROUND_CAP" "$where" "$(( A2A_ROUND_WINDOW_SECS / 3600 ))"
 }
 
+# ---------------------------------------------------------------------------
+# DIVE-3499: HANDING WORK BACK IS A ROW, NOT A MESSAGE — enforced.
+#
+# Rule 0 of the fleet's a2a section was a sentence in an auto-loaded file, read
+# ~1100 times a day and enforced by nothing. lodar's reply to it was "how will
+# you enforce that?", and the honest alternative to this guard was deleting the
+# rule: an unenforced line pays a per-turn byte cost fleet-wide to buy a reminder
+# that decays.
+#
+# WHAT IT REFUSES, and why this one may refuse where the ROUND CAP above only
+# warns. The file's dividing principle is "a control may only refuse what it can
+# actually IDENTIFY", and there is a second half to it that DIVE-3318 never
+# needed: a refusal is cheap when it names a channel that carries the SAME text
+# to the SAME agent. Both hold here:
+#
+#   IDENTIFIABLE — "the recipient is the assignee of an OPEN row named in this
+#   message" is a database fact, not a guess about tone. No vocabulary test, no
+#   opener-word heuristic; the two failure modes that made the ack detector hard
+#   are both absent.
+#
+#   NOT LOSSY — the remedy is `task reject --feedback=` / `task assign` /
+#   `task set-body`, all of which land the text on the row the recipient is
+#   already dispatched against. The round cap could not refuse because a refused
+#   correction was a LOST correction. A refusal here is a redirect.
+#
+# And the redirect is the whole point of the rule: the maker wakes FRESH, so a
+# ping about work they already own does not cost a message, it costs a full
+# reload of a PR they had closed out (lodar, 2026-08-16).
+#
+# WHAT IT DOES NOT REFUSE, stated here so the carve-outs are read as chosen:
+#   - A QUESTION (the body contains `?`). Rule 0's own carve-out is "a2a is for a
+#     decision you need from a NAMED seat now", and a decision you need now is
+#     asked, not asserted. This is the one soft edge in the guard and it is
+#     deliberate: it is trivially satisfiable by anyone determined to send, which
+#     is correct — the target is the REFLEX, not the exception.
+#   - A send with no derivable sender (root, a human relay). Handled by the
+#     caller's `[[ -n "$from" ]]` above.
+#   - The notification rails (`_5DIVE_A2A_NOTIFY=1`), already exempt.
+#   - Rows that are done/cancelled, and rows the recipient does not own.
+#
+# FAILS OPEN on an unreachable board. `db`/`sqlq` are absent when this library is
+# sourced on its own, and a control that refuses the fleet's sends because its
+# own store did not answer is worse than the traffic it removes — same failure
+# direction the round ledger already chose, and stated so it is not later read as
+# an oversight.
+# ---------------------------------------------------------------------------
+
+# Every task ident in the body, in order, deduped. `a2a_topic_of` deliberately
+# takes only the FIRST (one send is about one topic); a handback can name the row
+# it hands back anywhere in the body, so this one takes them all.
+a2a_idents_of() {
+  local rest="$1" seen=" " id
+  while [[ "$rest" =~ ([A-Z][A-Z0-9]+-[0-9]+) ]]; do
+    id="${BASH_REMATCH[1]}"
+    [[ "$seen" == *" ${id} "* ]] || { printf '%s\n' "$id"; seen+="${id} "; }
+    rest="${rest#*"$id"}"
+  done
+}
+
+# Every PR number the body names: a full `/pull/<n>` URL, a bare `#<n>`, or
+# `PR <n>` / `PR#<n>`. Numbers only — they are matched against the delivery_ref
+# BOUND TO A ROW THE RECIPIENT OWNS, which is what keeps a bare `#12` from
+# meaning every repo's twelfth PR.
+a2a_pr_nums_of() {
+  printf '%s\n' "$1" \
+    | grep -oE '(/pull/[0-9]+|#[0-9]+|\bPRs?[[:space:]]*#?[0-9]+)' 2>/dev/null \
+    | grep -oE '[0-9]+' 2>/dev/null | sort -un
+}
+
+# The open row `to` owns that this ident/PR is bound to, or nothing.
+# Prints `<ident>` on a hit. Returns non-zero when the board is unreachable, so
+# the caller can tell "no such row" from "could not look".
+a2a_open_row_owned() {
+  local to="$1" ident="${2:-}" pr="${3:-}"
+  declare -F db >/dev/null 2>&1 || return 2
+  declare -F sqlq >/dev/null 2>&1 || return 2
+  local where
+  if [[ -n "$ident" ]]; then
+    where="ident=$(sqlq "$ident")"
+  elif [[ "$pr" =~ ^[0-9]+$ ]]; then
+    # Digits only (checked here, not trusted from the caller), so the two LIKEs
+    # are safe to inline. `%/pull/N` catches the bound URL; `%#N` catches the
+    # `owner/repo#N` shorthand some rows bind instead.
+    where="(delivery_ref LIKE '%/pull/${pr}' OR delivery_ref LIKE '%#${pr}')"
+  else
+    return 1
+  fi
+  local hit
+  hit="$(db "SELECT ident FROM tasks
+              WHERE assignee=$(sqlq "$to")
+                AND status NOT IN ('done','cancelled')
+                AND ${where}
+              LIMIT 1;" 2>/dev/null)" || return 2
+  [[ -n "$hit" ]] || return 1
+  printf '%s' "$hit"
+}
+
+a2a_handback_refusal_msg() {
+  local to="$1" row="$2" what="$3"
+  printf 'refused: %s already owns %s (open, %s), so this is handing work back — and handing work back is a ROW, not a message. Put it where they are already dispatched: `5dive task reject %s --feedback="…"` to send it back with the reason, `5dive task set-body %s` to add context, or `5dive task assign %s <seat>` to move it. They wake FRESH on that row, so a ping about it does not cost a message — it costs them a full reload of work they had closed out. a2a is for a DECISION you need from a named seat now; if that is what this is, ask it as a question and it will send.' \
+    "$to" "$row" "$what" "$row" "$row" "$row"
+}
+
+# Prints the refusal text and returns 0 when the send must be refused; returns
+# non-zero (printing nothing) when it may proceed. Inverted against the usual
+# shell convention on purpose: the caller's `if _hb="$(...)"` needs the text and
+# the verdict in one call, exactly like a2a_is_ack + a2a_ack_refusal_msg.
+a2a_handback_refusal() {
+  local from="$1" to="$2" msg="$3"
+  # A question is a decision asked of a named seat, which is what a2a is FOR.
+  case "$msg" in *'?'*) return 1 ;; esac
+  local id row
+  while IFS= read -r id; do
+    [[ -n "$id" ]] || continue
+    if row="$(a2a_open_row_owned "$to" "$id" "")"; then
+      a2a_handback_refusal_msg "$to" "$row" "assigned to them"
+      return 0
+    fi
+  done < <(a2a_idents_of "$msg")
+  local n
+  while IFS= read -r n; do
+    [[ -n "$n" ]] || continue
+    if row="$(a2a_open_row_owned "$to" "" "$n")"; then
+      a2a_handback_refusal_msg "$to" "$row" "and PR #${n} is bound to it"
+      return 0
+    fi
+  done < <(a2a_pr_nums_of "$msg")
+  return 1
+}
+
 # The guard both send paths call, AFTER the body and both endpoints are
 # resolved and BEFORE a keystroke reaches the target's pane.
 #
@@ -236,7 +371,7 @@ a2a_round_warning_msg() {
 # one-way machine notices that nobody replies to and which are therefore not
 # rounds. A conversation routed through it is a rule broken, not a rule obeyed.
 a2a_round_guard() {
-  local from="$1" to="$2" msg="$3"
+  local from="$1" to="$2" msg="$3" _hb
   [[ "${_5DIVE_A2A_NOTIFY:-0}" == "1" ]] && return 0
   # An unmeasurable sender still gets the ack check (it needs no identity) but
   # cannot be round-counted against a pair — record nothing rather than build a
@@ -246,6 +381,14 @@ a2a_round_guard() {
     return 1
   fi
   [[ -n "$from" && -n "$to" ]] || return 0
+  # DIVE-3499: handing work back is a ROW, not a message. Placed after the
+  # measured-sender requirement above (a human/root caller with no derivable
+  # identity is not the reflex this refuses) and BEFORE the ledger write, so a
+  # refused send is not counted as a round — same treatment the ack refusal gets.
+  if _hb="$(a2a_handback_refusal "$from" "$to" "$msg")"; then
+    printf '%s' "$_hb"
+    return 1
+  fi
   local topic n
   topic="$(a2a_topic_of "$msg")"
   n="$(a2a_round_count "$from" "$to" "$topic")"

--- a/tests/a2a_handback_guard_unit.sh
+++ b/tests/a2a_handback_guard_unit.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# DIVE-3499: "handing work back is a ROW, not a message" is enforced — `agent send`
+# is REFUSED when the recipient already owns an open row bound to the ident or PR
+# the message names.
+#
+# Graded against a REAL sqlite board in a throwaway STATE_DIR (not a stubbed `db`):
+# the whole claim is "the guard reads the task table correctly", so a fake table
+# would grade the harness. The wiring is asserted separately by grepping both send
+# paths — a guard nothing calls passes every test it has.
+#
+# Run: bash tests/a2a_handback_guard_unit.sh
+set -uo pipefail
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692
+
+# DIVE-2211: name the tree this harness grades.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+check(){ if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3', got '$2')"; fi; }
+
+TMP="$(mktemp -d /tmp/a2a-handback-unit.XXXXXX)"
+trap 'rc=$?; rm -rf "$TMP"; echo "HARNESS-RC=$rc"' EXIT
+
+echo "== part 1: the guard with NO board reachable (fails OPEN) =="
+(
+  # A subshell with only the library sourced — `db`/`sqlq` do not exist here,
+  # which is the fresh-box / sourced-library case. A control that refused the
+  # fleet because its own store did not answer is worse than the traffic it
+  # removes, so this must be silent and permissive.
+  export A2A_ROUND_LEDGER="$TMP/rounds-open.tsv"
+  # shellcheck source=../src/lib/a2a_rounds.sh
+  . "$ROOT/src/lib/a2a_rounds.sh"
+  A2A_ROUND_LEDGER="$TMP/rounds-open.tsv"
+  out="$(a2a_round_guard main dev 'DIVE-4242 your PR is red, the typecheck fails' 2>/dev/null)"; rc=$?
+  if [[ "$rc" == 0 && -z "$out" ]]; then
+    printf '  ok   unreachable board -> the send proceeds, silently\n'
+  else
+    printf '  FAIL unreachable board must fail OPEN (rc=%s out=%s)\n' "$rc" "$out"; exit 1
+  fi
+  a2a_open_row_owned dev DIVE-4242 "" >/dev/null 2>&1
+  [[ $? == 2 ]] && printf '  ok   a2a_open_row_owned reports "could not look" (rc 2), not "no row"\n' \
+                || { printf '  FAIL a2a_open_row_owned must return 2 with no db()\n'; exit 1; }
+) || FAIL=$((FAIL+1))
+PASS=$((PASS+2))
+
+echo "== part 2: against a real board =="
+SRC=src
+export STATE_DIR="$TMP/state"
+export TASKS_DIR="$STATE_DIR/tasks"
+export TASKS_DB="$TASKS_DIR/tasks.db"
+mkdir -p "$TASKS_DIR"
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/state.sh lib/tasks_db.sh lib/a2a_rounds.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+# src/header.sh sets `set -e`. This harness grades REFUSALS, i.e. non-zero
+# returns, so `set -e` would kill it on its first correct assertion — as it did.
+set +e
+# src/lib/output.sh exports its OWN `ok`/`bad`, which silently replaced this
+# harness's counters — every assertion printed "OK — …" and PASS stayed at 2, so
+# a red arm would have printed and not counted. Redefine AFTER the sources.
+ok()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+check(){ if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3', got '$2')"; fi; }
+STATE_DIR="$TMP/state"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+A2A_ROUND_LEDGER="$TMP/rounds.tsv"
+# The DIVE-2249 store fence refuses a sourced-library writer aimed at the PROD
+# path only; this board is a throwaway under $TMP, so nothing is fenced. Stated
+# because "the fence let it through" must read as a property, not a bypass.
+tasks_db_init >/dev/null 2>&1 || { echo "  SKIP: tasks_db_init failed (no sqlite3?)"; echo "PASS=$PASS FAIL=$FAIL"; exit 0; }
+
+seed() { # <ident> <assignee> <status> [delivery_ref]
+  db "INSERT INTO tasks(ident,title,status,assignee,created_by,delivery_ref,created_at)
+      VALUES($(sqlq "$1"),$(sqlq "row $1"),$(sqlq "$3"),$(sqlq "$2"),'main',$(sqlq_or_null "${4:-}"),datetime('now'));" \
+    >/dev/null
+}
+seed DIVE-9001 dev  todo        'https://github.com/5dive-ai/5dive/pull/777'
+seed DIVE-9002 dev  done        ''
+seed DIVE-9003 main in_progress ''
+seed DIVE-9004 dev  blocked     ''
+
+echo "-- the refusal fires on the case the rule names --"
+out="$(a2a_round_guard main dev 'DIVE-9001 your PR is red, the typecheck fails on the second commit.' 2>/dev/null)"; rc=$?
+check "handing back a row the recipient owns is REFUSED (rc)" "$rc" "1"
+case "$out" in
+  *refused*DIVE-9001*"task reject"*) ok "the refusal names the row and the remedy verb" ;;
+  *) bad "refusal text is missing the row or the remedy: $out" ;;
+esac
+case "$out" in
+  *"set-body"*|*"assign"*) ok "the refusal offers the other two routes too" ;;
+  *) bad "refusal should name set-body/assign as well: $out" ;;
+esac
+# blocked is open. A row parked on a gate is the MOST likely thing to get pinged
+# about, so a status list that forgot it would miss the loudest case.
+out="$(a2a_round_guard main dev 'DIVE-9004 please pick this back up, it is unblocked now.' 2>/dev/null)"; rc=$?
+check "a BLOCKED row still counts as open" "$rc" "1"
+# The ident can sit anywhere in the body, not just at the front (a2a_topic_of
+# takes the first ident only; the handback check must take them all).
+out="$(a2a_round_guard main dev 'per our thread on DIVE-3318, the follow-up is DIVE-9001 and it is red.' 2>/dev/null)"; rc=$?
+check "a later ident in the body is still seen" "$rc" "1"
+
+echo "-- the PR arm --"
+out="$(a2a_round_guard main dev 'https://github.com/5dive-ai/5dive/pull/777 needs a rebase before it can land.' 2>/dev/null)"; rc=$?
+check "a PR URL bound to their open row is REFUSED" "$rc" "1"
+case "$out" in *"PR #777"*) ok "the PR refusal names the PR number" ;; *) bad "PR refusal text: $out" ;; esac
+out="$(a2a_round_guard main dev 'take another look at #777 before it lands.' 2>/dev/null)"; rc=$?
+check "the bare #N shorthand is caught too" "$rc" "1"
+out="$(a2a_round_guard main dev 'unrelated: #778 in another repo just merged.' 2>/dev/null)"; rc=$?
+check "a PR bound to NO row of theirs is not refused" "$rc" "0"
+
+echo "-- the negative controls: what must still send --"
+# THE ARM THAT MATTERS MOST. Each of these is a message the fleet needs to be
+# able to send, and every one of them names a row or a PR. If a future tightening
+# breaks them it has broken the rule's own carve-out, not just a test.
+neg=(
+  "DIVE-9002 is closed — noting the follow-up landed clean on the same tree."   # done row
+  "DIVE-9003 is mine, not yours — I am taking the rebase."                      # not their row
+  "DIVE-9001 — do you want the 24h or the 7d window before I cut it?"           # a QUESTION
+  "DIVE-9001 blocks the release cut, can you land it today?"                    # a QUESTION
+  "the release cut is blocked and nobody owns it"                               # no ident at all
+  "DIVE-4242 never existed on this board"                                       # unknown ident
+)
+for m in "${neg[@]}"; do
+  out="$(a2a_round_guard main dev "$m" 2>/dev/null)"; rc=$?
+  if [[ "$rc" == 0 ]]; then ok "sends: ${m:0:46}…"; else bad "must NOT be refused: $m -> $out"; fi
+done
+# A send to the row's own OWNER about someone ELSE's row is untouched.
+out="$(a2a_round_guard dev main 'DIVE-9001 is red on my side, I own it and I am fixing it.' 2>/dev/null)"; rc=$?
+check "the OWNER may still talk about their own row" "$rc" "0"
+
+echo "-- the refusal is not counted as a round --"
+rm -f "$A2A_ROUND_LEDGER"
+a2a_round_guard main dev 'DIVE-9001 your PR is red.' >/dev/null 2>&1
+n=$( [[ -r "$A2A_ROUND_LEDGER" ]] && grep -c . "$A2A_ROUND_LEDGER" || echo 0 )
+check "a refused handback writes no ledger row" "$n" "0"
+
+echo "-- the exemptions --"
+out="$(_5DIVE_A2A_NOTIFY=1 a2a_round_guard main dev 'DIVE-9001 gate filed, needs your answer.' 2>/dev/null)"; rc=$?
+check "the notification rail is exempt" "$rc" "0"
+out="$(a2a_round_guard '' dev 'DIVE-9001 your PR is red.' 2>/dev/null)"; rc=$?
+check "an unmeasurable sender (human/root relay) is not refused" "$rc" "0"
+
+echo "== part 3: wiring — both send paths must call the guard =="
+for f in src/cmd_agent_runtime.sh; do
+  n="$(grep -c 'a2a_round_guard' "$f")"
+  if (( n >= 2 )); then ok "both send paths in $f call a2a_round_guard ($n sites)"
+  else bad "$f has $n a2a_round_guard call sites, expected >= 2 (send + _deliver)"; fi
+done
+if grep -q 'a2a_handback_refusal' src/lib/a2a_rounds.sh \
+   && grep -A6 'a2a_handback_refusal "\$from" "\$to" "\$msg"' src/lib/a2a_rounds.sh | grep -q 'return 1'; then
+  ok "a2a_round_guard returns non-zero on a handback (the callers fail on it)"
+else
+  bad "the handback check is not wired into a2a_round_guard's refusal return"
+fi
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

`5dive agent send` is **refused** when the recipient is the assignee of an **open** row the message names — by ident, by a `/pull/<n>` URL, or by the `#<n>` bound to that row. The refusal names the row and the three remedies: `task reject --feedback=`, `task set-body`, `task assign`.

Both send rails get it: the check lives in `a2a_round_guard`, which `cmd_send` (direct) and `cmd_deliver` (scoped) both call and both fail on.

## Why it may REFUSE where the round cap only WARNS

`src/lib/a2a_rounds.sh` already carries the dividing principle — *a control may only refuse what it can actually identify* — and DIVE-3318 correctly landed the counter as a **warning**, because a counter cannot tell agreement from a correction and a refused correction is a **lost** correction.

Neither objection survives here:

- **Identifiable.** "The recipient is the assignee of an open row this message names" is a row in the task table. No vocabulary test, no opener-word heuristic — the two things that made the ack detector hard are both absent.
- **Not lossy.** The remedy puts the *same text* in front of the *same agent*, on the row they are already dispatched against. A refusal here is a redirect.

## Carve-outs, all deliberate

| case | verdict | why |
|---|---|---|
| body contains `?` | **sends** | rule 0's own carve-out: a2a is for a decision you need from a named seat *now*, and that is asked, not asserted. The one soft edge, and trivially satisfiable on purpose — the target is the reflex, not the exception. |
| no derivable sender | **sends** | root / a human relay is not the reflex this refuses |
| `_5DIVE_A2A_NOTIFY=1` | **sends** | the one-way notification rails, already exempt |
| row is done/cancelled, or owned by someone else | **sends** | not a handback |
| row is `blocked` | **refused** | blocked is open, and a row parked on a gate is the most likely thing to get pinged about |
| board unreachable | **sends** | fails OPEN — a control that silences the fleet because its own store did not answer is worse than the traffic it removes |

A refused send is **not** written to the round ledger, the same treatment the acknowledgement refusal gets.

## Evidence

`tests/a2a_handback_guard_unit.sh` — 23 assertions, green, **0.9s** (core tier), graded against a **real sqlite board** in a throwaway `STATE_DIR`, not a stubbed `db()`. The claim is "the guard reads the task table correctly", so a fake table would grade the harness.

Two mutations, both caught:

| mutation | result |
|---|---|
| neuter the call site (`if false && …`) | **9 failed** |
| delete the question carve-out | **2 failed** (both question negative controls) |

Regression: `tests/a2a_round_cap_unit.sh` **75 passed, 0 failed**. `shellcheck -S error` clean on both files.

One harness defect found and fixed while writing it: `src/lib/output.sh` exports its own `ok`/`bad`, which silently replaced the harness counters — every assertion printed and `PASS` stayed at 2, so a red arm would have printed and not counted. Redefined after the sources.

The negative-control block is the arm that matters most — six messages the fleet must still be able to send, every one of them naming a row or a PR.

## Residual

- The `?` carve-out is bypassable by anyone determined to send. Chosen, not overlooked.
- A **correction** about a row the recipient owns is refused and redirected to the row body, which reaches them with dispatch latency rather than instantly. That is the one real cost, and it is the tension DIVE-3318's gate answer was about; the difference is that here the text is not lost. Stated so it is graded, not discovered.
- The fleet's `CLAUDE.md` rule 0 does not yet say it is enforced. `5dive-cli` is not auto-deploying, so that one-clause edit belongs at `release-cut`, not here — writing it now would claim an enforcement no box has installed.

Closes DIVE-3499.
