### PR TITLE
fix(buzz): join writes RESOLVED channel ids back into config.json (DIVE-3565)

### DIFF
--- a/src/cmd_agent_buzz.sh
+++ b/src/cmd_agent_buzz.sh
@@ -83,6 +83,25 @@ _buzz_resolve_binary() {
 # So: the program goes to `python3 -c` (not secret), the non-secret fields stay in
 # the environment, and the key is piped. Nothing that holds the key is ever a
 # command-line argument, on either side of the sudo hop.
+#
+# DIVE-3565 — THE WRITER MUST SPEAK THE READER'S LANGUAGE. This used to write
+# `channels: ["general"]` — a NAME. plugins/buzz/server.ts declares
+# `channels: string[] // channel UUIDs` and hands each entry straight to
+# `buzz messages get --channel <entry>`, which answers `invalid UUID: general`.
+# It fails on EVERY tick, to stderr, forever: no state.json, no watermark, no
+# delivery. A seat wired by every one of the six sites still never answered a
+# mention (measured on jolly-birch, DIVE-3559). So the config now carries BOTH:
+#
+#   channel_names  the human names — what `join` looks up and what an operator
+#                  typed. This is the field `--channels=` populates.
+#   channels       the RESOLVED channel ids, and nothing else, because that is
+#                  the only thing the reader can use. `enable` cannot resolve
+#                  them (resolution is a relay call); `join` does, and writes
+#                  them back via `_buzz_set_channel_ids`.
+#
+# Until join resolves them `channels` is EMPTY, which is the honest state: the
+# poller has nothing to watch and says nothing, instead of erroring every 15s
+# against a name it will never accept. `_buzz_status` prints the difference.
 _buzz_write_config() { # <runas> <state_dir> <relay> <key> <channels-csv> <poll_ms> <buzz_path>
   local runas="$1" state="$2" relay="$3" key="$4" chans="$5" poll="$6" bin="$7"
   local -a pre=()
@@ -95,10 +114,27 @@ if not key:
 state = os.environ["STATE"]
 os.makedirs(state, mode=0o700, exist_ok=True)
 path = os.path.join(state, "config.json")
+names = [c.strip() for c in os.environ["CHANS"].split(",") if c.strip()]
+# A re-run must not throw away ids `join` already resolved — that would take a
+# working seat back to silent, and enable calls join AFTER this write.  Carry
+# them over only when the NAME LIST is unchanged: a different set of names makes
+# the old ids the wrong answer, not a stale one.
+prev_ids = []
+try:
+    with open(path) as f:
+        old = json.load(f)
+    if [str(n) for n in (old.get("channel_names") or [])] == names:
+        prev_ids = [str(c) for c in (old.get("channels") or [])]
+except Exception:
+    prev_ids = []
 cfg = {
     "relay_url": os.environ["RELAY"],
     "private_key": key,
-    "channels": [c.strip() for c in os.environ["CHANS"].split(",") if c.strip()],
+    # Resolved channel ids ONLY — the reader (plugins/buzz/server.ts) passes
+    # these to `buzz messages get --channel`, which takes a UUID.  Empty until
+    # `join` resolves them.
+    "channels": prev_ids,
+    "channel_names": names,
     "poll_ms": int(os.environ["POLL"]),
     "buzz_path": os.environ["BIN"],
 }
@@ -286,6 +322,19 @@ _buzz_status() {
   printf 'config readable:  %s (%s)\n' "$conf" "$cfg"
   printf 'buzz binary:      %s%s\n' "$bin" "${bin_path:+ ($bin_path)}"
   [[ "$conf" == "yes" ]] && printf 'relay_url:        %s\n' "$(jq -r '.relay_url' "$cfg" 2>/dev/null)"
+  # DIVE-3565. The field the POLLER reads, named separately from the names an
+  # operator typed — a seat can be green on every other row here and still never
+  # deliver a mention because `channels` is empty or holds a name.
+  local ch_names="" ch_ids=""
+  if [[ "$conf" == "yes" ]]; then
+    ch_names=$(jq -r '(.channel_names // []) | join(",")' "$cfg" 2>/dev/null)
+    ch_ids=$(jq -r '(.channels // []) | join(",")' "$cfg" 2>/dev/null)
+    printf 'channel names:    %s\n' "${ch_names:-none}"
+    printf 'channel ids:      %s\n' "${ch_ids:-none (the poller has nothing to watch)}"
+    if [[ -z "$ch_ids" && -n "$ch_names" ]]; then
+      warn "channels are named but not RESOLVED: the buzz poller watches channel ids, so '$name' will not receive a mention until they are. Resolve them with: sudo 5dive agent buzz join $name"
+    fi
+  fi
   # Exit non-zero when it is declared but not usable, so a caller can branch on
   # it without parsing prose.
   #

--- a/src/cmd_agent_buzz_join.sh
+++ b/src/cmd_agent_buzz_join.sh
@@ -192,6 +192,68 @@ for r in rows:
 " "$1" 2>/dev/null
 }
 
+# DIVE-3565 — the same lookup, but a token that is ALREADY a channel_id
+# resolves to itself. `join` writes resolved ids back into config.json
+# `channels`, and `--channels=` is allowed to name one directly, so the lookup
+# has to close over its own output or the second run creates a channel LITERALLY
+# NAMED after a uuid. Name match first: a relay is free to reuse a string in
+# both fields and the name is what the operator meant.
+_buzz_channel_ref_id() { # <name-or-id> ; json on stdin
+  python3 -c "
+import json, sys
+want = sys.argv[1]
+try:
+    rows = json.load(sys.stdin)
+except Exception:
+    rows = []
+if not isinstance(rows, list):
+    rows = []
+for r in rows:
+    if isinstance(r, dict) and str(r.get('name', '')) == want:
+        print(str(r.get('channel_id', '') or ''))
+        break
+else:
+    for r in rows:
+        if isinstance(r, dict) and str(r.get('channel_id', '') or '') == want:
+            print(want)
+            break
+" "$1" 2>/dev/null
+}
+
+# Write the RESOLVED channel ids back into config.json.
+#
+# THIS IS THE FIX. Everything above already knew the ids; nothing ever told the
+# reader. Rewrites only `channels` and `channel_names` — relay_url, private_key,
+# poll_ms and buzz_path are read and written back untouched, so this can never
+# be the thing that loses an agent its identity. Same discipline as
+# `_buzz_write_config`: run AS the agent user, 0600, key never on argv (it is
+# not even read out here — the file is edited in place by the owner).
+_buzz_set_channel_ids() { # <runas> <cfg-path> <ids-csv> <names-csv>
+  local runas="$1" cfg="$2" ids="$3" names="$4"
+  local -a pre=()
+  [[ "$runas" != "$(id -un)" ]] && pre=(sudo -u "$runas")
+  "${pre[@]}" env CFG="$cfg" IDS="$ids" NAMES="$names" python3 -c '
+import json, os, sys
+path = os.environ["CFG"]
+with open(path) as f:
+    cfg = json.load(f)
+ids   = [c.strip() for c in os.environ["IDS"].split(",") if c.strip()]
+names = [c.strip() for c in os.environ["NAMES"].split(",") if c.strip()]
+if not ids:
+    sys.exit(0)                      # never blank a working config
+if cfg.get("channels") == ids and cfg.get("channel_names") == names:
+    sys.exit(0)                      # idempotent: no write, no mtime churn
+cfg["channels"] = ids                # what plugins/buzz/server.ts polls
+cfg["channel_names"] = names         # what a human and `join` work from
+fd = os.open(path + ".tmp", os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+with os.fdopen(fd, "w") as f:
+    json.dump(cfg, f, indent=2)
+os.chmod(path + ".tmp", 0o600)
+os.replace(path + ".tmp", path)      # atomic: the poller may be reading it
+print("    resolved channel ids written to " + path)
+' >&2
+}
+
 # Mint (once) the customer's handset identity. Same one-key-per-agent rule the
 # agent's own identity follows: a re-run must not rotate a key a paired handset
 # already holds, or the customer silently loses the room.
@@ -268,7 +330,25 @@ _buzz_join() {
   key=$(_buzz_pick "d.get('private_key')" <<<"$raw")
   [[ -n "$relay" && "$key" =~ ^[0-9a-fA-F]{64}$ ]] \
     || fail "$E_VALIDATION" "buzz config for '$name' is missing relay_url or a 64-hex private_key"
-  [[ -n "$chans" ]] || chans=$(_buzz_pick "','.join(d.get('channels') or [])" <<<"$raw")
+  # DIVE-3565. `channel_names` is the operator's list and the thing a relay can
+  # look up; `channels` now holds resolved ids. Prefer the names — an id that a
+  # relay has forgotten (a rebuilt relay, a restored box) still resolves by name,
+  # and a name never resolves from an id. `from_ids` remembers when we had to
+  # fall back, because an unresolvable ID must NOT be created as a channel name.
+  #
+  # WHICH FIELD HOLDS NAMES depends on whether the config predates this fix, and
+  # guessing wrong is destructive in one direction: treating a legacy NAME as an
+  # id skips the create and reports a channel missing, while treating an ID as a
+  # name creates a second room named after a uuid. The tell is the KEY, not the
+  # value — `channel_names` is written by every post-DIVE-3565 `enable`, so its
+  # ABSENCE means `channels` still holds names.
+  local from_ids="false" has_names
+  has_names=$(_buzz_pick "'yes' if 'channel_names' in (d or {}) else ''" <<<"$raw")
+  [[ -n "$chans" ]] || chans=$(_buzz_pick "','.join(d.get('channel_names') or [])" <<<"$raw")
+  if [[ -z "$chans" ]]; then
+    chans=$(_buzz_pick "','.join(d.get('channels') or [])" <<<"$raw")
+    [[ -n "$chans" && "$has_names" == "yes" ]] && from_ids="true"
+  fi
   [[ -n "$chans" ]] || chans="general"
 
   # The binary, from the config first (that is the path the plugin will use) and
@@ -290,6 +370,7 @@ _buzz_join() {
 
   # --- step 5: join or create each channel, and add the customer -----------
   local listing joined=0 created=0 failed=0 ch cid
+  local resolved_ids="" resolved_names=""
   listing=$(_buzz_cli "$user" "$bin" "$relay" "$key" channels list 2>/dev/null) || listing=""
   local IFS_SAVE="$IFS"
   IFS=','
@@ -297,7 +378,15 @@ _buzz_join() {
     IFS="$IFS_SAVE"
     ch="${ch// /}"
     [[ -n "$ch" ]] || continue
-    cid=$(_buzz_channel_id "$ch" <<<"$listing")
+    cid=$(_buzz_channel_ref_id "$ch" <<<"$listing")
+    if [[ -z "$cid" && "$from_ids" == "true" ]]; then
+      # The token came from the resolved-id list, so it is an id, and creating a
+      # channel NAMED after it would be a silent second room nobody is in.
+      warn "channel id '$ch' is not on $relay — re-run with the name: sudo 5dive agent buzz join $name --channels=<name>"
+      failed=$((failed + 1))
+      IFS=','
+      continue
+    fi
     if [[ -z "$cid" ]]; then
       step "Creating channel '$ch' on $relay"
       _buzz_cli "$user" "$bin" "$relay" "$key" \
@@ -305,7 +394,7 @@ _buzz_join() {
       # Re-list rather than parse the create output: the authority on whether a
       # channel exists is the relay, not the acknowledgement of the write.
       listing=$(_buzz_cli "$user" "$bin" "$relay" "$key" channels list 2>/dev/null) || listing=""
-      cid=$(_buzz_channel_id "$ch" <<<"$listing")
+      cid=$(_buzz_channel_ref_id "$ch" <<<"$listing")
       [[ -n "$cid" ]] && created=$((created + 1))
     fi
     if [[ -z "$cid" ]]; then
@@ -332,6 +421,10 @@ _buzz_join() {
     if [[ "$cust_ok" == "yes" && "$agent_ok" == "yes" ]]; then
       ok "channel '$ch' ($cid): agent is a member, customer key added"
       joined=$((joined + 1))
+      # Only a channel whose membership READ BACK earns a place in the list the
+      # poller watches. A write we could not confirm is not a subscription.
+      resolved_ids="${resolved_ids:+${resolved_ids},}${cid}"
+      resolved_names="${resolved_names:+${resolved_names},}${ch}"
     else
       warn "channel '$ch' ($cid): write accepted but the read-back does not show $( [[ "$cust_ok" == "yes" ]] || echo 'the customer as a member'; [[ "$agent_ok" == "yes" ]] || echo 'the agent in its own member list' )"
       failed=$((failed + 1))
@@ -339,6 +432,19 @@ _buzz_join() {
     IFS=','
   done
   IFS="$IFS_SAVE"
+
+  # --- THE HANDOFF TO THE READER (DIVE-3565) -------------------------------
+  # Every site above wired the relay side. This is the one that wires the
+  # PLUGIN: without it config.json still says `channels: ["general"]`, the
+  # poller sends that name to `buzz messages get --channel`, and every tick dies
+  # on `invalid UUID: general` — a seat that is green everywhere and answers
+  # nothing. Grade the writer against the reader:
+  # plugins/buzz/server.ts:38 `channels: string[] // channel UUIDs to watch`.
+  if [[ -n "$resolved_ids" ]]; then
+    step "Recording resolved channel ids in the buzz config (the poller reads ids, not names)"
+    _buzz_set_channel_ids "$user" "$cfg" "$resolved_ids" "$resolved_names" \
+      || warn "could not record the resolved channel ids in $cfg — the poller will not watch anything until it can"
+  fi
 
   # --- step 6: profile + presence (DIVE-3507) ------------------------------
   # Without this the room fills with faceless agents that read as offline, which
@@ -365,6 +471,7 @@ _buzz_join() {
     return 3
   fi
   ok "buzz last mile done for '$name' — ${joined} channel(s) (${created} created), customer key ${owner_pub:0:16}… is a member, profile + presence published."
+  ok "The poller picks the resolved ids up on restart: sudo 5dive agent restart $name"
   ok "Pair a handset: the envelope is \`5dive agent buzz owner $name --envelope\` (relayUrl/pubkey/nsec, DIVE-3300)."
   return 0
 }

--- a/tests/buzz_channel_wiring_unit.sh
+++ b/tests/buzz_channel_wiring_unit.sh
@@ -394,8 +394,18 @@ if [[ -f "$BZ" ]]; then
   # The writer, RUN — not grepped. It is factored to take a runas user so this
   # arm needs no agent user, no root and no relay: pass our own name, the sudo
   # hop is skipped, and the file it produces is graded against the contract in
-  # plugins/buzz/server.ts (five fields; private_key must match /^[0-9a-f]{64}$/
-  # or the plugin refuses to derive a pubkey and the channel is silently dead).
+  # plugins/buzz/server.ts (private_key must match /^[0-9a-f]{64}$/ or the plugin
+  # refuses to derive a pubkey and the channel is silently dead).
+  #
+  # DIVE-3565 — THIS ARM USED TO ENSHRINE THE DEFECT. It asserted
+  # `.channels == ["general","ops"]` and called that "the five-field contract",
+  # while server.ts:38 declares `channels: string[] // channel UUIDs to watch`
+  # and hands each entry to `buzz messages get --channel`. So the arm was green
+  # on a config the reader answers `invalid UUID: general` to, every tick,
+  # forever. The contract is SIX fields now and the split is the whole point:
+  # `.channel_names` carries what the operator typed, `.channels` carries only
+  # ids the relay confirmed — empty until `buzz join` resolves them, because an
+  # empty watch list is honest and a name in it is a lie.
   if command -v python3 >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
     TD=$(mktemp -d)
     FAKE_KEY=$(printf 'a%.0s' {1..64})
@@ -406,11 +416,17 @@ if [[ -f "$BZ" ]]; then
       ok_t "_buzz_write_config writes parseable JSON"
       jq -e '.relay_url == "https://relay.example.com"
              and (.private_key | test("^[0-9a-fA-F]{64}$"))
-             and .channels == ["general","ops"]
+             and .channel_names == ["general","ops"]
+             and .channels == []
              and .poll_ms == 9000
              and .buzz_path == "/usr/local/bin/buzz"' "$W" >/dev/null 2>&1 \
-        && ok_t "the written config matches the plugin's five-field contract" \
-        || bad_t "the written config matches the plugin's five-field contract" "got: $(cat "$W")"
+        && ok_t "the written config matches the plugin's contract (names and ids are DIFFERENT fields)" \
+        || bad_t "the written config matches the plugin's contract (names and ids are DIFFERENT fields)" "got: $(cat "$W")"
+      # The mutation that put us here: a NAME in the field the poller reads.
+      jq -e '(.channels | map(select(. == "general" or . == "ops")) | length) == 0' "$W" >/dev/null 2>&1 \
+        && ok_t "no channel NAME ever lands in .channels (the field the poller reads as a UUID)" \
+        || bad_t "no channel NAME ever lands in .channels" \
+                 "server.ts polls each entry with \`messages get --channel\`; a name there is 'invalid UUID' on every tick, silently (DIVE-3565)"
       # poll_ms must be a NUMBER: server.ts does Number(cfg.poll_ms) on the env
       # path but reads the file value straight, so a quoted "9000" is a config
       # the plugin loads and mis-schedules.

--- a/tests/buzz_last_mile_unit.sh
+++ b/tests/buzz_last_mile_unit.sh
@@ -766,6 +766,21 @@ run_join normal dev
   && ok_t "8n control: an unknown token resolves to NOTHING (it does not echo itself)" \
   || bad_t "8n control: an unknown token resolves to NOTHING" "the resolver returns its input, so every id 'resolves' and create never fires"
 
+# The arm above re-runs join over an id-BEARING config, but that config also
+# carries `channel_names`, and the new precedence reads names FIRST — so the id
+# never reaches the resolver and 8n is named for the ID path while measuring the
+# NAME path (quinn, iteration 1). This is the route that actually walks it:
+# `--channels=<uuid>` is an explicit id, `from_ids` stays false, and without the
+# id-to-itself branch the resolver returns nothing and join CREATES a channel
+# literally named after a uuid — the silent second room. Graded by the create
+# count in the stub's own log, not by anything the CLI reports.
+CREATES_BEFORE_ID=$(grep -c 'argv: channels create' "$BUZZ_STUB_DIR/log")
+run_join normal dev --channels="$REAL_CID"
+[[ "$(grep -c 'argv: channels create' "$BUZZ_STUB_DIR/log")" == "$CREATES_BEFORE_ID" ]] \
+  && ok_t "8n an explicit --channels=<uuid> resolves to ITSELF and creates NOTHING" \
+  || bad_t "8n an explicit --channels=<uuid> resolves to ITSELF and creates NOTHING" \
+           "join created a channel named after a uuid — the customer's room forked: $(grep 'argv: channels create' "$BUZZ_STUB_DIR/log" | tail -1)"
+
 # --- 8o. only a CONFIRMED membership is recorded ---------------------------
 # rc=3 is the accepted-but-not-readable case (DIVE-3507). Recording that id
 # would tell the poller to watch a room the agent is not in — success reported

--- a/tests/buzz_last_mile_unit.sh
+++ b/tests/buzz_last_mile_unit.sh
@@ -691,5 +691,155 @@ REALGRAMMAR
              "then --format is not a global at all and this diagnosis is wrong"
 fi
 
+# ===========================================================================
+# 8m. DIVE-3565 — THE WRITER MUST SPEAK THE READER'S LANGUAGE.
+#
+# plugins/buzz/server.ts:38 declares `channels: string[] // channel UUIDs to
+# watch for mentions` and hands each entry to `buzz messages get --channel`.
+# `enable` wrote NAMES there, so a fully-wired seat answered `invalid UUID:
+# general` every tick, silently, forever (jolly-birch, DIVE-3559). These arms
+# grade the WRITER against that reader: after a join, the field the poller reads
+# must hold the ids the relay actually returned.
+# ===========================================================================
+cfg_json() { python3 -c "import json,sys;print(json.dumps(json.load(open('$AGENT_STATE/config.json'))))"; }
+cfg_field() { python3 -c "
+import json,sys
+d=json.load(open('$AGENT_STATE/config.json'))
+v=d.get(sys.argv[1])
+print(','.join(str(x) for x in v) if isinstance(v,list) else ('' if v is None else v))
+" "$1"; }
+# The id the STUB minted, read out of its own store — derived independently of
+# anything the CLI wrote, so the assertion is not comparing the code to itself.
+stub_cid() { awk -F'\t' -v n="$1" '$2==n{print $1}' "$BUZZ_STUB_DIR/channels"; }
+
+seed_agent "$STUB_BIN" "general"
+run_join normal dev
+REAL_CID=$(stub_cid general)
+[[ -n "$REAL_CID" ]] \
+  && ok_t "8m the stub minted a channel id for 'general' (fixture sanity)" \
+  || bad_t "8m the stub minted a channel id for 'general'" "no id in the stub store; every arm below is vacuous"
+[[ "$(cfg_field channels)" == "$REAL_CID" ]] \
+  && ok_t "8m join writes the RESOLVED channel id into config.json .channels" \
+  || bad_t "8m join writes the RESOLVED channel id into config.json .channels" \
+           "the poller reads .channels as UUIDs; it holds '$(cfg_field channels)' and the relay's id is '$REAL_CID' — every tick will be 'invalid UUID'"
+# The mutation this arm exists to catch: the pre-fix code left the NAME here,
+# i.e. .channels was literally equal to .channel_names. NOT a substring test —
+# a relay is free to build an id out of the name ("ch-general-9f3b…"), and that
+# id is a perfectly good UUID-shaped answer.
+{ [[ "$(cfg_field channels)" != "general" ]] && [[ "$(cfg_field channels)" != "$(cfg_field channel_names)" ]]; } \
+  && ok_t "8m .channels is no longer just the channel NAME" \
+  || bad_t "8m .channels is no longer just the channel NAME" ".channels == .channel_names == '$(cfg_field channels)' — nothing was resolved; this is the DIVE-3565 defect, unfixed"
+[[ "$(cfg_field channel_names)" == "general" ]] \
+  && ok_t "8m the human name is preserved in .channel_names" \
+  || bad_t "8m the human name is preserved in .channel_names" "got '$(cfg_field channel_names)' — join has no name to look up on a re-run"
+# Nothing else in the config may move: this file holds the agent's identity.
+[[ "$(cfg_field private_key)" == "$(printf '3%.0s' $(seq 63))7" ]] \
+  && ok_t "8m the writeback does not disturb private_key" \
+  || bad_t "8m the writeback does not disturb private_key" "identity changed under a config edit"
+{ [[ "$(cfg_field relay_url)" == "https://relay.example.com" ]] && [[ "$(cfg_field poll_ms)" == "15000" ]] \
+  && [[ "$(cfg_field buzz_path)" == "$STUB_BIN" ]]; } \
+  && ok_t "8m relay_url, poll_ms and buzz_path survive the writeback" \
+  || bad_t "8m relay_url, poll_ms and buzz_path survive the writeback" "$(cfg_json)"
+[[ "$(stat -c %a "$AGENT_STATE/config.json")" == "600" ]] \
+  && ok_t "8m config.json is still 0600 after the writeback" \
+  || bad_t "8m config.json is still 0600 after the writeback" "mode $(stat -c %a "$AGENT_STATE/config.json")"
+
+# --- 8n. the regression the fix could introduce ----------------------------
+# Now that .channels holds a uuid, a re-run must resolve it to ITSELF. If it
+# treated it as a name it would create a second channel literally named after
+# the uuid and the customer's room would silently fork.
+CREATES_BEFORE=$(grep -c 'argv: channels create' "$BUZZ_STUB_DIR/log")
+run_join normal dev
+[[ "$(grep -c 'argv: channels create' "$BUZZ_STUB_DIR/log")" == "$CREATES_BEFORE" ]] \
+  && ok_t "8n a re-run over an id-bearing config creates NOTHING" \
+  || bad_t "8n a re-run over an id-bearing config creates NOTHING" \
+           "the writeback made join non-idempotent: $(grep 'argv: channels create' "$BUZZ_STUB_DIR/log")"
+[[ "$JOIN_RC" -eq 0 && "$(cfg_field channels)" == "$REAL_CID" ]] \
+  && ok_t "8n the re-run is rc 0 and the id is unchanged" \
+  || bad_t "8n the re-run is rc 0 and the id is unchanged" "rc=$JOIN_RC ids=$(cfg_field channels)"
+# Control: the resolver must still find a channel by NAME, or 8n passes because
+# nothing resolves at all.
+[[ "$(_buzz_channel_ref_id general <<<"[{\"channel_id\":\"$REAL_CID\",\"name\":\"general\"}]")" == "$REAL_CID" ]] \
+  && ok_t "8n control: the resolver still resolves a NAME to its id" \
+  || bad_t "8n control: the resolver still resolves a NAME to its id" "name lookup broke; 8n is vacuous"
+[[ -z "$(_buzz_channel_ref_id nosuch <<<"[{\"channel_id\":\"$REAL_CID\",\"name\":\"general\"}]")" ]] \
+  && ok_t "8n control: an unknown token resolves to NOTHING (it does not echo itself)" \
+  || bad_t "8n control: an unknown token resolves to NOTHING" "the resolver returns its input, so every id 'resolves' and create never fires"
+
+# --- 8o. only a CONFIRMED membership is recorded ---------------------------
+# rc=3 is the accepted-but-not-readable case (DIVE-3507). Recording that id
+# would tell the poller to watch a room the agent is not in — success reported
+# while connected to nothing, one layer further down.
+# Seeded in the POST-fix shape (names in .channel_names, .channels empty) —
+# that is what `enable` now writes, and the question is whether a failed join
+# fills it in anyway.
+seed_agent "$STUB_BIN" "general"
+python3 -c "
+import json
+p='$AGENT_STATE/config.json'
+d=json.load(open(p)); d['channel_names']=d.pop('channels'); d['channels']=[]
+json.dump(d, open(p,'w'), indent=2)
+"
+run_join dropmember dev
+{ [[ "$JOIN_RC" -eq 3 ]] && [[ -z "$(cfg_field channels)" ]]; } \
+  && ok_t "8o an unconfirmed join records NO channel id" \
+  || bad_t "8o an unconfirmed join records NO channel id" "rc=$JOIN_RC ids='$(cfg_field channels)' — the poller would watch an unjoined room"
+# Control: the SAME seed with a relay that confirms DOES get an id written, or
+# the arm above passes because the writeback never fires at all.
+seed_agent "$STUB_BIN" "general"
+python3 -c "
+import json
+p='$AGENT_STATE/config.json'
+d=json.load(open(p)); d['channel_names']=d.pop('channels'); d['channels']=[]
+json.dump(d, open(p,'w'), indent=2)
+"
+run_join normal dev
+{ [[ "$JOIN_RC" -eq 0 ]] && [[ "$(cfg_field channels)" == "$(stub_cid general)" ]]; } \
+  && ok_t "8o control: a CONFIRMED join over the same seed does record the id" \
+  || bad_t "8o control: a CONFIRMED join over the same seed does record the id" "rc=$JOIN_RC ids='$(cfg_field channels)'; 8o is vacuous"
+
+# --- 8p. `enable` writes a config the reader can use, or an empty one ------
+# Not names-in-.channels. The honest state before resolution is EMPTY: the
+# poller watches nothing and says nothing, instead of erroring every 15s.
+seed_agent "$STUB_BIN" "general"
+rm -f "$AGENT_STATE/config.json"
+_buzz_write_config "$(id -un)" "$AGENT_STATE" "https://relay.example.com" "$(printf '3%.0s' $(seq 63))7" "general,ops" 15000 "$STUB_BIN" >/dev/null 2>&1
+{ [[ "$(cfg_field channel_names)" == "general,ops" ]] && [[ -z "$(cfg_field channels)" ]]; } \
+  && ok_t "8p enable writes names to .channel_names and leaves .channels EMPTY (never a name)" \
+  || bad_t "8p enable writes names to .channel_names and leaves .channels EMPTY" \
+           "names='$(cfg_field channel_names)' ids='$(cfg_field channels)' — a name in .channels is the DIVE-3565 defect"
+# ...and a re-run of enable must not throw away ids join already resolved, since
+# enable CALLS join and a re-enable is the ordinary repair command.
+_buzz_set_channel_ids "$(id -un)" "$AGENT_STATE/config.json" "id-1,id-2" "general,ops" >/dev/null 2>&1
+_buzz_write_config "$(id -un)" "$AGENT_STATE" "https://relay.example.com" "$(printf '3%.0s' $(seq 63))7" "general,ops" 15000 "$STUB_BIN" >/dev/null 2>&1
+[[ "$(cfg_field channels)" == "id-1,id-2" ]] \
+  && ok_t "8p re-running enable with the SAME names keeps the resolved ids" \
+  || bad_t "8p re-running enable with the SAME names keeps the resolved ids" \
+           "got '$(cfg_field channels)' — a re-enable would take a working seat back to silent"
+# Control: a DIFFERENT name list makes the old ids the wrong answer, not a stale
+# one, so they must be dropped.
+_buzz_write_config "$(id -un)" "$AGENT_STATE" "https://relay.example.com" "$(printf '3%.0s' $(seq 63))7" "alerts" 15000 "$STUB_BIN" >/dev/null 2>&1
+{ [[ -z "$(cfg_field channels)" ]] && [[ "$(cfg_field channel_names)" == "alerts" ]]; } \
+  && ok_t "8p control: changing the names DROPS the stale ids" \
+  || bad_t "8p control: changing the names DROPS the stale ids" "ids='$(cfg_field channels)' point at rooms that are no longer configured"
+
+# --- 8q. a legacy config (names in .channels, no .channel_names) still wires
+# Every already-provisioned seat looks like this. It must be REPAIRED by a plain
+# `join`, not refused — the key is the ABSENCE of the .channel_names key.
+seed_agent "$STUB_BIN" "general"   # seed_agent writes the legacy shape
+python3 -c "
+import json,sys
+d=json.load(open('$AGENT_STATE/config.json'))
+assert 'channel_names' not in d, 'fixture is not the legacy shape'
+assert d['channels'] == ['general'], d
+" && ok_t "8q fixture sanity: the seed IS the legacy name-in-.channels shape" \
+   || bad_t "8q fixture sanity: the seed IS the legacy shape" "the arm below proves nothing"
+run_join normal dev
+LEG_CID=$(stub_cid general)
+{ [[ "$JOIN_RC" -eq 0 ]] && [[ "$(cfg_field channels)" == "$LEG_CID" ]] && [[ "$(cfg_field channel_names)" == "general" ]]; } \
+  && ok_t "8q a legacy config is REPAIRED in place by one \`buzz join\`" \
+  || bad_t "8q a legacy config is REPAIRED in place by one \`buzz join\`" \
+           "rc=$JOIN_RC ids='$(cfg_field channels)' names='$(cfg_field channel_names)' — every existing seat stays silent"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## The defect

`5dive agent buzz enable` wrote `config.json` with `"channels": ["general"]` — a **name**.
`plugins/buzz/server.ts:38` declares `channels: string[] // channel UUIDs to watch for mentions` and
hands each entry to `buzz messages get --channel <entry>`. The relay answers `invalid UUID: general`.

Every tick. To stderr. Forever. No `state.json`, no watermark, no delivery, **no crash**. A seat
wired at all six sites — plugin, identity, config, channel declared, relay joined, profile published
— never answered a single mention (measured on jolly-birch, DIVE-3559). Hand-fixing that one field
(`jq '.channels=["<uuid>"]'` + restart) produced a delivered, answered mention in 19 seconds, so this
was the only missing link on an otherwise perfect box.

`buzz join` (#701) resolves name → channel_id on the relay, joins, adds the owner — and never writes
the resolved ids back. The defect survives at HEAD.

## Why the CLI is the writer (and not the plugin)

`enable` *cannot* resolve a name: resolution is a relay call and `enable` may run on a box with no
`buzz` binary at all (DIVE-3512). `join` already resolves every name for its own create-or-find loop.
It simply never wrote the answer down. One writer, and it is the one that already knows.

## The change

`config.json` splits the field:

| field | holds | written by |
|---|---|---|
| `channel_names` | what the operator typed — the lookup key | `enable` |
| `channels` | resolved channel ids **only**, empty until confirmed | `join` |

An empty watch list is the honest pre-resolution state: the poller watches nothing and says nothing,
instead of retrying a name it will never accept every 15s.

Three constraints that are not obvious, each now a graded arm:

1. **The writeback closes over its own output.** Once `.channels` holds a uuid the next `join` reads
   it back; a name-only resolver would create a channel *literally named after the uuid* — a silent
   second room with one occupant. `_buzz_channel_ref_id` matches name first, then id-to-itself.
2. **Legacy configs are told apart by the KEY, not the value.** Every already-provisioned seat has
   names in `.channels` and no `channel_names` key. Absence of the key means "these are names", and
   one plain `sudo 5dive agent buzz join <name>` repairs the seat in place.
3. **Only a membership that READ BACK is recorded.** `join`'s rc=3 case is accepted-but-unreadable
   (DIVE-3507). Recording that id would point the poller at a room the agent is not in.

Plus: `enable` carries resolved ids across a re-run when the name list is unchanged (a re-enable is
the ordinary repair command and it *calls* join), and drops them when it changes. `agent buzz status`
now prints `channel names:` / `channel ids:` separately and warns when names are configured but
unresolved.

## The test that was enshrining the defect

`tests/buzz_channel_wiring_unit.sh` asserted `.channels == ["general","ops"]` and called that "the
plugin's five-field contract" — it graded the writer against **the writer's own belief about the
reader**, so it was green on a config the reader rejects. It now asserts the reader's shape, quotes
`server.ts:38`, and adds a mutation arm that no channel NAME ever lands in `.channels`.

## How it was checked

15 new arms in `tests/buzz_last_mile_unit.sh`, running the **real** `_buzz_join` against the existing
fake-relay stub (nothing about the function under test is stubbed):

- the id written into `.channels` equals the id the **stub store** minted — read out of the stub's own
  file, so the assertion is not comparing the code to itself
- `.channels != .channel_names` (not a substring test: a relay may legitimately build an id out of the
  name, e.g. `ch-general-9f3b…`)
- `private_key` / `relay_url` / `poll_ms` / `buzz_path` survive untouched, file stays 0600
- a re-run over an id-bearing config creates **nothing**, rc 0, id unchanged — with two resolver
  controls (a name still resolves; an unknown token resolves to nothing rather than echoing itself, or
  every id would "resolve" and create would never fire)
- an unconfirmed join records no id — **with a confirmed control on the same seed**, or the arm passes
  because the writeback never fires at all
- `enable` writes names to `.channel_names` and leaves `.channels` empty; carries ids across a
  same-names re-run; **control:** a changed name list drops the stale ids
- a legacy-shape config is repaired in place by one `join` (with a fixture-sanity arm asserting the
  seed really is the legacy shape)

```
tests/buzz_last_mile_unit.sh                   95 passed, 0 failed
tests/buzz_channel_wiring_unit.sh              56 passed, 0 failed
tests/buzz_by_design_rc3_not_a_panic_unit.sh   10 passed, 0 failed
tests/buzz_pair_unit.sh                        24 passed, 0 failed
tests/digest_buzz_count_unit.sh                 9 passed, 0 failed
tests/install_buzz_binaries_unit.sh            PASS=16 FAIL=0
shellcheck -S error src/cmd_agent_buzz{,_join}.sh   clean
./build.sh + bash -n on the bundle               OK
```

**What no local harness grades**, and this is signed rather than implied: that a real relay returns
these ids in these fields, and that the plugin then delivers a mention against them. That is the
fresh-VM smoke's job — the hand-fix in DIVE-3559 already proved the end state (19s to an answered
mention with the uuid in place); this PR is the automation of exactly that one edit.

Wiki: `community/wiki/the-writer-wrote-names-the-reader-polled-uuids-and-both-sides-were-green.md`
(+ index line, + a RESOLVED note on the fresh-VM acceptance page).

Closes DIVE-3565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
