### PR TITLE
DIVE-3577: authorize a delegated act from a retired-but-resolved gate

### DIFF
--- a/src/lib/broker.sh
+++ b/src/lib/broker.sh
@@ -117,11 +117,67 @@ broker_gate_check() {
   guid=$(db "SELECT COALESCE(need_answered_uid,'')    FROM tasks WHERE id=${id};")
   gsig=$(db "SELECT COALESCE(need_answer_sig,'')      FROM tasks WHERE id=${id};")
   reviewer=$(db "SELECT COALESCE(routed_reviewer,'')  FROM tasks WHERE id=${id};")
+  # DIVE-3577: `tasks` alone is the WRONG table to key this precondition on.
+  # A gate lives on the row only until something RETIRES it, and retirement
+  # (_gate_archive_and_clear_sql) moves it to gate_history and nulls all six
+  # provenance columns. `task park` retires an ANSWERED gate that way — and
+  # parking is exactly what a row does while it waits for the delegated push it
+  # just got approved for. So the approval is destroyed by the ordinary
+  # lifecycle, and this predicate then reports "no gate", i.e. it renders
+  # "cleared and then archived" and "never asked" as the same observation
+  # (measured on DIVE-3560: gate_history holds `approve` / `lead:ops` /
+  # retired_by=park, and the live row reads gateless).
+  #
+  # So: when the live row carries NO current gate, fall back to the most recent
+  # RESOLVED gate in gate_history. Every check below is then applied to that
+  # record unchanged — the reject scan, the provenance arms and, under
+  # require_sig, the signed closure. That last one is why this is safe to read
+  # from an archive at all: _gate_closure_sign is keyed on (task id, type,
+  # answer, answered_by, answered_at, uid), all six of which gate_history
+  # preserves verbatim, so an archived answer verifies exactly as it did when it
+  # was live and a hand-edited history row still fails.
+  #
+  # DELIBERATELY the most recent one, not "any approval anywhere in the
+  # history": digging past a later rejection to find an older approval would let
+  # a retired `no` be out-voted by a stale `yes`. One row, the newest resolved
+  # one, then the same verdict reading as always.
+  #
+  # NOT applied when a current gate exists but is still OPEN: an unanswered
+  # question on the row is a live question, and an archived approval does not
+  # answer it. That case keeps refusing (with a pointer, below).
+  local gate_src="current" retired_by="" retired_at=""
+  if [[ -z "$gtype" && -z "$gansweredat" ]]; then
+    local hid
+    hid=$(db "SELECT id FROM gate_history
+               WHERE task_id=${id}
+                 AND need_answered_at IS NOT NULL AND need_answered_at<>''
+               ORDER BY id DESC LIMIT 1;")
+    if [[ -n "$hid" ]]; then
+      gate_src="archived"
+      gtype=$(db      "SELECT COALESCE(need_type,'')          FROM gate_history WHERE id=${hid};")
+      gansweredat=$(db "SELECT COALESCE(need_answered_at,'')  FROM gate_history WHERE id=${hid};")
+      ganswer=$(db    "SELECT COALESCE(need_answer,'')        FROM gate_history WHERE id=${hid};")
+      gby=$(db        "SELECT COALESCE(need_answered_by,'')   FROM gate_history WHERE id=${hid};")
+      guid=$(db       "SELECT COALESCE(need_answered_uid,'')  FROM gate_history WHERE id=${hid};")
+      gsig=$(db       "SELECT COALESCE(need_answer_sig,'')    FROM gate_history WHERE id=${hid};")
+      retired_by=$(db "SELECT COALESCE(retired_by,'')         FROM gate_history WHERE id=${hid};")
+      retired_at=$(db "SELECT COALESCE(retired_at,'')         FROM gate_history WHERE id=${hid};")
+    fi
+  fi
+  local from_note=""
+  [[ "$gate_src" == "archived" ]] &&     from_note=" [read from the gate archived by '${retired_by:-unknown}'${retired_at:+ at ${retired_at}} — the live row carries no gate]"
   if [[ -z "$gtype" ]]; then
     fail "$E_VALIDATION" "no gate on ${ident} — file a ${noun}-for-review gate first: 5dive task need ${ident} --type=approval --ask='${ask}' (files tier-1 to the org lead, who can clear it)"
   fi
   if [[ -z "$gansweredat" ]]; then
-    fail "$E_VALIDATION" "gate on ${ident} is OPEN (unanswered ${gtype}) — ${noun} refused until it clears (5dive task answer ${ident} ...)."
+    # An archived resolution cannot answer a question that is still being asked,
+    # but the reader deserves to know it is there — otherwise a re-file over an
+    # approval reads as "you never got approved" (DIVE-3577).
+    local prior_hint=""
+    if [[ "$(db "SELECT COUNT(*) FROM gate_history WHERE task_id=${id} AND need_answered_at IS NOT NULL AND need_answered_at<>'';")" != "0" ]]; then
+      prior_hint=" This row DOES carry an earlier resolved gate in its archive (5dive task gate-history ${ident}), but a NEWER gate is open and supersedes it."
+    fi
+    fail "$E_VALIDATION" "gate on ${ident} is OPEN (unanswered ${gtype}) — ${noun} refused until it clears (5dive task answer ${ident} ...).${prior_hint}"
   fi
   # DIVE-2614: the verdict word is read off the FIRST NON-BLANK LINE, as a
   # whole word (`\b`). Either half of the old check alone still misreads real
@@ -154,7 +210,7 @@ broker_gate_check() {
   # this list is maintained by hand, not enforced by the pattern.
   if printf '%s' "$gverdict" | grep -qiE '^\s*(no|reject|rejected|deny|denied|block|blocked)\b'; then
     audit_log "${surface} gate" error "$E_VALIDATION" -- "ident=${ident}" "line=${gverdict}"
-    fail "$E_VALIDATION" "gate on ${ident} was REJECTED ('${ganswer}') — ${noun} refused."
+    fail "$E_VALIDATION" "gate on ${ident} was REJECTED ('${ganswer}') — ${noun} refused.${from_note}"
   fi
   [[ "$gby" == human:* ]] && authorized=1
   # DIVE-1555: accept ANY lead-clear provenance (`lead:*`), not only one whose
@@ -226,7 +282,7 @@ broker_gate_check() {
     else
       detail=" — required 'human:*' or 'lead:*'; found '${gby:-unknown}', and this gate has no routed reviewer to attribute a decision answer to."
     fi
-    fail "$E_VALIDATION" "gate on ${ident} was not cleared by an authority delegated ${noun} accepts${detail}"
+    fail "$E_VALIDATION" "gate on ${ident} was not cleared by an authority delegated ${noun} accepts${detail}${from_note}"
   fi
   # DIVE-2801: THREE closure states, not two, and the preflight can tell them apart.
   #
@@ -256,7 +312,7 @@ broker_gate_check() {
   BROKER_GATE_SIG_STATE="unverified"
   if [[ "$require_sig" == "1" ]]; then
     if ! _gate_closure_verify "$id" "$gtype" "$ganswer" "$gby" "$gansweredat" "$guid" "$gsig"; then
-      fail "$E_VALIDATION" "gate on ${ident} has no valid signed closure — delegated ${noun} refused"
+      fail "$E_VALIDATION" "gate on ${ident} has no valid signed closure — delegated ${noun} refused${from_note}"
     fi
     BROKER_GATE_SIG_STATE="verified"
   elif [[ -z "$gsig" ]]; then

--- a/tests/push_gate_archived_unit.sh
+++ b/tests/push_gate_archived_unit.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# TIER: nightly — 13.1s measured on this box: core is at 83-86% of its 300s cap
+# (tests/lib/tier.sh), and the whole surface this grades is already nightly —
+# push_unit.sh (11.9s) and deploy_unit.sh are the siblings. Isolated store, no
+# root, no network, so the nightly sweep runs it unattended.
+# DIVE-3577 — a RETIRED-but-resolved gate must still authorize the delegated act.
+#
+# WHY THIS EXISTS. broker_gate_check keyed the precondition on the `tasks` row's
+# six need_* columns. A gate lives there only until something RETIRES it, and
+# retirement (_gate_archive_and_clear_sql) moves it to gate_history and nulls all
+# six. `task park` retires an ANSWERED gate that way — and parking is exactly what
+# a row does while it waits for the push it was just approved for. The approval was
+# therefore destroyed by the ordinary lifecycle, and push then refused verbatim:
+#
+#     error: no gate on DIVE-3560 — file a push-for-review gate first
+#
+# i.e. "approved, then archived" and "never asked" were the same observation.
+# Measured on the live board: DIVE-3560's gate_history row holds approve /
+# lead:ops / retired_by=park while the live row reads gateless.
+#
+# NOTE ON THE RECORD: the original report (and the wiki note) blamed ANSWERING the
+# gate. Arm 1 is the control that refutes that — an answered, untouched gate has
+# always passed. `park` is the retiring verb, and `need --withdraw` cannot even
+# reach an answered gate. Fixing the wrong verb would have shipped as "works".
+#
+# Pinned here:
+#   1. CONTROL / NON-VACUITY: answered + untouched still passes (the fixture drives
+#      the real predicate, and answering alone was never the defect);
+#   2. THE DEFECT: answered approval + `task park` → authorized off gate_history;
+#   3. a newest archived REJECTION is not out-voted by an older archived approval;
+#   4. an OPEN current gate is NOT superseded by an archived approval — it still
+#      refuses, and the refusal names the archive instead of hiding it;
+#   5. a row with no gate anywhere still gets the "no gate" refusal (the fallback
+#      does not paper over the genuinely-unasked case);
+#   6. authorization is re-applied to the archived record: a bare-agent answer in
+#      the archive is refused exactly as it would be live;
+#   7. the SIGNED CLOSURE verifies against the archive (require_sig=1), and a
+#      tampered archived answer fails it — the archive is not a trust bypass.
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/push-gate-archived.XXXXXX)" || { echo "FAIL - mktemp"; exit 1; }
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh lib/broker.sh cmd_task.sh cmd_org.sh \
+         lib/self.sh; do
+  [[ -f "$SRC/$f" ]] || continue
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+GATE_PROOF_KEY="$TMP/gate-proof.key"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"
+openssl rand -hex 32 > "$GATE_PROOF_KEY" 2>/dev/null || { echo "FAIL - no openssl"; exit 1; }
+set +e   # AFTER sourcing: header.sh turns `set -e` back on.
+tasks_db_init
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# Preconditions, not observables.
+task_need_notify() { return 0; }
+audit_log() { return 0; }
+_gate_proof_enforced() { return 0; }
+
+addt() { ( cmd_task_add "$@" ) 2>/dev/null | jq -r '.data.id'; }
+
+# File a push-for-review gate and answer it directly. Written to the columns so
+# the case is identical on every arm and does not ride on the answer path's own
+# policy checks (which are graded by the gate_* suites, not here).
+plant() { # <id> [answer] [by] [sign?]
+  local id="$1" answer="${2:-approve}" by="${3:-human:lodar}" sign="${4:-1}"
+  ( cmd_task_need "$id" --type=approval --tier=1 \
+      --ask="approve delegated push for review of branch dive-fixture" ) >/dev/null 2>&1
+  local ts; ts=$(db "SELECT datetime('now');")
+  local sig=""
+  (( sign )) && sig=$(_gate_closure_sign "$id" approval "$answer" "$by" "$ts" 1000)
+  db "UPDATE tasks
+         SET need_answer=$(sqlq "$answer"), need_answered_at=$(sqlq "$ts"),
+             need_answered_by=$(sqlq "$by"), need_answered_uid=1000,
+             need_answer_sig=$(sqlq "$sig")
+       WHERE id=${id};"
+}
+
+# The act under test, captured. Returns the refusal text (empty == authorized).
+chk() { ( broker_gate_check push "$1" "T$1" "${2:-0}" ) 2>&1 | tr -d '\n'; }
+park() { ( cmd_task_park "$1" --reason="awaiting delegated push" --wake=+12h ) >/dev/null 2>&1; }
+hist_n() { db "SELECT COUNT(*) FROM gate_history WHERE task_id=${1};"; }
+
+# --- 1. CONTROL: answered and untouched — always passed, still passes ---------
+t1=$(addt --assignee=dev -- "fixture: answered, never retired")
+plant "$t1"
+r1=$(chk "$t1")
+if [[ -z "$r1" ]]; then
+  ok_t "control: an ANSWERED, un-retired gate authorizes (answering alone was never the defect)"
+else
+  bad_t "an answered live gate must authorize — the fixture is not driving the predicate" "$r1"
+fi
+
+# --- 2. THE DEFECT: park retires the approval; the act must still authorize ---
+t2=$(addt --assignee=dev -- "fixture: answered then parked")
+plant "$t2"
+park "$t2"
+# Prove the PRECONDITION of the defect, not just its symptom: the live row is
+# gateless and the approval is in the archive. Without this the arm could pass
+# because park silently no-op'd (it refuses without --wake, which is how a first
+# draft of this harness "passed" against the unfixed tree).
+live_gate=$(db "SELECT COALESCE(need_type,'')||COALESCE(need_answer,'')||COALESCE(need_answered_by,'') FROM tasks WHERE id=${t2};")
+if [[ -z "$live_gate" && "$(hist_n "$t2")" == "1" ]]; then
+  ok_t "precondition: park left the live row gateless and archived exactly one gate"
+else
+  bad_t "park must retire the answered gate into gate_history" "live='${live_gate}' hist=$(hist_n "$t2")"
+fi
+arch=$(db "SELECT COALESCE(need_answer,'')||'|'||COALESCE(need_answered_by,'')||'|'||COALESCE(retired_by,'') FROM gate_history WHERE task_id=${t2};")
+if [[ "$arch" == "approve|human:lodar|park" ]]; then
+  ok_t "precondition: the archive carries the answer, the answerer and the retiring verb ($arch)"
+else
+  bad_t "the archive must preserve the approval" "got='$arch'"
+fi
+r2=$(chk "$t2")
+if [[ -z "$r2" ]]; then
+  ok_t "THE DEFECT: an approval retired by park still authorizes the delegated act"
+else
+  bad_t "a parked-away approval must still authorize — this is DIVE-3577" "$r2"
+fi
+
+# --- 3. a newer archived REJECTION is not out-voted by an older approval ------
+t3=$(addt --assignee=dev -- "fixture: approved, then rejected, both archived")
+plant "$t3" approve
+park "$t3"
+( cmd_task_start "$t3" ) >/dev/null 2>&1
+plant "$t3" "no — rejected, do not push"
+park "$t3"
+r3=$(chk "$t3")
+if [[ "$r3" == *REJECTED* ]]; then
+  ok_t "the NEWEST archived gate decides: a later rejection is not out-voted by an older approval"
+else
+  bad_t "digging past a rejection to an older approval is a bypass" "hist=$(hist_n "$t3") got='$r3'"
+fi
+
+# --- 4. an OPEN current gate supersedes the archive, and says so -------------
+t4=$(addt --assignee=dev -- "fixture: approved, then a fresh gate re-filed over it")
+plant "$t4"
+( cmd_task_need "$t4" --type=approval --tier=1 --ask="a SECOND question" ) >/dev/null 2>&1
+r4=$(chk "$t4")
+if [[ "$r4" == *"is OPEN"* ]]; then
+  ok_t "an OPEN current gate still refuses — an archived approval does not answer a live question"
+else
+  bad_t "a live unanswered gate must not be satisfied from the archive" "$r4"
+fi
+if [[ "$r4" == *"gate-history"* ]]; then
+  ok_t "and the refusal POINTS AT the archived resolution instead of hiding it"
+else
+  bad_t "the OPEN refusal should name the earlier resolved gate" "$r4"
+fi
+
+# --- 5. no gate anywhere: the original refusal survives ----------------------
+t5=$(addt --assignee=dev -- "fixture: never gated at all")
+r5=$(chk "$t5")
+if [[ "$r5" == *"no gate on"* && "$(hist_n "$t5")" == "0" ]]; then
+  ok_t "a row that never had a gate still gets 'no gate' (the fallback invents nothing)"
+else
+  bad_t "the genuinely-unasked case must keep refusing" "hist=$(hist_n "$t5") got='$r5'"
+fi
+
+# --- 6. authorization is re-applied to the archived record ------------------
+t6=$(addt --assignee=dev -- "fixture: archived approval answered by a bare agent")
+plant "$t6" approve "dev"
+park "$t6"
+r6=$(chk "$t6")
+if [[ "$r6" == *"not cleared by an authority"* ]]; then
+  ok_t "a bare-agent answer in the ARCHIVE is refused exactly as it would be live"
+else
+  bad_t "reading from the archive must not skip the provenance arms" "$r6"
+fi
+
+# --- 7. the signed closure verifies against the archive, and detects tamper --
+t7=$(addt --assignee=dev -- "fixture: signed approval, parked")
+plant "$t7" approve "human:lodar"
+park "$t7"
+r7=$(chk "$t7" 1)
+if [[ -z "$r7" ]]; then
+  ok_t "require_sig=1: the signed closure verifies against the ARCHIVED gate"
+else
+  bad_t "the closure is keyed on fields gate_history preserves; it must verify" "$r7"
+fi
+# The same arm's negative control: without it, a signature check that always
+# returned true would look identical above.
+db "UPDATE gate_history SET need_answer='approve EVERYTHING' WHERE task_id=${t7};"
+r7b=$(chk "$t7" 1)
+if [[ "$r7b" == *"no valid signed closure"* ]]; then
+  ok_t "negative control: a TAMPERED archived answer fails the closure check"
+else
+  bad_t "a hand-edited gate_history row must not authorize a privileged write" "$r7b"
+fi
+
+printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Fixes DIVE-3577: `broker_gate_check` (the one predicate behind delegated push AND deploy) read only the LIVE row's gate, but `task park` retires an answered gate into `gate_history` — so a row that got approved and then parked (exactly what a row does while waiting for its delegated push) reads gateless, and "approved" becomes indistinguishable from "never asked" (measured on DIVE-3560).

Fix: when the live row carries no gate at all, fall back to the NEWEST resolved gate in `gate_history`, applying every existing check unchanged (reject scan, provenance arms, signed closure — safe because `_gate_closure_sign` is keyed on the six fields `gate_history` preserves verbatim). Newest-only so a retired "no" cannot be out-voted by an older "yes"; a live OPEN gate still refuses, now naming the archive.

Maker: quinn (seat holds no push grant — branch pushed by main). Verified by main at 1f6d3b6: new `tests/push_gate_archived_unit.sh` 11/11 on the fix and 5/6-red on the parent tree (non-vacuity re-derived, not quoted); push_unit 121/0, deploy_unit 34/0, gate_history_unit 32/0, broker_surface_unit 52/0. Harness tiered NIGHTLY (13.1s; core at 83–86% of its cap) — accepted by verifier.

Wiki: community/wiki/a-precondition-must-be-keyed-on-a-fact-the-successful-path-preserves.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
