### PR TITLE
feat(buzz): pairing is per SERVER — one QR pairs the phone as the box owner (DIVE-3592)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -91,6 +91,7 @@ cat \
   src/cmd_agent_buzz_join.sh \
   src/cmd_agent_buzz_whois.sh \
   src/cmd_agent_buzz_pair.sh \
+  src/cmd_buzz.sh \
   src/cmd_agent_buzz_bridge.sh \
   src/cmd_agent_telegram.sh \
   src/cmd_agent_teambot.sh \

--- a/changelog.d/DIVE-3592.md
+++ b/changelog.d/DIVE-3592.md
@@ -1,0 +1,13 @@
+- **Pairing is per SERVER, not per agent** (DIVE-3592). `5dive buzz pair` runs
+  ONE pairing session for the box: the handset is paired as the OWNER's
+  identity, and "which agent should your phone pair with?" is no longer a
+  question anyone is asked — whether an agent talks in team chat stays
+  `5dive agent buzz enable <name>`. The owner key moved to
+  `${STATE_DIR}/buzz/owner.json` (root, 0600) and is mirrored into each buzz
+  agent's state dir, so `agent buzz pair <name>` keeps working and now hands out
+  the SAME identity. A key minted before this change is ADOPTED rather than
+  replaced — an already-paired handset keeps its rooms. The verb wires that
+  identity into every buzz agent's channels itself (no hand-run `join`) and
+  REFUSES to pair when it ends up a member of none. Refusals now print
+  `BUZZ-PAIR-RESULT: fail …` and exit non-zero, and a pairing session no longer
+  holds the fleet-wide registry lock for its 600s.

--- a/src/cmd_agent_buzz.sh
+++ b/src/cmd_agent_buzz.sh
@@ -178,7 +178,7 @@ _buzz_enable_last_mile() { # <name> <resolved_bin> <do_join>
   step "Last mile: joining channel(s), adding the customer's key as a member, publishing profile + presence"
   ( _buzz_join "$name" ) || rc=$?
   if ((rc == 0)); then
-    ok "buzz is wired end to end for '$name' — pair a handset with: sudo 5dive agent buzz owner $name --envelope"
+    ok "buzz is wired end to end for '$name' — pair a handset with: sudo 5dive buzz pair (ONE QR for this server, DIVE-3592)"
   else
     warn "buzz enabled for '$name' but the last mile did not fully wire (rc=$rc). A handset will land in a room the agent may not be in. Re-run: sudo 5dive agent buzz join $name"
   fi

--- a/src/cmd_agent_buzz_join.sh
+++ b/src/cmd_agent_buzz_join.sh
@@ -254,30 +254,114 @@ print("    resolved channel ids written to " + path)
 ' >&2
 }
 
-# Mint (once) the customer's handset identity. Same one-key-per-agent rule the
-# agent's own identity follows: a re-run must not rotate a key a paired handset
-# already holds, or the customer silently loses the room.
-_buzz_owner_key() { # <name> <user> [rotate]
-  local name="$1" user="$2" rotate="${3:-false}" state file key=""
-  state=$(_buzz_state_dir "$name")
-  file="${state}/owner.json"
-  if [[ "$rotate" != "true" ]]; then
-    key=$(sudo -u "$user" python3 -c "
+# ---------------------------------------------------------------------------
+# THE OWNER IDENTITY IS PER SERVER, NOT PER AGENT (DIVE-3592).
+#
+# One phone, one QR, one identity. "Which agent should your phone pair with?"
+# was an artifact of this key being minted per agent, and it is the wrong
+# question: the handset belongs to the person who owns the BOX. The only
+# per-agent choice is whether an agent talks in team chat, and that one already
+# has its own verb (`agent buzz enable`).
+#
+# The key lives at ${STATE_DIR}/buzz/owner.json (root-owned, 0600) and is
+# MIRRORED into each buzz agent's state dir. The mirror is a COPY, never a
+# second identity: the pairing session runs as the agent user and `agent buzz
+# owner <name>` reads it there, so every existing reader keeps working and they
+# now all answer with the SAME key. A mirror that has drifted from the server
+# key is the bug this row exists to end, so the mirror is rewritten on every
+# call rather than only when missing.
+#
+# ADOPTION, not a fresh mint, when the server file is absent and an agent
+# already holds an owner key: a handset paired before this change holds THAT
+# nsec, and minting a new server key would evict it from every room while every
+# surface still reported success. Adoption is deterministic (registry order)
+# and says out loud whose key became the server's.
+# ---------------------------------------------------------------------------
+_buzz_server_owner_file() { printf '%s/buzz/owner.json\n' "$STATE_DIR"; }
+
+# Read `private_key` out of an owner.json AS <user> (the file is 0600 and
+# agent-owned; root passes -u for the mirrors it did not write). Prints the key
+# or nothing — never fails the caller, because "absent" is a normal answer here.
+_buzz_read_owner_key() { # <user> <file>
+  local out
+  out=$(sudo -u "$1" python3 -c "
 import json, sys
 try:
-    print(json.load(open(sys.argv[1])).get('private_key', ''))
+    print(json.load(open(sys.argv[1])).get('private_key', '') or '')
 except Exception:
     print('')
-" "$file" 2>/dev/null || echo "")
+" "$2" 2>/dev/null) || out=""
+  printf '%s' "${out//[$'\n\r\t ']/}"
+}
+
+# Every agent that has a buzz config, in registry order. The predicate is the
+# CONFIG, not the registry's channel list: a seat whose channels were declared
+# but never enabled has no relay and no key, and joining on its behalf would be
+# a relay call with nothing to make it with.
+_buzz_enabled_agents() {
+  local reg names n
+  reg=$(registry_read)
+  names=$(jq -r '(.agents // {}) | keys[]?' <<<"$reg" 2>/dev/null) || names=""
+  while IFS= read -r n; do
+    [[ -n "$n" ]] || continue
+    if sudo -u "agent-$n" test -f "$(_buzz_state_dir "$n")/config.json" 2>/dev/null; then
+      printf '%s\n' "$n"
+    fi
+  done <<<"$names"
+  return 0
+}
+
+# The server-level owner key: read it, else adopt an agent's, else mint one.
+# <rotate>=true forces a NEW key — which evicts every already-paired handset
+# from every room, so it is only reachable through an explicit flag.
+_buzz_server_owner_key() { # [rotate]
+  local rotate="${1:-false}" file key="" adopted="" a cand
+  file=$(_buzz_server_owner_file)
+  if [[ "$rotate" != "true" ]]; then
+    key=$(_buzz_read_owner_key "$(id -un)" "$file")
+    if [[ ! "$key" =~ ^[0-9a-fA-F]{64}$ ]]; then
+      while IFS= read -r a; do
+        [[ -n "$a" ]] || continue
+        cand=$(_buzz_read_owner_key "agent-$a" "$(_buzz_state_dir "$a")/owner.json")
+        if [[ "$cand" =~ ^[0-9a-fA-F]{64}$ ]]; then key="$cand"; adopted="$a"; break; fi
+      done < <(_buzz_enabled_agents)
+    fi
   fi
   if [[ ! "$key" =~ ^[0-9a-fA-F]{64}$ ]]; then
     key=$(openssl rand -hex 32 2>/dev/null) \
-      || { echo "openssl is required to mint the customer's pairing key" >&2; return 1; }
-    local pub
-    pub=$(printf '%s' "$key" | _buzz_xonly_pubkey) || return 1
-    # Written by the same stdin discipline as config.json — 0600, agent-owned,
-    # and the key is never an argv element.
-    printf '%s' "$key" | sudo -u "$user" env STATE="$state" PUB="$pub" python3 -c '
+      || { echo "openssl is required to mint the owner pairing key" >&2; return 1; }
+  fi
+  local pub
+  pub=$(printf '%s' "$key" | _buzz_xonly_pubkey) || return 1
+  # Root-owned, 0600, and the key is never an argv element — the same discipline
+  # config.json and the mirrors below are written with.
+  printf '%s' "$key" | env OWNER_FILE="$file" PUB="$pub" python3 -c '
+import json, os, sys
+key = sys.stdin.read().strip()
+path = os.environ["OWNER_FILE"]
+os.makedirs(os.path.dirname(path), mode=0o700, exist_ok=True)
+fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+with os.fdopen(fd, "w") as f:
+    json.dump({"private_key": key, "pubkey": os.environ["PUB"],
+               "role": "owner", "scope": "server",
+               "note": "the BOX OWNER handset identity (DIVE-3592) — one per server, transferred by the DIVE-3300 pairing envelope. Mirrored per agent; not any agent key."}, f, indent=2)
+os.chmod(path, 0o600)
+' >&2 || return 1
+  if [[ -n "$adopted" ]]; then
+    step "Owner identity adopted from agent '$adopted' (${pub:0:16}…) — a handset paired before DIVE-3592 holds this key, so it keeps its rooms."
+  fi
+  printf '%s\n' "$key"
+}
+
+# The customer's handset identity, as this agent sees it: the SERVER key,
+# mirrored into the agent's own state dir. Same signature as before, so every
+# caller (join, owner, pair) keeps working — they just all get one key now.
+_buzz_owner_key() { # <name> <user> [rotate]
+  local name="$1" user="$2" rotate="${3:-false}" state key pub
+  state=$(_buzz_state_dir "$name")
+  key=$(_buzz_server_owner_key "$rotate") || return 1
+  pub=$(printf '%s' "$key" | _buzz_xonly_pubkey) || return 1
+  printf '%s' "$key" | sudo -u "$user" env STATE="$state" PUB="$pub" python3 -c '
 import json, os, sys
 key = sys.stdin.read().strip()
 state = os.environ["STATE"]
@@ -286,11 +370,10 @@ path = os.path.join(state, "owner.json")
 fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
 with os.fdopen(fd, "w") as f:
     json.dump({"private_key": key, "pubkey": os.environ["PUB"],
-               "role": "owner",
-               "note": "the CUSTOMER handset identity — transferred by the DIVE-3300 pairing envelope. Not the agent key."}, f, indent=2)
+               "role": "owner", "scope": "server-mirror",
+               "note": "MIRROR of the server owner identity (DIVE-3592). One handset identity per BOX; edit /var/lib/5dive/buzz/owner.json, never this copy."}, f, indent=2)
 os.chmod(path, 0o600)
 ' >&2 || return 1
-  fi
   printf '%s\n' "$key"
 }
 
@@ -497,7 +580,10 @@ _buzz_join() {
   fi
   ok "buzz last mile done for '$name' — ${joined} channel(s) (${created} created), customer key ${owner_pub:0:16}… is a member, profile + presence published."
   ok "The poller picks the resolved ids up on restart: sudo 5dive agent restart $name"
-  ok "Pair a handset: the envelope is \`5dive agent buzz owner $name --envelope\` (relayUrl/pubkey/nsec, DIVE-3300)."
+  # DIVE-3592: the handset is the BOX owner's, so the pairing verb is the server
+  # one. Naming the per-agent form here is what taught the dashboard to ask which
+  # agent a phone belongs to.
+  ok "Pair a handset: sudo 5dive buzz pair — ONE QR for this server (the raw envelope is \`5dive buzz owner --envelope\`, relayUrl/pubkey/nsec, DIVE-3300)."
   return 0
 }
 

--- a/src/cmd_agent_buzz_pair.sh
+++ b/src/cmd_agent_buzz_pair.sh
@@ -82,6 +82,20 @@ _buzz_pair_supports_stdin_nsec() { # <runas> <bin>
   grep -Eq -- "--nsec.*(stdin|'-'|\"-\")" <<<"$help" || grep -Eqi 'reads? the (key|nsec) from stdin' <<<"$help"
 }
 
+# A refusal is a RESULT, on the same stream the panel already parses.
+#
+# The panel drives this verb over a PTY, so the exit status it can see is the
+# shell's, not the verb's: a refusal that only printed `error: …` and exited was
+# indistinguishable from a session that ended normally — which is exactly what
+# lodar's first pairing attempts looked like (2026-08-18, sessions ending in
+# under a second with no markers at all). Every state refusal below prints the
+# terminal marker FIRST and then fails with its code, so the stream carries the
+# verdict and the exit status stays honest for a terminal caller.
+_buzz_pair_refuse() { # <code> <message>
+  printf 'BUZZ-PAIR-RESULT: fail %s\n' "$2"
+  fail "$1" "$2"
+}
+
 # cmd: 5dive agent buzz pair <name> [--timeout=<secs>]
 #
 # Requires `join` to have run (owner.json + the customer pubkey already a
@@ -107,7 +121,7 @@ _buzz_pair() {
   local reg
   reg=$(registry_read)
   jq -e --arg n "$name" '.agents[$n] != null' <<<"$reg" >/dev/null \
-    || fail "$E_NOT_FOUND" "no agent named '$name'"
+    || _buzz_pair_refuse "$E_NOT_FOUND" "no agent named '$name'"
   local user
   user=$(_buzz_pair_user "$name")
 
@@ -115,21 +129,28 @@ _buzz_pair() {
   # already refuses, naming `join`, when owner.json is absent) — reuse it
   # rather than grow a second bech32 implementation.
   local envelope relay nsec
-  envelope=$(_buzz_owner "$name" --envelope) || exit $?
+  # `_buzz_owner` refuses (naming the repair) when the owner identity is absent;
+  # it exits, so the marker has to be printed by whoever sees the non-zero rc.
+  local owner_rc=0
+  envelope=$(_buzz_owner "$name" --envelope) || owner_rc=$?
+  if ((owner_rc != 0)); then
+    printf 'BUZZ-PAIR-RESULT: fail no owner identity for %s (rc=%s; the error above says the repair)\n' "$name" "$owner_rc"
+    exit "$owner_rc"
+  fi
   relay=$(_buzz_pick "d.get('relayUrl')" <<<"$envelope")
   nsec=$(_buzz_pick "d.get('nsec')" <<<"$envelope")
   [[ -n "$relay" && -n "$nsec" ]] \
-    || fail "$E_GENERIC" "could not assemble the pairing envelope for '$name'"
+    || _buzz_pair_refuse "$E_GENERIC" "could not assemble the pairing envelope for '$name'"
 
   local ws_relay
   ws_relay=$(_buzz_relay_to_ws "$relay") \
-    || fail "$E_VALIDATION" "relay_url '$relay' has no ws form — expected an https://, http://, wss:// or ws:// URL"
+    || _buzz_pair_refuse "$E_VALIDATION" "relay_url '$relay' has no ws form — expected an https://, http://, wss:// or ws:// URL"
 
   local pair_bin
-  pair_bin=$(_buzz_resolve_pair_binary "$user") || fail "$E_NOT_INSTALLED" \
+  pair_bin=$(_buzz_resolve_pair_binary "$user") || _buzz_pair_refuse "$E_NOT_INSTALLED" \
     "no \`buzz-pair\` binary for '$name' (the agent's PATH, /usr/local/bin/buzz-pair, /opt/buzz/bin/buzz-pair). It ships beside \`buzz\` in 5dive-ai/buzz release cli-v0.1.0+ — install it, then re-run."
 
-  _buzz_pair_supports_stdin_nsec "$user" "$pair_bin" || fail "$E_NOT_INSTALLED" \
+  _buzz_pair_supports_stdin_nsec "$user" "$pair_bin" || _buzz_pair_refuse "$E_NOT_INSTALLED" \
     "this \`buzz-pair\` ($pair_bin) only accepts the key as a command-line argument, which is world-readable in /proc for the whole session — refusing to leak the customer's handset key. Install buzz-pair cli-v0.1.1+ (supports \`--nsec -\`, key on stdin)."
 
   step "Pairing session for '$name': rendezvous $ws_relay, envelope relay $relay (timeout ${timeout_s}s)"

--- a/src/cmd_buzz.sh
+++ b/src/cmd_buzz.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# DIVE-3592 — `5dive buzz pair`: ONE QR per SERVER.
+#
+# lodar hit the dashboard's "Which agent should your phone pair with?" and
+# rejected the shape: "isnt qr one per server?" — yes, and it is also the
+# recorded design (DIVE-3510). The phone pairs once, at box level, as the
+# OWNER's identity. Whether a given agent talks in team chat is a different
+# question with its own verb (`agent buzz enable <name>`), and it is not asked
+# at pairing time.
+#
+# The per-agent picker existed because the owner key was minted per agent.
+# `_buzz_owner_key` (DIVE-3592, src/cmd_agent_buzz_join.sh) makes that key
+# server-level, so `agent buzz pair <name>` and this verb now hand the handset
+# the SAME identity — the interim per-agent path keeps working and stops being
+# a choice that means anything.
+#
+# WHAT THIS VERB OWNS THAT THE PER-AGENT ONE CANNOT: membership. A handset that
+# is not a member of a channel cannot see it at all (DIVE-3331), so pairing at
+# box level has to wire the owner key into EVERY buzz agent's channels first —
+# and it must do that itself. DIVE-3510's lesson was a hand-added key, and the
+# row that files this one recorded the same failure again: a `join` that has to
+# be run by hand at a sudo prompt is not a product. So the wire-up runs here,
+# and if it leaves the owner in ZERO channels this verb REFUSES to pair rather
+# than hand the customer an identity that opens an empty app.
+#
+# THE MARKER CONTRACT IS THE PANEL'S ONLY SIGNAL (cmd_agent_buzz_pair.sh) and
+# it now covers refusals too: a refusal prints `BUZZ-PAIR-RESULT: fail …`
+# before it exits non-zero. The panel drives this over a PTY, where the exit
+# status it can observe is the SHELL's, not the verb's — so "no markers, no
+# error" was indistinguishable from success (measured on lodar's first pairing
+# attempts, 2026-08-18: sessions ended in under a second and read as ordinary
+# closures). A refusal now says so on the stream.
+
+# cmd: 5dive buzz pair [--timeout=<secs>] [--agent=<name>] [--no-wire]
+_buzz_server_pair() {
+  local timeout_s="600" host="" wire="true"
+  while (($#)); do
+    case "$1" in
+      --timeout=*) timeout_s="${1#*=}" ;;
+      --agent=*)   host="${1#*=}" ;;
+      --no-wire)   wire="false" ;;
+      -*) fail "$E_USAGE" "unknown flag: $1" ;;
+      *)  fail "$E_USAGE" "unexpected argument: $1 — pairing is per SERVER; there is no agent to name. (Use --agent=<name> only to pin which seat hosts the session.)" ;;
+    esac
+    shift
+  done
+  [[ "$timeout_s" =~ ^[0-9]+$ && "$timeout_s" -gt 0 ]] \
+    || fail "$E_USAGE" "--timeout wants a positive integer (seconds), got '$timeout_s'"
+
+  ensure_state
+  local agents=() a
+  while IFS= read -r a; do [[ -n "$a" ]] && agents+=("$a"); done < <(_buzz_enabled_agents)
+  ((${#agents[@]} > 0)) || _buzz_pair_refuse "$E_NOT_FOUND" \
+    "no agent on this box has buzz enabled, so there is no relay and no room to pair into — run: sudo 5dive agent buzz enable <name> --relay=<https://…>"
+  if [[ -n "$host" ]]; then
+    local found="no"
+    for a in "${agents[@]}"; do [[ "$a" == "$host" ]] && found="yes"; done
+    [[ "$found" == "yes" ]] || _buzz_pair_refuse "$E_NOT_FOUND" \
+      "--agent='$host' does not have buzz enabled (enabled here: ${agents[*]})"
+  fi
+
+  # --- the owner key into every agent's channels ----------------------------
+  # `join` is idempotent by construction and it is what adds the owner pubkey as
+  # a MEMBER, so running it per agent is both the wire-up and the assertion that
+  # the wire-up took. It refuses with `fail`, which exits — hence the subshell.
+  local wired=0 unwired=""
+  if [[ "$wire" == "true" ]]; then
+    step "Wiring the owner identity into every buzz agent's channels (${#agents[@]} agent(s)) — a handset that is not a MEMBER sees an empty app, not a quiet one"
+    for a in "${agents[@]}"; do
+      if ( with_registry_lock _buzz_join "$a" ) >&2; then
+        wired=$((wired + 1))
+        [[ -z "$host" ]] && host="$a"
+      else
+        unwired="${unwired:+$unwired, }$a"
+      fi
+    done
+    ((wired > 0)) || _buzz_pair_refuse "$E_GENERIC" \
+      "the owner key is a member of NO channel on this box — pairing now would hand the phone an identity that opens an empty app. The wire-up output above says why (relay, binary, or a write the relay did not read back). Fix it, then re-run."
+    if [[ -n "$unwired" ]]; then
+      warn "these agents did not wire and the handset will NOT see their channels: $unwired — repair with: sudo 5dive agent buzz join <name>"
+    fi
+  fi
+  [[ -n "$host" ]] || host="${agents[0]}"
+
+  step "One QR, one identity: this pairs the PHONE as the owner of this box, not as an agent. Which agents talk in team chat is 'sudo 5dive agent buzz enable <name>' and is not asked here."
+  local rc=0
+  _buzz_pair "$host" --timeout="$timeout_s" || rc=$?
+  return "$rc"
+}
+
+# cmd: 5dive buzz owner [--envelope]
+# The box's handset identity. Public half by default; --envelope prints the
+# DIVE-3300 payload and is therefore a PRIVATE key on stdout, same rule as the
+# per-agent verb it delegates to.
+_buzz_server_owner() {
+  local envelope=""
+  while (($#)); do
+    case "$1" in
+      --envelope) envelope="--envelope" ;;
+      -*) fail "$E_USAGE" "unknown flag: $1" ;;
+      *)  fail "$E_USAGE" "unexpected argument: $1 — the owner identity is per SERVER" ;;
+    esac
+    shift
+  done
+  ensure_state
+  local a first=""
+  while IFS= read -r a; do [[ -n "$a" && -z "$first" ]] && first="$a"; done < <(_buzz_enabled_agents)
+  [[ -n "$first" ]] || fail "$E_NOT_FOUND" \
+    "no agent on this box has buzz enabled — the envelope's relay comes from an agent's config. Run: sudo 5dive agent buzz enable <name> --relay=<https://…>"
+  # The key is server-level; the RELAY still comes from a config, and every
+  # buzz agent on a box shares one relay by construction (`enable --relay`).
+  if [[ -n "$envelope" ]]; then _buzz_owner "$first" --envelope; else _buzz_owner "$first"; fi
+}
+
+# cmd: 5dive buzz <pair|owner>
+cmd_buzz() {
+  local verb="${1:-}"
+  case "$verb" in
+    pair)  shift; _buzz_server_pair "$@" ;;
+    owner) shift; _buzz_server_owner "$@" ;;
+    ""|-h|--help)
+      fail "$E_USAGE" "usage: 5dive buzz pair [--timeout=<secs>] [--agent=<name>] [--no-wire]
+       5dive buzz owner [--envelope]
+
+Pairing is per SERVER: one QR pairs the phone as the OWNER of this box. Use
+'5dive agent buzz enable <name>' to choose which agents talk in team chat." ;;
+    *) fail "$E_USAGE" "unknown buzz verb '$verb' (pair|owner)" ;;
+  esac
+}

--- a/src/main.sh
+++ b/src/main.sh
@@ -103,7 +103,7 @@ Agents:
   5dive buzz pair [--timeout=<secs>] [--agent=<n>]   # DIVE-3592: ONE QR per SERVER — pairs the phone as the
                                                      # OWNER of this box, wiring that identity into every buzz
                                                      # agent's channels first. Prefer this over the per-agent
-                                                     # form; who talks in team chat is `agent buzz enable`.
+                                                     # form; who talks in team chat is \`agent buzz enable\`.
   5dive buzz owner [--envelope]                      # the box's handset identity (public half; --envelope is
                                                      # the DIVE-3300 payload and carries a PRIVATE key)
   5dive agent config <name> set workdir=<path>       # tmux cwd; "default" clears override

--- a/src/main.sh
+++ b/src/main.sh
@@ -100,6 +100,12 @@ Agents:
                                                      # the agent unit's liveness. rc 3 = declared, not usable
   5dive agent buzz pair <name> [--timeout=<secs>]    # DIVE-3551: run the NIP-AB pairing session (QR + SAS);
                                                      # emits BUZZ-PAIR-* marker lines the dashboard panel parses
+  5dive buzz pair [--timeout=<secs>] [--agent=<n>]   # DIVE-3592: ONE QR per SERVER — pairs the phone as the
+                                                     # OWNER of this box, wiring that identity into every buzz
+                                                     # agent's channels first. Prefer this over the per-agent
+                                                     # form; who talks in team chat is `agent buzz enable`.
+  5dive buzz owner [--envelope]                      # the box's handset identity (public half; --envelope is
+                                                     # the DIVE-3300 payload and carries a PRIVATE key)
   5dive agent config <name> set workdir=<path>       # tmux cwd; "default" clears override
   5dive agent config <name> set auth-profile=<name>  # swap profile; "default" clears override
   5dive agent config <name> set model=<id>           # runtime model (claude/codex/grok/antigravity)
@@ -743,9 +749,16 @@ main() {
         # log: a public key and a file PATH, never the body (see the verb's own
         # --message-file refusal to take prose in argv).
         buzz)
+          # DIVE-3592: `pair` is a LIVE SESSION (600s by default, waiting on a
+          # human with a phone). It writes no registry field of its own, and
+          # holding the fleet-wide registry lock for the width of a pairing
+          # session would stall every other seat's writes behind one customer
+          # scanning a QR. It joins `status`/`whois` on the lock-free side. The
+          # server-level `5dive buzz pair` takes the lock per join instead,
+          # around the wire-up only.
           if [[ "${1:-}" == "status" || "${1:-}" == "whois" ]]; then
             cmd_agent_buzz "$@"
-          elif [[ "${1:-}" == "inbound" ]]; then
+          elif [[ "${1:-}" == "inbound" || "${1:-}" == "pair" ]]; then
             AUDIT_CMD="agent buzz"; AUDIT_ARGS=("$@")
             cmd_agent_buzz "$@"
           else
@@ -935,6 +948,13 @@ main() {
       # more than the noise it costs.
       AUDIT_CMD="host"; AUDIT_ARGS=("$@")
       cmd_host "$@" ;;
+    buzz)
+      # DIVE-3592: pairing is per SERVER. Audited (it decides which handset
+      # holds the box owner identity) and NOT wrapped in the registry lock —
+      # `pair` blocks on a human with a phone, and its wire-up takes the lock
+      # per join instead.
+      AUDIT_CMD="buzz"; AUDIT_ARGS=("$@")
+      cmd_buzz "$@" ;;
     doctor)
       # Only audit when a mutating run is requested (--fix/--repair); read-only
       # runs (and --dry-run previews) would spam the log.

--- a/tests/buzz_bridge_unit.sh
+++ b/tests/buzz_bridge_unit.sh
@@ -128,7 +128,10 @@ grep -q 'derived from the caller' <<<"$OUT" \
 # The seam: _buzz_whois is the single reader (DIVE-3572) and _buzz_bridge_a2a_send
 # is the rail. Both are replaced so the ROUTING is graded with no registry, no
 # pane and no sudo — the arms below are about the decision, not the plumbing.
-WORK=$(mktemp -d); trap 'rm -rf "$WORK"' EXIT
+WORK=$(mktemp -d)
+# DIVE-2692: fold the tempdir cleanup into the ONE EXIT trap — bash has a single
+# slot, and a plain `rm -rf` trap here REPLACES the HARNESS-RC line set above.
+trap 'rc=$?; rm -rf "${WORK:-}"; echo "HARNESS-RC=$rc"' EXIT
 BODY="$WORK/body"; printf 'ship it\n' > "$BODY"
 SENT_LOG="$WORK/sent"
 

--- a/tests/buzz_identity_registry_unit.sh
+++ b/tests/buzz_identity_registry_unit.sh
@@ -96,6 +96,14 @@ printf '%s' "${NPUB%?}7" | _buzz_npub_to_hex >/dev/null 2>&1 \
 
 # --- fixture: a real registry in a scratch state dir ------------------------
 TMP=$(mktemp -d); trap 'rc=$?; rm -rf "$TMP"; echo "HARNESS-RC=$rc"' EXIT
+
+# DIVE-3592: the OWNER identity is per SERVER now — `_buzz_owner_key` reads and
+# writes ${STATE_DIR}/buzz/owner.json and mirrors it per agent. The default
+# /var/lib/5dive is root-owned, so an unprivileged harness that exercises `join`
+# has to own a STATE_DIR of its own. Set AFTER the source on purpose: REGISTRY
+# and friends are computed from STATE_DIR at source time and the seams below
+# depend on those staying put; the owner path is read at CALL time.
+STATE_DIR="$TMP/state"
 REGISTRY="$TMP/agents.json"
 REGISTRY_LOCK="$TMP/agents.lock"
 IN_REGISTRY_LOCK=1        # writer is called under the lock in production

--- a/tests/buzz_last_mile_unit.sh
+++ b/tests/buzz_last_mile_unit.sh
@@ -193,6 +193,14 @@ _buzz_lists_channel_id "1" <<<'channel 1  general  (member) 11 messages' \
 # smoke's job and it is signed for, not implied.
 # ===========================================================================
 STUB_ROOT=$(mktemp -d)
+
+# DIVE-3592: the OWNER identity is per SERVER now — `_buzz_owner_key` reads and
+# writes ${STATE_DIR}/buzz/owner.json and mirrors it per agent. The default
+# /var/lib/5dive is root-owned, so an unprivileged harness that exercises `join`
+# has to own a STATE_DIR of its own. Set AFTER the source on purpose: REGISTRY
+# and friends are computed from STATE_DIR at source time and the seams below
+# depend on those staying put; the owner path is read at CALL time.
+STATE_DIR="$STUB_ROOT/state"
 trap 'rc=$?; rm -rf "$STUB_ROOT"; echo "HARNESS-RC=$rc"' EXIT
 STUB_BIN="$STUB_ROOT/buzz"
 

--- a/tests/buzz_server_pairing_unit.sh
+++ b/tests/buzz_server_pairing_unit.sh
@@ -71,7 +71,11 @@ else
 fi
 
 # --- harness seams -----------------------------------------------------------
-TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+TMP=$(mktemp -d)
+# DIVE-2692: ONE EXIT trap — bash has a single slot, so the tempdir cleanup folds
+# into the HARNESS-RC line rather than replacing it (a replaced trap prints no
+# marker, and a harness killed mid-run then reads exactly like a pass).
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
 export STATE_DIR="$TMP/state"
 mkdir -p "$STATE_DIR"
 # Every sudo hop collapses onto this user: the harness owns the files it writes,

--- a/tests/buzz_server_pairing_unit.sh
+++ b/tests/buzz_server_pairing_unit.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# DIVE-3592 unit harness — pairing is per SERVER, not per agent.
+#
+# What this grades without a relay, a phone, or root:
+#
+#   1. src/cmd_buzz.sh is CONCATENATED into the bundle (the buzz_channel_wiring
+#      failure mode: a file that exists and is never bundled is "command not
+#      found" in the shipped binary), dispatched, and in the usage text
+#   2. `agent buzz pair` is on the LOCK-FREE side of the dispatch — a 600s
+#      pairing session must not hold the fleet-wide registry lock
+#   3. ONE IDENTITY PER BOX: _buzz_owner_key returns the same key for two
+#      different agents, and mirrors it into both state dirs
+#   4. ADOPTION, not a fresh mint: an agent that already holds an owner key
+#      (a handset paired before this row) becomes the server identity. Minting
+#      a new one would evict that handset from every room while every surface
+#      still reported success — so this arm is the eviction guard
+#   5. the wire-up runs for EVERY buzz agent, not just the session host (a
+#      handset that is not a member cannot see the channel at all, DIVE-3331)
+#   6. REFUSALS ARE RESULTS: no buzz agent, and wire-up-wired-nothing, both
+#      print `BUZZ-PAIR-RESULT: fail …` and exit NON-ZERO, and neither reaches
+#      the pairing session. The panel reads a PTY, where the exit status it can
+#      see is the shell's — a silent refusal is indistinguishable from success
+#
+# Run: bash tests/buzz_server_pairing_unit.sh   (no root, no network, no relay.)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+# shellcheck source=/dev/null
+source "$SRC/cmd_agent_buzz.sh"
+# shellcheck source=/dev/null
+source "$SRC/cmd_agent_buzz_join.sh"
+# shellcheck source=/dev/null
+source "$SRC/cmd_agent_buzz_pair.sh"
+# shellcheck source=/dev/null
+source "$SRC/cmd_buzz.sh"
+set +e  # header.sh enables set -e; the arms below deliberately probe non-zero rc
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# --- 1. bundled, dispatched, documented --------------------------------------
+grep -q '^  src/cmd_buzz\.sh \\$' build.sh \
+  && ok_t "build.sh concatenates cmd_buzz.sh" \
+  || bad_t "build.sh concatenates cmd_buzz.sh" \
+           "present but never concatenated — \`5dive buzz pair\` would be 'command not found' in the built bundle"
+grep -qE '^\s+buzz\)' "$SRC/main.sh" \
+  && ok_t "main.sh has a top-level 'buzz' verb" \
+  || bad_t "main.sh has a top-level 'buzz' verb" "the verb is unreachable"
+grep -q 'cmd_buzz "\$@"' "$SRC/main.sh" \
+  && ok_t "main.sh dispatches cmd_buzz" || bad_t "main.sh dispatches cmd_buzz" "unreachable"
+grep -q '5dive buzz pair' "$SRC/main.sh" \
+  && ok_t "usage text names '5dive buzz pair'" || bad_t "usage text names '5dive buzz pair'" "undiscoverable"
+
+# --- 2. the pairing session does not hold the fleet lock ---------------------
+if grep -q '"${1:-}" == "inbound" || "${1:-}" == "pair"' "$SRC/main.sh"; then
+  ok_t "agent buzz pair is dispatched WITHOUT with_registry_lock"
+else
+  bad_t "agent buzz pair is dispatched WITHOUT with_registry_lock" \
+        "a 600s pairing session would hold the fleet-wide registry lock for its whole width"
+fi
+
+# --- harness seams -----------------------------------------------------------
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+export STATE_DIR="$TMP/state"
+mkdir -p "$STATE_DIR"
+# Every sudo hop collapses onto this user: the harness owns the files it writes,
+# and the DIVE-3096 isolation layer refuses a real sudo inside a harness anyway.
+sudo() {
+  while (($#)); do case "$1" in -u) shift 2 ;; -H) shift ;; *) break ;; esac; done
+  "$@"
+}
+_buzz_state_dir() { printf '%s/home/%s\n' "$TMP" "$1"; }
+AGENTS_OUT=$'alpha\nbeta\n'
+_buzz_enabled_agents() { printf '%s' "$AGENTS_OUT"; }
+
+# --- 3. one identity per box -------------------------------------------------
+KA=$(_buzz_owner_key alpha "$(id -un)" 2>/dev/null)
+KB=$(_buzz_owner_key beta  "$(id -un)" 2>/dev/null)
+if [[ "$KA" =~ ^[0-9a-f]{64}$ && "$KA" == "$KB" ]]; then
+  ok_t "two agents hand out ONE owner key (the picker is now a choice about nothing)"
+else
+  bad_t "two agents hand out ONE owner key" "alpha=${KA:0:12}… beta=${KB:0:12}…"
+fi
+[[ -f "$STATE_DIR/buzz/owner.json" ]] \
+  && ok_t "the owner identity is written at the SERVER level (\$STATE_DIR/buzz/owner.json)" \
+  || bad_t "the owner identity is written at the SERVER level" "no $STATE_DIR/buzz/owner.json"
+MIRROR=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['private_key'])" \
+  "$TMP/home/alpha/owner.json" 2>/dev/null)
+[[ "$MIRROR" == "$KA" ]] \
+  && ok_t "the agent's owner.json is a MIRROR of the server key" \
+  || bad_t "the agent's owner.json is a MIRROR of the server key" "mirror=${MIRROR:0:12}… server=${KA:0:12}…"
+PERM=$(stat -c '%a' "$STATE_DIR/buzz/owner.json" 2>/dev/null)
+[[ "$PERM" == "600" ]] && ok_t "the server owner key is 0600" \
+  || bad_t "the server owner key is 0600" "mode=$PERM"
+K2=$(_buzz_owner_key alpha "$(id -un)" 2>/dev/null)
+[[ "$K2" == "$KA" ]] && ok_t "a re-run does NOT rotate the paired handset's key" \
+  || bad_t "a re-run does NOT rotate the paired handset's key" "the handset would silently lose every room"
+
+# --- 4. adoption beats minting ----------------------------------------------
+rm -rf "$STATE_DIR/buzz" "$TMP/home"
+PRE=$(openssl rand -hex 32)
+mkdir -p "$TMP/home/beta"
+python3 -c "
+import json,sys
+json.dump({'private_key': sys.argv[1], 'role': 'owner'}, open(sys.argv[2],'w'))
+" "$PRE" "$TMP/home/beta/owner.json"
+ADOPTED=$(_buzz_server_owner_key 2>/dev/null)
+[[ "$ADOPTED" == "$PRE" ]] \
+  && ok_t "an owner key minted before DIVE-3592 is ADOPTED, not replaced" \
+  || bad_t "an owner key minted before DIVE-3592 is ADOPTED, not replaced" \
+           "a handset paired tonight would be evicted from every room; got ${ADOPTED:0:12}… want ${PRE:0:12}…"
+ROT=$(_buzz_server_owner_key true 2>/dev/null)
+[[ "$ROT" =~ ^[0-9a-f]{64}$ && "$ROT" != "$PRE" ]] \
+  && ok_t "rotate=true still mints a new identity (the explicit escape hatch)" \
+  || bad_t "rotate=true still mints a new identity" "got ${ROT:0:12}…"
+
+# --- 5 + 6. the server pair verb --------------------------------------------
+ensure_state() { :; }
+with_registry_lock() { local fn="$1"; shift; "$fn" "$@"; }
+JOINED="$TMP/joined"; PAIRED="$TMP/paired"
+_buzz_join() { printf '%s\n' "$1" >>"$JOINED"; return "${JOIN_RC:-0}"; }
+_buzz_pair() { printf '%s\n' "$1" >>"$PAIRED"; return 0; }
+
+: >"$JOINED"; : >"$PAIRED"
+OUT=$( _buzz_server_pair --timeout=5 2>&1 ); RC=$?
+if ((RC == 0)) && [[ "$(sort -u "$JOINED" | tr '\n' ' ')" == "alpha beta " ]]; then
+  ok_t "the wire-up runs for EVERY buzz agent, not just the session host"
+else
+  bad_t "the wire-up runs for EVERY buzz agent" "rc=$RC joined='$(tr '\n' ' ' <"$JOINED")'"
+fi
+[[ $(wc -l <"$PAIRED") -eq 1 ]] \
+  && ok_t "exactly one pairing session is opened (one QR, one identity)" \
+  || bad_t "exactly one pairing session is opened" "$(wc -l <"$PAIRED") sessions"
+
+# no buzz agent at all
+AGENTS_OUT=""
+OUT=$( _buzz_server_pair 2>&1 ); RC=$?
+grep -q '^BUZZ-PAIR-RESULT: fail ' <<<"$OUT" \
+  && ok_t "no buzz agent: prints the terminal fail marker" \
+  || bad_t "no buzz agent: prints the terminal fail marker" \
+           "the panel reads a PTY and cannot see an exit code — a silent refusal reads as success. got: $OUT"
+((RC != 0)) && ok_t "no buzz agent: exits NON-ZERO" \
+  || bad_t "no buzz agent: exits NON-ZERO" "rc=$RC — an error: line with rc 0 is the DIVE-3592 defect"
+
+# every join failed: the owner is in no channel, so pairing must not happen
+AGENTS_OUT=$'alpha\nbeta\n'; JOIN_RC=1
+: >"$PAIRED"
+OUT=$( _buzz_server_pair 2>&1 ); RC=$?
+grep -q '^BUZZ-PAIR-RESULT: fail ' <<<"$OUT" && ((RC != 0)) \
+  && ok_t "zero channels wired: refuses with a marker and a non-zero rc" \
+  || bad_t "zero channels wired: refuses with a marker and a non-zero rc" "rc=$RC out=$OUT"
+[[ ! -s "$PAIRED" ]] \
+  && ok_t "zero channels wired: no pairing session is opened" \
+  || bad_t "zero channels wired: no pairing session is opened" \
+           "the handset would have been handed an identity that opens an empty app"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes DIVE-3592.

**Pairing is per-SERVER, not per-agent.** lodar hit the dashboard modal's "Which agent should your phone pair with?" and rejected the shape ("isnt qr one per server?"). It is — DIVE-3510 records the same design. This PR is the CLI half that makes the picker a choice about nothing.

## What changed

- **New `5dive buzz pair [--timeout=] [--agent=] [--no-wire]`** — one pairing session per SERVER. New `src/cmd_buzz.sh`, top-level dispatch in `main.sh`, audited. Deliberately NOT under `with_registry_lock`: a 600s session holding the fleet-wide lock was an existing defect, so `agent buzz pair` was moved off it too; the server verb takes the lock per-join around the wire-up only.
- **One owner identity per box** — moved to `${STATE_DIR}/buzz/owner.json` (root, 0600), mirrored into each buzz agent's state dir. `_buzz_owner_key <name> <user>` kept its signature, so `join`, `owner`, `pair` and the panel all keep working and now hand out ONE key.
- **Adoption over minting** — if the server file is absent and an agent already holds an owner key, that key becomes the server's. A handset paired under the old per-agent path keeps its rooms. A fresh mint is reachable only through `--rotate-owner-key`.
- **Membership is automatic** — the verb runs `join` for EVERY buzz agent before opening the session, and REFUSES to pair when it ends up a member of no channel. A handset that opens an empty app is the DIVE-3331/DIVE-3510 failure; no hand-run sudo step remains (gap 1 of the row's live-failure data).
- **Refusals are RESULTS** — every state refusal on the pair path prints `BUZZ-PAIR-RESULT: fail …` before exiting non-zero. The panel reads a PTY, where the exit status it observes is the SHELL's; that is why lodar's <1s failures were indistinguishable from a normal close. The marker, not the rc, is the fix that reaches the panel.

**Mint side, recorded:** unchanged — TRANSFER via the DIVE-3300 envelope, the mechanism `buzz-pair` implements today. This row moved the identity's SCOPE (per-agent → per-server), not who mints it. Device-minted (DIVE-3510's default answer) is a handset+protocol change, still open as its own question.

## How it was checked

New `tests/buzz_server_pairing_unit.sh`, 18 arms: one-key-per-box, the mirror, adoption vs mint, rotate as the control, wire-up-for-every-agent, and both refusal paths asserting marker AND non-zero rc AND that no session opens.

Green: `buzz_server_pairing` 18/18 · `buzz_last_mile` 96/96 · `buzz_pair` 24/24 · `buzz_channel_wiring` 56/56 · `buzz_identity_registry` 36/36 · `buzz_bridge` 47/47 · `buzz_by_design_rc3` 10/10 · `digest_buzz_count` 9/9.

`last_mile` and `identity_registry` needed a writable `STATE_DIR` of their own (the owner file now lives there). A CONTROL worktree at `origin/main` scored 96/96 and 36/36 on those two, so the counts are unchanged and no arm was weakened.

Not run: the paid Hetzner smoke — no provisioning-path change here.

## Not in this PR, and why

The dashboard picker itself (`app/src/app/dashboard/_components/mobile-app-card.tsx` + the per-row Pair buttons in `connect-buzz.tsx`). Removing it is a small edit, but the card gates its pair button on `PAIR_MIN_CLI` (`pair-cli-version.ts`, today `[0,19,42]` — the release that first carried `agent buzz pair`). `5dive buzz pair` exists in NO release yet; 5dive-cli ships on a deliberate `release-cut`. A floor naming an uncut version either hides the button forever or opens it onto `unknown verb`, so the app edit cannot be correct until this branch is cut and its version is known. That is the DIVE-3591 "same PR train" coordination: cut the CLI, then the modal edit lands with the real floor.

The interim per-agent path keeps working meanwhile and now pairs the SAME identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
