### PR TITLE
DIVE-3505: kill the pty ECHO race in tests/init_ux_unit.sh

### DIFF
--- a/tests/init_ux_unit.sh
+++ b/tests/init_ux_unit.sh
@@ -48,6 +48,17 @@ do
   [[ "$body" == *"$needle"* ]] || { echo "FAIL: missing masked-input wiring: $needle" >&2; exit 1; }
 done
 
+# DIVE-3505: the pty below now runs with ECHO cleared (see the note in drive()),
+# which is what makes it deterministic -- but it also retires the coverage the
+# echo race was providing by accident. A `_init_secret` that lost its `-s` would
+# have leaked the secret via KERNEL echo, and with echo off the pty can no longer
+# see that. Measured: mutating `read -r -s -n1` -> `read -r -n1` fails the old
+# harness and passes the echo-off one. So assert the no-echo read structurally,
+# where it is a fact about the source rather than a race against the tty.
+secret_body="$(declare -f _init_secret)"
+[[ "$secret_body" == *'read -r -s -n1'* ]] \
+  || { echo "FAIL: _init_secret must read with -s (no terminal echo)" >&2; exit 1; }
+
 [[ "$body" == *'_init_section 4 4 "Review and create"'* ]] \
   || { echo "FAIL: missing pre-create review stage" >&2; exit 1; }
 
@@ -58,14 +69,35 @@ import pty
 import select
 import shlex
 import sys
+import termios
 import time
 
 root = sys.argv[1]
 
 
+# DIVE-3505: this harness, not the product, owned a pty ECHO race that reds
+# `test-installed-host` at random. `_init_secret` reads with `read -r -s -n1`,
+# and bash's `-s` turns echo off on ENTRY and restores it on EXIT -- per call,
+# so with `-n1` that is one echo-off/echo-on cycle PER CHARACTER. Writing a
+# whole payload in one os.write leaves the unconsumed tail sitting in the tty
+# input buffer, and the kernel echoes it the moment echo comes back on. The
+# product was innocent: the failing runs showed the kernel echo AND the
+# product's own `*******` mask AND RESULT_LEN=7 all at once.
+#
+# Two independent layers, because either alone leaves a window:
+#   1. Clear ECHO in the CHILD before execv. Doing it from the parent after
+#      pty.fork() races the child: if bash has already entered a `read -s`, the
+#      termios it restores on exit is the one it saved -- echo ON -- and the
+#      buffered tail echoes anyway. Clearing it before bash exists means every
+#      save/restore cycle can only ever restore echo-off.
+#   2. Write payloads one byte at a time (below), so no unconsumed tail is ever
+#      parked in the buffer for an echo-on window to flush.
 def drive(shell_body, interactions, timeout=5, term="xterm-256color"):
     pid, fd = pty.fork()
     if pid == 0:
+        attrs = termios.tcgetattr(0)
+        attrs[3] &= ~termios.ECHO
+        termios.tcsetattr(0, termios.TCSANOW, attrs)
         os.environ["TERM"] = term
         os.environ["NO_COLOR"] = "1"
         command = f"source {shlex.quote(root)}/src/cmd_init.sh; {shell_body}"
@@ -82,7 +114,8 @@ def drive(shell_body, interactions, timeout=5, term="xterm-256color"):
                 ready, _, _ = select.select([fd], [], [], 0.1)
                 if ready:
                     output.extend(os.read(fd, 4096))
-            os.write(fd, payload)
+            for byte in payload:
+                os.write(fd, bytes([byte]))
 
         while time.monotonic() < deadline:
             ready, _, _ = select.select([fd], [], [], 0.1)


### PR DESCRIPTION
Fixes DIVE-3505. **Test-only change — `src/cmd_init.sh` is not touched.**

## The mechanism
`_init_secret` reads with `while IFS= read -r -s -n1 char`. Bash's `-s` turns echo off on **entry** and restores it on **exit** — per call — so with `-n1` that is one echo-off/echo-on cycle **per character**. `drive()` waited for the `API key:` marker and then wrote all 7 bytes of `hunter2\n` in a single `os.write`. The tail sat unconsumed in the tty input buffer and the kernel echoed it the moment echo came back on.

The red run proves the product is innocent — all three facts were present at once: the kernel echo `› API key: hunter2`, the product's own `*******` mask, and `RESULT_LEN=7`. If `_init_secret` had actually leaked, `*******` would be absent.

## The fix (two independent layers)
1. **Clear `ECHO` in the child before `execv`.** Doing it from the parent after `pty.fork()` races the child: if bash has already entered a `read -s`, the termios it restores on exit is the one it *saved* — echo ON — and the tail echoes anyway. Clearing it before bash exists means every save/restore cycle can only restore echo-off.
2. **Write payloads one byte at a time**, so no unconsumed tail is ever parked in the buffer for an echo-on window to flush.

## The coverage this would have silently retired, and what replaces it
Clearing `ECHO` also retires coverage the race was providing **by accident**: a `_init_secret` that lost its `-s` used to leak via *kernel* echo, and an echo-off pty cannot see that. Measured, not assumed — mutating `read -r -s -n1` → `read -r -n1` failed the old harness and **passed** the echo-off one on the first pass of this change.

Replaced with a structural assertion on `declare -f _init_secret`, where the no-echo read is a fact about the source instead of a race against the tty.

## Evidence (all on `494cf10`, this host)
| arm | result |
| --- | --- |
| control, unfixed harness, 40 runs | **1/40 red**, exact signature `› API key: hunter2` |
| fixed harness, 120 consecutive runs | **0/120 red** (acceptance asked for ≥50) |
| mutant `read -r -s -n1` → `read -r -n1` | **5/5 red** — retired coverage restored |
| mutant mask `printf '*'` → the real char | **3/3 red** — the pty leak assertion still bites |

First control run was invalid (`./tests/... Permission denied` — my runner, not the test, 40/40); re-run under `bash` and reported above.

## Residual
The pty arm no longer detects a *kernel*-echo leak; that class is now covered structurally, so a leak introduced by some path other than dropping `-s` from that one `read` would be missed by both. The product-side leak class (masking with the real character) is still covered end-to-end — mutant 2 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
