### PR TITLE
feat(task): merge-unverified reads back the closes the merge gate could not check (DIVE-3526)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased — feat(task): `merge-unverified` reads back the closes the merge gate could not check (DIVE-3526)
+
+Since DIVE-1935 the mandatory auto-detect merge gate has said so when its repo scan cannot
+complete: it warns, writes a `task.merge-gate-unverified` row to the audit log, and lets the close
+proceed (fail-open stays — DIVE-1830 refused fail-CLOSED for blast radius, and that is still the
+right refusal). All of that is firing — **196 stamped rows on 2026-08-17, every recent one
+`reason=partial-repo-scan-7-of-11`**. Nothing ever read them back, so DIVE-3300 closed
+2026-08-12 with the stamp and nobody re-derived it for five days. A record that is written and
+never read is a receipt, not a control.
+
+- **`5dive task merge-unverified [--limit=N] [--since=<Nd|Nh>] [--json]`** re-derives every stamped
+  ident's PR state now and surfaces the ones still carrying an OPEN pull request. Read-only: it
+  reports, it never reopens a row and it does not touch the gate.
+- **`merge-audit` could not have covered this, and it is not a limit you can raise.** That sweep is
+  text-driven — it resolves PR references found in a done row's own delivery_ref/result/body. The
+  auto-detect gate runs *only* when the row declared no binding at all, so the typical stamped row
+  names no PR anywhere in its text and yields `merge-audit` exactly zero references. DIVE-3300 is
+  that shape. This sweep is keyed on the stamped **ident** and re-runs the gate's own
+  open-PR-by-ident predicate instead.
+- **The scan is inverted, so the cost is per-repo and not per-ident.** Asking one ident of every
+  repo would be 11 x 196 calls here and the sweep would be unrunnable; each repo's open PRs are
+  listed once and every ident is matched in memory. The match is the gate's, character for
+  character: ident at word boundaries, case-insensitive, title and headRefName only — never the
+  body, so a "follow-up to DIVE-N" mention cannot raise a finding (DIVE-1835).
+- **It refuses to launder its own partial coverage**, which is the lesson of the ticket it consumes.
+  A repo whose listing fails is not a repo with no hits, and a full 200-PR page may have more behind
+  it; either one makes a quiet row `unconfirmed`, never `clean`, and the unanswered repos are named
+  rather than counted. **An unreadable audit log is a hard refusal, not "0 stamps"** — that
+  inference is the DIVE-1935 defect rebuilt in the consumer.
+- **Exit status is the consumable signal** (1 when any stamped close still has an open PR), because
+  a stamp with no consumer is the whole defect.
+
 ## Unreleased — fix(branch-hygiene): the weekly digest classifies branches by EVIDENCE, not age (DIVE-2394)
 
 `--apply` was already safe: it deletes only on a closed PR whose head SHA equals the branch's

--- a/src/task/delivery.sh
+++ b/src/task/delivery.sh
@@ -471,8 +471,14 @@ cmd_task_merge_unverified() {
   # done in awk, not jq, so `parsed` below counts PARSE failures only and is not
   # confounded by rows the filter legitimately dropped.
   local jqout parsed_n=0
-  jqout=$(printf '%s\n' "$cand" | jq -r '
-      select(.cmd == "task.merge-gate-unverified")
+  # `jq -R` + `fromjson?` is the whole point and NOT a style choice: without -R a single
+  # streaming jq parses the concatenated stream, so ONE truncated line ABORTS the parser
+  # and every stamp AFTER it is silently dropped — the sweep then prints "0 still carry an
+  # OPEN PR" and exits 0 while an open PR sits right there. With -R each line is read as a
+  # raw string and `fromjson?` turns a bad line into `empty`, containing it to itself.
+  jqout=$(printf '%s\n' "$cand" | jq -R -r '
+      fromjson? // empty
+      | select(.cmd == "task.merge-gate-unverified")
       | [ (.args[0] // ""),
           (.ts // ""),
           ([ .args[] | select(startswith("reason=")) ] | first // "reason=unrecorded"),

--- a/src/task/delivery.sh
+++ b/src/task/delivery.sh
@@ -383,6 +383,167 @@ cmd_task_merge_audit() {
      --arg n "$limit" --arg rp "$slugs" --arg f "$findings" --arg d "$deliv_n" --arg c "$cited_n" --arg u "$unver" --arg a "$amb" --arg r "$payload"
 }
 
+# `5dive task merge-unverified [--limit=N] [--since=<Nd|Nh>] [--json]` — DIVE-3526.
+#
+# THE STAMP HAD NO CONSUMER. DIVE-1935 taught the mandatory auto-detect gate to say
+# so when its repo scan could not complete: it warns, it writes a
+# `task.merge-gate-unverified` row to the audit log, and it lets the close proceed
+# (fail-open stays — DIVE-1830 refused fail-CLOSED for blast radius and that is
+# still the right refusal). All of that works and is firing: 196 stamped rows in
+# `agent-audit.log` on 2026-08-17, every recent one `reason=partial-repo-scan-7-of-11`.
+# The gap is one layer later — NOTHING EVER READ THEM BACK. DIVE-3300 closed
+# 2026-08-12 with exactly that stamp and nobody re-derived it for five days.
+# A record that is written and never read is a receipt, not a control.
+#
+# WHY `merge-audit` DOES NOT ALREADY COVER THIS, and it is not a limit you can raise.
+# That sweep is TEXT-DRIVEN: it pulls PR references out of a done row's own
+# delivery_ref/result/body and resolves them. The stamped population is precisely the
+# closes where the gate's own scan came up empty, and the auto-detect gate runs ONLY
+# when the row declared no binding at all — so the typical stamped row NAMES NO PR
+# ANYWHERE IN ITS TEXT and yields `merge-audit` exactly zero references to resolve.
+# DIVE-3300 is that shape: its result names a patch file and no pull request.
+# So this sweep is driven by the OTHER key — the ident the gate stamped — and
+# re-derives with the OTHER predicate: the gate's own open-PR-by-ident scan, run now.
+#
+# THE SCAN IS INVERTED ON PURPOSE. The gate asks one ident against every repo. Doing
+# that per stamped ident is repos x idents API calls (11 x 196 = 2156 here) and the
+# sweep would be unrunnable. Every ident asks the same question of the same repo, so
+# each repo's OPEN pull requests are listed ONCE and every ident is matched against
+# the result in memory: 11 calls, whatever the backlog. The MATCH is the gate's,
+# character for character — ident at word boundaries, case-insensitive, against
+# title and headRefName only, never the body (a "follow-up to DIVE-N" mention must
+# not raise a finding, DIVE-1835).
+#
+# AND IT REFUSES TO LAUNDER ITS OWN PARTIAL COVERAGE, which is the whole lesson of the
+# ticket it consumes. A repo whose listing fails is not a repo with no hits, and a
+# `--limit 200` page that comes back FULL may have more behind it. Either one makes a
+# quiet row `unconfirmed`, never `clean`, and the summary reports scanned-k-of-n. An
+# unreadable audit log is a hard failure, not "0 stamps found" — that inference is the
+# DIVE-1935 defect itself, rebuilt in the consumer.
+#
+# Read-only. It reports; it never reopens a row and never touches the gate.
+cmd_task_merge_unverified() {
+  tasks_db_init
+  local limit=500 since="" cutoff=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --limit=*) limit="${1#*=}"
+                 [[ "$limit" =~ ^[1-9][0-9]*$ ]] || fail "$E_VALIDATION" "--limit must be a positive integer" ;;
+      --since=*) since="${1#*=}"
+                 [[ "$since" =~ ^[1-9][0-9]*[dh]$ ]] || fail "$E_VALIDATION" "--since must look like 7d or 48h" ;;
+      --json)    JSON_MODE=1 ;;
+      -h|--help) printf 'usage: 5dive task merge-unverified [--limit=N] [--since=<Nd|Nh>] [--json]\n'; return 0 ;;
+      *)         fail "$E_USAGE" "unknown flag: $1" ;;
+    esac
+    shift
+  done
+  command -v jq >/dev/null 2>&1 || fail "$E_GENERIC" "task merge-unverified needs \`jq\` to read the audit log — install jq."
+  command -v gh >/dev/null 2>&1 || fail "$E_GENERIC" "task merge-unverified needs \`gh\` to re-derive PR state — install gh."
+
+  # The stamps live in the audit log, which is 640 root:claude. A caller who cannot
+  # READ it must not be told the backlog is empty: an unreadable log and a clean
+  # fleet are the same silence, and telling them apart is this verb's job.
+  local logf="${AUDIT_LOG:-/var/log/5dive/agent-audit.log}"
+  [[ -e "$logf" ]] || fail "$E_GENERIC" "task merge-unverified cannot find the audit log ($logf) — the stamps it consumes are written there; nothing was scanned. This is NOT an empty backlog."
+  [[ -r "$logf" ]] || fail "$E_GENERIC" "task merge-unverified cannot READ the audit log ($logf: $(stat -c '%A %U:%G' "$logf" 2>/dev/null || printf 'permissions unknown')) — it is 640 root:claude, so run this from a seat in group \`claude\`. An unreadable log reads exactly like a clean fleet; refusing rather than reporting 0 is the point."
+
+  if [[ -n "$since" ]]; then
+    local _n="${since%[dh]}" _u="${since: -1}"
+    cutoff=$(date -u -d "-${_n} ${_u/d/days}" +%Y-%m-%dT%H:%M:%S 2>/dev/null) || cutoff=""
+    [[ "$_u" == "h" ]] && cutoff=$(date -u -d "-${_n} hours" +%Y-%m-%dT%H:%M:%S 2>/dev/null)
+    [[ -n "$cutoff" ]] || fail "$E_GENERIC" "task merge-unverified could not compute a cutoff from --since=$since (\`date -u -d\` unusable on this host) — re-run without --since rather than reading an unfiltered sweep as a filtered one."
+  fi
+
+  # ident<TAB>ts<TAB>reason<TAB>seat, newest LAST so the dedupe below keeps the newest
+  # stamp per ident (a row re-closed after a reopen stamps twice).
+  local stamps
+  stamps=$(jq -rs --arg cut "$cutoff" '
+      .[] | select(.cmd == "task.merge-gate-unverified")
+      | select($cut == "" or (.ts >= $cut))
+      | [ (.args[0] // ""),
+          (.ts // ""),
+          ((.args[] | select(startswith("reason="))) // "reason=unrecorded"),
+          (.user // "") ] | @tsv
+    ' "$logf" 2>/dev/null | awk -F'\t' '$1 ~ /^DIVE-[0-9]+$/ { r[$1]=$0 } END { for (k in r) print r[k] }' | sort -t$'\t' -k2,2r | head -n "$limit")
+
+  local total_stamps=0
+  [[ -n "$stamps" ]] && total_stamps=$(printf '%s\n' "$stamps" | grep -c .)
+
+  local tok slugs; tok=$(_gate_gh_token); slugs=$(_gate_repo_slugs | paste -sd, -)
+  _gate_gh_reachable "$tok" || fail "$E_GENERIC" "task merge-unverified cannot reach GitHub — $(_gate_tok_why); machine-account rail not permitted on this seat. It would report every stamped close as quiet by asking nothing. Check \`5dive gh whoami\` and \`5dive task merge-gate-selftest\`, then re-run"
+
+  # ── one listing per repo, reused by every ident ──────────────────────────
+  local prs_f; prs_f=$(mktemp "${TMPDIR:-/tmp}/.5dive-mu-prs.XXXXXX")
+  local slug hits repos_total=0 repos_ok=0 unscanned="" capped=""
+  while IFS= read -r slug; do
+    [[ -n "$slug" ]] || continue
+    repos_total=$((repos_total+1))
+    if hits=$(_gate_gh "$tok" 20 pr list --repo "$slug" --state open --limit 200 \
+                --json number,headRefName,title \
+                -q '.[] | [(.number|tostring), (.title // ""), (.headRefName // "")] | @tsv' 2>/dev/null); then
+      repos_ok=$((repos_ok+1))
+      # A FULL page is not a complete answer. Say so rather than sweeping 201.
+      [[ $(printf '%s\n' "$hits" | grep -c .) -ge 200 ]] && capped="${capped:+$capped, }$slug"
+      while IFS= read -r line; do [[ -n "$line" ]] && printf '%s\t%s\n' "$slug" "$line" >>"$prs_f"; done <<<"$hits"
+    else
+      unscanned="${unscanned:+$unscanned, }$slug"
+    fi
+  done < <(_gate_repo_slugs)
+  local full_coverage=0
+  [[ $repos_ok -eq $repos_total && $repos_total -gt 0 && -z "$capped" ]] && full_coverage=1
+
+  local line tident tts treason tseat st verdict detail
+  local findings=0 clean=0 unconf=0 reopened=0 missing=0 json_rows=""
+  while IFS=$'\t' read -r tident tts treason tseat; do
+    [[ -n "$tident" ]] || continue
+    st=$(db "SELECT status FROM tasks WHERE ident='${tident}' LIMIT 1;")
+    detail=""
+    if [[ -z "$st" ]]; then
+      verdict="row-missing"; missing=$((missing+1))
+      detail="no such row in the task store"
+    elif [[ "$st" != "done" ]]; then
+      # The stamp recorded an unverified CLOSE. If the row is not closed now, that
+      # close was undone and there is nothing silent left to surface here.
+      verdict="reopened"; reopened=$((reopened+1)); detail="row is now '$st', not done"
+    else
+      # Neither the slug nor the PR number can contain "DIVE-<n>", so a whole-line
+      # match is the gate's title/headRefName predicate with no extra field surgery.
+      local hit h_slug h_num h_title
+      hit=$(grep -iE "(^|[^A-Za-z0-9])${tident}([^A-Za-z0-9]|$)" "$prs_f" 2>/dev/null | head -1 || true)
+      if [[ -n "$hit" ]]; then
+        IFS=$'\t' read -r h_slug h_num h_title _ <<<"$hit"
+        verdict="OPEN-PR"; findings=$((findings+1))
+        detail="$h_slug #$h_num still OPEN — \"$h_title\""
+      elif (( full_coverage )); then
+        verdict="clean"; clean=$((clean+1)); detail="no open PR names it in $repos_ok/$repos_total repos"
+      else
+        verdict="unconfirmed"; unconf=$((unconf+1))
+        detail="no open PR found, but only $repos_ok/$repos_total repos answered${capped:+ (page full in $capped)} — NOT clean"
+      fi
+    fi
+    json_rows+=$(jq -nc --arg t "$tident" --arg s "$tts" --arg r "${treason#reason=}" --arg u "$tseat" --arg v "$verdict" --arg d "$detail" \
+                   '{ident:$t,stampedAt:$s,reason:$r,seat:$u,verdict:$v,detail:$d}')$'\n'
+    [[ "${JSON_MODE:-0}" == "1" ]] || printf '%-12s %-20s %-11s %s\n' "$tident" "${tts%%+*}" "$verdict" "$detail"
+  done <<<"$stamps"
+  rm -f "$prs_f"
+
+  local payload; payload=$(printf '%s' "$json_rows" | jq -sc '.')
+  if [[ "${JSON_MODE:-0}" != "1" ]]; then
+    (( findings > 0 )) && printf 'note: `OPEN-PR` = this row CLOSED while the merge-gate could not check it, and an open\n      pull request naming the ident exists RIGHT NOW. Triage these: either land the PR,\n      close it as abandoned, or record on the row why the close was correct anyway.\n'
+    (( unconf > 0 )) && printf 'note: `unconfirmed` is NOT a clean row. %s of %s repos answered%s, so "no open PR" is a\n      statement about the repos that answered, never about the ones that did not\n      (DIVE-1935/1955). Re-run from a seat whose token reads them all.\n' "$repos_ok" "$repos_total" "${capped:+, and the 200-PR page was full in $capped}"
+    [[ -n "$unscanned" ]] && warn "repos that did NOT answer: $unscanned"
+  fi
+  ok "merge-unverified: $total_stamps stamped close(s) re-derived across $repos_ok/$repos_total repos — $findings still carry an OPEN PR ($clean clean, $unconf unconfirmed, $reopened reopened, $missing row-missing)" \
+     '{stamps:($n|tonumber), repos:($rp|split(",")), reposScanned:($ro|tonumber), reposTotal:($rt|tonumber), fullCoverage:($fc=="1"), unscanned:($us|split(", ")|map(select(.!=""))), pageCapped:($cp|split(", ")|map(select(.!=""))), findings:($f|tonumber), clean:($c|tonumber), unconfirmed:($u|tonumber), reopened:($re|tonumber), rowMissing:($m|tonumber), rows:($r|fromjson)}' \
+     --arg n "$total_stamps" --arg rp "$slugs" --arg ro "$repos_ok" --arg rt "$repos_total" --arg fc "$full_coverage" \
+     --arg us "$unscanned" --arg cp "$capped" --arg f "$findings" --arg c "$clean" --arg u "$unconf" \
+     --arg re "$reopened" --arg m "$missing" --arg r "$payload"
+  # Exit status is the consumable signal — a stamp with no consumer is what this verb
+  # exists to fix, so `merge-unverified && echo ok` must mean something to cron.
+  (( findings > 0 )) && return 1
+  return 0
+}
+
 # DIVE-477: hand a maker-completed task to its verifier instead of closing it.
 # Stash the original maker (first writer wins, so it survives re-routes) so a
 # verify FAIL can bounce straight back, bump the iteration counter, keep the

--- a/src/task/delivery.sh
+++ b/src/task/delivery.sh
@@ -454,20 +454,41 @@ cmd_task_merge_unverified() {
     [[ -n "$cutoff" ]] || fail "$E_GENERIC" "task merge-unverified could not compute a cutoff from --since=$since (\`date -u -d\` unusable on this host) — re-run without --since rather than reading an unfiltered sweep as a filtered one."
   fi
 
-  # ident<TAB>ts<TAB>reason<TAB>seat, newest LAST so the dedupe below keeps the newest
-  # stamp per ident (a row re-closed after a reopen stamps twice).
-  local stamps
-  stamps=$(jq -rs --arg cut "$cutoff" '
-      .[] | select(.cmd == "task.merge-gate-unverified")
-      | select($cut == "" or (.ts >= $cut))
+  # THE LOG IS NOT SLURPABLE AND THAT IS NOT A BUG TO FIX HERE. `agent-audit.log` is
+  # world-APPENDABLE by every seat on the box, so concurrent appends interleave and it
+  # carries occasional truncated lines: measured 2026-08-17, `jq -s` over the live
+  # 10 MB log exits 5 and yields NOTHING — one malformed line 9 MB back would take the
+  # whole sweep with it, and under `set -euo pipefail` it took the whole CLI run.
+  # So: grep the ~200 candidate lines out first (cheap, and it bounds the blast radius
+  # of a bad line to itself), parse them ONE AT A TIME, and COUNT what did not parse.
+  # A skipped line is a stamp this sweep did not consider and it is disclosed below —
+  # silently dropping it would be the same "empty is not an answer" defect one layer on.
+  local cand cand_n=0
+  cand=$(grep -F '"task.merge-gate-unverified"' "$logf" 2>/dev/null || true)
+  [[ -n "$cand" ]] && cand_n=$(printf '%s\n' "$cand" | grep -c . || true)
+
+  # ident<TAB>ts<TAB>reason<TAB>seat. The --since cutoff and the newest-wins dedupe are
+  # done in awk, not jq, so `parsed` below counts PARSE failures only and is not
+  # confounded by rows the filter legitimately dropped.
+  local jqout parsed_n=0
+  jqout=$(printf '%s\n' "$cand" | jq -r '
+      select(.cmd == "task.merge-gate-unverified")
       | [ (.args[0] // ""),
           (.ts // ""),
-          ((.args[] | select(startswith("reason="))) // "reason=unrecorded"),
+          ([ .args[] | select(startswith("reason=")) ] | first // "reason=unrecorded"),
           (.user // "") ] | @tsv
-    ' "$logf" 2>/dev/null | awk -F'\t' '$1 ~ /^DIVE-[0-9]+$/ { r[$1]=$0 } END { for (k in r) print r[k] }' | sort -t$'\t' -k2,2r | head -n "$limit")
+    ' 2>/dev/null || true)
+  [[ -n "$jqout" ]] && parsed_n=$(printf '%s\n' "$jqout" | grep -c . || true)
+  local unparsed=$(( cand_n - parsed_n )); (( unparsed < 0 )) && unparsed=0
+
+  local stamps
+  stamps=$(printf '%s\n' "$jqout" \
+    | awk -F'\t' -v cut="$cutoff" '$1 ~ /^DIVE-[0-9]+$/ && (cut == "" || $2 >= cut) { r[$1]=$0 }
+                                   END { for (k in r) print r[k] }' \
+    | sort -t$'\t' -k2,2r | head -n "$limit" || true)
 
   local total_stamps=0
-  [[ -n "$stamps" ]] && total_stamps=$(printf '%s\n' "$stamps" | grep -c .)
+  [[ -n "$stamps" ]] && total_stamps=$(printf '%s\n' "$stamps" | grep -c . || true)
 
   local tok slugs; tok=$(_gate_gh_token); slugs=$(_gate_repo_slugs | paste -sd, -)
   _gate_gh_reachable "$tok" || fail "$E_GENERIC" "task merge-unverified cannot reach GitHub — $(_gate_tok_why); machine-account rail not permitted on this seat. It would report every stamped close as quiet by asking nothing. Check \`5dive gh whoami\` and \`5dive task merge-gate-selftest\`, then re-run"
@@ -532,15 +553,20 @@ cmd_task_merge_unverified() {
     (( findings > 0 )) && printf 'note: `OPEN-PR` = this row CLOSED while the merge-gate could not check it, and an open\n      pull request naming the ident exists RIGHT NOW. Triage these: either land the PR,\n      close it as abandoned, or record on the row why the close was correct anyway.\n'
     (( unconf > 0 )) && printf 'note: `unconfirmed` is NOT a clean row. %s of %s repos answered%s, so "no open PR" is a\n      statement about the repos that answered, never about the ones that did not\n      (DIVE-1935/1955). Re-run from a seat whose token reads them all.\n' "$repos_ok" "$repos_total" "${capped:+, and the 200-PR page was full in $capped}"
     [[ -n "$unscanned" ]] && warn "repos that did NOT answer: $unscanned"
+    (( unparsed > 0 )) && warn "$unparsed stamp line(s) in $logf did not parse and were NOT swept — the log is world-appendable and interleaves; those closes are unexamined, not clean."
   fi
-  ok "merge-unverified: $total_stamps stamped close(s) re-derived across $repos_ok/$repos_total repos — $findings still carry an OPEN PR ($clean clean, $unconf unconfirmed, $reopened reopened, $missing row-missing)" \
-     '{stamps:($n|tonumber), repos:($rp|split(",")), reposScanned:($ro|tonumber), reposTotal:($rt|tonumber), fullCoverage:($fc=="1"), unscanned:($us|split(", ")|map(select(.!=""))), pageCapped:($cp|split(", ")|map(select(.!=""))), findings:($f|tonumber), clean:($c|tonumber), unconfirmed:($u|tonumber), reopened:($re|tonumber), rowMissing:($m|tonumber), rows:($r|fromjson)}' \
+  ok "merge-unverified: $total_stamps stamped close(s) re-derived across $repos_ok/$repos_total repos — $findings still carry an OPEN PR ($clean clean, $unconf unconfirmed, $reopened reopened, $missing row-missing${unparsed:+; $unparsed unparseable log line(s) skipped})" \
+     '{stamps:($n|tonumber), repos:($rp|split(",")), reposScanned:($ro|tonumber), reposTotal:($rt|tonumber), fullCoverage:($fc=="1"), unscanned:($us|split(", ")|map(select(.!=""))), pageCapped:($cp|split(", ")|map(select(.!=""))), findings:($f|tonumber), clean:($c|tonumber), unconfirmed:($u|tonumber), reopened:($re|tonumber), rowMissing:($m|tonumber), unparsedLogLines:($ul|tonumber), rows:($r|fromjson)}' \
      --arg n "$total_stamps" --arg rp "$slugs" --arg ro "$repos_ok" --arg rt "$repos_total" --arg fc "$full_coverage" \
      --arg us "$unscanned" --arg cp "$capped" --arg f "$findings" --arg c "$clean" --arg u "$unconf" \
-     --arg re "$reopened" --arg m "$missing" --arg r "$payload"
+     --arg re "$reopened" --arg m "$missing" --arg ul "$unparsed" --arg r "$payload"
   # Exit status is the consumable signal — a stamp with no consumer is what this verb
   # exists to fix, so `merge-unverified && echo ok` must mean something to cron.
-  (( findings > 0 )) && return 1
+  # `mark_reported` first: a findings exit is a REPORTED verdict (the rows are right
+  # there above it), and without the flag the EXIT-trap backstop renders this verb's
+  # own headline result as "exited 1 without reporting a reason — this is a bug in the
+  # CLI", which tells a reader to file a bug instead of triaging the rows.
+  if (( findings > 0 )); then mark_reported; return 1; fi
   return 0
 }
 

--- a/src/task/dispatch.sh
+++ b/src/task/dispatch.sh
@@ -101,6 +101,7 @@ _task_usage() {
   loops [--stuck] [--escalate-stuck] [--all] [--runs] [--watch[=secs]] [--kill <loopId>]
   merge <id>                                    merge the PR on a row THIS seat graded PASS (DIVE-3474)
   merge-audit [--limit=N] [--json]              closed rows whose named PR never merged
+  merge-unverified [--limit=N] [--since=Nd]     re-derive closes the merge-gate could NOT check
   merge-gate-selftest [--pr=<url>] [--json]     can THIS seat's merge-gate actually query GitHub?
   gate-history <id>                             displaced gates + when they retired
   reclaim <id>|--all [--dry-run]                reclaim node_modules from closed worktrees
@@ -248,6 +249,7 @@ cmd_task() {
     deliver)         cmd_task_deliver "$@" ;;
     merge)           cmd_task_merge "$@" ;;         # DIVE-3474 verifier merges what IT graded
     merge-audit)     cmd_task_merge_audit "$@" ;;   # DIVE-1935 retrospective sweep
+    merge-unverified) cmd_task_merge_unverified "$@" ;;  # DIVE-3526 consume the unverified stamp
     merge-gate-selftest) cmd_task_merge_gate_selftest "$@" ;;  # DIVE-1935 instrument check
     verify)          cmd_task_verify "$@" ;;
     verifier)        cmd_task_verifier "$@" ;;

--- a/tests/task_merge_unverified_sweep_unit.sh
+++ b/tests/task_merge_unverified_sweep_unit.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# DIVE-3526 isolated unit harness for `5dive task merge-unverified` — the consumer
+# for the `task.merge-gate-unverified` audit stamp.
+#
+# The stamp itself has worked since DIVE-1935 (the auto-detect merge gate warns,
+# writes the row, and lets the close proceed). Nothing ever read it back, so a close
+# the gate could not check looked exactly like a verified-clean one from the outside.
+# This harness grades the reader: it must re-derive each stamped ident's PR state NOW
+# and, above all, it must NOT report partial coverage as a clean sweep — that is the
+# DIVE-1935 defect itself, rebuilt one layer down in the consumer.
+#
+# Isolation matches the sibling gate harnesses: src/ libs into a throwaway STATE_DIR
+# (the live shared tasks.db is NEVER touched), `gh` STUBBED on PATH, and the audit log
+# is a FIXTURE FILE under $TMP — never /var/log/5dive/agent-audit.log, which is the
+# real fleet record and is root-owned.
+# Run: bash tests/task_merge_unverified_sweep_unit.sh  (no root, no network).
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+# The credential-free rail would reach the real network and grade LIVE pull requests
+# instead of the stub. Must sit after grading_tree.sh, which clears inherited FIVE_*.
+export FIVE_GATE_NO_ANON=1
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/merge-unverified-unit.XXXXXX)"
+mkdir -p "$TMP/bin"
+
+# sudo fail-closed: the token resolver's last arm shells out to `sudo -n -u claude gh
+# auth token` and would otherwise reach the HOST's real credential.
+printf '#!/usr/bin/env bash\nexit 1\n' >"$TMP/bin/sudo"; chmod +x "$TMP/bin/sudo"
+
+# --- stub gh ---------------------------------------------------------------
+# Only one call shape matters here: the per-repo open-PR listing the sweep makes
+# once per repo. Each repo's answer is read from a fixture file named for the slug;
+# a MISSING fixture means "this repo did not answer" (exit 1), which is how the
+# partial-coverage arm is driven.
+cat >"$TMP/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+repo=""
+for a in "$@"; do
+  [[ "$prev" == "--repo" ]] && repo="$a"
+  prev="$a"
+done
+f="$GH_STUB_DIR/$(printf '%s' "$repo" | tr '/' '_')"
+[[ -r "$f" ]] || exit 1
+cat "$f"
+exit 0
+STUB
+chmod +x "$TMP/bin/gh"
+export PATH="$TMP/bin:$PATH"
+export GH_STUB_DIR="$TMP/prs"; mkdir -p "$GH_STUB_DIR"
+# A resolved token short-circuits _gate_gh_reachable; the stub ignores its value.
+export GH_TOKEN=stub-token
+
+# Two repos, so "one answered, one did not" is expressible.
+export FIVE_GATE_REPOS="5dive-ai/5dive lodar/5dive-api"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh \
+         lib/registry.sh lib/tasks_db.sh lib/actor.sh cmd_push.sh \
+         cmd_task.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh" \
+  || { printf 'NOT OK - tests/lib/actor_seam.sh not reachable; the actor cannot be pinned\n'; exit 1; }
+actor_seam_selftest dev \
+  || { printf 'NOT OK - actor seam is inert: task_actor did not resolve to dev under the pin\n'; exit 1; }
+actor_seam_as dev
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+mkdir -p "$TASKS_DIR"; set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+tasks_db_init
+task_need_notify() { :; }
+audit_log() { :; }
+
+mkrow() { # <ident> <status>
+  db "INSERT INTO tasks (ident,title,status,assignee,created_by,created_at)
+      VALUES ('$1','row for $1','$2','dev','main',datetime('now'));" >/dev/null 2>&1
+}
+stamp() { # <ident> <ts> [reason]
+  printf '{"ts":"%s","user":"agent-dev","cmd":"task.merge-gate-unverified","result":"ok","code":0,"args":["%s","reason=%s","seat=agent-dev"]}\n' \
+    "$2" "$1" "${3:-partial-repo-scan-7-of-11}" >>"$AUDIT_LOG"
+}
+prlist() { # <slug> <number> <title> <headRefName>
+  printf '%s\t%s\t%s\n' "$2" "$3" "$4" >>"$GH_STUB_DIR/$(printf '%s' "$1" | tr '/' '_')"
+}
+answers() { : >"$GH_STUB_DIR/$(printf '%s' "$1" | tr '/' '_')"; }   # answered, zero open PRs
+
+AUDIT_LOG="$TMP/audit.log"; : >"$AUDIT_LOG"
+
+# ── T1: an audit log this seat cannot read must REFUSE, never report 0 stamps ──
+# The whole ticket is a record written and never read. A reader that answers
+# "0 stamped closes, all clean" out of a log it never opened is worse than no
+# reader at all: it manufactures the clearance the stamp exists to withhold.
+AUDIT_LOG="$TMP/does-not-exist.log"
+out=$( (cmd_task_merge_unverified 2>&1) ); rc=$?
+if (( rc != 0 )) && grep -qi "cannot find the audit log" <<<"$out"; then
+  ok_t "T1 absent audit log REFUSES (rc=$rc) instead of reporting an empty backlog"
+else
+  bad_t "T1 absent audit log did not refuse" "rc=$rc: $out"
+fi
+grep -qi "NOT an empty backlog" <<<"$out" \
+  && ok_t "T1b the refusal says explicitly that this is not an empty backlog" \
+  || bad_t "T1b refusal does not distinguish unreadable from clean" "$out"
+AUDIT_LOG="$TMP/audit.log"
+
+# ── T2: a stamped close with an open PR naming the ident is a FINDING, rc=1 ──
+mkrow DIVE-9001 done
+stamp DIVE-9001 "2026-08-12T02:49:11+00:00"
+answers lodar/5dive-api
+prlist 5dive-ai/5dive 777 "DIVE-9001 buzz-pair envelope" "dive-9001-envelope"
+out=$( (cmd_task_merge_unverified 2>&1) ); rc=$?
+if (( rc == 1 )) && grep -q "OPEN-PR" <<<"$out" && grep -q "#777" <<<"$out"; then
+  ok_t "T2 stamped close with a still-open PR is reported OPEN-PR and exits 1"
+else
+  bad_t "T2 open PR behind a stamped close was not surfaced" "rc=$rc: $out"
+fi
+
+# ── T3: full coverage + no open PR = clean, and it exits 0 ──
+: >"$AUDIT_LOG"; rm -f "$GH_STUB_DIR"/*
+mkrow DIVE-9002 done
+stamp DIVE-9002 "2026-08-12T03:00:00+00:00"
+answers 5dive-ai/5dive; answers lodar/5dive-api
+out=$( (cmd_task_merge_unverified 2>&1) ); rc=$?
+if (( rc == 0 )) && grep -q "clean" <<<"$out" && ! grep -q "OPEN-PR" <<<"$out"; then
+  ok_t "T3 a quiet ident under FULL coverage reads clean and exits 0"
+else
+  bad_t "T3 clean arm wrong" "rc=$rc: $out"
+fi
+
+# ── T4: THE ONE THAT MATTERS — partial coverage is `unconfirmed`, never clean ──
+# Identical fixture to T3 except one repo does not answer. If this arm ever reads
+# `clean`, the sweep has laundered a scan it did not complete, which is precisely
+# the DIVE-1935/1955 defect it was built to consume.
+rm -f "$GH_STUB_DIR"/*
+answers 5dive-ai/5dive            # lodar/5dive-api deliberately absent => exit 1
+out=$( (cmd_task_merge_unverified 2>&1) ); rc=$?
+# Assert on the ROW's verdict column, not on the whole output: the summary line
+# legitimately contains the word "clean" in its `0 clean` tally, and matching that
+# would make this arm pass on a laundered sweep.
+row=$(grep '^DIVE-9002' <<<"$out")
+if grep -q "unconfirmed" <<<"$row" && ! grep -qw "clean" <<<"${row%%no open PR*}"; then
+  ok_t "T4 a quiet ident under PARTIAL coverage reads unconfirmed, not clean"
+else
+  bad_t "T4 partial coverage was laundered as a clean sweep" "rc=$rc: $out"
+fi
+grep -q "1/2" <<<"$out" \
+  && ok_t "T4b the summary states the coverage it actually achieved (1/2 repos)" \
+  || bad_t "T4b coverage not stated" "$out"
+grep -qi "did NOT answer: lodar/5dive-api" <<<"$out" \
+  && ok_t "T4c the unanswered repo is NAMED, not just counted" \
+  || bad_t "T4c unanswered repo not named" "$out"
+
+# ── T5: a row that is no longer done is `reopened`, not a finding ──
+: >"$AUDIT_LOG"; rm -f "$GH_STUB_DIR"/*
+mkrow DIVE-9003 todo
+stamp DIVE-9003 "2026-08-12T04:00:00+00:00"
+answers 5dive-ai/5dive; answers lodar/5dive-api
+prlist 5dive-ai/5dive 778 "DIVE-9003 still in flight" "dive-9003"
+out=$( (cmd_task_merge_unverified 2>&1) ); rc=$?
+if (( rc == 0 )) && grep -q "reopened" <<<"$out" && ! grep -q "OPEN-PR" <<<"$out"; then
+  ok_t "T5 a stamped ident whose row reopened is not counted as a silent close"
+else
+  bad_t "T5 reopened arm wrong" "rc=$rc: $out"
+fi
+
+# ── T6: the ident matches at WORD BOUNDARIES, as the gate's own scan does ──
+# DIVE-900 must not be matched by an open PR naming DIVE-9004, or every low-numbered
+# ident in the backlog reports a finding it does not own.
+: >"$AUDIT_LOG"; rm -f "$GH_STUB_DIR"/*
+mkrow DIVE-900 done
+stamp DIVE-900 "2026-08-12T05:00:00+00:00"
+answers lodar/5dive-api
+prlist 5dive-ai/5dive 779 "DIVE-9004 unrelated work" "dive-9004-unrelated"
+out=$( (cmd_task_merge_unverified 2>&1) ); rc=$?
+if (( rc == 0 )) && ! grep -q "OPEN-PR" <<<"$out"; then
+  ok_t "T6 DIVE-900 is not matched by an open PR naming DIVE-9004 (word boundaries)"
+else
+  bad_t "T6 substring match leaked a finding" "rc=$rc: $out"
+fi
+# ...and the same ident IS matched when the PR really names it — a negative control
+# for T6, so a match predicate broken to never-match cannot pass this file.
+prlist 5dive-ai/5dive 780 "fix: DIVE-900 for real" "dive-900-real"
+out=$( (cmd_task_merge_unverified 2>&1) ); rc=$?
+if (( rc == 1 )) && grep -q "#780" <<<"$out"; then
+  ok_t "T6b control: an exact ident match in the title IS found"
+else
+  bad_t "T6b the match predicate finds nothing at all" "rc=$rc: $out"
+fi
+
+# ── T7: two stamps for one ident collapse to a single row (re-closed after a bounce) ──
+: >"$AUDIT_LOG"; rm -f "$GH_STUB_DIR"/*
+mkrow DIVE-9005 done
+stamp DIVE-9005 "2026-08-12T06:00:00+00:00"
+stamp DIVE-9005 "2026-08-13T06:00:00+00:00"
+answers 5dive-ai/5dive; answers lodar/5dive-api
+out=$( (cmd_task_merge_unverified 2>&1) ); rc=$?
+n=$(grep -c '^DIVE-9005' <<<"$out")
+if [[ "$n" == "1" ]]; then
+  ok_t "T7 a twice-stamped ident is reported once (newest stamp wins)"
+else
+  bad_t "T7 duplicate stamps produced $n rows" "$out"
+fi
+
+# ── T8: --since filters on the stamp's own timestamp ──
+: >"$AUDIT_LOG"; rm -f "$GH_STUB_DIR"/*
+mkrow DIVE-9006 done
+stamp DIVE-9006 "2020-01-01T00:00:00+00:00"
+answers 5dive-ai/5dive; answers lodar/5dive-api
+out=$( (cmd_task_merge_unverified --since=7d 2>&1) ); rc=$?
+if ! grep -q "DIVE-9006" <<<"$out"; then
+  ok_t "T8 --since=7d excludes a stamp from 2020"
+else
+  bad_t "T8 --since did not filter" "$out"
+fi
+out=$( (cmd_task_merge_unverified 2>&1) )
+grep -q "DIVE-9006" <<<"$out" \
+  && ok_t "T8b control: without --since the same stamp IS swept" \
+  || bad_t "T8b unfiltered sweep lost the row" "$out"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/task_merge_unverified_sweep_unit.sh
+++ b/tests/task_merge_unverified_sweep_unit.sh
@@ -228,5 +228,26 @@ grep -q "DIVE-9006" <<<"$out" \
   && ok_t "T8b control: without --since the same stamp IS swept" \
   || bad_t "T8b unfiltered sweep lost the row" "$out"
 
+# ── T9: a malformed line must not take the sweep with it, and must be DISCLOSED ──
+# Measured on the live log 2026-08-17: `jq -s` over /var/log/5dive/agent-audit.log
+# exits 5 and yields NOTHING. The log is world-appendable by every seat, so appends
+# interleave and truncated lines exist — one of them 9 MB back would otherwise silence
+# the entire sweep, and under the bundle's `set -euo pipefail` it killed the CLI run.
+: >"$AUDIT_LOG"; rm -f "$GH_STUB_DIR"/*
+mkrow DIVE-9007 done
+stamp DIVE-9007 "2026-08-14T06:00:00+00:00"
+printf '{"ts":"2026-08-14T06:30:00+00:00","cmd":"task.merge-gate-unverified","args":["DIVE-99\n' >>"$AUDIT_LOG"
+answers lodar/5dive-api
+prlist 5dive-ai/5dive 781 "DIVE-9007 still open" "dive-9007"
+out=$( (cmd_task_merge_unverified 2>&1) ); rc=$?
+if (( rc == 1 )) && grep -q "DIVE-9007" <<<"$out" && grep -q "#781" <<<"$out"; then
+  ok_t "T9 a truncated log line does not stop the sweep — the good stamps still resolve"
+else
+  bad_t "T9 one malformed line silenced the whole sweep" "rc=$rc: $out"
+fi
+grep -qi "did not parse" <<<"$out" \
+  && ok_t "T9b the skipped line is DISCLOSED, not silently dropped" \
+  || bad_t "T9b unparseable line was swallowed without a word" "$out"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/task_merge_unverified_sweep_unit.sh
+++ b/tests/task_merge_unverified_sweep_unit.sh
@@ -249,5 +249,27 @@ grep -qi "did not parse" <<<"$out" \
   && ok_t "T9b the skipped line is DISCLOSED, not silently dropped" \
   || bad_t "T9b unparseable line was swallowed without a word" "$out"
 
+# ── T9c: ORDERING. T9 alone is not enough and passing it is not evidence. ──────
+# A single streaming jq over the whole candidate set ABORTS on the first bad line and
+# drops every stamp AFTER it, so T9 with the bad line LAST goes green on exactly the
+# implementation this arm exists to forbid. Pin the bad line FIRST: the sweep must still
+# find the good stamp behind it, still exit 1, and still disclose the skip. Without this
+# arm the defect regresses invisibly (quinn, DIVE-3526 iteration 1).
+: >"$AUDIT_LOG"; rm -f "$GH_STUB_DIR"/*
+mkrow DIVE-9008 done
+printf '{"ts":"2026-08-14T06:30:00+00:00","cmd":"task.merge-gate-unverified","args":["DIVE-99\n' >>"$AUDIT_LOG"
+stamp DIVE-9008 "2026-08-14T07:00:00+00:00"
+answers lodar/5dive-api
+prlist 5dive-ai/5dive 782 "DIVE-9008 still open" "dive-9008"
+out=$( (cmd_task_merge_unverified 2>&1) ); rc=$?
+if (( rc == 1 )) && grep -q "DIVE-9008" <<<"$out" && grep -q "#782" <<<"$out"; then
+  ok_t "T9c a malformed line BEFORE the stamp does not swallow it (bad-line-first ordering)"
+else
+  bad_t "T9c a leading malformed line dropped every stamp behind it" "rc=$rc: $out"
+fi
+grep -qi "did not parse" <<<"$out" \
+  && ok_t "T9d the leading skipped line is DISCLOSED too" \
+  || bad_t "T9d leading unparseable line was swallowed without a word" "$out"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## The stamp had no consumer

DIVE-1935 taught the mandatory auto-detect merge gate to say so when its repo scan cannot complete: it warns, writes a `task.merge-gate-unverified` row to the audit log, and lets the close proceed. Fail-open stays — DIVE-1830 refused fail-CLOSED for blast radius and that is still the right refusal, so **this change does not touch the gate's shape at all.**

All of that is firing. **196 stamped rows in `agent-audit.log` on 2026-08-17**, every recent one `reason=partial-repo-scan-7-of-11`. Nothing ever read them back. DIVE-3300 closed 2026-08-12 with the stamp and nobody re-derived it for five days. A record that is written and never read is a receipt, not a control.

`5dive task merge-unverified [--limit=N] [--since=<Nd|Nh>] [--json]` is the reader. Read-only: it reports, it never reopens a row and it never touches the gate.

## Why `merge-audit` could not have covered this

Not a limit you can raise. That sweep is **text-driven** — it resolves PR references found in a done row's own `delivery_ref`/`result`/`body`. The auto-detect gate runs *only* when the row declared no binding at all, so the typical stamped row **names no PR anywhere in its text** and hands `merge-audit` exactly zero references to resolve. DIVE-3300 is that shape: its result names a patch file and no pull request.

This sweep is keyed on the stamped **ident** instead, and re-runs the gate's own open-PR-by-ident predicate.

## What it found on the live board

```
DIVE-3214  2026-08-11T04:12:57  OPEN-PR  lodar/5dive-api #88 still OPEN — "ops-digest: repoint the readers DIVE-3214 moved…"
DIVE-2675  2026-08-04T14:28:26  OPEN-PR  lodar/5dive-api #60 still OPEN — "DIVE-2675: the attestation names the commit it exercised…"
OK — merge-unverified: 141 stamped close(s) re-derived across 11/11 repos — 2 still carry an OPEN PR
     (133 clean, 0 unconfirmed, 0 reopened, 6 row-missing; 0 unparseable log line(s) skipped)   [8.9s]
```

Both verified independently of this code path (`gh pr view`, `5dive task show`): both rows are `status=done` with `delivery_ref = absent` — exactly the no-binding shape the auto-detect gate covers — and both PRs are OPEN today.

**The two are different cases and the diff does not conflate them.** PR #60 was opened 23 minutes *before* DIVE-2675 closed: the gate would have caught it with full repo coverage, and that is the defect class squarely. PR #88 was opened 11 hours *after* DIVE-3214 closed, so no gate could have caught it — only a re-derivation finds that one. The sweep is deliberately a wider net than the gate, and both are worth a human's eye.

## Design notes

- **The scan is inverted, so cost is per-repo not per-ident.** Asking one ident of every repo is 11 × 196 calls here and the sweep would be unrunnable. Each repo's open PRs are listed **once** and every ident is matched in memory: 11 calls whatever the backlog (8.9s over the full 141). The match is the gate's, character for character — ident at word boundaries, case-insensitive, **title and headRefName only, never the body**, so a "follow-up to DIVE-N" mention cannot raise a finding (DIVE-1835).
- **It refuses to launder its own partial coverage**, which is the whole lesson of the ticket it consumes. A repo whose listing fails is not a repo with no hits, and a full 200-PR page may have more behind it; either one makes a quiet row `unconfirmed`, **never `clean`**, and unanswered repos are **named**, not just counted.
- **An unreadable audit log is a hard refusal, not "0 stamps"** — that inference is the DIVE-1935 defect itself, rebuilt in the consumer.
- **A row that is no longer `done` is `reopened`, not a finding** — the stamp recorded an unverified *close*, and if the close was undone there is nothing silent left.
- **Exit status is the consumable signal** (1 on findings), because a stamp with no consumer is the whole defect. `mark_reported` is set first, or the EXIT-trap backstop renders this verb's own headline as *"exited 1 without reporting a reason — this is a bug in the CLI"* and sends the reader to file a bug instead of triaging the rows.

## Measured en route: the audit log is not slurpable, and it killed the first build

`agent-audit.log` is world-appendable by every seat, so appends interleave and truncated lines exist. **`jq -s` over the live 10 MB log exits 5 and yields nothing** — and under the bundle's `set -euo pipefail` that took the *entire CLI run* down with `exited 5 without reporting a reason`. The harness never saw it, because harnesses run `set +e`.

So the candidate lines are grepped out first (~200 of them, which bounds a bad line's blast radius to itself), parsed one at a time, and **what did not parse is counted and disclosed**. Silently dropping a stamp line would be the same "empty is not an answer" defect one layer on.

## Checked

`tests/task_merge_unverified_sweep_unit.sh` — 15 arms, **15 passed / 0 failed**, 1.9s (core tier; no root, no network — `gh` and `sudo` stubbed, audit log is a fixture under `$TMP`, never `/var/log`).

Coverage includes both directions of every predicate, not just the happy path: T6 asserts `DIVE-900` is **not** matched by an open PR naming `DIVE-9004`, and **T6b is its negative control** — an exact match *is* found, so a predicate broken to never-match cannot pass this file. T8b is the same for `--since`. T9 replays the truncated-line failure above and T9b asserts it is disclosed.

**Shown able to go red** — three mutations, each applied-and-asserted, then reverted:

| mutation | result |
|---|---|
| `full_coverage=1` unconditionally (launder partial coverage) | 12 passed, **1 failed** |
| word-boundary match → plain `grep -iF` substring | 11 passed, **2 failed** |
| absent audit log → `logf=/dev/null` instead of refusing | 11 passed, **2 failed** |

The first attempt at mutation 3 was a `sed` that silently did not apply; its "13 passed" is recorded here as a **non-result, not a pass**, and it was re-run through `python3` with the applied line echoed before grading.

## Not done, and it is the honest residual

**Nothing runs this on a schedule yet.** A verb that exists but is never invoked is the same defect one layer up, and I am not closing over that.

It cannot be a GitHub Actions job: the stamps live in `/var/log/5dive/agent-audit.log`, which is **host-local**, so CI has nothing to read. The natural home is a `/etc/cron.d` entry on the box modelled on `5dive-pr-queue-watch` (DIVE-2284 — "nothing watched the PR queue", daily 06:00 UTC, silent when clean). That is a host change plus a script in **5dive-api's** `scripts/` tree (the crontab runs out of `/opt/5dive-api/current/scripts/`, kept in step by `5dive-cron-scripts-sync.sh`, DIVE-3319) — a different repo from this diff and its own row. Flagged rather than smuggled in.

Also uncovered: the 4 repos this seat's token happens to read but a narrower seat's may not. This run got 11/11; a seat that gets 7/11 will correctly report `unconfirmed` rather than clean, which is the designed behaviour, but nobody has graded the sweep from such a seat.
