### PR TITLE
feat(task): sender-visible handoff receipt on the routing verbs (DIVE-3499)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -78,6 +78,7 @@ cat \
   src/lib/agent_env.sh \
   src/lib/tasks_db.sh \
   src/lib/actor.sh \
+  src/lib/routing_receipt.sh \
   src/lib/a2a_rounds.sh \
   src/cmd_auth.sh \
   src/cmd_account.sh \

--- a/changelog.d/DIVE-3499.md
+++ b/changelog.d/DIVE-3499.md
@@ -1,0 +1,29 @@
+## Unreleased — feat(task): a sender-visible handoff receipt on the routing verbs (DIVE-3499)
+
+`task reject`, `task assign` and `task set-body` now print one line to the CALLER
+naming who owns the row, where it sits in that seat's queue, and when that seat
+next wakes:
+
+```
+OK — DIVE-3330 assigned to dev2
+handoff: dev2 now owns it · queue position: 2 of 5 · next wake: in ~12m
+```
+
+**Why.** Every "I routed you a row, please look at it" agent-to-agent ping is a
+missing capability wearing the shape of a message. Measured case: ops put a full
+triage on DIVE-3330's body, the row was already `todo` and already
+`assignee=dev2`, and ops pinged a human-shaped seat anyway — because nothing told
+the SENDER the handoff had landed. It could not tell "dev2 will pick this up"
+from "this vanished". That ping costs the recipient a full fresh-context reload
+of work they had closed out. The receipt answers the question instead of policing
+the channel.
+
+The position is the dispatcher's own selection (`_hb_pick_tasks`: priority, then
+critical-path depth, then id, dep-blocked rows excluded), not a `COUNT(*)`, so it
+is a prediction rather than a decoration — and the two cannot drift.
+
+**Additive only.** The receipt cannot refuse, cannot add an exit code, and cannot
+change a status. Every input may be missing — the picker, the board, the
+registry, or the helper itself — and the verb still exits 0 and still does its
+work; an unresolvable fact is named as unknown, never guessed. Human output only:
+JSON mode is byte-identical.

--- a/src/lib/routing_receipt.sh
+++ b/src/lib/routing_receipt.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# ── routing receipt (DIVE-3499) ────────────────────────────────────────────────
+#
+# WHY THIS EXISTS. Every "I routed you a row, please look at it" a2a ping is a
+# missing capability wearing the shape of a message. Measured case (2026-08-16):
+# ops put a full triage of PR #635 on DIVE-3330's body, the row was ALREADY todo
+# and ALREADY assignee=dev2 — and ops pinged main's non-fresh window anyway,
+# because nothing told the SENDER that the handoff had landed. It could not tell
+# "dev2 will pick this up" from "this vanished", so it told a human-shaped seat
+# as insurance. The general case runs the other way too: a verifier bouncing a
+# row cannot see the maker now owns it, so it pings to close the gap.
+#
+# The fix is not to police the channel. It is to answer the question the ping was
+# asking, in the output of the verb that did the routing: WHO owns it now, WHERE
+# it sits in that seat's queue, and WHEN that seat next wakes.
+#
+# ── HARD CONSTRAINT (lodar, 2026-08-16 16:47Z), and it binds this file ────────
+#
+#   "it shoulnt be enfoced on the 5dive layer - because you may break the a2a"
+#
+# ADDITIVE ONLY. This code may add OUTPUT. It may NOT add a refusal, a new exit
+# code, a new precondition, or any new way for a routing verb to fail. The test,
+# applied to every line below: if this path can return non-zero where it returned
+# zero before, it is out of scope. A receipt that cannot be computed prints
+# nothing and changes no status.
+#
+# That is why `routing_receipt` runs its body in a SUBSHELL with stderr closed
+# and `|| true` on the outside: a subshell contains an `exit`, a `set -e` abort,
+# a missing `jq`, an unreadable registry and an unreachable board alike. There is
+# no path from anything in here to the caller's exit status.
+#
+# An earlier pass at this row built a REFUSAL in the send path instead. It was
+# withdrawn (quinn, iteration 1) for breaking exactly the constraint above. Do
+# not reintroduce a guard here; the receipt removes the REASON to ping, which is
+# the whole mechanism.
+
+# How far down the recipient's queue we are willing to look for the row. A seat
+# with more than this many runnable todos has a queue-depth problem, not a
+# receipt problem — past the scan we say "beyond position N" rather than guess.
+_RR_QUEUE_SCAN_LIMIT=200
+
+# routing_receipt <ident> <owner> [<what-happened>]
+#
+# Prints ONE human line naming all three facts. Human output only: in JSON mode
+# a stray line on stdout would corrupt the object `ok` emits, and the sender this
+# exists for is an agent reading the verb's prose. Deliberately no JSON field —
+# adding one changes a contract other verbs snapshot, and buys nothing for the
+# reflex being removed.
+routing_receipt() {
+  ( _routing_receipt_render "$@" ) 2>/dev/null || true
+  return 0
+}
+
+_routing_receipt_render() {
+  local ident="${1:-}" owner="${2:-}" what="${3:-now owns it}"
+  [[ -n "$ident" && -n "$owner" ]] || return 0
+  (( JSON_MODE )) && return 0
+  local pos wake
+  pos=$(_routing_receipt_queue_pos "$ident" "$owner")
+  wake=$(_routing_receipt_next_wake "$owner")
+  printf 'handoff: %s %s · %s · %s\n' "$owner" "$what" "$pos" "$wake"
+}
+
+# Where the row sits in the order the dispatcher will actually hand work to this
+# seat — NOT a raw COUNT(*). `_hb_pick_tasks` is the dispatcher's own selection
+# (priority, then critical-path depth, then id, dep-blocked rows excluded), so
+# reusing it is what makes "position 1 of 4" a prediction rather than a decoration.
+# Calling it also means the two cannot drift: if the ordering rule changes, this
+# changes with it.
+_routing_receipt_queue_pos() {
+  local ident="$1" owner="$2"
+  declare -F _hb_pick_tasks >/dev/null 2>&1 || { echo "queue position: unknown"; return 0; }
+  local id
+  id=$(db "SELECT id FROM tasks WHERE ident=$(sqlq "$ident");" 2>/dev/null || echo "")
+  [[ -n "$id" ]] || { echo "queue position: unknown"; return 0; }
+  local ids n=0 hit=0 row
+  ids=$(_hb_pick_tasks "$owner" "$_RR_QUEUE_SCAN_LIMIT" 2>/dev/null || echo "")
+  while IFS= read -r row; do
+    [[ -n "$row" ]] || continue
+    n=$(( n + 1 ))
+    [[ "$row" == "$id" ]] && hit=$n
+  done <<<"$ids"
+  if (( hit > 0 )); then
+    echo "queue position: ${hit} of ${n}"
+  elif (( n > 0 )); then
+    # Not in the dispatch list: in_progress, blocked by a dep, or a non-standard
+    # kind. Say WHICH of those rather than printing a number that would be wrong
+    # — a false "position 1" is worse than an honest miss, because the sender
+    # would stop asking on the strength of it.
+    local st blocked
+    st=$(db "SELECT COALESCE(status,'') FROM tasks WHERE id=${id};" 2>/dev/null || echo "")
+    blocked=$(db "SELECT COUNT(*) FROM task_deps d JOIN tasks b ON b.id=d.blocked_by
+                   WHERE d.task_id=${id} AND b.status NOT IN ('done','cancelled');" 2>/dev/null || echo 0)
+    if [[ "${blocked:-0}" != "0" ]]; then
+      echo "queue position: waiting on ${blocked} unfinished dependency(ies), behind ${n} runnable"
+    else
+      echo "queue position: not queued (status ${st:-unknown}), behind ${n} runnable"
+    fi
+  else
+    echo "queue position: 1 of 1 (nothing else queued for ${owner})"
+  fi
+}
+
+# When the dispatcher may next hand this seat a row. Same arithmetic as
+# `heartbeat ls` (lastRunAt + everyMin*60 - now), stated here rather than
+# imported because that value lives inside a display loop.
+#
+# "due now" is bounded by the cron driver's own 5-minute tick, and the line says
+# so: a sender told "due now" who then watches nothing happen for four minutes
+# has been given a new reason to ping, which is the defect this file is about.
+_routing_receipt_next_wake() {
+  local owner="$1"
+  command -v jq >/dev/null 2>&1 || { echo "next wake: unknown"; return 0; }
+  local reg; reg=$(registry_read 2>/dev/null || echo "")
+  [[ -n "$reg" ]] || { echo "next wake: unknown"; return 0; }
+  local enabled everyMin lastRun now nextIn
+  enabled=$(jq -r --arg n "$owner" '.agents[$n].heartbeat.enabled // false' <<<"$reg" 2>/dev/null || echo false)
+  if [[ "$enabled" != "true" ]]; then
+    # Not a failure and not a warning: plenty of seats are driven by hand or by
+    # their own cron. It is still the answer to "when does this land", and it is
+    # the one case where a sender legitimately may need to do something else.
+    echo "next wake: no auto-wake (heartbeat off for ${owner})"
+    return 0
+  fi
+  everyMin=$(jq -r --arg n "$owner" '.agents[$n].heartbeat.everyMin // 30' <<<"$reg" 2>/dev/null || echo 30)
+  lastRun=$(jq -r --arg n "$owner" '.agents[$n].heartbeat.lastRunAt // 0' <<<"$reg" 2>/dev/null || echo 0)
+  [[ "$everyMin" =~ ^[0-9]+$ ]] || everyMin=30
+  [[ "$lastRun" =~ ^[0-9]+$ ]] || lastRun=0
+  now=$(date +%s)
+  nextIn=$(( lastRun + everyMin * 60 - now ))
+  if (( nextIn <= 0 )); then
+    echo "next wake: due now (dispatcher ticks every 5 min)"
+  else
+    echo "next wake: in ~$(( (nextIn + 59) / 60 ))m"
+  fi
+}

--- a/src/task/crud.sh
+++ b/src/task/crud.sh
@@ -1088,6 +1088,15 @@ cmd_task_assign() {
                         THEN datetime('now') ELSE started_at END
       WHERE id=${id};"
   ok "$ident assigned to $who" '{id:($i|tonumber), ident:$id, assignee:$a}' --arg i "$id" --arg id "$ident" --arg a "$who"
+  # DIVE-3499: sender-visible receipt — owner, queue position, next wake. Cannot
+  # fail; see src/lib/routing_receipt.sh.
+  # The `|| true` and the stderr drop are the additive-only contract AT THE CALL
+  # SITE, not belt-and-braces: a tree that sources a SUBSET of src/ — which is
+  # what most harnesses do — has no routing_receipt, and bash turns that into
+  # rc=127 on a verb that had already succeeded. Measured on
+  # tests/task_reject_trace_unit.sh before this line existed. The wrapper's own
+  # containment cannot cover the case where the wrapper is what is missing.
+  routing_receipt "$ident" "$who" "now owns it" 2>/dev/null || true
 }
 
 # DIVE-1880: attach the maker→verifier rail to an ALREADY-FILED task. `--verifier`

--- a/src/task/delivery.sh
+++ b/src/task/delivery.sh
@@ -750,5 +750,16 @@ cmd_task_reject() {
   ok "$ident rejected — bounced back to maker '$maker' (iteration $iter${maxi:+/$maxi})" \
      '{id:($i|tonumber), ident:$id, status:"todo", bouncedTo:$m, role:"maker", iteration:($n|tonumber)}' \
      --arg i "$id" --arg id "$ident" --arg m "$maker" --arg n "$iter"
+  # DIVE-3499: the sender-visible receipt. A verifier who has just bounced a row
+  # cannot otherwise tell "the maker will pick this up" from "this vanished", and
+  # closes the gap by pinging them — which costs the maker a full reload of a PR
+  # they had closed out. Cannot fail; see src/lib/routing_receipt.sh.
+  # The `|| true` and the stderr drop are the additive-only contract AT THE CALL
+  # SITE, not belt-and-braces: a tree that sources a SUBSET of src/ — which is
+  # what most harnesses do — has no routing_receipt, and bash turns that into
+  # rc=127 on a verb that had already succeeded. Measured on
+  # tests/task_reject_trace_unit.sh before this line existed. The wrapper's own
+  # containment cannot cover the case where the wrapper is what is missing.
+  routing_receipt "$ident" "$maker" "now owns it (bounced back)" 2>/dev/null || true
 }
 

--- a/src/task/dispatch.sh
+++ b/src/task/dispatch.sh
@@ -410,6 +410,21 @@ cmd_task_set_body() {
     --arg id "$ident" --arg m "$mode" \
     --argjson pl "$prior_len" --argjson nl "$new_len" \
     --argjson pls "$prior_lines" --argjson nls "$new_lines"
+  # DIVE-3499: a body write is the third routing verb — it is how work is handed
+  # over WITHOUT a message (rule 0: "handing work back is a row, not a message").
+  # The measured ping this row exists to delete was exactly this shape: ops wrote
+  # a full triage onto DIVE-3330's body, the row was already todo and already
+  # assignee=dev2, and ops pinged a human-shaped seat anyway because nothing told
+  # it the write had landed anywhere a person would see. Cannot fail; see
+  # src/lib/routing_receipt.sh.
+  local _sb_owner; _sb_owner=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=${id};" 2>/dev/null || echo "")
+  # The `|| true` and the stderr drop are the additive-only contract AT THE CALL
+  # SITE, not belt-and-braces: a tree that sources a SUBSET of src/ — which is
+  # what most harnesses do — has no routing_receipt, and bash turns that into
+  # rc=127 on a verb that had already succeeded. Measured on
+  # tests/task_reject_trace_unit.sh before this line existed. The wrapper's own
+  # containment cannot cover the case where the wrapper is what is missing.
+  routing_receipt "$ident" "$_sb_owner" "owns it (body $mode)" 2>/dev/null || true
 }
 
 # `5dive task set-title <id|DIVE-N> <text...>` — DIVE-2848. `set-body` has existed

--- a/tests/routing_receipt_unit.sh
+++ b/tests/routing_receipt_unit.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# DIVE-3499 — the sender-visible handoff receipt on the ROUTING verbs.
+#
+# WHAT THIS GRADES, and why each arm is here rather than a smaller set:
+#
+#  A. The receipt exists on all three routing verbs (reject / assign / set-body)
+#     and names all THREE facts — owner, queue position, next wake. Fewer than
+#     three is not a partial pass: the sender's residual question is whichever
+#     one is missing, and that is the ping this row exists to delete.
+#  B. It reaches the CALLER on STDOUT. A receipt only the recipient can see, or
+#     one on stderr behind a 2>/dev/null, removes nothing. Every arm captures
+#     stdout ALONE (2>/dev/null on the call) so a line that landed on stderr
+#     reads as absent, not as a pass.
+#  C. The queue position is the DISPATCHER'S order, not a COUNT(*). Graded by
+#     building a board where the two differ (a high-priority row inserted last)
+#     and asserting the receipt tracks _hb_pick_tasks, not insertion order.
+#  D. THE HARD CONSTRAINT (lodar, 2026-08-16 16:47Z): additive only — the verb
+#     must still exit 0, and change nothing, when the receipt cannot be computed.
+#     Graded by breaking each of the receipt's three inputs in turn (the picker,
+#     the board, the registry) and asserting rc=0 AND the row still moved.
+#
+# Runs against a REAL sqlite board in a throwaway STATE_DIR — never the live
+# shared board. No root, no network.
+# Run: bash tests/routing_receipt_unit.sh
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/routing-receipt-unit.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh lib/routing_receipt.sh \
+         cmd_task.sh cmd_org.sh cmd_project.sh cmd_heartbeat.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"
+TASKS_DIR="$STATE_DIR/tasks"
+TASKS_DB="$TASKS_DIR/tasks.db"
+REGISTRY="$TMP/agents.json"
+# The receipt is HUMAN output by design (a stray line would corrupt the JSON
+# object `ok` emits), so this harness must run in human mode or it grades
+# nothing. Arm J asserts the JSON contract is untouched, with JSON_MODE flipped.
+JSON_MODE=0
+mkdir -p "$TASKS_DIR"
+set +e
+
+tasks_db_init
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# mk <title> <assignee> <priority> [status] -> row id
+mk() {
+  local title="$1" who="$2" prio="${3:-medium}" status="${4:-todo}"
+  db "INSERT INTO tasks (title, body, priority, assignee, created_by, kind, status)
+      VALUES ($(sqlq "$title"), '', $(sqlq "$prio"), $(sqlq "$who"), 'main', 'standard', $(sqlq "$status"));
+      SELECT last_insert_rowid();"
+}
+ident_of() { db "SELECT ident FROM tasks WHERE id=$1;"; }
+status_of() { db "SELECT status FROM tasks WHERE id=$1;"; }
+assignee_of() { db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=$1;"; }
+
+# Heartbeat state for a seat. reg <name> <enabled> <everyMin> <lastRunAt-epoch>
+#
+# Writes the WHOLE roster every time, not just the named seat: the registry is
+# also what `_task_require_lane` reads, so a one-seat file would make `assign`
+# refuse every other name in this harness for an unrelated reason and the receipt
+# arms would grade nothing while still looking like they ran.
+_RR_SEATS=(main dev2 dev3 quinn)
+reg() {
+  local target="$1" enabled="$2" every="$3" last="$4" body="" s
+  for s in "${_RR_SEATS[@]}"; do
+    [[ -n "$body" ]] && body+=","
+    if [[ "$s" == "$target" ]]; then
+      body+=$(printf '"%s":{"heartbeat":{"enabled":%s,"everyMin":%s,"lastRunAt":%s}}' \
+                "$s" "$enabled" "$every" "$last")
+    else
+      body+=$(printf '"%s":{"heartbeat":{"enabled":false,"everyMin":30,"lastRunAt":0}}' "$s")
+    fi
+  done
+  printf '{"agents":{%s}}\n' "$body" >"$REGISTRY"
+}
+reg main false 30 0   # seed the roster before the first lane check runs
+
+# has_all_three <captured-stdout> -> 0 if the receipt named owner+position+wake
+has_all_three() {
+  local out="$1" who="$2"
+  grep -q "^handoff: ${who} " <<<"$out" \
+    && grep -q 'queue position:' <<<"$out" \
+    && grep -q 'next wake:' <<<"$out"
+}
+
+echo "── A/B: the receipt exists, on stdout, on each routing verb ─────────────"
+
+# --- reject ------------------------------------------------------------------
+reg dev2 false 30 0
+R1=$(mk "receipt on reject" quinn high)
+db "UPDATE tasks SET maker_agent='dev2', verifier='quinn', iteration=1,
+      handoff_delivered_at=datetime('now'), status='todo' WHERE id=${R1};"
+I1=$(ident_of "$R1")
+ACTOR_OVERRIDE=quinn TASK_ACTOR=quinn \
+  OUT=$(cmd_task_reject "$I1" --feedback="needs another pass" 2>/dev/null)
+if has_all_three "$OUT" dev2; then
+  ok_t "reject prints a receipt naming owner + queue position + next wake on stdout"
+else
+  bad_t "reject receipt missing a fact (or landed on stderr)" "$OUT"
+fi
+[[ "$(assignee_of "$R1")" == "dev2" ]] \
+  && ok_t "reject still bounced the row to the maker" \
+  || bad_t "reject did not bounce the row" "assignee=$(assignee_of "$R1")"
+
+# --- assign ------------------------------------------------------------------
+R2=$(mk "receipt on assign" main medium)
+I2=$(ident_of "$R2")
+OUT=$(cmd_task_assign "$I2" dev2 2>/dev/null)
+if has_all_three "$OUT" dev2; then
+  ok_t "assign prints a receipt naming all three facts on stdout"
+else
+  bad_t "assign receipt missing a fact (or landed on stderr)" "$OUT"
+fi
+[[ "$(assignee_of "$R2")" == "dev2" ]] \
+  && ok_t "assign still moved the row" \
+  || bad_t "assign did not move the row" "assignee=$(assignee_of "$R2")"
+
+# --- set-body ----------------------------------------------------------------
+# The measured case this row was filed on: work handed over by a BODY WRITE, the
+# row already owned by the recipient, and the sender pinging anyway.
+R3=$(mk "receipt on set-body" dev2 medium)
+I3=$(ident_of "$R3")
+OUT=$(cmd_task_set_body "$I3" --append "triage: both arms fail on the ancestry check" 2>/dev/null)
+if has_all_three "$OUT" dev2; then
+  ok_t "set-body prints a receipt naming all three facts on stdout"
+else
+  bad_t "set-body receipt missing a fact (or landed on stderr)" "$OUT"
+fi
+grep -q 'ancestry check' <<<"$(db "SELECT body FROM tasks WHERE id=${R3};")" \
+  && ok_t "set-body still wrote the body" \
+  || bad_t "set-body did not write the body"
+
+echo "── C: the queue position is the DISPATCHER'S order, not a COUNT(*) ──────"
+
+# dev3's board, built so insertion order and dispatch order DISAGREE: the
+# high-priority row is inserted LAST, so a naive COUNT(*)-of-earlier-rows would
+# say "3 of 3" where the dispatcher will actually hand it over first.
+db "DELETE FROM tasks WHERE assignee='dev3';"
+Q1=$(mk "dev3 low a"  dev3 low)
+Q2=$(mk "dev3 low b"  dev3 low)
+Q3=$(mk "dev3 urgent" dev3 urgent)
+IQ3=$(ident_of "$Q3")
+# Route it with assign (dev3 -> dev3 is a legitimate no-op move; the receipt is
+# what is under test, and the position must not depend on the row having moved).
+OUT=$(cmd_task_assign "$IQ3" dev3 2>/dev/null)
+POS=$(sed -n 's/.*queue position: \([0-9]* of [0-9]*\).*/\1/p' <<<"$OUT")
+[[ "$POS" == "1 of 3" ]] \
+  && ok_t "urgent row inserted last reports 'queue position: 1 of 3' (dispatch order)" \
+  || bad_t "queue position is not the dispatcher's order" "got '${POS:-none}' from: $OUT"
+
+# And the low-priority one behind it reports a position that agrees with the
+# picker itself — re-derived here rather than hard-coded, so the arm cannot go
+# stale if the ordering rule legitimately changes.
+IQ1=$(ident_of "$Q1")
+OUT=$(cmd_task_assign "$IQ1" dev3 2>/dev/null)
+POS=$(sed -n 's/.*queue position: \([0-9]*\) of [0-9]*.*/\1/p' <<<"$OUT")
+EXPECT=$(_hb_pick_tasks dev3 200 | grep -n "^${Q1}$" | cut -d: -f1)
+[[ -n "$POS" && "$POS" == "$EXPECT" ]] \
+  && ok_t "reported position ($POS) equals the position _hb_pick_tasks would hand it ($EXPECT)" \
+  || bad_t "reported position disagrees with the dispatcher" "receipt=$POS picker=$EXPECT"
+
+# A dep-blocked row is NOT in the dispatch list. A number there would be a lie
+# the sender would act on, so the receipt must say what is actually true.
+QB=$(mk "dev3 blocked" dev3 high)
+db "INSERT OR IGNORE INTO task_deps (task_id, blocked_by) VALUES (${QB}, ${Q1});"
+OUT=$(cmd_task_assign "$(ident_of "$QB")" dev3 2>/dev/null)
+grep -q 'queue position: waiting on 1 unfinished dependency' <<<"$OUT" \
+  && ok_t "a dep-blocked row reports the blocker, not a fabricated position" \
+  || bad_t "dep-blocked row got a misleading position" "$OUT"
+
+echo "── D: next wake, all three states ──────────────────────────────────────"
+
+R4=$(mk "wake states" main medium); I4=$(ident_of "$R4")
+
+reg dev2 false 30 0
+OUT=$(cmd_task_assign "$I4" dev2 2>/dev/null)
+grep -q 'next wake: no auto-wake (heartbeat off for dev2)' <<<"$OUT" \
+  && ok_t "heartbeat off -> says the seat does not auto-wake" \
+  || bad_t "heartbeat-off wake line wrong" "$OUT"
+
+reg dev2 true 30 1
+OUT=$(cmd_task_assign "$I4" dev2 2>/dev/null)
+grep -q 'next wake: due now (dispatcher ticks every 5 min)' <<<"$OUT" \
+  && ok_t "overdue seat -> 'due now', bounded by the 5-min cron tick" \
+  || bad_t "due-now wake line wrong" "$OUT"
+
+reg dev2 true 30 "$(date +%s)"
+OUT=$(cmd_task_assign "$I4" dev2 2>/dev/null)
+grep -qE 'next wake: in ~(29|30)m' <<<"$OUT" \
+  && ok_t "seat that just ran -> 'in ~30m' from lastRunAt + everyMin" \
+  || bad_t "future-wake line wrong" "$OUT"
+
+echo "── E: ADDITIVE ONLY — every input can break and the verb still exits 0 ──"
+
+# The constraint, verbatim: "if this code path can return non-zero where it
+# returns zero today, it is out of scope." So each of the receipt's three
+# dependencies is broken in turn and the VERB is graded, not the receipt.
+
+R5=$(mk "additive: no picker" main medium); I5=$(ident_of "$R5")
+_HB_SAVED=$(declare -f _hb_pick_tasks)
+unset -f _hb_pick_tasks
+OUT=$(cmd_task_assign "$I5" dev2 2>/dev/null); RC=$?
+if (( RC == 0 )) && [[ "$(assignee_of "$R5")" == "dev2" ]]; then
+  ok_t "picker missing: assign still exits 0 and still moved the row"
+else
+  bad_t "picker missing broke the verb" "rc=$RC assignee=$(assignee_of "$R5")"
+fi
+grep -q 'queue position: unknown' <<<"$OUT" \
+  && ok_t "picker missing: says 'unknown' rather than inventing a position" \
+  || bad_t "picker missing produced a fabricated position" "$OUT"
+eval "$_HB_SAVED"
+
+R6=$(mk "additive: no registry" main medium); I6=$(ident_of "$R6")
+_REG_SAVED="$REGISTRY"; REGISTRY="$TMP/does-not-exist.json"
+OUT=$(cmd_task_assign "$I6" dev2 2>/dev/null); RC=$?
+if (( RC == 0 )) && [[ "$(assignee_of "$R6")" == "dev2" ]]; then
+  ok_t "registry missing: assign still exits 0 and still moved the row"
+else
+  bad_t "registry missing broke the verb" "rc=$RC assignee=$(assignee_of "$R6")"
+fi
+grep -q 'next wake:' <<<"$OUT" \
+  && ok_t "registry missing: the wake fact is still named (not silently dropped)" \
+  || bad_t "registry missing dropped the wake fact" "$OUT"
+REGISTRY="$_REG_SAVED"
+
+# A registry present but CORRUPT is the case a `jq` without a guard turns into a
+# non-zero exit — the exact shape the constraint forbids.
+R7=$(mk "additive: corrupt registry" main medium); I7=$(ident_of "$R7")
+printf 'not json at all {{{\n' >"$REGISTRY"
+OUT=$(cmd_task_assign "$I7" dev2 2>/dev/null); RC=$?
+if (( RC == 0 )) && [[ "$(assignee_of "$R7")" == "dev2" ]]; then
+  ok_t "corrupt registry: assign still exits 0 and still moved the row"
+else
+  bad_t "corrupt registry broke the verb" "rc=$RC assignee=$(assignee_of "$R7")"
+fi
+reg dev2 false 30 0
+
+# The receipt called with an owner it cannot resolve at all must print nothing
+# and exit 0 — "a receipt that cannot be printed should print nothing".
+OUT=$(routing_receipt "" "" 2>/dev/null); RC=$?
+[[ $RC -eq 0 && -z "$OUT" ]] \
+  && ok_t "receipt with no ident/owner: prints nothing, exits 0" \
+  || bad_t "empty-input receipt misbehaved" "rc=$RC out='$OUT'"
+
+# And the whole function is exit-proof. The stub targets `_routing_receipt_render`
+# specifically, NOT one of the two helpers below it: those are already called in
+# command substitutions, which are subshells of their own, so an `exit` inside
+# them is contained whether or not `routing_receipt` wraps anything — an arm
+# pointed there would pass on a version with the containment deleted and grade
+# nothing. `_routing_receipt_render` is the only call whose containment is the
+# wrapper's own doing, so it is the only place this control can live.
+_RENDER_SAVED=$(declare -f _routing_receipt_render)
+_routing_receipt_render() { exit 9; }
+OUT=$(routing_receipt DIVE-1 dev2 2>/dev/null); RC=$?
+[[ $RC -eq 0 ]] \
+  && ok_t "an exiting render cannot propagate a non-zero status to the caller" \
+  || bad_t "receipt propagated a failure" "rc=$RC"
+eval "$_RENDER_SAVED"
+
+# The other half of the same constraint: a render that FAILS (non-zero, no exit)
+# is equally contained. `set -e` is live in production via header.sh.
+_RENDER_SAVED=$(declare -f _routing_receipt_render)
+_routing_receipt_render() { return 7; }
+routing_receipt DIVE-1 dev2 >/dev/null 2>&1; RC=$?
+[[ $RC -eq 0 ]] \
+  && ok_t "a failing render cannot propagate a non-zero status to the caller" \
+  || bad_t "receipt propagated a return code" "rc=$RC"
+eval "$_RENDER_SAVED"
+
+# THE SAME CONSTRAINT WHERE THE WRAPPER ITSELF IS ABSENT. Not hypothetical: this
+# arm is here because adding the call sites broke tests/task_reject_trace_unit.sh
+# and tests/task_reject_actor_and_closed_unit.sh with rc=127 — they source a
+# SUBSET of src/ that does not include the new lib, and bash turns an unknown
+# command into a non-zero exit on a verb that had already done its work. A tree
+# that loads part of src/ is a real shape (every harness, and any future split),
+# so the verb must survive the helper not existing at all.
+R9=$(mk "additive: no helper" main medium); I9=$(ident_of "$R9")
+_RECEIPT_SAVED=$(declare -f routing_receipt)
+unset -f routing_receipt
+OUT=$(cmd_task_assign "$I9" dev2 2>/dev/null); RC=$?
+if (( RC == 0 )) && [[ "$(assignee_of "$R9")" == "dev2" ]]; then
+  ok_t "helper entirely absent: assign still exits 0 and still moved the row"
+else
+  bad_t "a missing routing_receipt broke the verb" "rc=$RC assignee=$(assignee_of "$R9")"
+fi
+eval "$_RECEIPT_SAVED"
+
+echo "── J: JSON mode is untouched ───────────────────────────────────────────"
+
+R8=$(mk "json contract" main medium); I8=$(ident_of "$R8")
+JSON_MODE=1
+OUT=$(cmd_task_assign "$I8" dev2 2>/dev/null); RC=$?
+JSON_MODE=0
+if (( RC == 0 )) && jq -e '.ok == true' <<<"$OUT" >/dev/null 2>&1; then
+  ok_t "JSON mode: output is still a single valid object (no receipt line leaked in)"
+else
+  bad_t "JSON mode output corrupted by the receipt" "rc=$RC out='$OUT'"
+fi
+
+echo "── W: wiring — the lib is SHIPPED, and every routing verb calls it ─────"
+
+# Everything above sources src/ directly, so it would stay green on a version
+# where the file exists and the installed CLI never loads it. build.sh is an
+# explicit manifest, not a glob: a new lib that is not listed is silently absent
+# from the artifact customers install.
+grep -q '^  src/lib/routing_receipt.sh \\$' build.sh \
+  && ok_t "build.sh manifest ships src/lib/routing_receipt.sh" \
+  || bad_t "routing_receipt.sh is not in the build manifest — the shipped CLI would not have it"
+
+for pair in "src/task/delivery.sh:reject" "src/task/crud.sh:assign" "src/task/dispatch.sh:set-body"; do
+  f="${pair%%:*}"; v="${pair##*:}"
+  grep -q 'routing_receipt "' "$f" \
+    && ok_t "the $v verb's file calls routing_receipt" \
+    || bad_t "no routing_receipt call in $f (the $v verb)"
+done
+
+echo
+printf 'routing_receipt_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
+(( FAIL == 0 )) || exit 1


### PR DESCRIPTION
Replaces #675, which built the **withdrawn** deliverable (a refusal in the send path) and broke the row's hard constraint. This branch is cut fresh from `origin/main`, so none of that code is here.

## What this builds

`task reject`, `task assign`, `task set-body` each print one line to the CALLER:

```
OK — DIVE-3330 assigned to dev2
handoff: dev2 now owns it · queue position: 2 of 5 · next wake: in ~12m
```

## Why

Every "I routed you a row, please look at it" a2a ping is a missing capability wearing the shape of a message. Measured 2026-08-16: ops put a full triage of PR #635 on DIVE-3330's body, the row was already `todo` and already `assignee=dev2`, and ops pinged main's non-fresh window anyway — because nothing confirmed to the SENDER that the routed row was received. The general case runs the other way too: a verifier bouncing a row cannot see the maker owns it again.

Not a guard. The receipt deletes the reason to ping.

## The hard constraint, and how it is graded

> lodar, 2026-08-16 16:47Z: *"it shoulnt be enfoced on the 5dive layer - because you may break the a2a"* — ADDITIVE ONLY. No refusal, no new exit code, no new precondition, no new way to fail. *"if this code path can return non-zero where it returns zero today, it is out of scope."*

`routing_receipt` runs its body in a subshell with stderr closed and `|| true` outside; each call site adds its own `2>/dev/null || true`. Four independent break-arms grade the VERB, not the receipt — picker missing, registry missing, registry corrupt, **helper entirely absent** — each asserting rc=0 AND that the row still moved.

That last arm is not hypothetical: adding the call sites initially broke `task_reject_trace_unit.sh` and `task_reject_actor_and_closed_unit.sh` with **rc=127**, because those harnesses source a subset of `src/`. Found, fixed at the call sites, and now graded.

## Evidence

- `tests/routing_receipt_unit.sh` — **26 assertions green in 3.3s** (core tier), against a REAL sqlite board in a throwaway `STATE_DIR`.
- **Four mutations, all caught:** neuter the assign call site -> 9 failed · drop the next-wake fact -> 7 · remove the subshell containment -> 2 · queue position becomes insertion order -> 3. (The missing-helper case was a real found defect, not a synthetic mutation.)
- Regression arms green (0 failures): `task_reject_actor_and_closed_unit`, `task_reject_trace_unit`, `handoff_ack_unit`, `heartbeat_pick_unit`, `release_cut_assign_unit`, `task_close_preserves_done_at_unit`.
- `shellcheck -S error -s bash` clean on the new lib, the harness and all three touched verb files.
- Bundle builds; `build.sh` manifest updated and asserted by a wiring arm (a lib that exists but is not shipped would otherwise pass every other arm).

CI was not waited on, per the deliver-on-push rule.

## Residual, stated rather than discovered

1. **JSON mode gets no receipt.** Deliberate — a stray stdout line corrupts the object `ok` emits, and adding fields changes a contract other verbs snapshot. Graded that JSON output is unchanged. Agents run these verbs in human mode.
2. **`task done`'s maker->verifier delivery is not covered.** It is a fourth routing event and arguably deserves the same line; kept out to stay inside the acceptance quinn wrote (reject / assign / body-write). Two lines to add if wanted.
3. **The fleet `CLAUDE.md` rule 0 still does not mention the receipt.** `5dive-cli` is not auto-deploying, so that edit belongs at release-cut — writing it now would describe output no box has installed.
4. **Core-tier budget:** +3.3s measured on this host, not in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
