### PR TITLE
DIVE-3580: attribute a confirmed budget red against the last green main run

### DIFF
--- a/.github/scripts/fetch-budget-baseline.sh
+++ b/.github/scripts/fetch-budget-baseline.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# DIVE-3580: FETCH THE LAST GREEN MAIN RUN'S PER-HARNESS REPORTS, for attributing a
+# confirmed budget red before it blocks a merge.
+#
+# Lives here for the simulate-installed-host.sh reason: BOTH confirm jobs must fetch
+# the same object the same way, and two copies of a fetch block are two baselines as
+# soon as one is edited.
+#
+# EVERY EXIT IS 0 EXCEPT USAGE. This script arms an instrument that may only ever
+# RELIEVE a red (tests/lib/tier.sh, DIVE-3580 block: 4 -> 6 on a positive uniform-lift
+# measurement, never anything else). A fetch that fails must therefore disarm the
+# instrument and let the red stand exactly as it did before DIVE-3580 — failing the
+# JOB here would turn an API hiccup into a red on a PR whose corpus nobody measured,
+# which is the exact class this whole ladder exists to remove. "No baseline" is said
+# out loud and the reports directory is simply left without files; the caller's glob
+# then passes no --baseline-report flags and run-harnesses.sh records
+# budget_attribution=off, which is a GRADED "not consulted", not a silent skip.
+#
+# GREEN RUNS ONLY (status=success), and that is load-bearing: a red main run's
+# reports may themselves carry the fleet-wide slow hour this is a baseline AGAINST,
+# and a baseline contaminated by the weather it grades would read every slow box as
+# normal. The freshest green run is the right one for the same reason — the corpus
+# drifts by ~a file a day, and the common-set join in tier.sh absorbs what remains.
+set -uo pipefail
+
+env="${1:?usage: fetch-budget-baseline.sh <pristine|installed>}"
+case "$env" in
+  pristine|installed) ;;
+  *) printf 'fetch-budget-baseline: unknown environment %s (want pristine|installed)\n' "$env" >&2; exit 2 ;;
+esac
+repo="${GITHUB_REPOSITORY:?fetch-budget-baseline: GITHUB_REPOSITORY is not set}"
+out="baseline-reports"
+mkdir -p "$out"
+
+disarm() { # <why>
+  printf 'fetch-budget-baseline: NO BASELINE — %s.\n' "$1"
+  printf 'Attribution is DISARMED for this run: an over-budget verdict stands exactly as it\n'
+  printf 'did before DIVE-3580. Nothing is weakened by this; only the relief is unavailable.\n'
+  exit 0
+}
+
+run_line="$(gh api "repos/$repo/actions/workflows/unit-tests.yml/runs?branch=main&status=success&per_page=1" \
+  --jq '.workflow_runs[0] | "\(.id)\t\(.head_sha)\t\(.created_at)"' 2>/dev/null)" || run_line=""
+[[ -n "$run_line" && "$run_line" != "null"* ]] || disarm "could not resolve a green unit-tests run on main"
+IFS=$'\t' read -r run_id head_sha created_at <<<"$run_line"
+[[ "$run_id" =~ ^[0-9]+$ ]] || disarm "the green-run lookup returned no usable run id"
+
+arts="$(gh api "repos/$repo/actions/runs/$run_id/artifacts?per_page=100" \
+  --jq '.artifacts[] | "\(.id)\t\(.name)"' 2>/dev/null)" || arts=""
+[[ -n "$arts" ]] || disarm "run $run_id lists no artifacts (expired or still uploading)"
+
+got=0
+for shard_name in "core-$env-1" "core-$env-2"; do
+  art_id="$(awk -F'\t' -v n="$shard_name" '$2 == n { print $1; exit }' <<<"$arts")"
+  [[ -n "$art_id" ]] || continue
+  tmp_zip="$(mktemp "${TMPDIR:-/tmp}/budget-baseline.XXXXXX.zip")" || continue
+  if gh api "repos/$repo/actions/artifacts/$art_id/zip" > "$tmp_zip" 2>/dev/null \
+     && unzip -o -q "$tmp_zip" -d "$out" 2>/dev/null; then
+    got=$(( got + 1 ))
+  fi
+  rm -f "$tmp_zip"
+done
+# The artifact also carries the shard's verdict hand-off file; only the report TSVs
+# are the baseline, and passing verdict files would feed the join lines it must skip.
+rm -f "$out"/core-verdict-*.txt 2>/dev/null || true
+
+(( got > 0 )) || disarm "run $run_id carried no core-$env-* artifacts"
+printf 'fetch-budget-baseline: baseline is run %s (%s, %s), %d shard artifact(s):\n' \
+  "$run_id" "$head_sha" "$created_at" "$got"
+ls -l "$out"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -536,14 +536,42 @@ jobs:
       # without bun, so every job that runs the corpus needs this step.
       - name: Install bun (harness precondition — acp_stdio_unit grades the ACP server)
         uses: oven-sh/setup-bun@v2
+      # DIVE-3580: the second box's verdict is only independent of the first while the
+      # fleet's draw is — and on #708 it was not: both runners confirmed a red that
+      # main's own next run of the SAME corpus refuted at 77% of cap. So the confirm
+      # run is handed the last GREEN main run's per-harness reports, and an over-budget
+      # total it can pin on a UNIFORM lift across unrelated files resolves as exit 6
+      # with budget_attribution=runner — no corpus finding — instead of exit 4. Fetch
+      # failure disarms the relief and changes nothing else (the script says so).
+      - name: Fetch the last green main run's per-harness baseline (DIVE-3580)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/fetch-budget-baseline.sh pristine
       - name: Confirm the budget red on a SECOND runner (DIVE-2829)
         run: |
+          args=()
+          for f in baseline-reports/core-pristine-[0-9]*.txt; do
+            [ -r "$f" ] && args+=("--baseline-report=$f")
+          done
+          set +e
           bash scripts/run-harnesses.sh --tier=core \
             --shard=${{ matrix.shard }}/${{ matrix.shards }} \
             --label=pristine-confirm \
             --report=core-pristine-confirm-${{ matrix.shard }}.txt --cross-runner=required \
             --runner-id="${GITHUB_JOB}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-s${{ matrix.shard }}" \
-            --prior-over-runner="${{ matrix.prior }}"
+            --prior-over-runner="${{ matrix.prior }}" "${args[@]}"
+          rc=$?
+          set -e
+          # DIVE-3580: HAND OFF ONLY THE ATTRIBUTED 6 — the exact grep discipline the
+          # first-box jobs apply to the cross-runner 6, because exit 6 has three
+          # producers here (calibration undetermined, cross-runner — impossible on this
+          # job, and attribution) and only the attributed one has POSITIVE evidence
+          # that the red is the box. A calibration 6 keeps the red it always had.
+          if [ "$rc" = 6 ] && grep -q '^# budget_attribution=runner$' core-pristine-confirm-${{ matrix.shard }}.txt; then
+            echo "budget red ATTRIBUTED TO THE RUNNER against the last green main run — no corpus finding; not blocking (DIVE-3580)."
+            exit 0
+          fi
+          exit "$rc"
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -579,14 +607,31 @@ jobs:
       # without bun, so every job that runs the corpus needs this step.
       - name: Install bun (harness precondition — acp_stdio_unit grades the ACP server)
         uses: oven-sh/setup-bun@v2
+      # DIVE-3580: same baseline, same hand-off discipline — see the pristine confirm job.
+      - name: Fetch the last green main run's per-harness baseline (DIVE-3580)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/fetch-budget-baseline.sh installed
       - name: Confirm the budget red on a SECOND runner (DIVE-2829)
         run: |
+          args=()
+          for f in baseline-reports/core-installed-[0-9]*.txt; do
+            [ -r "$f" ] && args+=("--baseline-report=$f")
+          done
+          set +e
           bash scripts/run-harnesses.sh --tier=core \
             --shard=${{ matrix.shard }}/${{ matrix.shards }} \
             --label=installed-host-confirm \
             --report=core-installed-confirm-${{ matrix.shard }}.txt --cross-runner=required \
             --runner-id="${GITHUB_JOB}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-s${{ matrix.shard }}" \
-            --prior-over-runner="${{ matrix.prior }}"
+            --prior-over-runner="${{ matrix.prior }}" "${args[@]}"
+          rc=$?
+          set -e
+          if [ "$rc" = 6 ] && grep -q '^# budget_attribution=runner$' core-installed-confirm-${{ matrix.shard }}.txt; then
+            echo "budget red ATTRIBUTED TO THE RUNNER against the last green main run — no corpus finding; not blocking (DIVE-3580)."
+            exit 0
+          fi
+          exit "$rc"
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/scripts/run-harnesses.sh
+++ b/scripts/run-harnesses.sh
@@ -120,6 +120,16 @@ CROSS_RUNNER=off; RUNNER_ID=""; PRIOR_OVER_RUNNER=""
 # box. The three measurements that forced this are beside the drift print below; the
 # short version is that this axis makes DIVE-2829's exact mistake one axis over.
 DRIFT_FATAL=off
+# DIVE-3580. PER-HARNESS BASELINE REPORTS FROM A GREEN RUN, for attributing an
+# over-budget verdict before it stands. Like --cross-runner this IS policy the
+# workflow passes: whether a prior green run's reports are available is a property
+# of the caller's topology (CI can fetch the last green main run; a laptop has
+# nothing), not of the tier. One-sided in the same direction as everything else on
+# this gate: attribution can only turn a 4 into a 6, on a POSITIVE uniform-lift
+# measurement against these files — absent, unreadable or thin baselines leave the
+# red exactly as it stands. It is DATA, not a number: the thresholds it is judged
+# against live in tests/lib/tier.sh like every other policy constant.
+declare -a BASELINES=()
 for a in "$@"; do case "$a" in
   --tier=*)   TIER="${a#--tier=}" ;;
   # The seam that lets tests/corpus_tier_budget_unit.sh grade THIS script against a
@@ -195,13 +205,15 @@ for a in "$@"; do case "$a" in
   --drift-fatal=*) DRIFT_FATAL="${a#--drift-fatal=}" ;;
   --runner-id=*) RUNNER_ID="${a#--runner-id=}" ;;
   --prior-over-runner=*) PRIOR_OVER_RUNNER="${a#--prior-over-runner=}" ;;
+  # DIVE-3580: repeatable — pass every shard of the green run, merged by the join.
+  --baseline-report=*) BASELINES+=("${a#--baseline-report=}") ;;
   --top=*)    TOP="${a#--top=}" ;;
   *) printf 'unknown arg: %s\n' "$a" >&2; exit 2 ;;
 esac; done
 
 case "$TIER" in
   core|full) ;;
-  *) printf 'usage: run-harnesses.sh --tier=core|full [--budget=<seconds>] [--label=<env>] [--report=<file>] [--corpus-dir=<dir>] [--confirm-top=<n>] [--no-calibrate] [--cal-us=<us/iter>] [--cal-baseline-us=<us/iter>] [--cal-cli=<path>] [--no-cal-post] [--cal-post-us=<us/iter>] [--cross-runner=off|required] [--runner-id=<id>] [--prior-over-runner=<id>] [--drift-fatal=off|required]\n' >&2; exit 2 ;;
+  *) printf 'usage: run-harnesses.sh --tier=core|full [--budget=<seconds>] [--label=<env>] [--report=<file>] [--corpus-dir=<dir>] [--confirm-top=<n>] [--no-calibrate] [--cal-us=<us/iter>] [--cal-baseline-us=<us/iter>] [--cal-cli=<path>] [--no-cal-post] [--cal-post-us=<us/iter>] [--cross-runner=off|required] [--runner-id=<id>] [--prior-over-runner=<id>] [--drift-fatal=off|required] [--baseline-report=<file>]...\n' >&2; exit 2 ;;
 esac
 [[ "$CONFIRM_TOP" =~ ^[0-9]+$ ]] || { printf 'run-harnesses: --confirm-top must be a non-negative integer, got %s\n' "$CONFIRM_TOP" >&2; exit 2; }
 # DIVE-2829: an unrecognised MODE is usage, never a silent fall back to `off`. A typo
@@ -618,6 +630,37 @@ if (( BUDGET > 0 && total_ms > EFF_MS && ${#failed[@]} == 0 && CONFIRM_TOP > 0 )
   done
 fi
 
+# ---------------------------------------------------------------------------------
+# DIVE-3580: ATTRIBUTE AN OVER-BUDGET TOTAL BEFORE THE VERDICT STANDS.
+#
+# Runs ONLY when this run is otherwise headed for exit 4 (over the effective cap,
+# nothing failed, budget measurable) AND the caller supplied baseline reports from a
+# GREEN run. Verdict and thresholds live in tests/lib/tier.sh; what happens here is
+# mechanics: the in-memory per-harness vector goes to a temp TSV (the --report file
+# may not exist and is not owed one), and the verdict is carried to the report, the
+# over-budget print and the exit ladder. See the tier.sh block for the #708
+# measurement, the one-sidedness argument and the two named residuals.
+ATTR_VERDICT="off"; ATTR_DETAIL=""
+if (( BUDGET > 0 && undetermined == 0 && total_ms > EFF_MS && ${#failed[@]} == 0 && ${#BASELINES[@]} > 0 )); then
+  _attr_red="$(mktemp "${TMPDIR:-/tmp}/run-harnesses-attr.XXXXXX" 2>/dev/null)" || _attr_red=""
+  if [[ -n "$_attr_red" ]]; then
+    for i in "${!NAME[@]}"; do printf '%s\t%s\t%s\n' "${MS[$i]}" "${RC[$i]}" "${NAME[$i]}"; done > "$_attr_red"
+    if ATTR_DETAIL="$(tier_budget_attribution "$EFF_MS" "$_attr_red" "${BASELINES[@]}")"; then :; fi
+    rm -f "$_attr_red" 2>/dev/null || true
+    # The verdict word travels in the line itself; parse it back out rather than
+    # inferring it from the exit status, so a usage error (exit 2, empty line)
+    # reads as unmeasurable and not as anything stronger.
+    case "$ATTR_DETAIL" in
+      verdict=runner\ *)        ATTR_VERDICT="runner" ;;
+      verdict=corpus\ *)        ATTR_VERDICT="corpus" ;;
+      verdict=unmeasurable\ *)  ATTR_VERDICT="unmeasurable" ;;
+      *)                         ATTR_VERDICT="unmeasurable"; ATTR_DETAIL="verdict=unmeasurable reason=attribution-did-not-run" ;;
+    esac
+  else
+    ATTR_VERDICT="unmeasurable"; ATTR_DETAIL="verdict=unmeasurable reason=no-tempfile"
+  fi
+fi
+
 # DIVE-2555: GRADE EACH HEADER'S OWN NUMBER AGAINST THE CLOCK THAT JUST RAN IT.
 #
 # `# TIER: nightly — 14.3s measured` is the entire argument a reviewer gets that a
@@ -689,6 +732,13 @@ if [[ -n "$REPORT" ]]; then
     # whether this run was even allowed to exit 5, so a later reader does not have to date
     # the YAML to know what the number meant.
     printf '# header_drift_wrong=%d\n# drift_fatal_policy=%s\n' "$drift_wrong" "$DRIFT_FATAL"
+    # DIVE-3580: appended on the same append-never-substitute terms. budget_attribution
+    # is UNCONDITIONAL for the DIVE-3188 reason — `off` is a GRADED "not consulted"
+    # (no baseline, or nothing to attribute), and a missing field must keep meaning a
+    # pre-DIVE-3580 report rather than defaulting to anything. The confirm jobs key
+    # their pass/fail on this field plus the exit code, so it is load-bearing, not log.
+    printf '# budget_attribution=%s\n# budget_attribution_detail=%s\n' \
+      "$ATTR_VERDICT" "${ATTR_DETAIL:--}"
     for i in "${!NAME[@]}"; do printf '%s\t%s\t%s\n' "${MS[$i]}" "${RC[$i]}" "${NAME[$i]}"; done
   } > "$REPORT"
 fi
@@ -930,6 +980,30 @@ elif (( total_ms > EFF_MS )); then
     printf '    fd81f7b attempt 1  324s (108%%)  RED        fd81f7b attempt 2  291s (96%%)  green\n'
     printf 'Only if the SECOND runner is also over is the finding below about your corpus.\n'
   fi
+  # DIVE-3580: WHAT THE BASELINE COMPARISON SAYS, when one was available. Printed in
+  # all three arms so an unarmed run and a satisfied one cannot read the same — the
+  # DIVE-2829 lesson, one instrument over. The verdict's effect is applied at the
+  # exit ladder; this is the human-readable half.
+  if [[ "$ATTR_VERDICT" == "runner" ]]; then
+    printf '\nATTRIBUTED TO THE RUNNER (DIVE-3580) — THIS IS EXIT 6 (UNDETERMINED), NOT EXIT 4.\n'
+    printf 'Against the supplied green-run baseline, this corpus FITS the cap at baseline prices\n'
+    printf 'and the overage is a lift spread across unrelated harnesses, which is what a slow box\n'
+    printf 'does and what corpus growth does not (measured on #708: uniform 1.32x across 172\n'
+    printf 'files, refuted by the next green run of the same corpus at 77%% of cap):\n'
+    printf '    %s\n' "$ATTR_DETAIL"
+    printf 'A second box agreeing does not un-say this: both boxes drew from the same fleet in\n'
+    printf 'the same hour (DIVE-2829 confirmed the #708 red that main then refuted). No corpus\n'
+    printf 'finding is made; nothing here says your corpus is inside its cap either.\n'
+  elif [[ "$ATTR_VERDICT" == "corpus" ]]; then
+    printf '\nBASELINE ATTRIBUTION AGREES WITH THIS RED (DIVE-3580): against the supplied green-run\n'
+    printf 'baseline the overage is in the CORPUS — new files, or growth concentrated in the files\n'
+    printf 'that grew — not spread as runner weather. Exit 4 stands:\n'
+    printf '    %s\n' "$ATTR_DETAIL"
+  elif [[ "$ATTR_VERDICT" == "unmeasurable" ]]; then
+    printf '\nBASELINE ATTRIBUTION COULD NOT BE TAKEN (DIVE-3580): %s\n' "$ATTR_DETAIL"
+    printf 'The red stands exactly as it would have before this instrument existed — relief is\n'
+    printf 'granted only on a positive measurement, never on a missing one.\n'
+  fi
   # DIVE-2728: measured against the EFFECTIVE cap, so the covering set is the set that
   # actually gets this run inside the cap it was graded on. And the line above it says
   # so out loud, because "over by 22s" against an unstated cap is how a reader ends up
@@ -1094,6 +1168,11 @@ fi
 # ORDER — this is checked before `over`, so it can only ever turn a 4 into a 6; `over`
 # is still set, still printed, and still the thing a second box confirms.
 (( cross_unconfirmed == 0 )) || exit 6
+# DIVE-3580: an over-budget total the baseline comparison pins on the RUNNER resolves
+# in the same slot, for the same reason, and with the same one-sidedness: 4 -> 6 only,
+# decided on a positive measurement against a named green run. corpus and unmeasurable
+# fall through and keep their 4 — the gate is weakened for nothing it did not measure.
+if (( over == 1 )) && [[ "$ATTR_VERDICT" == "runner" ]]; then exit 6; fi
 (( over == 0 )) || exit 4
 # DIVE-3163: EXIT 5 IS NOW OPT-IN AND THE DEFAULT IS A WARNING. The gate this used to be
 # was a one-box assertion about a cause it cannot measure (the three samples are beside the

--- a/tests/budget_attribution_unit.sh
+++ b/tests/budget_attribution_unit.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# DIVE-3580 — THE BUDGET RED'S BASELINE ATTRIBUTION, GRADED AT BOTH LAYERS.
+#
+# WHAT FORCED IT: PR #708 was red-blocked at 306s/300s, CONFIRMED on a second runner
+# (DIVE-2829), and main's own next run of the SAME 172-harness corpus read 232s (77%)
+# and 200s (66%). Two boxes are not independent when the fleet draws slow the same
+# hour, so the confirm rail gained a third instrument: compare the red run's
+# per-harness vector against the last GREEN main run's over the COMMON file set —
+# a uniform lift across unrelated files is the box, concentration or new files are
+# the corpus. tests/lib/tier.sh (the DIVE-3580 block) carries the derivation, the
+# thresholds and the two named residuals; this harness holds every arm of the verdict
+# open, and the NEGATIVE arms are the load-bearing half: the instrument may only ever
+# RELIEVE a red (4 -> 6), so the arms that matter most are the ones proving a missing,
+# thin or disagreeing baseline leaves exit 4 exactly where it stands today.
+#
+# Core tier on purpose: ~7s, dominated by five 8-file fixture-corpus runs, and it
+# guards the verdict logic of the gate every PR is graded by.
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+# DIVE-2692 + TMP cleanup folded into ONE trap (bash keeps only the last per signal).
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 2
+ROOT="$PWD"
+RUNNER="$ROOT/scripts/run-harnesses.sh"
+TIERLIB="$ROOT/tests/lib/tier.sh"
+
+TMP="$(mktemp -d /tmp/budget-attribution.XXXXXX)" || exit 2
+CORPUS="$TMP/corpus"; mkdir -p "$CORPUS"
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s\n     %s\n' "$1" "${2:-}"; }
+want() { if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1" "expected [$2] got [$3]"; fi; }
+has() { if [[ "$2" == *"$3"* ]]; then ok "$1"; else bad "$1" "missing [$3] in: $2"; fi; }
+hasnt() { if [[ "$2" != *"$3"* ]]; then ok "$1"; else bad "$1" "unexpectedly found [$3] in: $2"; fi; }
+
+attr() { OUT="$(bash "$TIERLIB" attribute "$@" 2>&1)"; RC=$?; }
+
+# Fixture vectors. ms<TAB>rc<TAB>path, the run-harnesses report body shape. The
+# uniform pair is #708's shape scaled down: every common file lifted ~1.3x, no file
+# dominating; the baseline prices the corpus comfortably inside the cap.
+mkvec() { # <file> <ms-per-file> <count> [prefix]
+  local f="$1" ms="$2" n="$3" p="${4:-tests/fx}" i
+  : > "$f"; for (( i = 1; i <= n; i++ )); do printf '%s\t0\t%s%02d.sh\n' "$ms" "$p" "$i" >> "$f"; done
+}
+
+# --- 1-7: the verdict function, every arm ------------------------------------
+mkvec "$TMP/base.txt" 1000 10                     # baseline: 10 files x 1.0s = 10s
+mkvec "$TMP/red-uniform.txt" 1300 10              # red: same 10 files x 1.3s = 13s
+attr 12000 "$TMP/red-uniform.txt" "$TMP/base.txt" # cap 12s: over at 13s, fits at 10s
+want "a uniform 1.3x lift that fits at baseline prices is the RUNNER (exit 0)" "0" "$RC"
+has  "…and says so with its numbers" "$OUT" "verdict=runner reason=uniform-lift-fits-at-baseline-prices"
+
+{ mkvec "$TMP/red-conc.txt" 1000 9; printf '4000\t0\ttests/fx10.sh\n' >> "$TMP/red-conc.txt"; }
+attr 12000 "$TMP/red-conc.txt" "$TMP/base.txt"    # one file +3s carries all the excess
+want "growth concentrated in one existing file is the CORPUS (exit 1)" "1" "$RC"
+has  "…named as concentration, not as weather" "$OUT" "verdict=corpus reason=concentrated-excess"
+
+{ cp "$TMP/base.txt" "$TMP/red-new.txt"; printf '5000\t0\ttests/newA.sh\n' >> "$TMP/red-new.txt"; }
+attr 12000 "$TMP/red-new.txt" "$TMP/base.txt"     # 10s common + 5s new = 15s > 12s cap
+want "new files that reprice the corpus over its cap are the CORPUS" "1" "$RC"
+# ORDER ARM: the new file drops common cover to 67%, under the 80% floor — repriced
+# must be judged FIRST or real growth reads as "could not measure".
+has  "…convicted as over-at-baseline-prices even though the new file thins the cover" \
+  "$OUT" "verdict=corpus reason=over-at-baseline-prices"
+
+# One surviving common file lifted 3.5x, ten renamed files: repriced (1s common at
+# baseline + 1s renamed at their own price) FITS the 4s cap, so what fires is the
+# 77% cover against the 80% floor — the relief refusal, not a conviction.
+{ mkvec "$TMP/red-thin.txt" 100 10 tests/renamed; printf '3500\t0\ttests/fx01.sh\n' >> "$TMP/red-thin.txt"; }
+attr 4000 "$TMP/red-thin.txt" "$TMP/base.txt"
+want "a mostly-renamed corpus (thin common set) is UNMEASURABLE, never relief" "1" "$RC"
+has  "…and says which refusal it is" "$OUT" "verdict=unmeasurable reason=thin-common-set"
+
+: > "$TMP/base-empty.txt"
+attr 12000 "$TMP/red-uniform.txt" "$TMP/base-empty.txt"
+want "an empty baseline is UNMEASURABLE (exit 1)" "1" "$RC"
+has  "…as no-common-measurement" "$OUT" "verdict=unmeasurable reason=no-common-measurement"
+
+attr 12000 "$TMP/red-uniform.txt" "$TMP/no-such-file.txt"
+want "an unreadable baseline is UNMEASURABLE, not an error that greens anything" "1" "$RC"
+has  "…and names the unreadable file class" "$OUT" "verdict=unmeasurable reason=baseline-unreadable"
+
+attr notanumber "$TMP/red-uniform.txt" "$TMP/base.txt"
+want "a non-integer cap is USAGE (exit 2), not a verdict" "2" "$RC"
+
+# --- 8-12: the runner wiring, end to end --------------------------------------
+mk() { printf '#!/usr/bin/env bash\nsleep 0.15\nexit 0\n' > "$CORPUS/$1"; }
+for i in 1 2 3 4 5 6 7 8; do mk "h$i.sh"; done
+for i in 1 2 3 4 5 6 7 8; do printf '100\t0\t%s/h%d.sh\n' "$CORPUS" "$i"; done > "$TMP/cb-uniform.txt"
+for i in 1 2 3 4 5 6 7 8; do printf '160\t0\t%s/h%d.sh\n' "$CORPUS" "$i"; done > "$TMP/cb-heavy.txt"
+
+run() { OUT="$(bash "$RUNNER" --no-calibrate --corpus-dir="$CORPUS" --tier=core --confirm-top=0 "$@" 2>&1)"; RC=$?; }
+
+run --budget=1 --label=t --report="$TMP/r-runner.txt" --baseline-report="$TMP/cb-uniform.txt"
+want "over + uniform-lift baseline resolves 4 -> 6 (UNDETERMINED, no corpus finding)" "6" "$RC"
+has  "…the report carries the graded verdict" "$(cat "$TMP/r-runner.txt")" "# budget_attribution=runner"
+has  "…and the human print says which exit and why" "$OUT" "ATTRIBUTED TO THE RUNNER (DIVE-3580)"
+
+run --budget=1 --label=t --report="$TMP/r-off.txt"
+want "the SAME over-budget corpus with NO baseline keeps its exit 4 — relief is strictly opt-in" "4" "$RC"
+has  "…and the report says the instrument was not consulted (a graded off, not an absence)" \
+  "$(cat "$TMP/r-off.txt")" "# budget_attribution=off"
+
+run --budget=1 --label=t --report="$TMP/r-corpus.txt" --baseline-report="$TMP/cb-heavy.txt"
+want "a baseline that agrees the corpus is over leaves exit 4 standing" "4" "$RC"
+has  "…recorded as a corpus verdict" "$(cat "$TMP/r-corpus.txt")" "# budget_attribution=corpus"
+
+run --budget=60 --label=t --report="$TMP/r-green.txt" --baseline-report="$TMP/cb-uniform.txt"
+want "a green run with a baseline supplied stays green — attribution touches only a would-be 4" "0" "$RC"
+has  "…and its report reads off" "$(cat "$TMP/r-green.txt")" "# budget_attribution=off"
+
+printf '#!/usr/bin/env bash\nexit 1\n' > "$CORPUS/h9.sh"
+run --budget=1 --label=t --report="$TMP/r-fail.txt" --baseline-report="$TMP/cb-uniform.txt"
+want "a FAILING harness still dominates: exit 1, never a weather downgrade over a red test" "1" "$RC"
+rm -f "$CORPUS/h9.sh"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+(( fail == 0 )) || exit 1
+exit 0

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -693,6 +693,34 @@ if grep -rn -- '--confirm-top' .github/workflows/ >/dev/null 2>&1; then
   bad "no CI workflow passes --confirm-top" "$(grep -rn -- '--confirm-top' .github/workflows/)"
 else ok "no CI workflow passes --confirm-top"; fi
 
+# --- DIVE-3580: the baseline attribution's CI wiring, pinned HERE because this
+# harness is the one workflow-structure-guards runs UNCONDITIONALLY on every PR —
+# a workflow-only edit selects no tests/*.sh harness, so an arm living in
+# tests/budget_attribution_unit.sh would grade the removal of the fetch step
+# nightly, after the merge (the DIVE-3479 lesson, applied at introduction).
+_wf3580=.github/workflows/unit-tests.yml
+_bfetch="$(grep -c 'fetch-budget-baseline\.sh' "$_wf3580" || true)"
+if [[ "$_bfetch" == 2 ]]; then
+  ok "BOTH confirm jobs fetch the attribution baseline through the ONE shared script (DIVE-3580)"
+else bad "both confirm jobs fetch the attribution baseline through the one shared script" "count=$_bfetch (want 2)"; fi
+[[ -r .github/scripts/fetch-budget-baseline.sh ]] \
+  && ok "…and the shared script exists where the workflow points" \
+  || bad "…and the shared script exists where the workflow points" "no file at .github/scripts/fetch-budget-baseline.sh"
+# The hand-off grep discipline: exit 6 has more than one producer in a confirm job
+# (calibration undetermined, attribution), and only the ATTRIBUTED one — graded,
+# positive, in the report — may resolve the job green. Pin the exact grep, twice.
+_bhand="$(grep -cF "grep -q '^# budget_attribution=runner\$'" "$_wf3580" || true)"
+if [[ "$_bhand" == 2 ]]; then
+  ok "BOTH confirm jobs hand off ONLY the attributed 6 (the graded-field grep, exactly twice)"
+else bad "both confirm jobs hand off only the attributed 6" "count=$_bhand (want 2)"; fi
+# And the flag stays where a second box has already agreed: the two confirm
+# invocations, nowhere else — a first-box job passing it would grant relief no
+# second runner earned, one job earlier than DIVE-2829 allows.
+_bflag="$(grep -rh -- '--baseline-report=' .github/workflows/ | grep -vc '^[[:space:]]*#' || true)"
+if [[ "$_bflag" == 2 ]]; then
+  ok "no non-confirm CI invocation passes --baseline-report (2 sites, both confirm jobs)"
+else bad "no non-confirm CI invocation passes --baseline-report" "count=$_bflag (want 2)"; fi
+
 # --- DIVE-2667: the tier must run often enough to ATTRIBUTE a break ------------
 # The nightly was red on main for ~17h across ~12 commits because full-sweep ran
 # once a day and is not in the per-PR check set. Two properties are pinned here,

--- a/tests/lib/tier.sh
+++ b/tests/lib/tier.sh
@@ -361,6 +361,137 @@ tier_cal_diverge_pct() {
   printf '%s\n' "$(( (post - pre) * 100 / pre ))"
 }
 
+# ------------------------------------------------------------------ DIVE-3580
+# ATTRIBUTE A CONFIRMED BUDGET RED BEFORE IT BLOCKS A MERGE.
+#
+# WHAT FORCED THIS (PR #708, 2026-08-18, wiki: refute-a-budget-red-with-the-next-
+# green-run-of-the-same-corpus): a graded-PASS PR was red-blocked at 306s/300s,
+# CONFIRMED on a second runner per DIVE-2829 — and main's own next run of the SAME
+# 172-harness corpus read 232s (77%) and 200s (66%). The corpus was never over.
+# Two boxes agreeing is not independence when the whole fleet draws slow the same
+# hour, and the calibration probe read the slow box at 90% (fast) while the
+# harnesses drew 129% (slow) — measured anti-correlated, again (DIVE-2736).
+#
+# THE DISCRIMINATOR THE CONFIRM JOB DID NOT HAVE, derived by hand twice on #708
+# (quinn per-file from raw logs, olivia from the next main run) and mechanical
+# here: compare this run's PER-HARNESS vector against the last GREEN main run's,
+# over the COMMON file set. A lift spread evenly across UNRELATED harnesses is
+# the box; real corpus growth is CONCENTRATED in the files that grew (or lives in
+# files the baseline has never seen, which reprice as themselves).
+#
+# ONE-SIDED, like every override on this gate: the verdict below can only turn a
+# would-be exit 4 into exit 6 (no corpus finding), never a 6 into a 4 and never a
+# green into anything. No baseline, a thin common set, or any parse failure keeps
+# the red exactly as it stands today — relief is granted only on a POSITIVE
+# measurement against a NAMED green run.
+#
+# THE TWO RESIDUALS, NAMED (each is the other instrument's job):
+#   * UNIFORM REAL GROWTH — a shared helper that slows every harness reads as
+#     weather here. That event is exactly what the DIVE-3477 growth tripwire's
+#     windowed us/harness median exists to catch, out of band, against a FIXED
+#     reference this comparison deliberately is not.
+#   * SINGLE-FILE WEATHER — a network-priced file spiking on BOTH boxes reads as
+#     concentrated, i.e. corpus. Bounded by DIVE-2592: both runs already re-timed
+#     their top-3 and kept the min, so a spike must survive min-of-two twice
+#     before it can reach this verdict at all.
+#
+# THE THRESHOLDS, derived from the one fully-measured weather pair (#708 confirm
+# 308s vs main-green 232s, same 172 files) rather than picked: top-3 excess share
+# measured 17% there, while growth concentrated in <=3 files is >=~100% by
+# construction — 50 sits ~3x above the measured weather case and strictly below
+# any small-set growth. Common-set cover measured 100%; below 80 the comparison
+# is about a different corpus and refuses. Starting values, policy like the clamp
+# pair — refutable by the next measured case, in this file, with its evidence.
+TIER_ATTR_TOP_EXCESS_N=3
+TIER_ATTR_CONC_MAX_PCT=50
+TIER_ATTR_MIN_COMMON_COVER_PCT=80
+
+# tier_budget_attribution <effective_cap_ms> <red_report> <baseline_report>...
+#
+# Reports are run-harnesses.sh TSV bodies (ms<TAB>rc<TAB>path; '#' headers are
+# skipped). Baseline reports are merged, so passing every shard of the green run
+# makes shard drift irrelevant: files are joined by NAME, and the red shard's
+# files are looked up in the whole green corpus.
+#
+# Prints ONE line:
+#   verdict=<runner|corpus|unmeasurable> reason=<slug> lift_pct=N common=N \
+#     common_cover_pct=N repriced_s=N top_excess_share_pct=N new_files=N new_s=N
+# Exit 0 only on verdict=runner (a downgrade is admissible); 1 otherwise; 2 usage.
+# The three verdicts are spelled apart for the tier_cal_ref_admissible reason: a
+# caller that cannot tell "the corpus grew" from "I could not measure" will answer
+# the wrong one.
+tier_budget_attribution() {
+  local cap_ms="${1:?tier_budget_attribution <effective_cap_ms> <red_report> <baseline_report>...}"
+  local red="${2:?tier_budget_attribution <effective_cap_ms> <red_report> <baseline_report>...}"
+  shift 2
+  [[ "$cap_ms" =~ ^[0-9]+$ ]] || { printf 'tier_budget_attribution: cap_ms must be an integer of milliseconds, got %s\n' "$cap_ms" >&2; return 2; }
+  (( $# >= 1 )) || { printf 'tier_budget_attribution: at least one baseline report is required\n' >&2; return 2; }
+  [[ -r "$red" ]] || { printf 'verdict=unmeasurable reason=red-report-unreadable\n'; return 1; }
+  local b unreadable=0
+  for b in "$@"; do [[ -r "$b" ]] || unreadable=1; done
+  if (( unreadable )); then printf 'verdict=unmeasurable reason=baseline-unreadable\n'; return 1; fi
+  awk -F'\t' -v cap_ms="$cap_ms" -v red="$red" \
+      -v topn="$TIER_ATTR_TOP_EXCESS_N" -v conc_max="$TIER_ATTR_CONC_MAX_PCT" \
+      -v min_cover="$TIER_ATTR_MIN_COMMON_COVER_PCT" '
+    /^#/ { next }
+    NF >= 3 && $1 ~ /^[0-9]+$/ && $2 == "0" {
+      if (FILENAME == red) { redms[$3] = $1 } else { basems[$3] = $1 }
+    }
+    END {
+      done = 0
+      for (f in redms) {
+        red_total += redms[f]
+        if (f in basems) {
+          common++; src += redms[f]; sbc += basems[f]
+          ex = redms[f] - basems[f]
+          if (ex > 0) { excess[f] = ex; tex += ex }
+        } else { newf++; srn += redms[f] }
+      }
+      out = "lift_pct=%d common=%d common_cover_pct=%d repriced_s=%d top_excess_share_pct=%d new_files=%d new_s=%d\n"
+      if (red_total <= 0 || common == 0 || sbc <= 0) {
+        printf "verdict=unmeasurable reason=no-common-measurement " out, 0, common, 0, 0, 0, newf, srn/1000
+        exit 1
+      }
+      cover = src * 100 / red_total
+      lift = src * 100 / sbc
+      repriced = sbc + srn
+      # Top-N per-file excess share. asorti by value is gawk-only; ubuntu-latest
+      # ships mawk-compatible gawk but the control plane may not, so select the
+      # top N by scan — N is 3, the corpus is a few hundred, O(N*n) is nothing.
+      top = 0
+      for (k = 0; k < topn; k++) {
+        bestf = ""; best = 0
+        for (f in excess) if (!(f in used) && excess[f] > best) { best = excess[f]; bestf = f }
+        if (bestf == "") break
+        used[bestf] = 1; top += best
+      }
+      share = (tex > 0) ? top * 100 / tex : 0
+      # REPRICED BEFORE COVER, deliberately: new files lower the cover by existing,
+      # and a corpus that is over the cap even at baseline prices (common files at
+      # the green run cost, new files at their own) has grown whatever the cover
+      # says. Cover only gates the RELIEF verdict — a thin common set cannot
+      # support a uniformity claim, but it can still convict a repriced overage.
+      if (repriced > cap_ms) {
+        printf "verdict=corpus reason=over-at-baseline-prices " out, lift, common, cover, repriced/1000, share, newf, srn/1000
+        exit 1
+      }
+      if (cover < min_cover) {
+        printf "verdict=unmeasurable reason=thin-common-set " out, lift, common, cover, repriced/1000, share, newf, srn/1000
+        exit 1
+      }
+      if (tex <= 0) {
+        printf "verdict=unmeasurable reason=no-excess-to-attribute " out, lift, common, cover, repriced/1000, share, newf, srn/1000
+        exit 1
+      }
+      if (share >= conc_max) {
+        printf "verdict=corpus reason=concentrated-excess " out, lift, common, cover, repriced/1000, share, newf, srn/1000
+        exit 1
+      }
+      printf "verdict=runner reason=uniform-lift-fits-at-baseline-prices " out, lift, common, cover, repriced/1000, share, newf, srn/1000
+      exit 0
+    }' "$red" "$@"
+}
+
 # DIVE-2867: WHO IS ALLOWED TO MOVE TIER_CAL_BASELINE_US, AND ON WHAT EVIDENCE.
 #
 # The constant above has now been re-derived twice by argument (173000 -> 119000, then a
@@ -647,6 +778,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     clamp)  tier_cal_clamp_pct "${2:?clamp <raw_pct>}" ;;
     diverge) tier_cal_diverge_pct "${2:?diverge <pre_us> <post_us>}" "${3:?diverge <pre_us> <post_us>}" ;;
     refadmit) shift; tier_cal_ref_admissible "${1:?refadmit <candidate_us> <current_us> <concordant_sample>...}" "${2:?refadmit <candidate_us> <current_us> <concordant_sample>...}" "${@:3}" ;;
-    *) printf 'usage: tier.sh {list core|nightly|full [dir] | of <file> | reason <file> | claim <file> | budget core|full | scale <us> [baseline] | clamp <pct> | diverge <pre_us> <post_us> | refadmit <candidate_us> <current_us> <concordant_sample>...}\n' >&2; exit 2 ;;
+    attribute) shift; tier_budget_attribution "${1:?attribute <effective_cap_ms> <red_report> <baseline_report>...}" "${2:?attribute <effective_cap_ms> <red_report> <baseline_report>...}" "${@:3}" ;;
+    *) printf 'usage: tier.sh {list core|nightly|full [dir] | of <file> | reason <file> | claim <file> | budget core|full | scale <us> [baseline] | clamp <pct> | diverge <pre_us> <post_us> | refadmit <candidate_us> <current_us> <concordant_sample>... | attribute <effective_cap_ms> <red_report> <baseline_report>...}\n' >&2; exit 2 ;;
   esac
 fi


### PR DESCRIPTION
## What

A confirmed budget red now attributes itself against the last GREEN main run before it blocks a merge. A lift spread uniformly across unrelated harnesses — the shape a slow box produces and corpus growth does not — resolves as exit 6 with `budget_attribution=runner` (no corpus finding) instead of exit 4, and the confirm job passes with the verdict in its log and artifact. Everything else keeps its red.

## Why (DIVE-3580, split out of DIVE-3579)

PR #708, graded PASS, was red-blocked at 306s/300s on `core-pristine-confirm` — confirmed on a second runner per DIVE-2829 — and main's own next run of the SAME 172-harness corpus read 232s (77% of cap) and 200s (66%). The corpus was never over. A second box is not independent when the whole fleet draws slow the same hour, and the calibration probe read the slow box at 90% (fast) while the harnesses drew 129% (slow) — the measured anti-correlation again (DIVE-2736/3163). Wiki: `refute-a-budget-red-with-the-next-green-run-of-the-same-corpus`, `attribute-a-sharded-budget-red-by-summing-the-common-harness-set`.

## How

- `tests/lib/tier.sh` — `tier_budget_attribution <cap_ms> <red_report> <baseline>...`: joins per-harness vectors by file name (baseline shards merged, so shard re-splits don't matter), then: over even at baseline prices → **corpus**; common cover < 80% → **unmeasurable**; top-3 per-file excess ≥ 50% of total excess → **corpus**; else **runner**. Thresholds derived from the #708 pair (measured top-3 share 17%, cover 100%) and written beside the constants with the two named residuals: uniform REAL growth reads as weather here and is the DIVE-3477 tripwire's job; single-file weather reads as corpus and has already survived DIVE-2592's min-of-two re-timing on BOTH boxes.
- `scripts/run-harnesses.sh` — `--baseline-report=` (repeatable). Strictly one-sided: consulted only when the run is otherwise headed for exit 4; only a positive `runner` verdict downgrades (4→6). Report fields appended, never substituted; `budget_attribution=off` is a graded "not consulted".
- `unit-tests.yml` + `.github/scripts/fetch-budget-baseline.sh` — both confirm jobs fetch the last green main `unit-tests` run's report artifacts (one shared script; any fetch failure disarms the relief, changes nothing else, and says so) and pass only the attributed 6 through, by the same grep discipline as the first-box cross-runner hand-off.
- `tests/budget_attribution_unit.sh` (core, ~7s) — all verdict arms at function and runner layer, negatives load-bearing (no baseline → 4 stands; heavy baseline → 4 stands; failing harness dominates; green untouched). CI-wiring arms live in `tests/corpus_tier_budget_unit.sh` so `workflow-structure-guards` grades a workflow-only edit on every PR (the DIVE-3479 lesson).

## Evidence

- Real #708 pair (confirm report 308s vs main-green 232s, same 172 files): `verdict=runner reason=uniform-lift-fits-at-baseline-prices lift_pct=132 common=172 common_cover_pct=100 repriced_s=231 top_excess_share_pct=17`.
- Synthetic single-file +80s growth → `corpus reason=concentrated-excess (share 100%)`; +120s of new files → `corpus reason=over-at-baseline-prices` (judged before the cover check, deliberately).
- Local: `tests/budget_attribution_unit.sh` 23/0 · `tests/corpus_tier_budget_unit.sh` 165/0 · `tests/header_drift_window_unit.sh` 27/0 · `bash -n` + shellcheck clean · actionlint: same single pre-existing info as origin/main.

## What this does NOT do

It does not weaken the gate's existence (DIVE-2525's reverse gear stands: corpus growth, new files, thin baselines, missing baselines, calibration 6s and failing harnesses all keep their verdicts), does not touch thresholds or the cap, and does not reuse the cross-runner control for a question it never measured (DIVE-3163's rule: move the VERDICT, not the threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
