### PR TITLE
fix(agent): agent info separates DECLARED from BOUND channels (DIVE-2766)

### DIFF
--- a/src/cmd_agent.sh
+++ b/src/cmd_agent.sh
@@ -543,6 +543,76 @@ PY
   mv -f "$tmp" "$file"
 }
 
+# DIVE-2766: DECLARED channels are not BOUND channels.
+#
+# `channels:` on `info` is read straight out of the registry, so a box where
+# every channel was REFUSED at runtime still prints
+# `channels: telegram,dashboard (@bot)` beside `state: active`. That is accurate
+# about what was declared and it is rendered in the grammar of an observation,
+# which is how four consecutive red `telegram-roundtrip-openrouter` runs were
+# triaged as credential routing while the agent had simply never bound a channel
+# (DIVE-2765 / DIVE-2754). Same class as the DIVE-2362 send receipt: the field
+# describes the CALL, not the delivery.
+#
+# What is measurable from here is the refusal, not the success. The gate is
+# inside the Claude Code binary and it announces itself in the session's own
+# output — `--channels ignored (…)` followed by one of the `Channels are not …`
+# branches (`community/wiki/the-channels-gate-is-inside-claude-code-not-our-plugin-staging.md`).
+# There is NO corresponding success banner in the binary (checked against
+# 2.1.233), so this probe can prove REFUSED and can never prove BOUND.
+#
+# Hence three states and deliberately not two:
+#   n/a       — nothing declared, so there is nothing to bind.
+#   refused   — POSITIVE evidence: the refusal banner is in the pane.
+#   unknown   — everything else, INCLUDING a clean capture. The banner prints at
+#               session start and rolls off the scrollback, so "not found" is
+#               not "bound". Reporting a clean capture as bound would rebuild
+#               this ticket's defect one layer down.
+# Never `bound`. An unprobeable state renders UNKNOWN, never silently as the
+# declared value — the v0.16 "fails loud" direction, where NOT-REACHED is not a
+# synonym for green.
+#
+# Emits `<state>|<detail>|<evidence>` on stdout and always exits 0: like every
+# other probe on this command it degrades to a reported unknown, never a failed
+# `info`.
+agent_channels_binding() { # agent_channels_binding <name> <declared-channels>
+  local name="$1" declared="$2" pane="" line=""
+  case "$declared" in
+    ""|none|null) printf 'n/a||\n'; return 0 ;;
+  esac
+  # Same instrument the runtime commands use (cmd_agent_runtime.sh). A missing
+  # session, a denied sudo and an absent tmux are one answer here — unknown —
+  # and the detail says which, because "cannot probe" and "probed clean" have
+  # completely different remedies and render identically otherwise.
+  if ! sudo -n -u "agent-${name}" tmux has-session -t "agent-${name}" 2>/dev/null; then
+    printf 'unknown|no readable tmux session for agent-%s (not running, or this caller cannot read it) — run this as root on the box|\n' "$name"
+    return 0
+  fi
+  pane=$(sudo -n -u "agent-${name}" tmux capture-pane -t "agent-${name}" -p -J -S -2000 2>/dev/null) || pane=""
+  if [[ -z "$pane" ]]; then
+    printf 'unknown|tmux capture-pane returned nothing for agent-%s|\n' "$name"
+    return 0
+  fi
+  # Match the FAMILY, not one branch: the binary picks between several
+  # `Channels are not …` endings (capability / third-party / org policy) and it
+  # gained a new one between 2.1.222 and 2.1.233, so pinning the exact sentence
+  # would have gone quietly blind on an upgrade.
+  # `Channels are not …` is preferred over `--channels ignored` when both are in
+  # the pane (they print as a pair): the second line names WHICH branch of the
+  # gate fired, and the branch is the whole diagnosis. Taking whichever came
+  # first would have surfaced the line that says only "something was ignored".
+  line=$(grep -m1 -E 'Channels are not ' <<<"$pane" 2>/dev/null) || line=""
+  [[ -n "$line" ]] || line=$(grep -m1 -E 'channels ignored' <<<"$pane" 2>/dev/null) || line=""
+  if [[ -n "$line" ]]; then
+    # Trim to keep one banner line on one output line.
+    line="${line//|/ }"
+    printf 'refused|the session announced the channel gate|%s\n' "$(printf '%s' "$line" | tr -d '\r' | cut -c1-160)"
+    return 0
+  fi
+  printf 'unknown|no refusal banner in the last 2000 lines of the pane — the banner prints at session start and rolls off, so this is NOT evidence the channels bound|\n'
+  return 0
+}
+
 # Single-agent detail: registry identity/config + live systemd state, plus the
 # resolved coding-CLI version and selected model. Added so each fork's /status
 # reads one uniform source (cliName/cliVersion/model) instead of shelling each
@@ -619,6 +689,17 @@ cmd_info() {
   # measured here and the other is inherited with its age attached. `|| true`:
   # the overlay is best-effort like every other probe on this command — an
   # unreadable store degrades to `unobserved`, never to a failed `info`.
+  # DIVE-2766: measure the channel BINDING beside the declared value. See
+  # agent_channels_binding for why this can report REFUSED and can never report
+  # BOUND, and why a clean capture is `unknown` rather than a green.
+  local _chan_declared _cb _cb_state _cb_detail _cb_evidence
+  _chan_declared=$(jq -r --arg n "$name" '.agents[$n].channels // "none"' <<<"$reg")
+  _cb=$(agent_channels_binding "$name" "$_chan_declared" || true)
+  [[ -n "$_cb" ]] || _cb='unknown|channel binding probe did not run|'
+  _cb_state="${_cb%%|*}"
+  _cb_detail="${_cb#*|}"; _cb_detail="${_cb_detail%%|*}"
+  _cb_evidence="${_cb##*|}"
+
   local sup
   sup=$(sup_info_for_agent "$name" 2>/dev/null || true)
   [[ -n "$sup" ]] || sup='{"output":"unknown","transacting":null,"classification":"unobserved","verdict":null,"stateNote":"output unknown — the task store was not readable from here","line":"unobserved — the task store was not readable from here","note":"store unreadable"}'
@@ -640,10 +721,28 @@ cmd_info() {
     --arg model "$model" \
     --arg effort "$effort" \
     --arg ocUnpinned "$oc_unpinned" \
+    --arg cbState "$_cb_state" \
+    --arg cbDetail "$_cb_detail" \
+    --arg cbEvidence "$_cb_evidence" \
     '.agents[$n] as $a | {
       name: $n,
       type: $a.type,
+      # DIVE-2766: `channels` is the DECLARED value and always was. It keeps its
+      # name and its shape so no consumer breaks, but it is no longer the only
+      # channel field on this record, and `channelsBinding` below is the one that
+      # answers the question a reader of `channels` thought they were asking.
       channels: ($a.channels // "none"),
+      channelsDeclared: ($a.channels // "none"),
+      channelsBinding: {
+        state: $cbState,
+        # `measured` is true ONLY for a positive refusal. `n/a` measured nothing
+        # (there was nothing to measure) and `unknown` measured nothing either;
+        # collapsing those into a true would hand a consumer the same false
+        # confidence in JSON that the printed line used to hand a human.
+        measured: ($cbState == "refused"),
+        detail: (if $cbDetail == "" then null else $cbDetail end),
+        evidence: (if $cbEvidence == "" then null else $cbEvidence end)
+      },
       workdir: ($a.workdir // $default_wd),
       authProfile: ($a.authProfile // null),
       botUsername: ($a.botUsername // null),
@@ -700,7 +799,13 @@ cmd_info() {
       "type:        \(.type)",
       "cli:         \(.cliName) \(.cliVersion // "unknown")",
       "model:       \(.model // (if .modelUnpinnedWithCreds then "— UNPINNED (see warning below)" else "—" end))\(if .effort then " · effort \(.effort)" else "" end)",
-      "channels:    \(.channels)\(if .botUsername then " (@\(.botUsername))" else "" end)",
+      # DIVE-2766: the word DECLARED is the fix. It is what this line always
+      # reported and never said, and the `bound:` line under it is what the
+      # reader was actually after.
+      "channels:    \(.channels)\(if .botUsername then " (@\(.botUsername))" else "" end)\(if .channelsBinding.state == "n/a" then "" else " — DECLARED (registry)" end)",
+      (if .channelsBinding.state == "n/a" then empty else
+        "bound:       \(if .channelsBinding.state == "refused" then "NO — REFUSED at runtime" else "unknown — \(.channelsBinding.detail // "not probeable from here")" end)\(if .channelsBinding.evidence then "\n             ↳ \(.channelsBinding.evidence)" else "" end)"
+       end),
       "profile:     \(.authProfile // "-")",
       "workdir:     \(.workdir)",
       "isolation:   \(.isolation) (label\(if .isolationLabelled then "" else ", defaulted — unset in registry" end))",
@@ -714,6 +819,9 @@ cmd_info() {
       # knew was dark, and the seat itself, by construction, cannot read this.
       (if .supervisor.verdict then
          "\nWARNING: this seat is UP and REACHABLE but NOT TRANSACTING (\(.supervisor.verdict)): \(.supervisor.note). Whatever is queued behind it is not moving. The `state:` line above and every other liveness signal (unit / tmux / poller / registry label) read healthy — that agreement is the DIVE-3272 defect, not evidence against this line. Check model capacity (auth-profile, quota reset) and reassign or park the queue: 5dive task ls --assignee=\(.name)"
+       else empty end),
+      (if .channelsBinding.state == "refused" then
+         "\nWARNING: this agent DECLARES channels (\(.channelsDeclared)) and its session REFUSED them. It cannot receive or reply on any of them, however healthy every other line above looks — the registry, the unit and the bot username are all still correct, which is exactly why this reads as paired. The gate is inside the coding-CLI binary, not our plugin staging, so re-running `agent create` or re-installing the plugins will not move it (DIVE-2765). Do not attribute an unanswered message or a red round-trip on this agent to credential routing until this line is clear."
        else empty end),
       (if .modelUnpinnedWithCreds then
          "\nWARNING: this openclaw agent has a credential on disk and NO model pin. That is not a neutral default — openclaw model ids are `<provider>/<model>`, so with nothing pinned it uses its built-in default, whose provider prefix is not the one you configured. It will consult a credential that does not exist and return HTTP 401 while your key sits unused (DIVE-3112). Repair: sudo 5dive agent auth set openclaw --provider=<provider> --api-key=<key> --auth-profile=\(.authProfile // "<profile>") --model=<provider>/<model>"

--- a/tests/agent_info_channels_binding_unit.sh
+++ b/tests/agent_info_channels_binding_unit.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# DIVE-2766 isolated unit harness for agent_channels_binding (cmd_agent.sh) and
+# for the `channels:`/`bound:` render program `agent info` prints from it.
+#
+# The property under test is NOT "does it spot a refused channel". It is: can
+# this surface ever report a state a BOUND agent and an UNPROBED agent SHARE?
+# That is the whole defect — `channels: telegram,dashboard (@bot)` printed beside
+# `state: active` on a box where every channel had been refused, which sent the
+# triage of four consecutive red telegram-roundtrip-openrouter runs at credential
+# routing (community/wiki/the-channels-gate-is-inside-claude-code-not-our-plugin-staging.md).
+# So the arms below deliberately include the three "nothing visibly wrong" shapes
+# that must NOT collapse into each other: nothing-declared, probed-clean, and
+# could-not-probe. A clean capture reporting anything but `unknown` rebuilds the
+# ticket one layer down, and §3 is the arm that grades it.
+#
+# `sudo` and `tmux` are stubbed, so this runs with no root, no tmux and no agent.
+# Run: bash tests/agent_info_channels_binding_unit.sh
+#
+# GRADED BY MUTATION on this box (control plane, not CI), 2026-08-16, against 38
+# passing — nine mutations of src/cmd_agent.sh, each applied alone:
+#   clean capture reports "bound" instead of unknown ....... 2 red
+#   no-session branch reports "bound" ...................... 1 red
+#   measured: true for every non-n/a state ................. 1 red
+#   refusal grep pinned to one sentence, not the family .... 3 red
+#   `Channels are not ` preference dropped (first match) ... 1 red
+#   `|`-strip dropped from the evidence line ............... 1 red
+#   DECLARED suffix dropped from the channels: line ........ 1 red
+#   refused WARNING block dropped .......................... 1 red
+#   n/a arm emits a bound: line ............................ 1 red
+# TWO SURVIVORS on the first pass, both reported and both closed rather than
+# papered over, because each named a real hole:
+#   - `measured` survived §1-§5 entirely. A render-only harness cannot see the
+#     object program that feeds it, so §6 was added.
+#   - the `|`-strip survived an assertion that the evidence contained no `|`:
+#     ${##*|} keeps the tail after the last separator, so a TRUNCATED banner
+#     still parses clean. §2.3 now asserts the whole string.
+set -uo pipefail
+
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+
+PASS=0; FAIL=0
+t() {  # <desc> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then PASS=$((PASS+1)); else
+    FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  expected: $2"; echo "  actual:   $3"
+  fi
+}
+tc() {  # <desc> <needle> <haystack> — contains
+  if [[ "$3" == *"$2"* ]]; then PASS=$((PASS+1)); else
+    FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  expected to contain: $2"; echo "  actual:              $3"
+  fi
+}
+tnc() { # <desc> <needle> <haystack> — does NOT contain
+  if [[ "$3" != *"$2"* ]]; then PASS=$((PASS+1)); else
+    FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  expected NOT to contain: $2"; echo "  actual:                  $3"
+  fi
+}
+
+# The probe under test, lifted out of cmd_agent.sh so no state/registry/systemd
+# machinery has to boot. Extracted by name rather than pasted: a copy would grade
+# the copy, which is the failure mode this comment exists to prevent.
+fnsrc=$(sed -n '/^agent_channels_binding() {/,/^}/p' "$SRC/cmd_agent.sh")
+[[ -n "$fnsrc" ]] || { echo "FAIL: could not extract agent_channels_binding from $SRC/cmd_agent.sh"; exit 1; }
+eval "$fnsrc"
+
+# Stubbed privilege + tmux. SESSION says whether has-session succeeds; PANE is
+# what capture-pane emits. Every real caller of this function reaches tmux only
+# through these two verbs.
+SESSION=yes; PANE=""
+sudo() {
+  case "$*" in
+    *has-session*)   [[ "$SESSION" == "yes" ]] ;;
+    *capture-pane*)  printf '%s\n' "$PANE" ;;
+    *)               return 1 ;;
+  esac
+}
+
+st() { printf '%s' "${1%%|*}"; }                       # state field
+de() { local r="${1#*|}"; printf '%s' "${r%%|*}"; }    # detail field
+ev() { printf '%s' "${1##*|}"; }                       # evidence field
+
+# ---- §1 refused: positive evidence, every branch of the gate ---------------
+# The binary picks between several `Channels are not …` endings and gained a new
+# one between 2.1.222 and 2.1.233, so the arms cover the FAMILY. A probe pinned
+# to one sentence goes quietly blind on a coding-CLI upgrade, and quiet is the
+# entire complaint on this ticket.
+SESSION=yes
+PANE=$'boot\n ▎ --channels ignored (plugin:telegram@5dive-plugins, plugin:dashboard@5dive-plugins)\n ▎ Channels are not currently available\n> '
+r=$(agent_channels_binding smoke-rt-or telegram,dashboard)
+t  "1.1 the DIVE-2765 pane is refused"            "refused" "$(st "$r")"
+tc "1.2 evidence names the BRANCH, not the ignore" "Channels are not currently available" "$(ev "$r")"
+
+PANE=$'Channels are not enabled for your org (policy)'
+t "1.3 org-policy branch is refused"      "refused" "$(st "$(agent_channels_binding x telegram)")"
+PANE=$'Channels are not available on third-party providers'
+t "1.4 third-party branch is refused"     "refused" "$(st "$(agent_channels_binding x telegram)")"
+PANE=$'Channels are not available on Bedrock, Vertex, or Foundry'
+t "1.5 provider branch is refused"        "refused" "$(st "$(agent_channels_binding x telegram)")"
+# Only the ignore line, no second line: still a refusal, and the evidence has to
+# fall back to it rather than reporting nothing.
+PANE=$'--channels ignored (plugin:telegram@5dive-plugins)'
+r=$(agent_channels_binding x telegram)
+t  "1.6 ignore line alone is refused"     "refused" "$(st "$r")"
+tc "1.7 falls back to the ignore line"    "--channels ignored" "$(ev "$r")"
+
+# ---- §2 the field separator cannot be smuggled in from the pane -----------
+# The three fields ride one `|`-delimited line, and the pane is attacker-shaped
+# input in the weak sense that it is arbitrary terminal output. A banner
+# containing `|` must not shift evidence into detail.
+PANE='Channels are not currently available | tail | more'
+r=$(agent_channels_binding x telegram)
+t  "2.1 pipe-bearing banner still refused"     "refused" "$(st "$r")"
+t  "2.2 detail field is not displaced"         "the session announced the channel gate" "$(de "$r")"
+# Asserting only "the evidence contains no |" is NOT enough and the mutation pass
+# proved it: without the substitution the last field still parses clean, because
+# ${##*|} silently keeps the tail after the final pipe. The banner has to arrive
+# WHOLE, so the arm asserts the whole string.
+t   "2.3 the banner arrives whole, separators neutralised" \
+    "Channels are not currently available   tail   more" "$(ev "$r")"
+tnc "2.4 and carries no bare separator"        "|" "$(ev "$r")"
+
+# ---- §3 the three quiet shapes, which must NOT collapse -------------------
+# 3.1 is the arm this harness exists for: a clean capture is NOT a green. The
+# banner prints at session start and rolls off the scrollback, so "no banner in
+# the last 2000 lines" is silence, not confirmation
+# (community/wiki/a-skipped-job-is-silence-not-a-green.md).
+PANE=$'just some ordinary agent output\nnothing about channels here\n'
+r=$(agent_channels_binding x telegram)
+t   "3.1 probed-clean is unknown, never bound"  "unknown" "$(st "$r")"
+tnc "3.2 and never says bound"                  "bound"   "$(st "$r")"
+tc  "3.3 and says WHY it is not evidence"       "rolls off" "$(de "$r")"
+
+PANE=""
+t "3.4 empty capture is unknown"  "unknown" "$(st "$(agent_channels_binding x telegram)")"
+tc "3.5 empty capture says which" "capture-pane returned nothing" "$(de "$(agent_channels_binding x telegram)")"
+
+SESSION=no
+r=$(agent_channels_binding x telegram)
+t  "3.6 no readable session is unknown"     "unknown" "$(st "$r")"
+tc "3.7 names the two causes it cannot separate" "not running, or this caller cannot read it" "$(de "$r")"
+# Cannot-probe and probed-clean are both `unknown` on purpose — neither is
+# evidence — but they have different remedies, so the DETAIL must differ.
+SESSION=yes; PANE=$'ordinary output\n'
+a=$(de "$(agent_channels_binding x telegram)"); SESSION=no
+b=$(de "$(agent_channels_binding x telegram)")
+if [[ "$a" != "$b" ]]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); echo "FAIL: 3.8 probed-clean and cannot-probe share a detail string"
+fi
+
+# ---- §4 nothing declared is its own state --------------------------------
+# An agent with no channels has nothing to bind, and printing `bound: unknown`
+# at it would manufacture a doubt about a seat that is fine.
+SESSION=yes; PANE=$'Channels are not currently available'
+for d in "" none null; do
+  t "4.x declared '${d:-<empty>}' is n/a" "n/a" "$(st "$(agent_channels_binding x "$d")")"
+done
+
+# ---- §5 the render, which is the half a human actually reads -------------
+# Extracted from the source the same way the function was.
+render=$(sed -n '/^      "name:        .(.name)",$/,/^    . <<<"\$obj"$/p' "$SRC/cmd_agent.sh" | sed '$d')
+[[ -n "$render" ]] || { echo "FAIL: could not extract the info render program"; exit 1; }
+rec() { # rec <state> <evidence>
+  jq -nc --arg s "$1" --arg e "$2" '{
+    name:"a", type:"claude", cliName:"claude", cliVersion:"1", model:null, effort:null,
+    modelUnpinnedWithCreds:false, channels:"telegram,dashboard", channelsDeclared:"telegram,dashboard",
+    channelsBinding:{state:$s, measured:($s=="refused"), detail:"d", evidence:(if $e=="" then null else $e end)},
+    botUsername:"b", authProfile:null, workdir:"/w", isolation:"admin", isolationLabelled:true,
+    sudo:{measured:true,grant:"g",scope:"s",runas:"r",extraEntries:false,diverges:false},
+    supervisor:{stateNote:"n",note:"o",line:"l",verdict:null}, createdAt:"t"}'
+}
+out=$(rec refused "Channels are not currently available" | jq -r "$render")
+tc "5.1 the channels line says DECLARED"      "— DECLARED (registry)" "$out"
+tc "5.2 a refused seat prints bound: NO"      "bound:       NO — REFUSED at runtime" "$out"
+tc "5.3 with the banner beside it"            "Channels are not currently available" "$out"
+tc "5.4 and warns that other lines look fine" "WARNING: this agent DECLARES channels" "$out"
+tc "5.5 and names where the gate is"          "inside the coding-CLI binary" "$out"
+
+out=$(rec unknown "" | jq -r "$render")
+tc  "5.6 an unprobed seat prints bound: unknown" "bound:       unknown" "$out"
+tnc "5.7 and never the word REFUSED"             "REFUSED" "$out"
+tnc "5.8 and raises no warning"                  "WARNING: this agent DECLARES" "$out"
+
+out=$(rec "n/a" "" | jq -r "$render")
+tnc "5.9 a channel-less seat gets no bound: line" "bound:" "$out"
+tnc "5.10 and no DECLARED suffix"                 "DECLARED (registry)" "$out"
+
+# ---- §6 the JSON record, which is what the dashboard reads ---------------
+# §5 grades the printed lines and CANNOT see the object program that feeds them
+# — the coverage hole quinn measured on the DIVE-3274 detector
+# (community/wiki/a-detectors-tests-can-grade-the-branch-and-not-the-read.md),
+# and the hole this harness fell into on its first mutation pass: flipping
+# `measured` to true for every non-n/a state survived §1–§5 at full green.
+# `measured` is the field a consumer keys on to decide whether a value is a
+# MEASUREMENT, so a true on `unknown` hands the dashboard in JSON the same false
+# confidence the printed line used to hand a human.
+cbprog=$(sed -n '/^      channelsBinding: {$/,/^      },$/p' "$SRC/cmd_agent.sh" | sed '$s/,$//')
+[[ -n "$cbprog" ]] || { echo "FAIL: could not extract the channelsBinding object program"; exit 1; }
+cb() { # cb <state> <detail> <evidence>
+  jq -nc --arg cbState "$1" --arg cbDetail "$2" --arg cbEvidence "$3" "{ $cbprog }"
+}
+t "6.1 refused is measured"          "true"  "$(cb refused d e | jq -r '.channelsBinding.measured')"
+t "6.2 unknown is NOT measured"      "false" "$(cb unknown d ''  | jq -r '.channelsBinding.measured')"
+t "6.3 n/a is NOT measured"          "false" "$(cb "n/a" "" ""   | jq -r '.channelsBinding.measured')"
+t "6.4 empty detail is null, not ''" "null"  "$(cb "n/a" "" ""   | jq -r '.channelsBinding.detail')"
+t "6.5 empty evidence is null"       "null"  "$(cb unknown d ""  | jq -r '.channelsBinding.evidence')"
+t "6.6 state rides through verbatim" "unknown" "$(cb unknown d "" | jq -r '.channelsBinding.state')"
+
+echo "-- $PASS passed, $FAIL failed --"
+(( FAIL == 0 ))


### PR DESCRIPTION
## What

`agent info` reported **DECLARED** channels as if they were **BOUND**. This separates the two and adds a 38-arm harness.

## Why

A declared channel is a line in the registry; a bound one has a live credential behind it. Rendering them identically means the one question an operator asks `agent info` to answer — *can this seat actually reach that channel?* — was being answered with a value that cannot distinguish yes from no.

## Grading

Graded PASS by quinn (verifier), who re-derived rather than read the report:

- new harness **38/38**, with **9 independent mutations killed**
- `agent_info_supervisor_unit` **88/88**, still green
- a real `agent info` run on this host renders correctly

## Provenance

DIVE-2766, filed by main2 2026-08-05, maker dev2. Opened by main because dev2 holds no `_gh_do` grant and therefore cannot open its own PR — the row was blocked on that alone, not on any decision.

Companion PR in `lodar/5dive-api` carries the second half (the smoke box's SSH key), tracked on the same row.
