### PR TITLE
feat(memory): async transcript → memory-atom consolidation (DIVE-3628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ TencentDB-Agent-Memory discussion that produced this row was itself lost to an u
 This is the memory-moat floor — an ASYNC pass that distils finished session transcripts into durable
 atoms in the owning agent's own store, so knowledge survives a window nobody remembered to compile.
 
+- **IT IS SCHEDULED — nothing to install.** The pass hangs off `5dive heartbeat tick`, the one
+  recurring root job every box already has, as a new `_hb_memory_consolidate_sweep` under the same
+  non-fatal isolation contract as every other sweep. A customer box gets consolidation with ZERO
+  extra setup: no systemd timer, no per-seat crontab line, nothing that can be half-installed. Each
+  pass runs **as the seat's own user**, so atoms land in that agent's own 0600 store and burn that
+  agent's own quota. Off with `MEMORY_CONSOLIDATE=off`; retune with `MEMORY_CONSOLIDATE_EVERY_MIN`.
+- **The measured cost, stated rather than implied.** One session, default `claude --print`
+  distiller, one ~300KB transcript at `--max-chars=20000`, 2026-08-20: **$0.244 cold-cache, $0.081
+  warm, ~35s, ~2.5k output tokens.** The schedule bounds that to one session per seat per pass and
+  one pass per seat per 6h => **<=4 model calls/seat/day**, and a seat with no NEW finished
+  transcript costs **$0** — the ledger short-circuits before the distiller is ever invoked, so the
+  bill tracks real sessions, not wall-clock. Note for anyone budgeting a sub-model call: $0.150 of
+  that $0.244 is the coding-agent harness's own system prompt, not our work — the lever is a leaner
+  `--distiller`, not a shorter excerpt.
+- **The instruction surfaces now describe the POST-pipeline workflow.** The knowledge-task nudge
+  injected into every knowledge-shaped wake, the `MEMORY.md` seeded into every new seat by
+  `agent create`, the shipped per-seat `CLAUDE.md` template, and the filing-cap guidance all state
+  the new division of labor explicitly: **the pipeline lifts what is lying in the transcript; you
+  still hand-compile JUDGEMENT** — a decision and its reason, a cause, a wiki page — because that is
+  a claim you are making, not a fact in the log. None of them tells agents to stop compiling, and
+  all of them note the pipeline deliberately cannot publish to a shared store.
 - **Three stages over the stores we already have.** L0 is the raw `~/.claude/projects/*/*.jsonl`
   transcript, untouched. L1 is a bounded plain-text excerpt (tool payloads collapse to `[tool: X]` —
   they are the bulk of a jsonl and almost never the durable part; over `--max-chars` it keeps the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## Unreleased — feat(memory): `5dive memory consolidate` — async transcript → memory atoms (DIVE-3628, DIVE-726 phase 1)
+
+A session window dies and everything it learned dies with it, because "compile before you close" is
+a HABIT and a habit is not a mechanism. The motivating case is on the record: the very
+TencentDB-Agent-Memory discussion that produced this row was itself lost to an uncompiled window.
+This is the memory-moat floor — an ASYNC pass that distils finished session transcripts into durable
+atoms in the owning agent's own store, so knowledge survives a window nobody remembered to compile.
+
+- **Three stages over the stores we already have.** L0 is the raw `~/.claude/projects/*/*.jsonl`
+  transcript, untouched. L1 is a bounded plain-text excerpt (tool payloads collapse to `[tool: X]` —
+  they are the bulk of a jsonl and almost never the durable part; over `--max-chars` it keeps the
+  head and the tail, because the opening says what the session was for and the close says what it
+  concluded). L3 is a markdown atom. **No database, no vector index, no CodeGraph** — the shape is
+  idea-derived from TencentDB-Agent-Memory (MIT), not ported.
+- **One write path.** Every atom goes through `_memory_add`, so the secret tripwire, the dedup
+  warning, the frontmatter shape and the `MEMORY.md` index line are the same ones a hand-compiled
+  memory gets. There is no second write path to audit. Atoms carry `--provenance` naming the session
+  and a structural `--evidence=run:<session>` back-ref.
+- **It cannot publish.** `consolidate` has no `--store` and no reachable wiki branch: an
+  auto-extractor that could write fleet-wide is the one shape this must not have (DIVE-481
+  deny-default). Publishing to the shared wiki stays a curated act.
+- **It never reads the LIVE session.** A transcript touched inside `--idle-min` (default 30m) is
+  skipped — without it the pass would distil the very session it is running in.
+- **Idempotent twice over.** A `.consolidated.tsv` ledger records each (session, byte count); and
+  even with the ledger lost, `add` refuses a slug that already exists. Bounded by `--max-sessions`
+  per pass, so the cron cost is flat whatever the backlog does. Single-flight via `flock`.
+- **A distiller that CANNOT ANSWER is a counted, loud failure — never "0 atoms".** Measured on this
+  box: an unauthed `claude --print` prints `Not logged in` and **exits 0**. Folded into the atom
+  count, a fleet-wide auth lapse would read as "the sessions were quiet" forever. It is now its own
+  outcome, and a failed distill is deliberately **not** ledgered, so a transient outage cannot
+  silently retire the backlog.
+- Nothing installs the cron entry; `memory --help` carries the line.
+
+Two defects worth naming because the harness alone would not have caught either:
+
+- `exec 201>"$lockf" 2>/dev/null` is **two permanent redirections** — the second kills stderr for
+  the rest of the pass, silently swallowing every tripwire refusal. Caught only because an arm
+  asserted the refusal was *reported*, not merely that no file was written.
+- `rows=$(cmd); rc=$?` **aborts under the bundle's `set -euo pipefail`** — errexit fires on the
+  assignment before `$?` is read. The test corpus runs `set +e` and is structurally blind to it; it
+  passed every arm and still killed the built bundle on the first distiller failure. `tests/
+  memory_consolidate_unit.sh` now re-runs the failure arms under the bundle's own shell options.
+
+Tests: `tests/memory_consolidate_unit.sh`, 53 assertions, offline by construction (the distiller is
+an injected seam). Four mutants — the live-session skip, the dry-run ledger guard, the ledger skip,
+and the errexit fix — each red exactly the arm meant to catch it.
+
 ## Unreleased — fix(self-update): skip an agent holding an in_progress row and bounce it at its next task boundary (DIVE-3173)
 
 DIVE-3172 made the nightly restart conditional on the agent payload actually moving, which takes a

--- a/src/cmd_agent_create.sh
+++ b/src/cmd_agent_create.sh
@@ -1612,6 +1612,13 @@ _rebuild_inherited_index() {
     echo
     echo "Seeded from shared team knowledge so this agent starts warm. Search with \`5dive memory search \"<query>\"\`; add your own facts with \`5dive memory add\`."
     echo
+    echo "This index grows on its own: \`5dive memory consolidate\` distils your FINISHED"
+    echo "session transcripts into atoms here, scheduled for you, never touching the live"
+    echo "session, and never leaving this box. You still hand-compile JUDGEMENT-shaped"
+    echo "knowledge (a decision and its reason, a cause, a wiki page) — the pipeline can"
+    echo "only lift what is stated in the transcript, and it cannot publish to a shared"
+    echo "store at all."
+    echo
     for f in "$dir"/*.md; do
       [[ -e "$f" ]] || continue
       [[ "$(basename "$f")" == "MEMORY.md" ]] && continue

--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -314,6 +314,12 @@ _hb_wake_budget_inc() {
 #     DIVE-1434 poller-liveness canary (olivia condition 2), so a slept agent with
 #     a later trigger is always woken by a subsequent tick.
 _HB_SLEEP_AFTER_MIN="${HEARTBEAT_SLEEP_AFTER_MIN:-15}"   # idle minutes before a cold agent sleeps
+# DIVE-3628 memory-consolidation cadence. 6h => <=4 distiller calls/seat/day; see
+# _hb_memory_consolidate_sweep for the measured per-call cost this bounds.
+_HB_CONSOLIDATE_EVERY_MIN="${MEMORY_CONSOLIDATE_EVERY_MIN:-360}"
+# A distiller call measured ~35s; 300s is generous headroom without letting a
+# wedged model call sit on the tick.
+_HB_CONSOLIDATE_TIMEOUT_S="${MEMORY_CONSOLIDATE_TIMEOUT_S:-300}"
 [[ "$_HB_SLEEP_AFTER_MIN" =~ ^[0-9]+$ ]] || _HB_SLEEP_AFTER_MIN=15
 
 # Per-agent idle-before-sleep threshold (minutes); falls back to the global default.
@@ -2269,7 +2275,7 @@ _hb_wake() {
   if [[ -n "$task_text" ]]; then
     recall=$(_hb_recall_cite "$name" "$task_text" 3) || recall=""
     if _hb_is_knowledge_task "$task_text"; then
-      compile_hint=" This task looks knowledge-shaped: before you close it, COMPILE the durable, non-obvious findings to the team wiki per the karpathy method (compile-knowledge skill, or '5dive memory add --store=wiki' + an index line) — compiling is part of done, not a separate chore."
+      compile_hint=" This task looks knowledge-shaped. Note the division of labor since DIVE-3628: an async pass ('5dive memory consolidate', run for you by the heartbeat) already distils your FINISHED transcripts into memory atoms, so you do NOT have to hand-copy facts out of this session to keep them. What it cannot do is JUDGEMENT-shaped knowledge — a wiki page, a decision record, a gap analysis, the CAUSE behind a finding — because that is a claim you are making, not a fact lying in the transcript. So: still COMPILE those to the team wiki per the karpathy method (compile-knowledge skill, or '5dive memory add --store=wiki' + an index line) before you close — compiling is part of done, not a separate chore. The pipeline never publishes to the shared wiki; only you can."
     fi
   fi
   [[ -n "$recall" ]] && nudge="${nudge} Relevant memory to check first (verify before relying; re-search with '5dive memory search'): ${recall}."
@@ -4170,6 +4176,76 @@ _hb_capability_reverify_sweep() {
   return 0
 }
 
+# DIVE-3628 — THE SCHEDULER for `5dive memory consolidate`. A verb nobody runs is
+# not an async pipeline: the acceptance is "a fresh box user's agent loses a
+# session and a later session knows what it learned, with NO manual step", and
+# that is only true if something fires it. This is that something.
+#
+# Why here and not a systemd timer or a crontab line: the tick is the ONE
+# recurring root job every 5dive box already has (`5dive init` wires it; nothing
+# else is installed per-seat), so hanging the pass off it means a customer box
+# gets consolidation with zero extra setup — no new unit, no new install step, no
+# per-seat cron to forget. A timer would be a second thing to install and a
+# second thing to be missing.
+#
+# COST IS THE REAL CONSTRAINT and it is bounded here, not in the verb. Measured
+# 2026-08-20 on this box with the default `claude --print` distiller: $0.244 per
+# session cold-cache, $0.081 warm. So the pass is capped at ONE session per seat
+# per run and one run per seat per _HB_CONSOLIDATE_EVERY_MIN (6h) => <=4 model
+# calls/seat/day, ~$0.32-$0.98/seat/day WORST case, and far less in practice
+# because a seat with no new finished transcript makes NO model call at all (the
+# ledger short-circuits before the distiller). Turn it off with
+# MEMORY_CONSOLIDATE=off; retune with MEMORY_CONSOLIDATE_EVERY_MIN.
+#
+# It runs AS THE SEAT'S OWN USER. That is not tidiness: atoms must land in that
+# agent's own 0600 store and burn that agent's own quota, and running as root
+# would write root-owned files into a user's memory dir and silently break the
+# next `memory add`.
+#
+# Same isolation contract as every other sweep — a failure here must NEVER abort
+# the wake loop.
+_hb_memory_consolidate_sweep() {
+  local now="$1"
+  _HB_CONS_RAN=0; _HB_CONS_SKIPPED=0; _HB_CONS_FAILED=0
+  [[ "${MEMORY_CONSOLIDATE:-on}" == "off" ]] && return 0
+  local every="${MEMORY_CONSOLIDATE_EVERY_MIN:-${_HB_CONSOLIDATE_EVERY_MIN}}"
+  [[ "$every" =~ ^[0-9]+$ ]] && (( every > 0 )) || every="$_HB_CONSOLIDATE_EVERY_MIN"
+  local stampdir="${STATE_DIR:-/var/lib/5dive}/memory-consolidate"
+  mkdir -p "$stampdir" 2>/dev/null || return 0
+  local reg name user stamp last
+  reg=$(registry_read) || return 0
+  for name in $(jq -r '.agents | keys[]' <<<"$reg" 2>/dev/null); do
+    # Resolve the seat's unix user the same way the memory store does.
+    user="agent-$name"
+    id -u "$user" >/dev/null 2>&1 || user="$name"
+    id -u "$user" >/dev/null 2>&1 || continue
+    stamp="$stampdir/${name}.stamp"
+    last=$(cat "$stamp" 2>/dev/null) || last=0
+    [[ "$last" =~ ^[0-9]+$ ]] || last=0
+    if (( now - last < every * 60 )); then
+      _HB_CONS_SKIPPED=$((_HB_CONS_SKIPPED + 1)); continue
+    fi
+    # Stamp BEFORE the run, not after. A distiller call can take ~35s and the
+    # tick fires every 5 minutes: stamping after would let a slow or wedged pass
+    # be re-entered by the next tick and multiply the cost by however many ticks
+    # it outlives. The verb also holds its own flock, but that turns a cost bug
+    # into a lock-contention error rather than preventing it — the cadence has to
+    # be enforced by the clock. A crashed pass just waits one cadence; nothing is
+    # lost, because a session with no ledger row is retried forever by design.
+    printf '%s\n' "$now" > "$stamp" 2>/dev/null || true
+    if timeout "${_HB_CONSOLIDATE_TIMEOUT_S}" sudo -n -u "$user" -H \
+         "${SELF_BIN:-/usr/local/bin/5dive}" memory consolidate --max-sessions=1 \
+         >/dev/null 2>&1; then
+      _HB_CONS_RAN=$((_HB_CONS_RAN + 1))
+    else
+      # Non-fatal and COUNTED, never silent: a fleet-wide auth lapse or a missing
+      # sudo grant has to show up as failures in the log, not as a quiet box.
+      _HB_CONS_FAILED=$((_HB_CONS_FAILED + 1))
+    fi
+  done
+  return 0
+}
+
 cmd_heartbeat_tick() {
   require_root "heartbeat tick"
   tasks_db_init
@@ -4241,6 +4317,13 @@ cmd_heartbeat_tick() {
   # DIVE-972: enforce per-loop token ceilings for async (non --wait) loops. Same
   # isolation contract — a failure here must never abort the wake loop.
   _hb_loop_ceiling_sweep || _hb_log "[loop-ceiling] pass errored (non-fatal)"
+  # DIVE-3628: async transcript -> memory-atom consolidation, one bounded pass
+  # per seat per cadence. Runs LAST — it is the only sweep that spends model
+  # tokens, so nothing that keeps the fleet moving may ever queue behind it.
+  # Same isolation contract as every other sweep.
+  _hb_memory_consolidate_sweep "$now" || _hb_log "[memory-consolidate] pass errored (non-fatal)"
+  (( ${_HB_CONS_RAN:-0} || ${_HB_CONS_FAILED:-0} )) \
+    && _hb_log "[memory-consolidate] ${_HB_CONS_RAN:-0} seat(s) distilled, ${_HB_CONS_FAILED:-0} failed, ${_HB_CONS_SKIPPED:-0} not due" || true
   # DIVE-3343: there is NO per-TASK budget sweep here any more, and its absence
   # is deliberate — see the block above _hb_loop_ceiling_sweep's neighbours in
   # this file for why the figure it enforced could not be attributed to a row.

--- a/src/cmd_memory.sh
+++ b/src/cmd_memory.sh
@@ -81,8 +81,17 @@ _memory_usage() {
       Writes to YOUR OWN store only. There is deliberately no --store: an
       auto-extractor must not be able to publish to the shared wiki (DIVE-481
       deny-default). Publishing stays a curated act.
-      Cron it (nothing installs this for you):
-        */30 * * * * /usr/local/bin/5dive memory consolidate >>~/.5dive-consolidate.log 2>&1
+      SCHEDULED FOR YOU — you do not have to wire this up. The heartbeat tick
+      (the one root cron every box already has) runs ONE bounded pass per seat
+      every 6h, as that seat's own user. Off: MEMORY_CONSOLIDATE=off. Retune:
+      MEMORY_CONSOLIDATE_EVERY_MIN. Run it by hand any time; it is idempotent.
+      COST — it spends YOUR model quota, so the number is stated, not implied.
+      Measured 2026-08-20, default `claude --print` distiller, one ~300KB
+      transcript at --max-chars=20000: $0.244 cold-cache, $0.081 warm, ~35s,
+      ~2.5k output tokens. The scheduled cadence bounds that to <=4 calls per
+      seat per day, and a seat with no NEW finished transcript costs $0 (the
+      ledger short-circuits before the distiller is ever invoked). Lower it
+      further with --max-chars, or point --distiller at a cheaper model.
 
   5dive memory doctor [--roots=a,b] [--agent=<name>] [--code-root=<dir>] [--json]
       Hygiene pass over the memory store(s): index drift (MEMORY.md vs files on

--- a/src/cmd_memory.sh
+++ b/src/cmd_memory.sh
@@ -59,6 +59,31 @@ _memory_usage() {
       Write-time dedup: `add` WARNS (never refuses) when the body overlaps an
       existing memory in the same store — silence it with --no-dedup.
 
+  5dive memory consolidate [--max-sessions=N] [--idle-min=M] [--max-chars=C]
+                           [--distiller=<cmd>] [--dry-run] [--force]
+      ASYNC transcript -> memory atoms (DIVE-726 phase 1). Distils your own
+      FINISHED session transcripts into durable atoms (facts, preferences,
+      constraints, events) written into your own store through the same
+      `memory add` path — so knowledge outlives a window nobody remembered to
+      compile. Built for cron, not for a live session:
+        --max-sessions  transcripts per pass (default 3) — bounds the cost
+        --idle-min      never touch a transcript written inside N minutes
+                        (default 30). This is what keeps it off the LIVE session.
+        --max-chars     excerpt cap per transcript (default 20000)
+        --distiller     command reading the excerpt on stdin, returning
+                        {"atoms":[...]} (default: headless `claude --print`;
+                        env FIVEDIVE_MEMORY_DISTILLER also sets it)
+        --dry-run       print the atoms, write nothing, leave the ledger alone
+        --force         re-distil a transcript the ledger already records
+      Idempotent: a ledger (.consolidated.tsv beside the store) records each
+      (session, byte count), and `add` refuses a slug that already exists — so a
+      re-run is a no-op even if the ledger is lost.
+      Writes to YOUR OWN store only. There is deliberately no --store: an
+      auto-extractor must not be able to publish to the shared wiki (DIVE-481
+      deny-default). Publishing stays a curated act.
+      Cron it (nothing installs this for you):
+        */30 * * * * /usr/local/bin/5dive memory consolidate >>~/.5dive-consolidate.log 2>&1
+
   5dive memory doctor [--roots=a,b] [--agent=<name>] [--code-root=<dir>] [--json]
       Hygiene pass over the memory store(s): index drift (MEMORY.md vs files on
       disk), dangling [[wiki-links]], stale source refs (file:line no longer in
@@ -840,12 +865,354 @@ _memory_doctor() {
 }
 
 # cmd_memory — dispatch for the `memory` subcommand tree.
+# ---- async transcript → atom consolidation (DIVE-3628, DIVE-726 phase 1) ----
+#
+# THE FAILURE THIS EXISTS FOR: a session window dies and everything it learned
+# dies with it, because "compile before you close" is a HABIT and habits are not
+# a mechanism. The motivating case is recorded in the wiki: the very discussion
+# that produced this row was itself lost to an uncompiled window
+# ([[tencentdb-agent-memory-vs-5dive-gap-analysis]]).
+#
+# SHAPE (their L0→L1→L3, ours): L0 is the raw jsonl transcript, already on disk
+# and untouched. L1 is a bounded EXCERPT of it. L3 is a durable markdown atom in
+# the agent's own store. The lift is idea-derived, not code-derived — no port.
+#
+# WHY IT IS ASYNC AND NOT A HOOK: a hook runs inside the dying session and pays
+# for itself in that session's context. This pass runs from cron, out of band,
+# against transcripts nobody is writing to — so the distillation cost never
+# lands on a live window, and a session that dies ABRUPTLY (the actual failure)
+# is still consolidated, because nothing is asked of it at death.
+#
+# SCOPE GUARDS HELD (DIVE-3628 body):
+#   - reuses the existing stores. No database, no vector index, no CodeGraph.
+#   - every write goes through _memory_add, so the secret tripwire, the dedup
+#     warning, the frontmatter shape and the MEMORY.md index line are the SAME
+#     ones a hand-compiled memory gets. There is no second write path to audit.
+#   - deny-default sharing (DIVE-481): consolidate has NO --store flag and can
+#     only ever write `mine`. Publishing to the shared wiki stays a deliberate,
+#     curated act. An auto-extractor that could publish fleet-wide is the one
+#     shape this must not have.
+#
+# The three things that make it safe to leave running unattended:
+#   1. It never reads the LIVE session. A transcript touched inside --idle-min
+#      is skipped. The pass itself runs in a session that is writing a
+#      transcript; without this it would distill its own thinking.
+#   2. It is idempotent. The ledger records (session, bytes); a re-run over an
+#      unchanged transcript does no work and writes nothing. Belt and braces:
+#      _memory_add refuses an existing slug without --force, so even a ledger
+#      loss cannot duplicate an atom — it re-derives the same slug and conflicts.
+#   3. It is bounded. --max-sessions per pass and --max-chars per transcript, so
+#      the cron cost is flat whatever the store or the backlog does.
+#
+# THE DISTILLER IS A SEAM (--distiller). Default is a headless `claude -p`. The
+# harness injects a stub, which is what makes the unit test genuinely offline
+# rather than offline-looking: the module under test sends no live message, not
+# merely the test file.
+
+_MEM_CONSOLIDATE_PROMPT='You are distilling one finished agent session transcript into durable memory atoms.
+
+Return ONLY a JSON object: {"atoms":[...]}. No prose, no code fence.
+
+Each atom: {"type","name","description","body","confidence"}
+  type        one of: reference | user | feedback | project
+                reference = a durable FACT about the system or the world
+                user      = a PREFERENCE or trait of the human you work for
+                feedback  = a CONSTRAINT or correction on how work should be done
+                project   = an EVENT or ongoing commitment not derivable from the repo
+  name        kebab-case slug, <= 64 chars, specific enough to be unique
+  description one line; this is what recall ranks on, so make it searchable
+  body        2-6 sentences, self-contained. For feedback and project, follow the
+              fact with a "**Why:**" line and a "**How to apply:**" line.
+  confidence  high | medium | low
+
+RULES
+- Only DURABLE and NON-OBVIOUS facts. Nothing the repo, the git history or the
+  task board already records. Nothing that only mattered inside this session.
+- Absent anything durable, return {"atoms":[]}. An empty answer is a correct
+  answer and is much better than filler.
+- Convert relative dates ("yesterday", "last week") to absolute ones.
+- Never include a token, key, password or credential value. Reference where a
+  secret LIVES, never what it is.
+- At most 5 atoms.'
+
+# _memory_consolidate_excerpt <jsonl> <max-chars>
+# L0 → L1: a bounded plain-text excerpt of one transcript. Tool payloads are the
+# bulk of a jsonl and almost never the durable part, so they collapse to a name;
+# what survives is what a person said and what the agent concluded.
+_memory_consolidate_excerpt() {
+  python3 - "$1" "$2" <<'PYEOF'
+import json, sys
+path, cap = sys.argv[1], int(sys.argv[2])
+out = []
+try:
+    fh = open(path, encoding="utf-8", errors="replace")
+except OSError:
+    sys.exit(0)
+with fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except ValueError:
+            continue
+        if rec.get("type") not in ("user", "assistant"):
+            continue
+        msg = rec.get("message") or {}
+        content = msg.get("content")
+        if isinstance(content, str):
+            parts = [content]
+        elif isinstance(content, list):
+            parts = []
+            for blk in content:
+                if not isinstance(blk, dict):
+                    continue
+                if blk.get("type") == "text":
+                    parts.append(blk.get("text", ""))
+                elif blk.get("type") == "tool_use":
+                    parts.append("[tool: %s]" % blk.get("name", "?"))
+                elif blk.get("type") == "tool_result":
+                    parts.append("[tool result]")
+        else:
+            continue
+        txt = "\n".join(p for p in parts if p and p.strip())
+        if not txt.strip():
+            continue
+        out.append("%s: %s" % (rec.get("type"), txt.strip()))
+text = "\n\n".join(out)
+# Over the cap, keep the HEAD and the TAIL. The opening carries what the session
+# was for and the close carries what it concluded; the middle is the tool churn.
+if len(text) > cap:
+    half = cap // 2
+    text = text[:half] + "\n\n[... transcript middle elided ...]\n\n" + text[-half:]
+sys.stdout.write(text)
+PYEOF
+}
+
+# _memory_consolidate_parse — validate the distiller's JSON, emit one
+# TSV row per ACCEPTED atom (type, name, description, confidence, body-b64).
+# Anything malformed is dropped with a warning on stderr rather than written: a
+# distiller is a model, so the parse layer is a validation boundary, not a
+# formality. base64 keeps a multi-line body inside one row.
+#
+# EXIT 3 = the distiller produced nothing parseable (crashed, was not logged in,
+# answered in prose). That is NOT the same event as a session with nothing
+# durable in it, and collapsing the two is the whole succeeding-in-appearance
+# trap: an unauthed `claude --print` prints "Not logged in" and EXITS 0, so a
+# fleet-wide auth lapse would read as "the sessions were quiet" forever. Measured
+# on this box 2026-08-20.
+_memory_consolidate_parse() {
+  # The payload arrives as a FILE, not on stdin: `python3 - <<PY` already spends
+  # stdin on the program text, so a parser that read sys.stdin would silently
+  # see the python source and drop every atom. It fails as "found nothing",
+  # which is exactly the shape a working pass over a quiet session has.
+  python3 - "$1" <<'PYEOF'
+import base64, json, re, sys
+raw = open(sys.argv[1], encoding="utf-8", errors="replace").read().strip()
+# Tolerate a fenced block or leading prose — cheaper than failing a whole pass.
+m = re.search(r'\{.*\}', raw, re.S)
+if not m:
+    sys.stderr.write("consolidate: distiller returned no JSON object\n")
+    sys.exit(3)
+try:
+    doc = json.loads(m.group(0))
+except ValueError as e:
+    sys.stderr.write("consolidate: distiller JSON did not parse (%s)\n" % e)
+    sys.exit(3)
+atoms = doc.get("atoms")
+if not isinstance(atoms, list):
+    sys.stderr.write("consolidate: distiller JSON has no atoms[] array\n")
+    sys.exit(3)
+TYPES = {"reference", "user", "feedback", "project"}
+CONF = {"high", "medium", "low"}
+for a in atoms[:5]:
+    if not isinstance(a, dict):
+        continue
+    t = str(a.get("type", "")).strip()
+    n = str(a.get("name", "")).strip()
+    d = " ".join(str(a.get("description", "")).split())
+    b = str(a.get("body", "")).strip()
+    c = str(a.get("confidence", "")).strip() or "medium"
+    if t not in TYPES:
+        sys.stderr.write("consolidate: dropped atom with bad type %r\n" % t); continue
+    if not re.match(r'^[a-z0-9][a-z0-9-]{0,63}$', n):
+        sys.stderr.write("consolidate: dropped atom with bad slug %r\n" % n); continue
+    if not d or not b:
+        sys.stderr.write("consolidate: dropped atom %r with empty description/body\n" % n); continue
+    if c not in CONF:
+        c = "medium"
+    print("\t".join([t, n, d, c, base64.b64encode(b.encode()).decode()]))
+PYEOF
+}
+
+_memory_consolidate() {
+  local max_sessions=3 idle_min=30 max_chars=20000 distiller="" dry=0 force=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --max-sessions=*) max_sessions="${1#*=}" ;;
+      --idle-min=*)     idle_min="${1#*=}" ;;
+      --max-chars=*)    max_chars="${1#*=}" ;;
+      --distiller=*)    distiller="${1#*=}" ;;
+      --dry-run)        dry=1 ;;
+      --force)          force=1 ;;
+      -h|--help)        _memory_usage; return 0 ;;
+      *)                fail "$E_USAGE" "memory consolidate: unknown arg: $1" ;;
+    esac
+    shift
+  done
+  printf '%s' "$max_sessions" | grep -qE '^[0-9]+$' || fail "$E_VALIDATION" "--max-sessions must be a number"
+  printf '%s' "$idle_min"     | grep -qE '^[0-9]+$' || fail "$E_VALIDATION" "--idle-min must be a number (minutes)"
+  printf '%s' "$max_chars"    | grep -qE '^[0-9]+$' || fail "$E_VALIDATION" "--max-chars must be a number"
+  [ "$max_chars" -ge 500 ] || fail "$E_VALIDATION" "--max-chars below 500 leaves nothing to distill"
+
+  # Own store only. Same resolution rule as `memory add` so both verbs agree on
+  # which dir "mine" means; never invent a store the harness did not bootstrap.
+  local dir="" d
+  for d in "$HOME"/.claude/projects/*/memory; do
+    [ -d "$d" ] || continue
+    [ -z "$dir" ] && dir="$d"
+    [ -f "$d/MEMORY.md" ] && { dir="$d"; break; }
+  done
+  [ -n "$dir" ] || fail "$E_NOT_FOUND" "no memory store found under ~/.claude/projects/*/memory"
+
+  local ledger="$dir/.consolidated.tsv"
+  [ -f "$ledger" ] || : > "$ledger"
+
+  # Single-flight. Cron can fire a second pass while the first is still inside a
+  # distiller call; two passes over the same transcript would race the ledger and
+  # double-write. Non-blocking: the second pass declines rather than queues.
+  local lockf="$dir/.consolidate.lock"
+  # BRACES MATTER: `exec 201>f 2>/dev/null` is TWO permanent redirections, and the
+  # second one kills stderr for the whole rest of the pass — every tripwire
+  # refusal and dedup warning would vanish and the run would read as "found
+  # nothing". Grouping scopes the 2>/dev/null to the open attempt alone.
+  { exec 201>"$lockf"; } 2>/dev/null || true
+  if command -v flock >/dev/null 2>&1; then
+    flock -n 201 || fail "$E_CONFLICT" "another consolidate pass holds $lockf — declining rather than racing it"
+  fi
+
+  if [ -z "$distiller" ]; then
+    distiller="${FIVEDIVE_MEMORY_DISTILLER:-}"
+  fi
+  if [ -z "$distiller" ]; then
+    command -v claude >/dev/null 2>&1 || [ -x /home/claude/.local/bin/claude ] \
+      || fail "$E_NOT_FOUND" "no distiller: pass --distiller=<cmd> or install the claude CLI"
+    local _cl; _cl=$(command -v claude 2>/dev/null || echo /home/claude/.local/bin/claude)
+    distiller="$_cl --print"
+  fi
+
+  local considered=0 processed=0 written=0 refused=0 dupes=0 skipped_live=0 skipped_done=0
+  local distill_failed=0
+  local -a written_files=()
+  local now; now=$(date +%s)
+  local t
+  # Newest first: the most recent dead session is the one whose loss hurts most.
+  while IFS= read -r t; do
+    [ -f "$t" ] || continue
+    [ "$processed" -ge "$max_sessions" ] && break
+    considered=$((considered+1))
+    local sid; sid=$(basename "$t" .jsonl)
+    local mt; mt=$(stat -c %Y "$t" 2>/dev/null || echo 0)
+    local bytes; bytes=$(stat -c %s "$t" 2>/dev/null || echo 0)
+    # (1) never the live session — including the one this pass is running in.
+    if [ $(( (now - mt) / 60 )) -lt "$idle_min" ]; then
+      skipped_live=$((skipped_live+1)); continue
+    fi
+    # (2) idempotence — same session at the same byte count is already distilled.
+    if [ "$force" -ne 1 ] && grep -qF "$(printf '%s\t%s\t' "$sid" "$bytes")" "$ledger" 2>/dev/null; then
+      skipped_done=$((skipped_done+1)); continue
+    fi
+    local excerpt; excerpt=$(_memory_consolidate_excerpt "$t" "$max_chars") || excerpt=""
+    if [ -z "$(printf '%s' "$excerpt" | tr -d '[:space:]')" ]; then
+      skipped_done=$((skipped_done+1)); continue
+    fi
+    processed=$((processed+1))
+    local rawf; rawf=$(mktemp "${TMPDIR:-/tmp}/5dive-mem-distill.XXXXXX") || continue
+    printf '%s\n\n---- TRANSCRIPT ----\n%s\n' "$_MEM_CONSOLIDATE_PROMPT" "$excerpt" \
+      | eval "$distiller" > "$rawf" 2>/dev/null || :
+    # `x=$(cmd); rc=$?` ABORTS under the bundle's `set -euo pipefail` — errexit
+    # fires on the assignment before $? is ever read. The harness runs `set +e`
+    # (corpus convention) and so is structurally blind to this; measured against
+    # the built bundle 2026-08-20. `|| rc=$?` is the form that survives both.
+    local rows prc=0
+    rows=$(_memory_consolidate_parse "$rawf") || prc=$?
+    rm -f "$rawf"
+    if [ "$prc" -eq 3 ]; then
+      # No ledger row on a distiller failure. Stamping one would retire the
+      # transcript permanently on a transient auth blip — the backlog would be
+      # silently consumed by an outage and never re-tried.
+      distill_failed=$((distill_failed+1))
+      continue
+    fi
+    local n_written=0 n_refused=0 n_dupe=0
+    while IFS=$'\t' read -r a_type a_name a_desc a_conf a_body64; do
+      [ -n "${a_name:-}" ] || continue
+      local a_body; a_body=$(printf '%s' "$a_body64" | base64 -d 2>/dev/null) || continue
+      if [ "$dry" -eq 1 ]; then
+        echo "  would write: [$a_type] $a_name — $a_desc"
+        n_written=$((n_written+1)); continue
+      fi
+      # The ONE write path. No --store: consolidate cannot publish (DIVE-481).
+      local addout addrc=0
+      addout=$(printf '%s\n' "$a_body" | ( _memory_add \
+          --name="$a_name" --type="$a_type" --description="$a_desc" \
+          --confidence="$a_conf" \
+          --provenance="distilled from session $sid ($(date -u +%F))" \
+          --evidence="run:$sid" ) 2>&1) || addrc=$?
+      if [ "$addrc" -eq 0 ]; then
+        n_written=$((n_written+1))
+        written_files+=("$dir/${a_type}_$(printf '%s' "$a_name" | tr '-' '_').md")
+        echo "  ✓ [$a_type] $a_name"
+      elif printf '%s' "$addout" | grep -q 'already exists'; then
+        n_dupe=$((n_dupe+1))
+      else
+        # A refusal is a RESULT, not an error to swallow: the secret tripwire
+        # firing on a distilled atom is exactly the case we want counted and
+        # visible, and it must never look like "nothing was found".
+        n_refused=$((n_refused+1))
+        echo "  ✗ refused [$a_type] $a_name — $(printf '%s' "$addout" | tail -1)" >&2
+      fi
+    done <<< "$rows"
+    written=$((written+n_written)); refused=$((refused+n_refused)); dupes=$((dupes+n_dupe))
+    # Ledger last, and only on a real pass: a dry run must leave the backlog
+    # exactly as it found it, or the first real pass silently skips everything.
+    if [ "$dry" -eq 0 ]; then
+      printf '%s\t%s\t%s\t%s\t%s\n' "$sid" "$bytes" "$(date -u +%FT%TZ)" "$n_written" "$n_refused" >> "$ledger"
+    fi
+  done < <(ls -1t "$HOME"/.claude/projects/*/*.jsonl 2>/dev/null)
+
+  if (( JSON_MODE )); then
+    jq -nc --argjson considered "$considered" --argjson processed "$processed" \
+       --argjson written "$written" --argjson refused "$refused" --argjson dupes "$dupes" \
+       --argjson live "$skipped_live" --argjson done "$skipped_done" \
+       --argjson dfail "$distill_failed" \
+       --arg store "$dir" --arg ledger "$ledger" --argjson dry "$([ "$dry" -eq 1 ] && echo true || echo false)" \
+      '{ok:true, data:{store:$store, ledger:$ledger, dry_run:$dry, considered:$considered,
+        processed:$processed, atoms_written:$written, atoms_refused:$refused,
+        atoms_duplicate:$dupes, skipped_live:$live, skipped_consolidated:$done,
+        distiller_failed:$dfail}}'
+  else
+    echo "consolidate: $processed session(s) distilled → $written atom(s) into $dir"
+    echo "  skipped: $skipped_live live (touched < ${idle_min}m ago) · $skipped_done already consolidated · $dupes duplicate atom(s)"
+    # Trailing `[ x ] && echo` is the last command of the function under errexit
+    # when the test is false — it would return 1 and abort the caller. `|| :`.
+    [ "$refused" -gt 0 ] && echo "  refused: $refused atom(s) — see stderr (tripwire/validation)" >&2 || :
+    # Loud, and never folded into "0 atoms": a distiller that cannot answer is a
+    # different event from a session with nothing worth keeping.
+    [ "$distill_failed" -gt 0 ] && echo "  DISTILLER FAILED on $distill_failed session(s) — not ledgered, will retry next pass (is the CLI logged in?)" >&2 || :
+    [ "$dry" -eq 1 ] && echo "  (dry run — nothing written, ledger untouched)" || :
+  fi
+  return 0
+}
+
 cmd_memory() {
   local sub="${1:-}"; shift 2>/dev/null || true
   case "$sub" in
     search)      _memory_search "$@" ;;
     add|compile) _memory_add "$@" ;;
     doctor|hygiene) _memory_doctor "$@" ;;
+    consolidate|distill) _memory_consolidate "$@" ;;
     ""|-h|--help) _memory_usage ;;
     *)           _memory_usage; fail "$E_USAGE" "memory: unknown subcommand: $sub" ;;
   esac

--- a/src/task/crud.sh
+++ b/src/task/crud.sh
@@ -375,7 +375,8 @@ An internal-machinery finding gets its own ident ONLY if it has ALREADY blocked 
 REFUSED TITLE (recorded in policy_refusals, not lost): ${title}
 This is a budget on NEW ROWS, not on noticing things. Put it where it already has context:
   · a finding on work you are doing  →  append it to the BODY of the row you found it on
-  · durable, reusable knowledge      →  community/wiki/ (see the compile-knowledge skill)
+  · durable, reusable knowledge      →  community/wiki/ (see the compile-knowledge skill; a
+    plain fact from this session needs no row and no page — 'memory consolidate' already lifts it)
   · someone must ACT and it is serious →  --priority=high (high and urgent are never capped)
 There is no bypass flag. If it is serious enough to need one, it is serious enough to be high."
       fi

--- a/telegram-agent-CLAUDE.md
+++ b/telegram-agent-CLAUDE.md
@@ -9,6 +9,15 @@ see must go through `mcp__plugin_telegram_telegram__reply`.
   blocks them (their pickers are tmux-only; the Telegram user can't see
   them and the agent would hang). Inline questions and plans as numbered
   lines in a reply instead.
-- Compile durable, non-obvious knowledge into your memory so it survives
-  restarts (use the `compile-knowledge` skill) — and into a shared `wiki/`
-  if you work as a team. Skip filler; most tasks produce nothing durable.
+- Memory is TWO layers, and only one of them is your job.
+  - AUTOMATIC: `5dive memory consolidate` distils your FINISHED session
+    transcripts into memory atoms in your own store. It is scheduled for
+    you, it never reads the live session, and everything it writes stays
+    on this box. You do not have to hand-copy facts out of a session to
+    keep them — that is what stops knowledge dying with the window.
+  - STILL YOURS: judgement-shaped knowledge — a wiki page, a decision and
+    why, a gap analysis, the CAUSE behind a finding. The pipeline can only
+    lift what is lying in the transcript; a conclusion you drew is not.
+    Use the `compile-knowledge` skill for these, into a shared `wiki/` if
+    you work as a team. The pipeline deliberately cannot publish there.
+  Skip filler; most tasks produce nothing durable.

--- a/tests/heartbeat_memory_consolidate_unit.sh
+++ b/tests/heartbeat_memory_consolidate_unit.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# DIVE-3628 unit harness for _hb_memory_consolidate_sweep — THE SCHEDULER.
+#
+# The verb was already covered by tests/memory_consolidate_unit.sh. What was
+# never covered, and what quinn bounced iteration 1 for, is that anything FIRES
+# it: "a verb with no scheduler is not an async pipeline". So every arm here is
+# about the firing decision, not about distillation.
+#
+# The arms that matter are the ones that would let COST run away, because that is
+# the failure this sweep is one tick away from at all times (the tick fires every
+# 5 minutes; a distiller call costs real money and takes ~35s):
+#   - the cadence gate is proved by a SECOND call in the same window making no
+#     further invocation — a gate that let everything through would still pass a
+#     "did it run at all" arm.
+#   - the stamp is written BEFORE the run, proved by a distiller that FAILS
+#     still leaving a stamp. Stamping after would re-enter a wedged pass on
+#     every tick and multiply the spend by however many ticks it outlives.
+#   - the off switch is proved by zero invocations, not by a flag being read.
+#   - a failing seat is proved to be COUNTED, not swallowed: a fleet auth lapse
+#     must not read as a quiet box (the same succeeding-in-appearance trap the
+#     verb's own DISTILLER FAILED class exists for).
+# Run: bash tests/heartbeat_memory_consolidate_unit.sh
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/hb-consol-unit.XXXXXX)"
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "  ok   — $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "  FAIL — $1"; }
+check(){ if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3', got '$2')"; fi; }
+
+# --- Extract the sweep + its constants from the module ------------------------
+# cmd_heartbeat.sh is ~4000 lines and sourcing it whole drags in a registry, a
+# DB and root checks. The sweep is self-contained, so the harness lifts exactly
+# it. Extraction is ASSERTED (not assumed): if the function is renamed or moved,
+# this harness fails loudly instead of testing an empty string and going green.
+SWEEP_SRC=$(awk '/^_hb_memory_consolidate_sweep\(\) \{/,/^\}/' "$SRC/cmd_heartbeat.sh")
+if [ -z "$SWEEP_SRC" ]; then
+  echo "  FAIL — could not extract _hb_memory_consolidate_sweep from $SRC/cmd_heartbeat.sh"
+  echo "PASS=0 FAIL=1"; exit 1
+fi
+grep -q '^_HB_CONSOLIDATE_EVERY_MIN=' "$SRC/cmd_heartbeat.sh" \
+  && ok "the cadence constant _HB_CONSOLIDATE_EVERY_MIN is defined in the module" \
+  || bad "_HB_CONSOLIDATE_EVERY_MIN is not defined in the module"
+grep -q '^_HB_CONSOLIDATE_TIMEOUT_S=' "$SRC/cmd_heartbeat.sh" \
+  && ok "the timeout constant _HB_CONSOLIDATE_TIMEOUT_S is defined in the module" \
+  || bad "_HB_CONSOLIDATE_TIMEOUT_S is not defined in the module"
+
+eval "$SWEEP_SRC"
+_HB_CONSOLIDATE_EVERY_MIN=360
+_HB_CONSOLIDATE_TIMEOUT_S=300
+STATE_DIR="$TMP/state"
+SELF_BIN="$TMP/fake-5dive"
+CALLS="$TMP/calls.log"
+
+_hb_log() { :; }
+registry_read() { printf '%s' "${REG:-{\"agents\":{}\}}"; }
+# Stub the whole invocation chain. `timeout` and `sudo` are the two commands the
+# sweep shells out through, so both are replaced by recorders — otherwise a
+# "green" arm could be green because sudo refused.
+timeout() { shift; "$@"; }
+sudo()    { local u=""; while [ $# -gt 0 ]; do case "$1" in -u) u="$2"; shift 2;; -n|-H) shift;; *) break;; esac; done
+            printf '%s\t%s\n' "$u" "$*" >> "$CALLS"; return "${STUB_RC:-0}"; }
+id()      { case "${2:-}" in agent-alice|agent-bob) return 0;; *) return 1;; esac; }
+
+REG='{"agents":{"alice":{},"bob":{}}}'
+reset() { rm -rf "$STATE_DIR" "$CALLS"; : > "$CALLS"; STUB_RC=0; unset MEMORY_CONSOLIDATE MEMORY_CONSOLIDATE_EVERY_MIN; }
+ncalls() { wc -l < "$CALLS" | tr -d ' '; }
+NOW=1000000000
+
+echo "== scheduler fires at all =="
+reset
+_hb_memory_consolidate_sweep "$NOW"
+check "both enrolled seats get exactly one pass on a cold start" "$(ncalls)" "2"
+check "_HB_CONS_RAN counts them"                                 "$_HB_CONS_RAN" "2"
+grep -q '^agent-alice	' "$CALLS" && ok "the pass runs as the SEAT's user (agent-alice), not root" \
+  || bad "the pass did not run as agent-alice"
+grep -q 'memory consolidate --max-sessions=1' "$CALLS" \
+  && ok "the pass is bounded to ONE session per run (the cost bound)" \
+  || bad "the invocation is not capped at --max-sessions=1"
+
+echo "== the cadence gate (the runaway-cost arm) =="
+_hb_memory_consolidate_sweep "$NOW"
+check "a second tick inside the window invokes NOTHING further" "$(ncalls)" "2"
+check "and reports the seats as not-due"                        "$_HB_CONS_SKIPPED" "2"
+_hb_memory_consolidate_sweep "$((NOW + 359*60))"
+check "one minute short of the cadence is still not due"        "$(ncalls)" "2"
+_hb_memory_consolidate_sweep "$((NOW + 361*60))"
+check "past the cadence it runs again"                          "$(ncalls)" "4"
+
+echo "== NEGATIVE CONTROL: the gate is a clock, not a constant refusal =="
+# Without this arm, "invokes nothing further" is satisfied by a sweep that is
+# simply broken after its first call.
+reset
+MEMORY_CONSOLIDATE_EVERY_MIN=1
+_hb_memory_consolidate_sweep "$NOW"
+_hb_memory_consolidate_sweep "$((NOW + 120))"
+check "a 1-minute cadence DOES re-fire two minutes later"       "$(ncalls)" "4"
+
+echo "== the off switch =="
+reset
+MEMORY_CONSOLIDATE=off
+_hb_memory_consolidate_sweep "$NOW"
+check "MEMORY_CONSOLIDATE=off invokes nothing"                  "$(ncalls)" "0"
+check "and leaves no stamp behind to skew the next run"         "$(ls "$STATE_DIR/memory-consolidate" 2>/dev/null | wc -l | tr -d ' ')" "0"
+
+echo "== stamp BEFORE the run, so a wedged pass cannot be re-entered =="
+reset
+STUB_RC=1
+_hb_memory_consolidate_sweep "$NOW"
+check "a FAILING pass is counted, not swallowed"                "$_HB_CONS_FAILED" "2"
+check "and still stamped (a failure must not re-run every 5m)"  "$(ls "$STATE_DIR/memory-consolidate" 2>/dev/null | wc -l | tr -d ' ')" "2"
+STUB_RC=0
+_hb_memory_consolidate_sweep "$NOW"
+check "so the very next tick invokes nothing"                   "$(ncalls)" "2"
+
+echo "== a seat with no unix user is skipped, not run as root =="
+reset
+REG='{"agents":{"alice":{},"ghost":{}}}'
+_hb_memory_consolidate_sweep "$NOW"
+check "only the resolvable seat runs"                           "$(ncalls)" "1"
+grep -q 'ghost' "$CALLS" && bad "the unresolvable seat was invoked anyway" \
+  || ok "the unresolvable seat was skipped"
+REG='{"agents":{"alice":{},"bob":{}}}'
+
+echo "== a broken registry is survivable =="
+reset
+REG='not json'
+_hb_memory_consolidate_sweep "$NOW"; rc=$?
+check "an unparseable registry returns 0 (never aborts the tick)" "$rc" "0"
+check "and invokes nothing"                                       "$(ncalls)" "0"
+REG='{"agents":{"alice":{},"bob":{}}}'
+
+echo "== the tick actually CALLS the sweep (the whole point) =="
+grep -q '_hb_memory_consolidate_sweep "\$now"' "$SRC/cmd_heartbeat.sh" \
+  && ok "cmd_heartbeat_tick invokes _hb_memory_consolidate_sweep" \
+  || bad "the sweep exists but the tick never calls it — a verb with no scheduler"
+# NOT `awk ... | grep -q`. This harness runs under `set -o pipefail` (corpus
+# convention) and `grep -q` exits on its FIRST match, SIGPIPEing awk — so the
+# pipeline reports 141 and the arm reads FALSE on code that is present and
+# correct. Cost the first time: two red arms accusing correct code. Buffer the
+# text, then match it.
+TICK_BODY=$(awk '/^cmd_heartbeat_tick\(\) /,/^\}/' "$SRC/cmd_heartbeat.sh")
+case "$TICK_BODY" in
+  *_hb_memory_consolidate_sweep*) ok "and the call is INSIDE cmd_heartbeat_tick, not merely in the file" ;;
+  *) bad "the call is not inside cmd_heartbeat_tick" ;;
+esac
+case "$TICK_BODY" in
+  *"_hb_memory_consolidate_sweep \"\$now\" || _hb_log"*) ok "the call carries the non-fatal isolation contract every sweep owes" ;;
+  *) bad "the sweep call is not isolated — a failure could abort the wake loop" ;;
+esac
+
+echo "== the instruction surfaces describe the POST-pipeline workflow =="
+# lodar's acceptance: "a reviewer can read each surface and see it describes the
+# post-pipeline workflow". Asserted mechanically so the text cannot silently
+# revert to the pre-pipeline wording.
+surf() {
+  if grep -q "memory consolidate" "$1"; then ok "$2 names the pipeline"; else bad "$2 does not name the pipeline"; fi
+}
+surf "$SRC/cmd_heartbeat.sh"     "the knowledge-task nudge (cmd_heartbeat.sh)"
+surf "$SRC/cmd_agent_create.sh"  "the seeded per-seat MEMORY.md (cmd_agent_create.sh)"
+surf "$SRC/task/crud.sh"         "the filing-cap guidance (task/crud.sh)"
+surf "telegram-agent-CLAUDE.md"  "the shipped per-seat CLAUDE.md template"
+# ...and STILL tell agents to hand-compile judgement. lodar: "It must NOT tell
+# agents to stop compiling." A surface that only announced the pipeline would
+# pass the arm above and fail the intent.
+for f in "$SRC/cmd_heartbeat.sh" "$SRC/cmd_agent_create.sh" "telegram-agent-CLAUDE.md"; do
+  grep -qi "compile" "$f" && ok "$(basename "$f") still instructs hand-compiling" \
+    || bad "$(basename "$f") dropped the hand-compile instruction"
+done
+grep -q 'MEMORY_CONSOLIDATE=off' "$SRC/cmd_memory.sh" \
+  && ok "the help states the off switch" || bad "the help does not state the off switch"
+grep -qE '\$0\.(244|081)' "$SRC/cmd_memory.sh" \
+  && ok "the help states the MEASURED per-session cost" || bad "the help does not state a measured cost"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/memory_consolidate_unit.sh
+++ b/tests/memory_consolidate_unit.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# DIVE-3628 unit harness for `5dive memory consolidate` — the async
+# transcript -> memory-atom pipeline (DIVE-726 phase 1).
+#
+# OFFLINE BY CONSTRUCTION, not by convention. The distiller is a SEAM
+# (--distiller), and every arm here injects a stub script, so the module under
+# test never reaches a model — the usual failure is a clean-looking test file
+# whose module still sends a live message.
+#
+# The arms that matter are the NEGATIVE CONTROLS, not the happy path:
+#   - the live-session skip is proved by re-running with --idle-min=0 and
+#     watching the SAME transcript get processed. Without that arm, "skipped"
+#     is satisfied by the pass being broken in any other way.
+#   - dry-run is proved by a REAL run afterwards still writing. A dry run that
+#     quietly stamped the ledger would look identical on its own.
+#   - idempotence is proved twice, once with the ledger and once with the
+#     ledger deleted, because those are two different mechanisms.
+#   - the secret tripwire arm asserts BOTH "refused" and "no file on disk".
+# Run: bash tests/memory_consolidate_unit.sh
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/mem-consol-unit.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do
+  source "$SRC/$f"
+done
+# shellcheck source=/dev/null
+source "$SRC/cmd_memory.sh"
+JSON_MODE=0
+set +e
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "  ok   — $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "  FAIL — $1"; }
+check(){ if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3', got '$2')"; fi; }
+
+export HOME="$TMP/home"
+PROJ="$HOME/.claude/projects/proj"
+STORE="$PROJ/memory"
+mkdir -p "$STORE"; : > "$STORE/MEMORY.md"
+LEDGER="$STORE/.consolidated.tsv"
+
+# --- transcript fixtures -----------------------------------------------------
+# Reserved-fake identifiers only (CLAUDE.md): no real id, email or address.
+mk_transcript() { # <path> <user text> <assistant text>
+  local p="$1" u="$2" a="$3"
+  python3 - "$p" "$u" "$a" <<'PY'
+import json, sys
+p, u, a = sys.argv[1], sys.argv[2], sys.argv[3]
+recs = [
+  {"type":"user","message":{"role":"user","content":u}},
+  {"type":"assistant","message":{"role":"assistant","content":[
+      {"type":"tool_use","name":"Bash","input":{"command":"x"*4000}},
+      {"type":"text","text":a}]}},
+  {"type":"system","content":"ignored"},
+]
+with open(p,"w") as fh:
+    for r in recs: fh.write(json.dumps(r)+"\n")
+PY
+}
+
+mk_transcript "$PROJ/aaaa-1111.jsonl" "keep the deploy gate manual" "Understood, recorded."
+mk_transcript "$PROJ/bbbb-2222.jsonl" "second session about billing" "Noted."
+touch -d '3 hours ago' "$PROJ/aaaa-1111.jsonl" "$PROJ/bbbb-2222.jsonl"
+
+# --- distiller stubs ---------------------------------------------------------
+stub() { # <name> <stdout payload>
+  local f="$TMP/$1.sh"
+  { echo '#!/usr/bin/env bash'; echo 'cat >/dev/null'; printf 'cat <<%s\n%s\n%s\n' "'JSONEOF'" "$2" "JSONEOF"; } > "$f"
+  chmod +x "$f"; echo "$f"
+}
+
+GOOD=$(stub good '{"atoms":[
+ {"type":"feedback","name":"deploy-gate-stays-manual","description":"the deploy gate is deliberately manual","body":"The deploy gate is manual on purpose.\n**Why:** an automatic gate cannot be declined.\n**How to apply:** never automate it.","confidence":"high"},
+ {"type":"reference","name":"billing-lives-in-api","description":"billing code lives in the api service","body":"Billing and subscription code lives in the api service, not the app.","confidence":"medium"}]}')
+EMPTY=$(stub empty '{"atoms":[]}')
+GARBAGE=$(stub garbage 'I could not do that, sorry.')
+# Assembled at runtime, never committed as a literal: the repo's PII/secret push
+# guard reads what the tree CONTAINS, and a token-shaped fixture is the exact
+# string it exists to stop. The reserved-fake id (1234567890) is the CLAUDE.md one.
+TOKENISH="BOT""_TOKEN=1234567890:$(printf 'A%.0s' $(seq 35))"
+SECRET=$(stub secret '{"atoms":[{"type":"reference","name":"leaky-atom","description":"a leaky one","body":"The bot uses '"$TOKENISH"' to talk.","confidence":"high"}]}')
+MALFORMED=$(stub malformed '{"atoms":[
+ {"type":"nonsense","name":"bad-type","description":"d","body":"b"},
+ {"type":"reference","name":"Bad_Slug!","description":"d","body":"b"},
+ {"type":"reference","name":"empty-body","description":"d","body":"   "},
+ {"type":"reference","name":"survivor-atom","description":"the one good atom in a bad batch","body":"This is the only well formed atom in the batch and it must survive.","confidence":"low"}]}')
+
+run() { ( _memory_consolidate "$@" ) ; }
+
+echo "── excerpt (L0 -> L1): keeps speech, collapses tool payloads, caps ──"
+EX=$(_memory_consolidate_excerpt "$PROJ/aaaa-1111.jsonl" 20000)
+printf '%s' "$EX" | grep -q 'keep the deploy gate manual' && ok "user turn survives" || bad "user turn survives"
+printf '%s' "$EX" | grep -q '\[tool: Bash\]' && ok "tool_use collapses to its name" || bad "tool_use collapses to its name"
+printf '%s' "$EX" | grep -q 'xxxxxxxxxx' && bad "4KB tool payload elided" || ok "4KB tool payload elided"
+printf '%s' "$EX" | grep -q 'ignored' && bad "non user/assistant records skipped" || ok "non user/assistant records skipped"
+EXC=$(_memory_consolidate_excerpt "$PROJ/aaaa-1111.jsonl" 600)
+[ "${#EXC}" -le 700 ] && ok "--max-chars caps the excerpt (${#EXC} <= 700)" || bad "--max-chars caps the excerpt (got ${#EXC})"
+
+echo "── happy path: atoms land in the OWN store, through memory add ──"
+OUT=$(run --distiller="$GOOD" --max-sessions=1 2>&1); RC=$?
+check "exit 0" "$RC" "0"
+[ -f "$STORE/feedback_deploy_gate_stays_manual.md" ] && ok "feedback atom written" || bad "feedback atom written"
+[ -f "$STORE/reference_billing_lives_in_api.md" ] && ok "reference atom written" || bad "reference atom written"
+grep -q 'deploy-gate-stays-manual' "$STORE/MEMORY.md" && ok "MEMORY.md index line appended" || bad "MEMORY.md index line appended"
+F="$STORE/feedback_deploy_gate_stays_manual.md"
+grep -q '^  type: feedback$' "$F" && ok "frontmatter type from the atom" || bad "frontmatter type from the atom"
+grep -q '^  confidence: high$' "$F" && ok "confidence carried through" || bad "confidence carried through"
+grep -q 'distilled from session aaaa-1111' "$F" && ok "provenance names the session" || bad "provenance names the session"
+grep -q '"run:aaaa-1111"' "$F" && ok "structural evidence back-ref run:<session>" || bad "structural evidence back-ref run:<session>"
+grep -q '\*\*Why:\*\*' "$F" && ok "multi-line body survives base64 round-trip" || ok "multi-line body survives base64 round-trip"
+check "ledger has one row" "$(wc -l < "$LEDGER")" "1"
+grep -q '^aaaa-1111' "$LEDGER" && ok "ledger keyed on the newest session first" || bad "ledger keyed on the newest session first"
+
+echo "── idempotence: a second pass over an unchanged transcript is a no-op ──"
+BEFORE=$(ls "$STORE" | wc -l)
+run --distiller="$GOOD" --max-sessions=1 >/dev/null 2>&1
+check "no new files on re-run (ledger hit)" "$(ls "$STORE" | wc -l)" "$BEFORE"
+check "the consolidated session is recorded exactly once" "$(grep -c '^aaaa-1111' "$LEDGER")" "1"
+# Belt and braces: even with the ledger LOST, `add`'s existing-slug refusal holds.
+cp "$LEDGER" "$TMP/ledger.bak"; : > "$LEDGER"
+run --distiller="$GOOD" --max-sessions=1 >/dev/null 2>&1
+check "no new files with the ledger deleted (add refuses the slug)" "$(ls "$STORE" | wc -l)" "$BEFORE"
+cp "$TMP/ledger.bak" "$LEDGER"
+
+echo "── NEGATIVE CONTROL: the live-session skip is the idle rule, not a break ──"
+mk_transcript "$PROJ/cccc-3333.jsonl" "a session still being written" "Live."
+OUT=$(run --distiller="$EMPTY" --max-sessions=5 2>&1)
+printf '%s' "$OUT" | grep -q '1 live' && ok "fresh transcript reported as skipped-live" || bad "fresh transcript reported as skipped-live (got: $OUT)"
+grep -q '^cccc-3333' "$LEDGER" && bad "live transcript stayed out of the ledger" || ok "live transcript stayed out of the ledger"
+# Same transcript, same pass, only the idle rule relaxed -> it MUST be processed.
+OUT=$(run --distiller="$EMPTY" --max-sessions=5 --idle-min=0 2>&1)
+grep -q '^cccc-3333' "$LEDGER" && ok "CONTROL: --idle-min=0 processes that very transcript" || bad "CONTROL: --idle-min=0 processes that very transcript (got: $OUT)"
+
+echo "── dry-run writes nothing AND does not poison the ledger ──"
+mk_transcript "$PROJ/dddd-4444.jsonl" "a fourth session" "Fine."
+touch -d '3 hours ago' "$PROJ/dddd-4444.jsonl"
+D4=$(stub d4 '{"atoms":[{"type":"project","name":"fourth-session-atom","description":"an atom from the fourth session","body":"A durable project fact distilled from the fourth session transcript.","confidence":"medium"}]}')
+LB=$(wc -l < "$LEDGER")
+OUT=$(run --distiller="$D4" --max-sessions=1 --dry-run 2>&1)
+printf '%s' "$OUT" | grep -q 'would write: \[project\] fourth-session-atom' && ok "dry run names the atom" || bad "dry run names the atom (got: $OUT)"
+[ -f "$STORE/project_fourth_session_atom.md" ] && bad "dry run wrote no file" || ok "dry run wrote no file"
+check "dry run left the ledger untouched" "$(wc -l < "$LEDGER")" "$LB"
+run --distiller="$D4" --max-sessions=1 >/dev/null 2>&1
+[ -f "$STORE/project_fourth_session_atom.md" ] && ok "CONTROL: the real pass after a dry run still writes" || bad "CONTROL: the real pass after a dry run still writes"
+
+echo "── secret tripwire: a leaky atom is REFUSED and counted, never written ──"
+mk_transcript "$PROJ/eeee-5555.jsonl" "a session that mentions a token" "Ok."
+touch -d '3 hours ago' "$PROJ/eeee-5555.jsonl"
+ERR=$(run --distiller="$SECRET" --max-sessions=1 2>&1 >/dev/null)
+[ -f "$STORE/reference_leaky_atom.md" ] && bad "leaky atom not on disk" || ok "leaky atom not on disk"
+printf '%s' "$ERR" | grep -q 'refused' && ok "refusal is reported, not swallowed" || bad "refusal is reported, not swallowed (got: $ERR)"
+grep -q 'leaky-atom' "$STORE/MEMORY.md" && bad "no index line for a refused atom" || ok "no index line for a refused atom"
+
+echo "── malformed atoms are dropped individually; the good one still lands ──"
+mk_transcript "$PROJ/ffff-6666.jsonl" "a mixed batch session" "Ok."
+touch -d '3 hours ago' "$PROJ/ffff-6666.jsonl"
+run --distiller="$MALFORMED" --max-sessions=1 >/dev/null 2>&1
+[ -f "$STORE/reference_survivor_atom.md" ] && ok "well-formed atom in a bad batch survives" || bad "well-formed atom in a bad batch survives"
+ls "$STORE" | grep -qi 'bad_type\|bad_slug\|empty_body' && bad "malformed atoms dropped" || ok "malformed atoms dropped"
+
+echo "── a distiller that CANNOT ANSWER is a counted failure, not a quiet zero ──"
+# Measured on this box 2026-08-20: an unauthed `claude --print` prints
+# "Not logged in · Please run /login" and EXITS 0. Folding that into "0 atoms"
+# would let a fleet-wide auth lapse read as "the sessions were quiet".
+mk_transcript "$PROJ/iiii-9999.jsonl" "a session the distiller cannot handle" "Ok."
+touch -d '3 hours ago' "$PROJ/iiii-9999.jsonl"
+NOAUTH=$(stub noauth 'Not logged in · Please run /login')
+ERR=$(run --distiller="$NOAUTH" --max-sessions=1 2>&1 >/dev/null)
+printf '%s' "$ERR" | grep -q 'DISTILLER FAILED on 1 session' && ok "distiller failure is counted and loud" || bad "distiller failure is counted and loud (got: $ERR)"
+grep -q '^iiii-9999' "$LEDGER" && bad "a failed distill is NOT ledgered (it must retry)" || ok "a failed distill is NOT ledgered (it must retry)"
+# CONTROL: a distiller that legitimately finds nothing IS ledgered and is silent.
+run --distiller="$EMPTY" --max-sessions=1 >/dev/null 2>&1
+grep -q '^iiii-9999' "$LEDGER" && ok "CONTROL: an honest empty answer retires the transcript" || bad "CONTROL: an honest empty answer retires the transcript"
+ERR=$(run --distiller="$EMPTY" --max-sessions=1 --force 2>&1 >/dev/null)
+printf '%s' "$ERR" | grep -q 'DISTILLER FAILED' && bad "CONTROL: an empty answer is not reported as a failure" || ok "CONTROL: an empty answer is not reported as a failure"
+
+echo "── a distiller that returns prose is a quiet no-op, not a crash ──"
+mk_transcript "$PROJ/gggg-7777.jsonl" "a seventh session" "Ok."
+touch -d '3 hours ago' "$PROJ/gggg-7777.jsonl"
+BEFORE=$(ls "$STORE" | wc -l)
+run --distiller="$GARBAGE" --max-sessions=1 >/dev/null 2>&1
+check "garbage distiller exits 0" "$?" "0"
+check "garbage distiller wrote nothing" "$(ls "$STORE" | wc -l)" "$BEFORE"
+
+echo "── bounded: --max-sessions caps the pass ──"
+for n in 1 2 3 4 5; do
+  mk_transcript "$PROJ/hhhh-800$n.jsonl" "session $n" "Ok."
+  touch -d '3 hours ago' "$PROJ/hhhh-800$n.jsonl"
+done
+LB=$(wc -l < "$LEDGER")
+run --distiller="$EMPTY" --max-sessions=2 >/dev/null 2>&1
+check "exactly 2 sessions consumed" "$(( $(wc -l < "$LEDGER") - LB ))" "2"
+
+echo "── deny-default sharing: consolidate cannot publish (DIVE-481) ──"
+run --distiller="$GOOD" --store=wiki >/dev/null 2>&1
+[ "$?" -ne 0 ] && ok "--store is refused outright" || bad "--store is refused outright"
+grep -q '\-\-store' <<< "$(declare -f _memory_consolidate)" && bad "no --store branch exists in the code" || ok "no --store branch exists in the code"
+grep -q 'store=wiki' <<< "$(declare -f _memory_consolidate)" && bad "the wiki store is unreachable from consolidate" || ok "the wiki store is unreachable from consolidate"
+
+echo "── ERREXIT: the corpus runs set +e; the BUNDLE runs set -euo pipefail ──"
+# The harness convention (`set +e`) is structurally blind to errexit aborts, and
+# that is not hypothetical: `rows=$(parse); rc=$?` passed every arm above and
+# still killed the built bundle on the first distiller failure (measured
+# 2026-08-20). Every arm that can make an inner command exit non-zero is
+# re-run here under the bundle's own shell options.
+errexit_run() { ( set -euo pipefail; _memory_consolidate "$@" ) ; }
+mk_transcript "$PROJ/jjjj-1010.jsonl" "an errexit arm session" "Ok."
+touch -d '3 hours ago' "$PROJ/jjjj-1010.jsonl"
+errexit_run --distiller="$NOAUTH" --max-sessions=1 >/dev/null 2>&1
+check "distiller failure survives errexit" "$?" "0"
+errexit_run --distiller="$GARBAGE" --max-sessions=1 --force >/dev/null 2>&1
+check "unparseable output survives errexit" "$?" "0"
+errexit_run --distiller="$SECRET" --max-sessions=1 --force >/dev/null 2>&1
+check "a tripwire refusal survives errexit" "$?" "0"
+errexit_run --distiller="$EMPTY" --max-sessions=1 --force >/dev/null 2>&1
+check "an empty answer survives errexit" "$?" "0"
+errexit_run --distiller="$GOOD" --max-sessions=1 --force >/dev/null 2>&1
+check "a duplicate-slug refusal survives errexit" "$?" "0"
+errexit_run --distiller="$EMPTY" --max-sessions=1 --dry-run >/dev/null 2>&1
+check "dry run survives errexit" "$?" "0"
+
+echo "── validation ──"
+run --distiller="$EMPTY" --max-sessions=x >/dev/null 2>&1; [ "$?" -ne 0 ] && ok "--max-sessions must be numeric" || bad "--max-sessions must be numeric"
+run --distiller="$EMPTY" --idle-min=-1 >/dev/null 2>&1; [ "$?" -ne 0 ] && ok "--idle-min must be numeric" || bad "--idle-min must be numeric"
+run --distiller="$EMPTY" --max-chars=10 >/dev/null 2>&1; [ "$?" -ne 0 ] && ok "--max-chars floor is enforced" || bad "--max-chars floor is enforced"
+run --distiller="$EMPTY" --nope >/dev/null 2>&1; [ "$?" -ne 0 ] && ok "unknown flag refused" || bad "unknown flag refused"
+
+echo "── no store bootstrapped ⇒ clear failure, never an invented dir ──"
+OLDHOME="$HOME"; export HOME="$TMP/blank"; mkdir -p "$HOME/.claude/projects"
+run --distiller="$EMPTY" >/dev/null 2>&1; [ "$?" -ne 0 ] && ok "fails when no memory store exists" || bad "fails when no memory store exists"
+[ -d "$TMP/blank/.claude/projects"/*/memory ] 2>/dev/null && bad "invented no store dir" || ok "invented no store dir"
+export HOME="$OLDHOME"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## DIVE-3628 — memory moat phase 1: async transcript → memory atoms

`5dive memory consolidate`. A session window dies and everything it learned dies with it, because
"compile before you close" is a HABIT and a habit is not a mechanism. The motivating case is on the
record: the TencentDB-Agent-Memory discussion that produced this row was itself lost to an
uncompiled window.

### Shape

L0 the raw `~/.claude/projects/*/*.jsonl`, untouched → L1 a bounded plain-text excerpt (tool
payloads collapse to `[tool: X]`; over `--max-chars` it keeps head + tail) → L3 a markdown atom in
the agent's own store. Idea-derived from TencentDB-Agent-Memory (MIT); **no code ported, no
database, no vector index, no CodeGraph.**

### Scope guards from the row, and how each is held

| Guard | How |
|---|---|
| Reuse the existing stores | Every atom goes through `_memory_add`. One write path — the tripwire, dedup warning, frontmatter and `MEMORY.md` index line are the same ones a hand-compiled memory gets. |
| Deny-default sharing (DIVE-481) | `consolidate` has **no `--store`** and no reachable wiki branch. An auto-extractor that could publish fleet-wide is the one shape this must not have. |
| No new store | A `.consolidated.tsv` ledger beside the memory dir. That is the whole persistence layer. |
| PII fixture rules | Inherited tripwire; the harness's token-shaped fixture is assembled at runtime so the tree never contains one. |

### The three properties that make it safe to leave on a cron

1. **Never reads the LIVE session** — a transcript touched inside `--idle-min` (default 30m) is
   skipped. Without it the pass distils the very session it runs in.
2. **Idempotent twice over** — the ledger records (session, byte count); and with the ledger *lost*,
   `add` still refuses an existing slug. Both are tested.
3. **Bounded** — `--max-sessions` per pass, `--max-chars` per transcript, `flock` single-flight.

### A distiller that cannot answer is a counted, loud outcome — never "0 atoms"

Measured on this box: an unauthed `claude --print` prints `Not logged in` and **exits 0**. Folded
into the atom count, a fleet-wide auth lapse reads as "the sessions were quiet" forever. It is now
its own outcome (`distiller_failed`), and a failed distill is deliberately **not** ledgered, so an
outage cannot silently retire the backlog.

### Two defects the harness alone would not have caught

- `exec 201>"$lockf" 2>/dev/null` is **two permanent redirections** — the second kills stderr for
  the rest of the pass, swallowing every tripwire refusal. Caught only because an arm asserted the
  refusal was *reported*, not merely that no file was written.
- `rows=$(cmd); rc=$?` **aborts under the bundle's `set -euo pipefail`**. The corpus convention is
  `set +e`, so it is structurally blind to this: the code passed every arm and still killed the
  built bundle on the first distiller failure. The harness now re-runs the failure arms under the
  bundle's own shell options.

### Evidence

- `bash tests/memory_consolidate_unit.sh` → **PASS=53 FAIL=0**. Offline by construction: the
  distiller is an injected seam (`--distiller`), so the module under test never reaches a model.
- **Four mutants, each red exactly the arm meant to catch it** — the live-session skip (2 arms), the
  dry-run ledger guard (2), the ledger skip (1), the errexit fix (2).
- **Real bundle, real box, real transcripts**: `./build.sh && ./5dive memory consolidate --dry-run
  --max-sessions=1 --max-chars=6000` runs green against my own 980 transcripts, correctly skips the
  2 live sessions, and reports the unauthed distiller loudly. Ledger confirmed 0 bytes after.
- `scripts/pii-scan-range.sh origin/main HEAD` → clean.

### Residual I am signing

**No atom has been produced by a real model end-to-end.** This seat's `claude` CLI is not logged in
for headless use, so the default distiller could be exercised as far as "it runs, its output is
captured, its failure is classified" and no further. Everything downstream of the distiller is
covered by the injected seam. A verifier on an authed seat can close this with one command:
`5dive memory consolidate --dry-run --max-sessions=1`.

Nothing installs the cron entry; `5dive memory --help` carries the line.
