### PR TITLE
feat(buzz): 'agent buzz pair' — NIP-AB pairing session as a CLI verb (DIVE-3551)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -89,6 +89,7 @@ cat \
   src/cmd_agent_config.sh \
   src/cmd_agent_buzz.sh \
   src/cmd_agent_buzz_join.sh \
+  src/cmd_agent_buzz_pair.sh \
   src/cmd_agent_telegram.sh \
   src/cmd_agent_teambot.sh \
   src/cmd_agent_pairing.sh \

--- a/src/cmd_agent_buzz.sh
+++ b/src/cmd_agent_buzz.sh
@@ -37,13 +37,15 @@ cmd_agent_buzz() {
     enable) shift; _buzz_enable "$@" ;;
     join)   shift; _buzz_join "$@" ;;
     owner)  shift; _buzz_owner "$@" ;;
+    pair)   shift; _buzz_pair "$@" ;;
     status) shift; _buzz_status "$@" ;;
     ""|-h|--help)
       fail "$E_USAGE" "usage: 5dive agent buzz enable <name> [--relay=<https://…>] [--channels=<csv>] [--poll-ms=<n>] [--buzz-path=<path>] [--rotate-key] [--no-join]
        5dive agent buzz join <name> [--channels=<csv>] [--rotate-owner-key]
        5dive agent buzz owner <name> [--envelope]
+       5dive agent buzz pair <name> [--timeout=<secs>]
        5dive agent buzz status <name>" ;;
-    *) fail "$E_USAGE" "unknown buzz verb '$verb' (enable|join|owner|status)" ;;
+    *) fail "$E_USAGE" "unknown buzz verb '$verb' (enable|join|owner|pair|status)" ;;
   esac
 }
 

--- a/src/cmd_agent_buzz_pair.sh
+++ b/src/cmd_agent_buzz_pair.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# DIVE-3551 — the NIP-AB pairing session, as a CLI verb.
+#
+# The dashboard's Connect Buzz panel needs to run a pairing session: show a
+# nostrpair:// QR, let the human compare the SAS on both ends, and report
+# whether the handset imported the identity. That session is a live socket with
+# an interactive step, and it must be THE SAME code path an OSS self-hoster
+# runs in a terminal, or the two drift (the DIVE-3509 rule: CLI first, panel on
+# top). So the panel drives THIS verb over the existing PTY shell session and
+# parses the BUZZ-PAIR-* marker lines below; a human in a terminal reads the
+# same lines as prose.
+#
+# THE MARKER LINES ARE A CONTRACT (the panel regexes them from a PTY stream):
+#   BUZZ-PAIR-QR: nostrpair://…      render this as a QR for the handset camera
+#   BUZZ-PAIR-SAS: <code>            show it; ask "does the phone show this?"
+#   BUZZ-PAIR-RESULT: ok             the handset imported the identity
+#   BUZZ-PAIR-RESULT: fail <why>     it did not (mismatch/timeout/relay/…)
+# One marker per line, always at line start. Grep-stable: tests/buzz_pair_unit.sh
+# grades every one of them against a stub buzz-pair.
+#
+# TWO RELAY URLS, TWO SCHEMES, BY DESIGN (do not "fix" one into the other):
+#   --relay          the pairing rendezvous. qr.rs's DECODER accepts wss/ws
+#                    ONLY, while our config stores https:// — and encode_qr
+#                    percent-encodes whatever it is handed, so an untranslated
+#                    URL mints a QR that renders fine everywhere we can see and
+#                    is refused by the handset when it decodes. Translated here,
+#                    scheme swap only (community/wiki/the-pairing-rendezvous-is-
+#                    the-customers-own-relay-and-its-scheme-is-the-trap.md).
+#   --envelope-relay the Buzz app's join URL inside the transferred envelope.
+#                    Release builds of the app REFUSE non-https here. VERBATIM.
+# The customer's own relay is the rendezvous — buzz IS a nostr relay and the
+# pairing session authenticates with its own ephemeral keys, so no extra
+# infrastructure and no third party sees the (already NIP-44-encrypted) leg.
+#
+# THE KEY TRAVELS ON STDIN, NEVER ON ARGV — same rule as _buzz_write_config and
+# _buzz_cli, same measured reason (/proc/<pid>/cmdline is world-readable, no
+# hidepid on our boxes). The shipped buzz-pair at cli-v0.1.0 only takes the
+# nsec as an argv element, so this verb REFUSES to run against it and names the
+# fix, rather than leaking the customer's handset key for the width of a
+# pairing session. cli-v0.1.1's `--nsec -` reads it from the first stdin line.
+
+# The user the session runs as. In production this is the agent user; a
+# harness overrides it to its own name so every sudo hop collapses (the same
+# convention _buzz_write_config documents — the DIVE-3096 isolation layer
+# refuses sudo inside harnesses, so a seam is the only honest way to grade the
+# full verb path).
+_buzz_pair_user() { printf 'agent-%s\n' "$1"; }
+
+# Where the `buzz-pair` binary is, or empty. Same search discipline as
+# _buzz_resolve_binary: the agent's own PATH view first, then the two control
+# plane locations. Never invented.
+_buzz_resolve_pair_binary() {
+  local user="$1" p
+  p=$(sudo -u "$user" -H bash -lc 'command -v buzz-pair' 2>/dev/null) || p=""
+  [[ -n "$p" ]] && { printf '%s\n' "$p"; return 0; }
+  for p in /usr/local/bin/buzz-pair /opt/buzz/bin/buzz-pair; do
+    [[ -x "$p" ]] && { printf '%s\n' "$p"; return 0; }
+  done
+  return 1
+}
+
+# https->wss / http->ws, host:port/path/query verbatim. The offline arm grades
+# this against qr.rs's OWN decoder (round-trip + an https control that must be
+# rejected), so the rule lives where the test can hold it.
+_buzz_relay_to_ws() {
+  case "$1" in
+    https://*) printf 'wss://%s' "${1#https://}" ;;
+    http://*)  printf 'ws://%s'  "${1#http://}" ;;
+    wss://*|ws://*) printf '%s' "$1" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Does this buzz-pair read the nsec from stdin (`--nsec -`)? cli-v0.1.0 does
+# not; its --help describes --nsec with no stdin form. Probed from the help
+# text because probing by RUNNING it would either leak (argv) or consume a key.
+_buzz_pair_supports_stdin_nsec() { # <runas> <bin>
+  local runas="$1" bin="$2" help
+  local -a pre=()
+  [[ "$runas" != "$(id -un)" ]] && pre=(sudo -u "$runas")
+  help=$("${pre[@]}" "$bin" source --help 2>&1) || return 1
+  grep -Eq -- "--nsec.*(stdin|'-'|\"-\")" <<<"$help" || grep -Eqi 'reads? the (key|nsec) from stdin' <<<"$help"
+}
+
+# cmd: 5dive agent buzz pair <name> [--timeout=<secs>]
+#
+# Requires `join` to have run (owner.json + the customer pubkey already a
+# member): pairing hands the handset an identity, and an identity with no room
+# membership lands the customer in an empty lobby — the panel must never mint
+# that state. Refusals are loud and name the next command, per the DIVE-3509
+# rule that a surface must not report success while connected to nothing.
+_buzz_pair() {
+  local name="" timeout_s="600"
+  while (($#)); do
+    case "$1" in
+      --timeout=*) timeout_s="${1#*=}" ;;
+      -*) fail "$E_USAGE" "unknown flag: $1" ;;
+      *)  [[ -z "$name" ]] && name="$1" || fail "$E_USAGE" "unexpected argument: $1" ;;
+    esac
+    shift
+  done
+  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent buzz pair <name> [--timeout=<secs>]"
+  [[ "$timeout_s" =~ ^[0-9]+$ && "$timeout_s" -gt 0 ]] \
+    || fail "$E_USAGE" "--timeout wants a positive integer (seconds), got '$timeout_s'"
+
+  ensure_state
+  local reg
+  reg=$(registry_read)
+  jq -e --arg n "$name" '.agents[$n] != null' <<<"$reg" >/dev/null \
+    || fail "$E_NOT_FOUND" "no agent named '$name'"
+  local user
+  user=$(_buzz_pair_user "$name")
+
+  # The envelope: {relayUrl,pubkey,nsec}. _buzz_owner already builds it (and
+  # already refuses, naming `join`, when owner.json is absent) — reuse it
+  # rather than grow a second bech32 implementation.
+  local envelope relay nsec
+  envelope=$(_buzz_owner "$name" --envelope) || exit $?
+  relay=$(_buzz_pick "d.get('relayUrl')" <<<"$envelope")
+  nsec=$(_buzz_pick "d.get('nsec')" <<<"$envelope")
+  [[ -n "$relay" && -n "$nsec" ]] \
+    || fail "$E_GENERIC" "could not assemble the pairing envelope for '$name'"
+
+  local ws_relay
+  ws_relay=$(_buzz_relay_to_ws "$relay") \
+    || fail "$E_VALIDATION" "relay_url '$relay' has no ws form — expected an https://, http://, wss:// or ws:// URL"
+
+  local pair_bin
+  pair_bin=$(_buzz_resolve_pair_binary "$user") || fail "$E_NOT_INSTALLED" \
+    "no \`buzz-pair\` binary for '$name' (the agent's PATH, /usr/local/bin/buzz-pair, /opt/buzz/bin/buzz-pair). It ships beside \`buzz\` in 5dive-ai/buzz release cli-v0.1.0+ — install it, then re-run."
+
+  _buzz_pair_supports_stdin_nsec "$user" "$pair_bin" || fail "$E_NOT_INSTALLED" \
+    "this \`buzz-pair\` ($pair_bin) only accepts the key as a command-line argument, which is world-readable in /proc for the whole session — refusing to leak the customer's handset key. Install buzz-pair cli-v0.1.1+ (supports \`--nsec -\`, key on stdin)."
+
+  step "Pairing session for '$name': rendezvous $ws_relay, envelope relay $relay (timeout ${timeout_s}s)"
+
+  # First stdin line to the child is the nsec; everything after is forwarded
+  # verbatim (the y/n SAS answer, from a terminal or from the panel's PTY).
+  # printf is a builtin: the key is never an argv element on either side of the
+  # sudo hop. The transform is line-based and flushed per line, because the
+  # panel parses a live PTY stream; buzz-pair's own [y/n] prompt has no newline
+  # and would sit in the pipe, so the SAS marker line carries the instruction.
+  # The feeder is a process substitution, not a pipeline element, so the verb
+  # does not wait on `cat` still holding the terminal after the child exits;
+  # it is killed explicitly below instead of being left to eat a stray line.
+  local rc=0 feeder_pid
+  local -a pre=()
+  [[ "$user" != "$(id -un)" ]] && pre=(sudo -u "$user")
+  exec 3< <({ printf '%s\n' "$nsec"; cat; })
+  feeder_pid=$!
+  timeout "$timeout_s" \
+    "${pre[@]}" "$pair_bin" source --relay "$ws_relay" --envelope-relay "$relay" --nsec - <&3 2>&1 \
+    | awk '
+      { print; fflush() }
+      /^nostrpair:\/\// { print "BUZZ-PAIR-QR: " $0; fflush() }
+      /^SAS code: /     { sas=$0; sub(/^SAS code: /, "", sas)
+                          print "BUZZ-PAIR-SAS: " sas
+                          print "confirm: if the phone shows the same code, type y then enter (n aborts)"
+                          fflush() }
+    '
+  rc=${PIPESTATUS[0]}
+  exec 3<&-
+  kill "$feeder_pid" 2>/dev/null || true
+  # timeout(1) reports 124; the child reports 1 on any pairing failure and its
+  # last stderr line (already on the stream above) says why.
+  if ((rc == 0)); then
+    printf 'BUZZ-PAIR-RESULT: ok\n'
+    ok "handset paired for '$name' — it holds the customer identity and lands in the joined channel(s)."
+    return 0
+  fi
+  if ((rc == 124)); then
+    printf 'BUZZ-PAIR-RESULT: fail timeout after %ss\n' "$timeout_s"
+  else
+    printf 'BUZZ-PAIR-RESULT: fail rc=%s (the line above this marker says why)\n' "$rc"
+  fi
+  return 3
+}

--- a/src/main.sh
+++ b/src/main.sh
@@ -89,6 +89,8 @@ Agents:
                                                      # --rotate-key mints a NEW key (the handset must re-pair)
   5dive agent buzz status <name>                     # is buzz actually wired? plugin/config/binary, not
                                                      # the agent unit's liveness. rc 3 = declared, not usable
+  5dive agent buzz pair <name> [--timeout=<secs>]    # DIVE-3551: run the NIP-AB pairing session (QR + SAS);
+                                                     # emits BUZZ-PAIR-* marker lines the dashboard panel parses
   5dive agent config <name> set workdir=<path>       # tmux cwd; "default" clears override
   5dive agent config <name> set auth-profile=<name>  # swap profile; "default" clears override
   5dive agent config <name> set model=<id>           # runtime model (claude/codex/grok/antigravity)

--- a/tests/buzz_pair_unit.sh
+++ b/tests/buzz_pair_unit.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# DIVE-3551 unit harness for `agent buzz pair` — the NIP-AB session verb.
+#
+# What this grades WITHOUT a relay, a phone, or root — and deliberately only
+# that (whether a relay accepts the session is the fresh-VM smoke's job):
+#
+#   1. the file is CONCATENATED into the bundle (the buzz_channel_wiring
+#      failure mode: present but never bundled = "command not found")
+#   2. `agent buzz pair` is dispatched and in the usage text
+#   3. _buzz_relay_to_ws — scheme swap ONLY, everything else verbatim. This is
+#      the qr.rs trap: its DECODER accepts wss/ws only while our configs store
+#      https://, and encode validates nothing, so an untranslated URL is a QR
+#      that renders everywhere and fails on the handset (wiki: the-pairing-
+#      rendezvous-is-the-customers-own-relay-and-its-scheme-is-the-trap.md)
+#   4. the same translation against the REAL decoder when a buzz-pair binary is
+#      present: translated URL DECODES, raw https is REJECTED (control arm)
+#   5. the BUZZ-PAIR-* marker contract against a stub buzz-pair, full verb
+#      path: QR + SAS markers appear, RESULT: ok on success, RESULT: fail on a
+#      SAS mismatch, rc 0/3 respectively, and the timeout arm marks fail
+#   6. THE KEY IS NEVER AN ARGV ELEMENT (the DIVE-3509 push-gate rule): the
+#      stub logs its argv; the nsec must not be in it, `--nsec -` must be
+#   7. the stdin-support probe: a cli-v0.1.0-shaped --help (no stdin form)
+#      must be REFUSED, a cli-v0.1.1-shaped one accepted — with the real
+#      0.1.0 help text as the control, so the probe cannot rot into always-yes
+#
+# Run: bash tests/buzz_pair_unit.sh   (no root, no network, no relay.)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+# shellcheck source=/dev/null
+source "$SRC/cmd_agent_buzz.sh"
+# shellcheck source=/dev/null
+source "$SRC/cmd_agent_buzz_join.sh"
+# shellcheck source=/dev/null
+source "$SRC/cmd_agent_buzz_pair.sh"
+set +e  # header.sh enables set -e; the arms below deliberately probe non-zero rc
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# --- 1. the file is in the bundle -------------------------------------------
+grep -q '^  src/cmd_agent_buzz_pair\.sh \\$' build.sh \
+  && ok_t "build.sh concatenates cmd_agent_buzz_pair.sh" \
+  || bad_t "build.sh concatenates cmd_agent_buzz_pair.sh" \
+           "present but never concatenated — \`agent buzz pair\` would be 'command not found' in the built bundle"
+
+# --- 2. dispatched + in usage ------------------------------------------------
+grep -qE '^\s+pair\)\s+shift; _buzz_pair' "$SRC/cmd_agent_buzz.sh" \
+  && ok_t "cmd_agent_buzz dispatches 'pair'" \
+  || bad_t "cmd_agent_buzz dispatches 'pair'" "the verb is unreachable"
+grep -q 'buzz pair <name>' "$SRC/cmd_agent_buzz.sh" \
+  && ok_t "usage text names 'buzz pair'" \
+  || bad_t "usage text names 'buzz pair'" "undiscoverable"
+
+# --- 3. _buzz_relay_to_ws ----------------------------------------------------
+t3() { # <desc> <in> <want>
+  local got
+  got=$(_buzz_relay_to_ws "$2")
+  [[ "$got" == "$3" ]] && ok_t "relay_to_ws: $1" \
+    || bad_t "relay_to_ws: $1" "in='$2' want='$3' got='$got'"
+}
+t3 "https host"        "https://relay.example.com"       "wss://relay.example.com"
+t3 "https host:port"   "https://relay.example.com:7443"  "wss://relay.example.com:7443"
+t3 "path kept"         "https://r.example.com/nostr"     "wss://r.example.com/nostr"
+t3 "http -> ws"        "http://192.0.2.7:8080"           "ws://192.0.2.7:8080"
+t3 "wss passthrough"   "wss://already.example.com"       "wss://already.example.com"
+if _buzz_relay_to_ws "ftp://192.0.2.7" >/dev/null 2>&1; then
+  bad_t "relay_to_ws refuses a non-http(s)/ws(s) scheme" "ftp:// accepted"
+else
+  ok_t "relay_to_ws refuses a non-http(s)/ws(s) scheme"
+fi
+
+# --- 4. against the REAL decoder, when one is around -------------------------
+# nostrpair:// URI minted by hand per qr.rs's format; 127.0.0.1:1 makes decode
+# success distinguishable (a fast connect-refused, never InvalidQr).
+REAL_PAIR=""
+for c in /usr/local/bin/buzz-pair /opt/buzz/bin/buzz-pair; do
+  [[ -x "$c" ]] && REAL_PAIR="$c" && break
+done
+if [[ -n "$REAL_PAIR" ]]; then
+  PUB=$(printf 'a%.0s' {1..64}); SEC=$(printf 'b%.0s' {1..64})
+  enc() { python3 -c 'import sys,urllib.parse;print(urllib.parse.quote(sys.argv[1],safe=""))' "$1"; }
+  out=$(printf 'nostrpair://%s?secret=%s&relay=%s&v=1' "$PUB" "$SEC" "$(enc "$(_buzz_relay_to_ws https://127.0.0.1:1)")" \
+        | timeout 10 "$REAL_PAIR" target 2>&1)
+  if grep -q 'relay URL must use wss:// or ws:// scheme' <<<"$out"; then
+    bad_t "real decoder accepts the TRANSLATED url" "still rejected: $out"
+  else
+    ok_t "real decoder accepts the TRANSLATED url ($REAL_PAIR)"
+  fi
+  out=$(printf 'nostrpair://%s?secret=%s&relay=%s&v=1' "$PUB" "$SEC" "$(enc https://127.0.0.1:1)" \
+        | timeout 10 "$REAL_PAIR" target 2>&1)
+  if grep -q 'relay URL must use wss:// or ws:// scheme' <<<"$out"; then
+    ok_t "real decoder REJECTS the raw https url (control)"
+  else
+    bad_t "real decoder REJECTS the raw https url (control)" \
+          "decoded — the decoder loosened; the translation layer may be retirable, but deliberately: $out"
+  fi
+else
+  printf 'note - no buzz-pair binary on this box; decoder round-trip arms ran only in the fresh-VM smoke\n'
+fi
+
+# --- 5 + 6. the verb end to end against a stub buzz-pair ---------------------
+WORK=$(mktemp -d)
+STUBDIR="$WORK/bin"; mkdir -p "$STUBDIR"
+ARGS_LOG="$WORK/argv.log"; export ARGS_LOG
+
+cat >"$STUBDIR/buzz-pair" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "source" && "${2:-}" == "--help" ]]; then
+  echo "      --nsec <NSEC>  nsec of the key to transfer; use '-' to read the nsec from stdin"
+  exit 0
+fi
+printf '%s\n' "$@" >> "$ARGS_LOG"
+IFS= read -r _nsec_line   # --nsec -: first stdin line is the key
+if [[ "${STUB_MODE:-ok}" == "hang" ]]; then sleep 30; exit 1; fi
+echo "QR URI (contains session secret — do not share beyond the target device):"
+echo "nostrpair://cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc?secret=dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd&relay=wss%3A%2F%2Fr.example.com&v=1"
+echo "Waiting for target to scan QR code..."
+echo "SAS code: 4217"
+printf 'Does your other device show 4217? [y/n]: '
+IFS= read -r ans
+if [[ "$ans" != "y" ]]; then echo "error: SAS mismatch — session aborted"; exit 1; fi
+echo "Sending identity..."
+echo "Transfer complete! ✓"
+EOF
+chmod +x "$STUBDIR/buzz-pair"
+PATH="$STUBDIR:$PATH"
+
+# Seams: a one-agent registry, a canned envelope (the real _buzz_owner needs
+# owner.json + sudo), and binary resolution pinned at the stub. The nsec is a
+# RESERVED FAKE, never a real key.
+FAKE_NSEC="nsec1testonlytestonlytestonlytestonlytestonlytestonlyq7clt5"
+ensure_state() { :; }
+registry_read() { printf '{"agents":{"tagent":{"type":"claude"}}}'; }
+# the documented harness convention: run as ourselves, every sudo hop collapses
+# (the DIVE-3096 isolation layer refuses sudo inside harnesses by design)
+_buzz_pair_user() { id -un; }
+_buzz_owner() { printf '{"relayUrl": "https://r.example.com", "pubkey": "%s", "nsec": "%s"}' \
+                  "$(printf 'e%.0s' {1..64})" "$FAKE_NSEC"; }
+_buzz_resolve_pair_binary() { printf '%s\n' "$STUBDIR/buzz-pair"; }
+
+out=$(printf 'y\n' | _buzz_pair tagent 2>&1); rc=$?
+[[ $rc -eq 0 ]] && ok_t "pair: rc 0 on success" || bad_t "pair: rc 0 on success" "rc=$rc; out: $out"
+grep -q '^BUZZ-PAIR-QR: nostrpair://' <<<"$out" \
+  && ok_t "pair: BUZZ-PAIR-QR marker" || bad_t "pair: BUZZ-PAIR-QR marker" "$out"
+grep -q '^BUZZ-PAIR-SAS: 4217$' <<<"$out" \
+  && ok_t "pair: BUZZ-PAIR-SAS marker carries the code" || bad_t "pair: BUZZ-PAIR-SAS marker carries the code" "$out"
+grep -q '^BUZZ-PAIR-RESULT: ok$' <<<"$out" \
+  && ok_t "pair: BUZZ-PAIR-RESULT ok" || bad_t "pair: BUZZ-PAIR-RESULT ok" "$out"
+
+# the key rule: on stdin, never argv — and the stub must have been told so.
+if grep -q "$FAKE_NSEC" "$ARGS_LOG" 2>/dev/null; then
+  bad_t "pair: nsec is NOT an argv element" "found the key in the stub's argv: $(cat "$ARGS_LOG")"
+else
+  ok_t "pair: nsec is NOT an argv element"
+fi
+grep -qx -- '-' "$ARGS_LOG" 2>/dev/null && grep -qx -- '--nsec' "$ARGS_LOG" \
+  && ok_t "pair: '--nsec -' requested (key expected on stdin)" \
+  || bad_t "pair: '--nsec -' requested (key expected on stdin)" "argv: $(tr '\n' ' ' <"$ARGS_LOG" 2>/dev/null)"
+grep -qx -- '--envelope-relay' "$ARGS_LOG" && grep -qx -- 'https://r.example.com' "$ARGS_LOG" \
+  && ok_t "pair: envelope relay stays https, VERBATIM" \
+  || bad_t "pair: envelope relay stays https, VERBATIM" "argv: $(tr '\n' ' ' <"$ARGS_LOG" 2>/dev/null)"
+grep -qx -- 'wss://r.example.com' "$ARGS_LOG" \
+  && ok_t "pair: rendezvous relay is the TRANSLATED wss url" \
+  || bad_t "pair: rendezvous relay is the TRANSLATED wss url" "argv: $(tr '\n' ' ' <"$ARGS_LOG" 2>/dev/null)"
+
+out=$(printf 'n\n' | _buzz_pair tagent 2>&1); rc=$?
+[[ $rc -eq 3 ]] && ok_t "pair: rc 3 on SAS mismatch" || bad_t "pair: rc 3 on SAS mismatch" "rc=$rc"
+grep -q '^BUZZ-PAIR-RESULT: fail' <<<"$out" \
+  && ok_t "pair: BUZZ-PAIR-RESULT fail on mismatch" || bad_t "pair: BUZZ-PAIR-RESULT fail on mismatch" "$out"
+
+export STUB_MODE=hang
+out=$(printf '' | _buzz_pair tagent --timeout=1 2>&1); rc=$?
+unset STUB_MODE
+grep -q '^BUZZ-PAIR-RESULT: fail timeout after 1s' <<<"$out" \
+  && ok_t "pair: timeout marks RESULT fail timeout" || bad_t "pair: timeout marks RESULT fail timeout" "rc=$rc out: $out"
+
+# --- 7. the stdin-support probe, with the 0.1.0 text as CONTROL ---------------
+cat >"$STUBDIR/pair-v010" <<'EOF'
+#!/usr/bin/env bash
+# the REAL cli-v0.1.0 --nsec help line, verbatim — must NOT read as stdin-capable
+echo "      --nsec <NSEC>  nsec (bech32) of the key to transfer. If omitted, generates a test key."
+EOF
+chmod +x "$STUBDIR/pair-v010"
+if _buzz_pair_supports_stdin_nsec "$(id -un)" "$STUBDIR/pair-v010"; then
+  bad_t "probe: cli-v0.1.0 help is refused (control)" "read the argv-only build as stdin-capable — the refusal arm is dead"
+else
+  ok_t "probe: cli-v0.1.0 help is refused (control)"
+fi
+_buzz_pair_supports_stdin_nsec "$(id -un)" "$STUBDIR/buzz-pair" \
+  && ok_t "probe: stdin-capable help is accepted" \
+  || bad_t "probe: stdin-capable help is accepted" "would refuse the fixed build too"
+
+rm -rf "$WORK"
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
CLI half of the dashboard Connect Buzz panel (DIVE-3551): `5dive agent buzz pair <name>` runs the NIP-AB pairing session and emits a stable marker-line contract (`BUZZ-PAIR-QR:` / `BUZZ-PAIR-SAS:` / `BUZZ-PAIR-RESULT:`) that the panel parses from the existing PTY shell websocket — one code path for OSS terminals and the managed dashboard.

Two relay URLs, two schemes, by design:
- `--relay` (rendezvous): translated https->wss, because qr.rs's DECODER accepts wss/ws only while encode validates nothing — an untranslated URL mints a QR every surface we own renders happily and the handset refuses.
- `--envelope-relay`: verbatim https, because release builds of the Buzz app refuse anything else inside the envelope.

Security: the customer nsec goes to buzz-pair on stdin (`--nsec -`), never argv (`/proc/<pid>/cmdline` is world-readable, no hidepid — the DIVE-3509 push-gate rule). The shipped cli-v0.1.0 buzz-pair only takes argv, so the verb refuses it by probing `source --help`, naming cli-v0.1.1 as the fix; that patch goes to 5dive-ai/buzz separately.

Tests: `tests/buzz_pair_unit.sh` — 22 arms, offline, ~1.5s (core tier): marker contract + rc mapping (ok / SAS-mismatch / timeout) against a stub, scheme translation against the REAL decoder when a binary is present (with the raw-https control arm), the argv-leak arm, and the stdin-probe graded with cli-v0.1.0's verbatim help text as the refusal control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
