### PR TITLE
DIVE-3679: red changed-harnesses on a TOP-LEVEL verdict violation, not on not-reached

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -314,6 +314,39 @@ jobs:
         run: |
           bash tests/meta/harness-verdict-probe.sh \
             --only='${{ steps.changed.outputs.names }}' --label=changed
+      # DIVE-3679: and the probe's INJECTION POINT must be at top level. This is the
+      # static complement to the step above, and it is deliberately NOT the guard
+      # DIVE-3678 proposed. That one would have red-ed a touched harness reported
+      # `not-reached` "in every environment this lane can offer" — and this lane offers
+      # ONE `ubuntu-latest` runner, so the quantifier collapses to "not-reached in one
+      # pristine run". That is exactly the DIVE-2039 false accusation, aimed at every
+      # harness whose verdict is legitimately reachable only on an installed host. The
+      # union consumes SEVEN reports across two real environments for precisely that
+      # reason; a single lane cannot make a cross-environment claim, and adding an
+      # installed-host job here would make N=2 against a union of 7 and only move the
+      # boundary.
+      #
+      # What IS decidable in one environment is the static property: `head -n $((n-1))
+      # | bash -n` — bash's own parser saying whether the position the probe injects
+      # into is a complete program. It accuses nobody for skipping.
+      #
+      # WARN-ONLY, on this row's own instruction, until the two negative-control arms
+      # have been READ on DIVE-3679 rather than merely run by its author. To enforce,
+      # add `--enforce` to the line below and nothing else; the guard already exits 1
+      # on a violation under that flag, and it exits 1 REGARDLESS of the flag if its
+      # own selector resolves to nothing (a check reporting clean on what it never
+      # looked at is the hole, not the finding).
+      #
+      # Measured before shipping, on origin/main at 07a4345: 444 harnesses, 441 top
+      # level, 0 violations, 3 with neither probe family (exactly the probe's
+      # ALLOW_UNPROBEABLE list). Controls: buzz_preseed_dm_live.sh at 07a4345^ reds;
+      # the same harness at 07a4345 — live-only, skips in every pristine lane — is
+      # green.
+      - name: The probe's injection point must be at TOP LEVEL (static, DIVE-3679)
+        if: steps.changed.outputs.names != ''
+        run: |
+          bash tests/meta/harness-verdict-toplevel.sh \
+            --only='${{ steps.changed.outputs.names }}' --label=changed
 
   # DIVE-2525: this job used to open with the harness-verdict PROBE (DIVE-2013),
   # which runs the whole corpus a SECOND time — the single most expensive thing on

--- a/tests/corpus_tier_budget_unit.sh
+++ b/tests/corpus_tier_budget_unit.sh
@@ -427,8 +427,20 @@ mkdir -p "$FAKE/tests/meta"
 # without it each run would probe the other stub too, and the kill counts these
 # arms assert are counts over the whole run.
 FAKE_PROBE="$FAKE/tests/meta/$(basename "$PROBE")"
+# DIVE-3679: the probe now SOURCES tests/lib/harness-verdict-detect.sh (one verdict
+# detector, shared with the static top-level guard, so the two instruments cannot
+# disagree about which line is the verdict). It resolves that path relative to its own
+# location, which in this fake corpus is $FAKE — so the fake tree has to carry the
+# dependency too. Symlinked like the probe itself, and folded into the SAME seam
+# variable: a missing lib must report the seam as broken, not fail five arms with a
+# `source: no such file` that reads like a defect in the thing they grade.
+PROBE_LIB="tests/lib/harness-verdict-detect.sh"
+mkdir -p "$FAKE/tests/lib"
 SEAM=0
-[[ -r "$PROBE" ]] && ln -s "$PWD/$PROBE" "$FAKE_PROBE" 2>/dev/null && SEAM=1
+[[ -r "$PROBE" && -r "$PROBE_LIB" ]] \
+  && ln -s "$PWD/$PROBE" "$FAKE_PROBE" 2>/dev/null \
+  && ln -s "$PWD/$PROBE_LIB" "$FAKE/$PROBE_LIB" 2>/dev/null \
+  && SEAM=1
 CSTUB=hang_before_verdict.sh
 if (( SEAM )); then
   # Hangs on its CLEAN run, before any verdict, in every environment — the kill is

--- a/tests/harness_toplevel_guard_unit.sh
+++ b/tests/harness_toplevel_guard_unit.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# DIVE-3679 — tests/meta/harness-verdict-toplevel.sh
+#
+# The guard's two owed negative controls, made PERMANENT. The row asked for them
+# before the guard was allowed to fail anything; running them once on the author's box
+# arms nothing, so they live here and red in CI the moment the guard stops
+# discriminating. That is the whole difference between "the arms ran" and "the arms
+# are armed" — a monitor has to be shown it can FIRE, in the environment where it
+# fires, not just shown it does not false-alarm.
+#
+# Weighted toward the FALSE-CLEAN direction, because that is the direction that costs
+# a release: a guard that never accuses passes every day and is worth nothing, and a
+# guard that accuses a correctly-wired harness is the DIVE-2039 mistake DIVE-3678 was
+# rejected for. So both a firing arm and a NON-firing arm are graded, plus the two
+# ways this check could report clean on something it never looked at.
+#
+# Hermetic apart from arms 3/4, which grade the REAL harness that caused DIVE-3675 at
+# a pinned commit and its parent. Those skip loudly (never silently) on a shallow
+# clone; every job that runs this corpus uses fetch-depth 0 for exactly that reason.
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
+GUARD="$PWD/tests/meta/harness-verdict-toplevel.sh"
+[[ -r "$GUARD" ]] || { printf 'FAIL: %s not found\n' "$GUARD"; exit 1; }
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/hvt.XXXXXX") || exit 2
+PASS=0; FAIL=0; SKIP=0
+ok()   { PASS=$((PASS+1)); printf 'ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf 'FAIL %s\n     %s\n' "$1" "${2:-}"; }
+skip() { SKIP=$((SKIP+1)); printf 'SKIP %s\n     %s\n' "$1" "${2:-}"; }
+
+# ---------------------------------------------------------------------------
+# ARM 1 — IT FIRES. Verdict inside an arm no pristine lane enters: the exact shape
+# that read `not-reached` in all seven environments and refused the v0.21.3 cut.
+# ---------------------------------------------------------------------------
+cat > "$TMP/violating.sh" <<'STUB'
+#!/usr/bin/env bash
+FAIL=0
+if [[ -n "${LIVE_RELAY:-}" ]]; then
+  echo "live arm"
+  [[ "$FAIL" -eq 0 ]]
+fi
+STUB
+out=$(bash "$GUARD" --enforce "$TMP/violating.sh" 2>&1); rc=$?
+if (( rc == 1 )) && grep -q VIOLATION <<<"$out"; then
+  ok "a verdict inside an arm is a VIOLATION and --enforce exits non-zero"
+else bad "a verdict inside an arm is a VIOLATION and --enforce exits non-zero" "rc=$rc — $out"; fi
+
+# ---------------------------------------------------------------------------
+# ARM 2 — IT DOES NOT OVER-FIRE. A harness that skips everything in this
+# environment but ends in one top-level verdict is CORRECT and must pass. This is the
+# arm that separates this guard from the one DIVE-3678 proposed: `not-reached` here is
+# legitimate, and reding on it would accuse every installed-host-only harness.
+# ---------------------------------------------------------------------------
+cat > "$TMP/healthy.sh" <<'STUB'
+#!/usr/bin/env bash
+FAIL=0
+live_arms() {
+  if [[ -z "${LIVE_RELAY:-}" ]]; then echo "SKIP: no relay"; return; fi
+  echo "live arm"
+}
+live_arms
+[[ "$FAIL" -eq 0 ]]
+STUB
+out=$(bash "$GUARD" --enforce "$TMP/healthy.sh" 2>&1); rc=$?
+if (( rc == 0 )) && grep -q 'top level' <<<"$out"; then
+  ok "a skip-everywhere harness with ONE top-level verdict is green (no false accusation)"
+else bad "a skip-everywhere harness with ONE top-level verdict is green (no false accusation)" "rc=$rc — $out"; fi
+
+# ---------------------------------------------------------------------------
+# ARMS 3/4 — the REAL pair, pinned. 07a4345 is the DIVE-3675 fix; its parent is the
+# tree that broke the train. A stub can be written to satisfy any instrument; these
+# two cannot.
+# ---------------------------------------------------------------------------
+PIN=07a4345
+REAL=tests/buzz_preseed_dm_live.sh
+if git cat-file -e "$PIN^:$REAL" 2>/dev/null && git cat-file -e "$PIN:$REAL" 2>/dev/null; then
+  git show "$PIN^:$REAL" > "$TMP/real_parent.sh"
+  out=$(bash "$GUARD" --enforce "$TMP/real_parent.sh" 2>&1); rc=$?
+  if (( rc == 1 )); then ok "the real harness at ${PIN}^ — the tree that refused the v0.21.3 cut — REDS"
+  else bad "the real harness at ${PIN}^ — the tree that refused the v0.21.3 cut — REDS" "rc=$rc — $out"; fi
+  git show "$PIN:$REAL" > "$TMP/real_fixed.sh"
+  out=$(bash "$GUARD" --enforce "$TMP/real_fixed.sh" 2>&1); rc=$?
+  if (( rc == 0 )); then ok "the same harness at ${PIN} — live-only, skips in every pristine lane — is GREEN"
+  else bad "the same harness at ${PIN} — live-only, skips in every pristine lane — is GREEN" "rc=$rc — $out"; fi
+else
+  skip "the real DIVE-3675 pair at ${PIN}/${PIN}^" "commit or path not present — shallow clone? this corpus is run with fetch-depth 0 (DIVE-2229)"
+  skip "the real DIVE-3675 pair at ${PIN}/${PIN}^ (fixed side)" "same"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 5 — WARN-ONLY STILL REPORTS. The guard ships warn-only, so the claim "it is
+# reporting" has to be graded too: without --enforce a violation must exit 0 AND
+# still print the finding. A warn-only mode that also went quiet would be a guard
+# that is wired to nothing while looking installed.
+# ---------------------------------------------------------------------------
+out=$(bash "$GUARD" "$TMP/violating.sh" 2>&1); rc=$?
+if (( rc == 0 )) && grep -q VIOLATION <<<"$out" && grep -q 'WARN-ONLY' <<<"$out"; then
+  ok "warn-only exits 0 but still PRINTS the violation"
+else bad "warn-only exits 0 but still PRINTS the violation" "rc=$rc — $out"; fi
+
+# ---------------------------------------------------------------------------
+# ARM 6 — A SELECTOR THAT RESOLVED TO NOTHING IS NOT A PASS, in either mode. This is
+# the false-clean shape `changed-harnesses` already guards on its base commit: a
+# check reporting clean on what it never looked at.
+# ---------------------------------------------------------------------------
+out=$(bash "$GUARD" --only=no_such_harness_xyz.sh 2>&1); rc=$?
+if (( rc == 1 )) && grep -q BLOCKED <<<"$out"; then
+  ok "an --only that matches no harness BLOCKS rather than reporting clean"
+else bad "an --only that matches no harness BLOCKS rather than reporting clean" "rc=$rc — $out"; fi
+
+# ---------------------------------------------------------------------------
+# ARM 7 — NO SECOND ACCUSATION PATH. A harness with neither probe family (no counter,
+# no `set -e`) is the probe's UNPROBEABLE and fails THERE. If this guard also failed
+# it, the two instruments could disagree about the same file, and the fix for one
+# would be a red in the other.
+# ---------------------------------------------------------------------------
+printf '#!/usr/bin/env bash\necho hello\n' > "$TMP/noverdict.sh"
+out=$(bash "$GUARD" --enforce "$TMP/noverdict.sh" 2>&1); rc=$?
+if (( rc == 0 )) && grep -q 'no-verdict-line' <<<"$out"; then
+  ok "no identifiable verdict is reported, not accused (the probe owns UNPROBEABLE)"
+else bad "no identifiable verdict is reported, not accused (the probe owns UNPROBEABLE)" "rc=$rc — $out"; fi
+
+# ---------------------------------------------------------------------------
+# ARM 8 — THE ABORT FAMILY IS GRADED TOO. `set -e` plus bare assertions has no
+# counter, and the probe injects a bare `false` before the LAST executable line. If
+# this guard skipped that family it would print a clean pass over 25 of the 444
+# harnesses on main — measured, not estimated.
+# ---------------------------------------------------------------------------
+cat > "$TMP/abort_violating.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -n "${LIVE_RELAY:-}" ]]; then
+  [[ 1 -eq 1 ]]
+fi
+STUB
+out=$(bash "$GUARD" --enforce "$TMP/abort_violating.sh" 2>&1); rc=$?
+if (( rc == 1 )) && grep -q 'abort family' <<<"$out"; then
+  ok "an abort-family harness whose last executable line is inside an arm REDS"
+else bad "an abort-family harness whose last executable line is inside an arm REDS" "rc=$rc — $out"; fi
+
+printf -- '-----\nRESULT: %d passed, %d failed, %d skipped\n' "$PASS" "$FAIL" "$SKIP"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/lib/harness-verdict-detect.sh
+++ b/tests/lib/harness-verdict-detect.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# DIVE-3679: ONE verdict detector, sourced by BOTH callers.
+#
+# `tests/meta/harness-verdict-probe.sh` (empirical, DIVE-2013) and
+# `tests/meta/harness-verdict-toplevel.sh` (static, this row) must agree on WHICH
+# line is the harness's verdict, because the static guard's whole claim is about the
+# line the probe would mutate. Two copies of the detector are two detectors as soon
+# as one of them is edited — the same argument .github/scripts/simulate-installed-
+# host.sh carries for the installed-host seeding. So `counter_verdict` moved here
+# verbatim (comments and all) and the probe now sources this file; extracting it
+# without rewiring the original caller would have armed nothing.
+#
+# Lives in tests/lib/, which `tests/*.sh` does not glob and which the
+# `changed-harnesses` diff filter explicitly excludes — so this is a library, not a
+# harness, and it is never probed as one.
+
+# Extract the verdict variable from a harness's last executable line.
+# Prints "<var>\t<lineno>" or nothing. Handles the shapes olivia's census found:
+# [[ "$V" -eq N ]] / [[ $V -eq N ]] / [ "$V" -eq N ] / (( V == N )) /
+# [[ "$V" == "N" ]] / exit $V.
+# TWO harness families need TWO mutations, and conflating them is how this probe
+# produced three FALSE POSITIVES on its first run (byo_model_create, codex_bin_
+# resolution, openclaw_runtime — all `set -euo pipefail` with bare `[[ ]]`
+# assertions). Their exit status IS wired; the probe had grabbed a STRING operand
+# out of the last `[[ ]]` and "incremented" it, which proves nothing. Ground truth:
+# breaking a real assertion in byo_model_create by hand exits 1.
+#
+#   COUNTER family  — a numeric counter initialised to a number AND incremented,
+#                     consumed by a final verdict expression. Mutation: bump it.
+#   ABORT family    — `set -e` with assertions that exit on failure and no counter.
+#                     Mutation: inject a bare `false`, which set -e must turn into
+#                     a non-zero exit. (Wrong for the counter family, where a bare
+#                     `false` changes no counter and the harness correctly exits 0
+#                     — which is exactly the false positive, inverted.)
+#
+# Picking the wrong mutation gives a confident wrong answer, which is the defect
+# class this check exists to find. So the counter test is STRICT and `false` is
+# only used when no counter exists AND `set -e` is in force.
+counter_verdict() {   # -> "<var>\t<lineno>\t<last|not-last>"
+  local f="$1" n line var="" last_exec=""
+  last_exec=$(grep -nvE '^[[:space:]]*(#|$)' "$f" | tail -1 | cut -d: -f1)
+  while read -r n; do
+    line=$(sed -n "${n}p" "$f")
+    # An INVERTED verdict (-ne / !=) is SATISFIED by incrementing — refuse to guess.
+    [[ "$line" =~ (-ne|\!=)[[:space:]] ]] && continue
+    var=""
+    # Regexes live in VARIABLES: an unquoted `)` or `[^)]` inside [[ =~ ]] is a
+    # bash syntax error, not a regex. `exit $(( FAIL > 0 ))` is matched first —
+    # the bare `exit $VAR` form below would miss it entirely.
+    # Anchored right after `$((` — a greedy `.*` here backtracks to the shortest
+    # suffix and captures 'L' out of 'FAIL', which is a silently WRONG variable
+    # rather than no match. Same trap as everything else tonight: the broken form
+    # succeeds at something.
+    local re_arith='exit[[:space:]]+\$\(\([[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*[><=!]'
+    local re_exit='exit[[:space:]]+\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?'
+    local re_dbl='\(\([[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=='
+    local re_test='\[\[?[[:space:]]+"?\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?"?[[:space:]]+(-eq|==)'
+    if   [[ "$line" =~ $re_arith ]]; then var="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ $re_exit  ]]; then var="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ $re_dbl   ]]; then var="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ $re_test  ]]; then var="${BASH_REMATCH[1]}"
+    fi
+    [[ -n "$var" ]] || continue
+    # STRICT, and this is the line that separates a real verdict from the STRING
+    # operand that produced three false positives: every assignment to the
+    # variable must be a NUMERIC LITERAL or an arithmetic expression over itself.
+    # A counter (`FAIL=0` … `FAIL=$((FAIL+1))`) and a flag (`fail=0` … `fail=1`)
+    # both qualify; `setup_src=$(cat …)` does not, because incrementing a captured
+    # string proves nothing about whether the exit status is wired.
+    # Assignments must be matched in STATEMENT POSITION. Matching the bare
+    # substring `VAR=` also hits `echo "... FAIL=$FAIL"`, which is text inside a
+    # string, not an assignment — that false hit made 12 correctly-wired harnesses
+    # look UNPROBEABLE, a regression I introduced while fixing five others and did
+    # not see because I re-tested only the five.
+    local asn="(^[[:space:]]*(local[[:space:]]+)?|[;&|][[:space:]]*)${var}="
+    grep -qE "${asn}[0-9]+([[:space:]]|;|\)|$)" "$f" || continue
+    # Every statement-position assignment must be a numeric literal or arithmetic
+    # over the variable itself. A counter (FAIL=0 … FAIL=$((FAIL+1))) and a flag
+    # (fail=0 … fail=1) both qualify; `setup_src=$(cat …)` does not — incrementing
+    # a captured string proves nothing about whether the exit status is wired, and
+    # that is what produced three false UNWIRED verdicts on the first run.
+    if grep -oE "${asn}[^[:space:];]*" "$f" \
+       | grep -qvE "${var}=([0-9]+|\\\$\(\(.*${var}.*\)\))$"; then
+      continue
+    fi
+    printf '%s\t%s\t%s\n' "$var" "$n" "$([[ "$n" == "$last_exec" ]] && echo last || echo not-last)"
+    return 0
+  done < <(grep -nvE '^[[:space:]]*(#|$)' "$f" | tail -12 | cut -d: -f1 | tac)
+  return 1
+}
+
+# DIVE-3679: the STATIC half — is the probe's INJECTION POINT at top level?
+#
+# WHICH INSTRUMENT THIS IS, because the row asks explicitly and "leading indentation
+# is a proxy, not a parse": this is A REAL PARSE, PERFORMED BY BASH ITSELF. Neither
+# indentation nor a hand-rolled lexer.
+#
+# THE CLAIM, spelled exactly. harness-verdict-probe.sh inserts its canary and its
+# mutation immediately BEFORE the terminal verdict-shaped line (`awk NR==n{...}`), so
+# what has to be true is not a property of that line's whitespace but of the position
+# ahead of it: lines 1..n-1 must be a COMPLETE bash program. If they are, the
+# injection lands at a top-level statement boundary and executes in every environment
+# the harness runs in. If they are not, the injection lands inside an unclosed
+# construct — an arm no CI runner enters (DIVE-3675), or mid-way through a `\`
+# continuation, where the inserted lines break the statement outright.
+#
+# So: `head -n $((n-1)) file | bash -n`. Bash's own grammar answers the question, and
+# "syntax error: unexpected end of file" IS the finding. A prefix of a file that
+# already parses cannot fail for any other reason.
+#
+# WHY NOT THE HAND-ROLLED VERSION. It was written first — an awk keyword-balance
+# scanner over if/case/while/until/for/select/{ with quote and heredoc state — and
+# measured against this parse on all 444 harnesses on origin/main. It cost three
+# rounds of false accusations (19, then 48, then 6: a `\` continuation swallowing its
+# own `done`, a whole-line skip losing the `}` that followed a closing quote, and a
+# `<<'TAG'` written inside a quoted string wedging the heredoc state forever). Every
+# one of those was an ACCUSATION against a correctly-wired harness, which is the
+# failure mode DIVE-2039 exists to prevent and the reason DIVE-3678's guard was
+# rejected. Bash's parser has none of them by construction. The lesson generalises:
+# a guard whose instrument is a re-implementation of a parser the platform already
+# ships is a guard whose false-positive rate is its author's bug count.
+#
+# NOT A SUBSTITUTE FOR THE PROBE. harness-verdict-probe.sh's own header records that
+# static analysis cannot close the DIVE-2013 class — three instruments measured, all
+# agreeing, none sound; none can see a harness whose assertions never fire, a verdict
+# placed before the last assertion, or a `set -e` verdict bypassed. "The injection
+# point is at top level" is a STRICTLY NARROWER claim than "the verdict is wired", so
+# it does not inherit that refutation — and it must never be cited as doing the
+# probe's job.
+#
+# verdict_injection_point_top_level <file> <lineno>
+#   exit 0 = top level; exit 1 = not, with bash's own complaint on stdout.
+verdict_injection_point_top_level() {
+  local f="$1" n="$2" pfx err
+  # A verdict on line 1 has an empty prefix, which is trivially complete.
+  (( n <= 1 )) && return 0
+  pfx=$(mktemp) || return 2
+  err=$(mktemp) || { rm -f "$pfx"; return 2; }
+  head -n $(( n - 1 )) "$f" > "$pfx"
+  if bash -n "$pfx" 2>"$err"; then rm -f "$pfx" "$err"; return 0; fi
+  # Re-point bash's line numbers at the real file: the prefix has the same numbering,
+  # only a different name, so only the path is rewritten.
+  sed -e "s#$pfx#$f#g" "$err" | tail -2
+  rm -f "$pfx" "$err"
+  return 1
+}

--- a/tests/meta/harness-verdict-probe.sh
+++ b/tests/meta/harness-verdict-probe.sh
@@ -114,80 +114,13 @@ WIRED=(); UNWIRED=(); UNPROBEABLE=(); ALREADY_RED=(); ALLOWED=(); NOT_REACHED=()
 # KILL is not evidence that the harness's exit status is wired to anything).
 TIMED_OUT=()
 
-# Extract the verdict variable from a harness's last executable line.
-# Prints "<var>\t<lineno>" or nothing. Handles the shapes olivia's census found:
-# [[ "$V" -eq N ]] / [[ $V -eq N ]] / [ "$V" -eq N ] / (( V == N )) /
-# [[ "$V" == "N" ]] / exit $V.
-# TWO harness families need TWO mutations, and conflating them is how this probe
-# produced three FALSE POSITIVES on its first run (byo_model_create, codex_bin_
-# resolution, openclaw_runtime — all `set -euo pipefail` with bare `[[ ]]`
-# assertions). Their exit status IS wired; the probe had grabbed a STRING operand
-# out of the last `[[ ]]` and "incremented" it, which proves nothing. Ground truth:
-# breaking a real assertion in byo_model_create by hand exits 1.
-#
-#   COUNTER family  — a numeric counter initialised to a number AND incremented,
-#                     consumed by a final verdict expression. Mutation: bump it.
-#   ABORT family    — `set -e` with assertions that exit on failure and no counter.
-#                     Mutation: inject a bare `false`, which set -e must turn into
-#                     a non-zero exit. (Wrong for the counter family, where a bare
-#                     `false` changes no counter and the harness correctly exits 0
-#                     — which is exactly the false positive, inverted.)
-#
-# Picking the wrong mutation gives a confident wrong answer, which is the defect
-# class this check exists to find. So the counter test is STRICT and `false` is
-# only used when no counter exists AND `set -e` is in force.
-counter_verdict() {   # -> "<var>\t<lineno>\t<last|not-last>"
-  local f="$1" n line var="" last_exec=""
-  last_exec=$(grep -nvE '^[[:space:]]*(#|$)' "$f" | tail -1 | cut -d: -f1)
-  while read -r n; do
-    line=$(sed -n "${n}p" "$f")
-    # An INVERTED verdict (-ne / !=) is SATISFIED by incrementing — refuse to guess.
-    [[ "$line" =~ (-ne|\!=)[[:space:]] ]] && continue
-    var=""
-    # Regexes live in VARIABLES: an unquoted `)` or `[^)]` inside [[ =~ ]] is a
-    # bash syntax error, not a regex. `exit $(( FAIL > 0 ))` is matched first —
-    # the bare `exit $VAR` form below would miss it entirely.
-    # Anchored right after `$((` — a greedy `.*` here backtracks to the shortest
-    # suffix and captures 'L' out of 'FAIL', which is a silently WRONG variable
-    # rather than no match. Same trap as everything else tonight: the broken form
-    # succeeds at something.
-    local re_arith='exit[[:space:]]+\$\(\([[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*[><=!]'
-    local re_exit='exit[[:space:]]+\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?'
-    local re_dbl='\(\([[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=='
-    local re_test='\[\[?[[:space:]]+"?\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?"?[[:space:]]+(-eq|==)'
-    if   [[ "$line" =~ $re_arith ]]; then var="${BASH_REMATCH[1]}"
-    elif [[ "$line" =~ $re_exit  ]]; then var="${BASH_REMATCH[1]}"
-    elif [[ "$line" =~ $re_dbl   ]]; then var="${BASH_REMATCH[1]}"
-    elif [[ "$line" =~ $re_test  ]]; then var="${BASH_REMATCH[1]}"
-    fi
-    [[ -n "$var" ]] || continue
-    # STRICT, and this is the line that separates a real verdict from the STRING
-    # operand that produced three false positives: every assignment to the
-    # variable must be a NUMERIC LITERAL or an arithmetic expression over itself.
-    # A counter (`FAIL=0` … `FAIL=$((FAIL+1))`) and a flag (`fail=0` … `fail=1`)
-    # both qualify; `setup_src=$(cat …)` does not, because incrementing a captured
-    # string proves nothing about whether the exit status is wired.
-    # Assignments must be matched in STATEMENT POSITION. Matching the bare
-    # substring `VAR=` also hits `echo "... FAIL=$FAIL"`, which is text inside a
-    # string, not an assignment — that false hit made 12 correctly-wired harnesses
-    # look UNPROBEABLE, a regression I introduced while fixing five others and did
-    # not see because I re-tested only the five.
-    local asn="(^[[:space:]]*(local[[:space:]]+)?|[;&|][[:space:]]*)${var}="
-    grep -qE "${asn}[0-9]+([[:space:]]|;|\)|$)" "$f" || continue
-    # Every statement-position assignment must be a numeric literal or arithmetic
-    # over the variable itself. A counter (FAIL=0 … FAIL=$((FAIL+1))) and a flag
-    # (fail=0 … fail=1) both qualify; `setup_src=$(cat …)` does not — incrementing
-    # a captured string proves nothing about whether the exit status is wired, and
-    # that is what produced three false UNWIRED verdicts on the first run.
-    if grep -oE "${asn}[^[:space:];]*" "$f" \
-       | grep -qvE "${var}=([0-9]+|\\\$\(\(.*${var}.*\)\))$"; then
-      continue
-    fi
-    printf '%s\t%s\t%s\n' "$var" "$n" "$([[ "$n" == "$last_exec" ]] && echo last || echo not-last)"
-    return 0
-  done < <(grep -nvE '^[[:space:]]*(#|$)' "$f" | tail -12 | cut -d: -f1 | tac)
-  return 1
-}
+# DIVE-3679: `counter_verdict` moved to tests/lib/harness-verdict-detect.sh, verbatim
+# and with every comment, so this probe and the STATIC guard
+# (tests/meta/harness-verdict-toplevel.sh) name the same line as the verdict. The
+# static guard's entire claim is about the line THIS file would mutate, so two
+# copies of the detector would be two detectors the first time one was edited.
+# shellcheck source=tests/lib/harness-verdict-detect.sh
+source tests/lib/harness-verdict-detect.sh
 
 CORPUS_N=0; for t in tests/*.sh; do [[ -e "$t" ]] && CORPUS_N=$(( CORPUS_N + 1 )); done
 only_set=" ${ONLY//,/ } "

--- a/tests/meta/harness-verdict-toplevel.sh
+++ b/tests/meta/harness-verdict-toplevel.sh
@@ -50,6 +50,14 @@
 # WARN-ONLY IS THE DEFAULT and `--enforce` is opt-in, per this row: the guard must
 # not fail anything until both negative-control arms are on the row.
 set -uo pipefail
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source.
+# NOTE the absence of `2>/dev/null`. Redirecting the source's stderr would also
+# swallow the helper's own stderr line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/../lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 2
 # shellcheck source=tests/lib/harness-verdict-detect.sh
 source tests/lib/harness-verdict-detect.sh

--- a/tests/meta/harness-verdict-toplevel.sh
+++ b/tests/meta/harness-verdict-toplevel.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# DIVE-3679: RED ON A TOP-LEVEL VERDICT VIOLATION, NOT ON `not-reached`.
+#
+# WHY NOT `not-reached`, which is what DIVE-3678 proposed. The `changed-harnesses`
+# job is ONE `runs-on: ubuntu-latest` runner: one checkout, one ./build.sh, one
+# setup-bun, one probe pass. No matrix, no installed host. So "not-reached in every
+# environment this lane can offer" evaluates, here, to "not-reached in one pristine
+# run" — which is precisely the false accusation DIVE-2039 exists to prevent, aimed
+# at the whole class of harnesses whose verdict is legitimately reachable only on an
+# installed host with real sudo and seeded host state. `not-reached` is a claim about
+# THIS environment; "runs nowhere" is a claim about the UNION of environments, and no
+# single lane can make it however it is wired — adding an installed-host job makes
+# N=2 against a union of 7 and only moves the boundary.
+#   community/wiki/the-pr-harness-lane-is-one-environment-so-not-reached-cannot-be-the-guard.md
+#
+# WHAT IS SOUND IN ONE ENVIRONMENT is the STATIC property: the probe's INJECTION
+# POINT — immediately above the terminal verdict-shaped line — must be a top-level
+# statement boundary, not a position inside an arm. That is a property of the DIFF,
+# decidable here, and it accuses nobody for skipping: an installed-host-only harness
+# with a top-level terminal verdict passes, and the harness that broke the v0.21.3
+# cut fails. It is decided by BASH'S OWN PARSER, not by indentation and not by a
+# hand-rolled lexer — see tests/lib/harness-verdict-detect.sh for what that cost.
+#
+# THIS IS A COMPLEMENT TO THE PROBE, NEVER A REPLACEMENT. The probe's own header
+# records that static analysis cannot close the DIVE-2013 class (three instruments
+# measured, all agreeing, none sound: a harness whose assertions never fire, a
+# verdict before the last assertion, a `set -e` verdict bypassed). Top-level-NESS of
+# the terminal verdict-shaped line is a strictly NARROWER claim than "the verdict is
+# wired", so it does not inherit that refutation — and it must never be cited as
+# doing the probe's job. And hardening `changed-harnesses` is hardening the
+# INSTRUMENT; the union's whole-corpus claim is still the product.
+#   community/wiki/a-test-of-the-instrument-is-not-an-exit-from-the-gate.md
+#
+# NO THIRD ALLOWLIST. `ALLOW_UNPROBEABLE` means "no identifiable verdict variable"
+# and `SLOW_HARNESSES` means "killed by the timeout"; neither is this. A harness that
+# is genuinely live-only does not need an exemption, because it can always be GIVEN a
+# top-level terminal verdict — that is exactly what the DIVE-3675 fix did (`return`
+# out of `live_arms()` instead of `exit` from mid-file, behaviour and exit status
+# unchanged). A list created before a case requires it is a widened safety control
+# with nothing measured behind it.
+#
+# NO IDENTIFIABLE VERDICT IS NOT A FINDING HERE. If counter_verdict cannot name a
+# verdict variable, this prints `no-verdict-line` and does not fail: that condition
+# is the probe's UNPROBEABLE, it already fails there, and a second accusation path
+# for the same condition would let the two instruments disagree about the same file.
+#
+# Usage:
+#   harness-verdict-toplevel.sh --only=a.sh,b.sh [--label=changed] [--report=f] [--enforce]
+#   harness-verdict-toplevel.sh tests/foo.sh tests/bar.sh
+# WARN-ONLY IS THE DEFAULT and `--enforce` is opt-in, per this row: the guard must
+# not fail anything until both negative-control arms are on the row.
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 2
+# shellcheck source=tests/lib/harness-verdict-detect.sh
+source tests/lib/harness-verdict-detect.sh
+
+ONLY=""; LABEL=""; REPORT=""; ENFORCE=0; FILES=()
+for a in "$@"; do case "$a" in
+  --only=*)   ONLY="${a#--only=}" ;;
+  --label=*)  LABEL="${a#--label=}" ;;
+  --report=*) REPORT="${a#--report=}" ;;
+  --enforce)  ENFORCE=1 ;;
+  --warn-only) ENFORCE=0 ;;
+  -*) printf 'unknown arg: %s\n' "$a" >&2; exit 2 ;;
+  *)  FILES+=("$a") ;;
+esac; done
+
+if (( ${#FILES[@]} == 0 )) && [[ -n "$ONLY" ]]; then
+  only_set=" ${ONLY//,/ } "
+  for t in tests/*.sh; do
+    [[ -e "$t" ]] || continue
+    [[ "$only_set" == *" $(basename "$t") "* ]] && FILES+=("$t")
+  done
+fi
+# An EMPTY selection with no selector is "nothing was asked", which is fine. An
+# empty selection from a NON-EMPTY --only is a selector that matched nothing, and
+# reporting that as a pass is the shape of hole this whole workflow exists to close.
+if (( ${#FILES[@]} == 0 )); then
+  if [[ -n "$ONLY" ]]; then
+    printf 'harness-verdict-toplevel: BLOCKED — --only=%s matched no tests/*.sh; refusing to report clean on a selection that never resolved.\n' "$ONLY" >&2
+    exit 1
+  fi
+  printf 'harness-verdict-toplevel: nothing selected, nothing to grade.\n'
+  exit 0
+fi
+
+OK=(); VIOLATION=(); NOVERDICT=()
+for f in "${FILES[@]}"; do
+  b=$(basename "$f")
+  # BOTH probe families, selected exactly as harness-verdict-probe.sh selects them —
+  # the counter family (mutate the verdict variable, injected before its line) and the
+  # ABORT family (`set -e` plus bare assertions, a `false` injected before the LAST
+  # executable line). Grading only the counter family would have left 25 of the 444
+  # harnesses on origin/main silently ungraded: the check would print a clean pass on
+  # files it never looked at, which is the hole this workflow exists to close.
+  cv=$(counter_verdict "$f") || cv=""
+  if [[ -n "$cv" ]]; then
+    var=$(cut -f1 <<<"$cv"); ln=$(cut -f2 <<<"$cv"); pos=$(cut -f3 <<<"$cv")
+  elif grep -qE '^set -[a-z]*e' "$f"; then
+    ln=$(grep -nvE '^[[:space:]]*(#|$)' "$f" | tail -1 | cut -d: -f1)
+    var="(abort family: 'false' under set -e)"; pos="last"
+  else
+    # Neither family: the probe reports this as UNPROBEABLE and FAILS there. A second
+    # accusation path for the same condition would let the two instruments disagree
+    # about the same file, so this is reported and is not a finding here.
+    NOVERDICT+=("$b")
+    printf '  %-52s no-verdict-line (no counter, no `set -e` — the probe owns this as UNPROBEABLE)\n' "$b"
+    continue
+  fi
+  if why=$(verdict_injection_point_top_level "$f" "$ln"); then
+    OK+=("$b")
+    printf '  %-52s ok        verdict `%s` at line %s (%s), injection point at top level\n' "$b" "$var" "$ln" "$pos"
+  else
+    VIOLATION+=("$b:$ln")
+    printf '  %-52s VIOLATION verdict `%s` at line %s (%s executable line): the probe injects immediately above it, and lines 1-%s are not a complete program — bash says:\n' \
+      "$b" "$var" "$ln" "$pos" "$(( ln - 1 ))"
+    printf '      %s\n' "$why"
+  fi
+done
+
+printf '\nharness-verdict-toplevel%s: %d ok, %d VIOLATION, %d no-verdict-line (of %d selected)\n' \
+  "${LABEL:+ [$LABEL]}" "${#OK[@]}" "${#VIOLATION[@]}" "${#NOVERDICT[@]}" "${#FILES[@]}"
+# DIVE-3679: assert the buckets sum to N. A file that fell out of every bucket would
+# read as a clean pass on a harness nobody looked at.
+sum=$(( ${#OK[@]} + ${#VIOLATION[@]} + ${#NOVERDICT[@]} ))
+if (( sum != ${#FILES[@]} )); then
+  printf 'harness-verdict-toplevel: BLOCKED — buckets sum to %d against %d selected; a harness fell out of every bucket.\n' "$sum" "${#FILES[@]}" >&2
+  exit 1
+fi
+if [[ -n "$REPORT" ]]; then
+  { printf '# harness-verdict-toplevel label=%s selected=%d\n' "${LABEL:-none}" "${#FILES[@]}"
+    for x in "${OK[@]:-}";        do [[ -n "$x" ]] && printf 'ok\t%s\n' "$x"; done
+    for x in "${VIOLATION[@]:-}"; do [[ -n "$x" ]] && printf 'violation\t%s\n' "$x"; done
+    for x in "${NOVERDICT[@]:-}"; do [[ -n "$x" ]] && printf 'no-verdict-line\t%s\n' "$x"; done
+  } > "$REPORT"
+fi
+
+if (( ${#VIOLATION[@]} == 0 )); then exit 0; fi
+cat >&2 <<'MSG'
+
+A harness's terminal verdict-shaped line sits inside an arm rather than at top level.
+harness-verdict-probe.sh injects its mutation immediately before that line, so in any
+environment that does not enter the arm the mutation never executes and the probe
+reports `not-reached`. That is tolerated per-environment and correctly so — and when
+it happens in ALL of them the nightly union reports NEVER PROBED and refuses the
+release cut. It has cost the train twice: DIVE-3148 and DIVE-3675.
+
+The fix is not an allowlist. Give the harness ONE terminal verdict at top level,
+after the last arm — `return` out of the arm's function instead of `exit`ing from
+mid-file, and end the file in the verdict expression. Behaviour and exit status do
+not change; see tests/buzz_preseed_dm_live.sh and commit 07a4345.
+MSG
+if (( ENFORCE )); then exit 1; fi
+printf 'harness-verdict-toplevel: WARN-ONLY (--enforce not passed) — reporting, not failing.\n' >&2
+exit 0


### PR DESCRIPTION
DIVE-3678 proposed reding `changed-harnesses` when a harness the diff touched comes back `not-reached` **in every environment that lane can offer**. Measured on `origin/main`: that lane is ONE `runs-on: ubuntu-latest` job — one checkout, one `./build.sh`, one `setup-bun`, one probe pass. No matrix, no installed host. So the quantifier collapses to *"not-reached in one pristine run"*, which is exactly the DIVE-2039 false accusation, aimed at every harness whose verdict is legitimately reachable only on an installed host with real sudo and seeded host state. The union consumes **seven** reports across two genuinely different environments for precisely that reason, and adding an installed-host job here would make N=2 against a union of 7 — it moves the boundary, it does not fix it.

**So that guard is not built.** This is the static one.

## The property, stated exactly

`harness-verdict-probe.sh` does not evaluate the verdict line — it **inserts** its canary and mutation immediately *before* it (`awk 'NR==n{print …}'`). So the thing that must hold is a property of the **injection point**: lines `1..n-1` must be a complete bash program. If they are, the injection lands at a top-level statement boundary and executes in every environment the harness runs in. If not, it lands inside an unclosed construct — an arm no CI runner enters (DIVE-3675) — or mid-way through a `\` continuation, where the inserted lines break the statement outright.

One predicate, both defects. It is a property of the **diff**, decidable in one environment, and it accuses nobody for skipping.

## Which instrument — and why not the one I wrote first

**A real parse, performed by bash itself:** `head -n $((n-1)) "$f" | bash -n`. Not indentation, and not a hand-rolled lexer. `syntax error: unexpected end of file` *is* the finding; a prefix of a file that already parses cannot fail for any other reason.

An awk keyword-balance scanner was built first (if/case/while/until/for/select/`{`, with quote and heredoc state and a declared under-count bias), then measured against the bash parse over all 444 harnesses on `origin/main`:

| instrument | falsely accused (of 444) | the actual bug |
|---|---|---|
| awk v1 | **19** | a `\` continuation suppressed statement-position for the *whole* next line, so `for … \` / `… ; do … ; done` never saw its own `done` |
| awk v2 | **48** | skipping a line that begins inside a multi-line quote lost the `}` that came *after* the closing quote (`seed() { db "INSERT …` / `… );"; }`) |
| awk v3 | **6** | a `<<'TAG'` written *inside a quoted string* wedged heredoc state forever, so every later `fi` was skipped |
| `bash -n` on the prefix | **0** | — |

Every one of those was a false accusation against a correctly-wired harness — the DIVE-2039 mistake DIVE-3678 was rejected for, reproduced inside its replacement, three times. The scanner is deleted rather than kept as a cross-check. An under-count bias is not a safety property when the state machine can get stuck: a wedged heredoc does not under-count, it over-counts everything after it.

## The two negative-control arms this row made a precondition

Not one-off runs — pinned arms in a committed harness (`tests/harness_toplevel_guard_unit.sh`), so they re-fire in CI:

- **arm 3** — `tests/buzz_preseed_dm_live.sh` at `07a4345^`, the tree that refused the v0.21.3 cut → **REDS**: `verdict SEEN1 at line 189 (not-last executable line): lines 1-188 are not a complete program — bash says: line 189: syntax error: unexpected end of file`
- **arm 4** — the same harness at `07a4345`, live-only and skipping in every pristine lane → **GREEN**: `verdict FAIL at line 236 (last), injection point at top level`

Six more arms in the same harness: a stub violation fires; a skip-everywhere stub with one top-level verdict does **not** fire; warn-only exits 0 **and still prints**; an `--only` matching nothing BLOCKS; no-verdict-line is reported, not accused; an abort-family violation reds. **Negative control on the harness itself:** blunt the guard so it never accuses and **4 of the 8 arms red**.

## Full-corpus census, before shipping

445 harnesses on the branch, ~15s, locally: **442 ok, 0 VIOLATION, 3 no-verdict-line.** The 3 are *exactly* the probe's `ALLOW_UNPROBEABLE` list (`council_amend_e2e.sh`, `council_roster_lineage_e2e.sh`, `schema_sync_unit.sh`) — a free corroboration that the family selection matches the probe's.

Worth noting *which* instrument made that number obtainable. DIVE-3678's writeup named the false-positive population as the thing it could not measure. For the static guard the population is measurable locally, with no CI, no credentials and no box — because the guard **is** the instrument that measures it.

## Scope, as this row constrained it

- **Both probe families are graded** — the counter family and the `set -e` abort family (a bare `false` injected before the last executable line). Counter-only looked complete and silently left **25 of 444** ungraded: a clean pass over files never looked at.
- **No third allowlist.** Neither family present → reported, never accused. That is the probe's `UNPROBEABLE`, it already fails there, and a second accusation path would let the two instruments disagree about the same file — where the fix for one is a red in the other.
- **`harness-verdict-union.sh` untouched**; the tolerance of `not-reached` is unchanged in every sharded lane.
- **WARN-ONLY in `changed-harnesses`**, per the row: the guard must not fail anything until the arms have been *read*, not merely run by their author. `--enforce` is one word on one line. It exits 1 regardless of the flag if its own selector resolves to nothing.
- **One detector.** `counter_verdict` moved verbatim to `tests/lib/harness-verdict-detect.sh` and the probe now **sources** it. The static claim is about the line the probe would mutate, so a copy becomes a second detector the first time either is edited; extracting without rewiring the original caller would have armed nothing.

## Collateral repair, called out because it edits someone else's guard

The extraction broke 5 arms of `tests/corpus_tier_budget_unit.sh`, which symlinks the probe into a fake corpus at `$FAKE/tests/meta/`: the probe resolves its lib relative to its own location, so the fake tree has to carry the dependency. Symlinked alongside the probe and folded into the **same** `SEAM` variable, so a missing lib reports a broken seam rather than five reds that read like a defect in the thing they grade.

**Baselined against pristine `origin/main` in a detached worktree: 165 passed / 0 failed. On this branch: 165 / 0. Identical.**

## What this is not

A **complement** to `harness-verdict-probe.sh`, never a replacement. That file's own header records that static analysis cannot close the DIVE-2013 class — three instruments measured, all agreeing, none sound; none can see a harness whose assertions never fire, a verdict placed before the last assertion, or a `set -e` verdict bypassed. *"The injection point is a top-level statement boundary"* is a **strictly narrower** claim than *"the verdict is wired"*, so it does not inherit that refutation — and it must never be cited as doing the probe's job. Both statements are in the guard's own header.

And hardening `changed-harnesses` hardens the **instrument**; the union's whole-corpus claim is still the product (`community/wiki/a-test-of-the-instrument-is-not-an-exit-from-the-gate.md`).

## Residuals, stated so they are not read as covered

1. **The guard has never executed on a GitHub runner.** Everything above is this host's bash 5.x. It ships warn-only, so its first CI exposure cannot fail anyone's PR.
2. **`--enforce` is off**, deliberately, per the row.
3. **The census is a snapshot** of the corpus at `07a4345`+branch. It says the guard accuses nothing today; it does not bound future harness shapes. That is what the permanent arms are for.
4. **Still unmeasured:** how many of the 444 come back `not-reached` on a pristine lane — DIVE-3678's original gap. Not needed for the static guard, and still the first number to get if anyone revisits the empirical one.

## Commits

- `71026f2` — the guard, the shared detector, the permanent arms, the CI wiring, the `corpus_tier_budget_unit.sh` seam repair. This is the sha the row's gate was cleared against, after an independent re-derivation of both control arms and the census.
- `eb99106` — `tests/meta/harness-verdict-toplevel.sh` sources `tests/lib/grading_tree.sh` (DIVE-2211 contract), which `harness-tree-guard` blocked the push for. A separate commit rather than an amend, so that verification is not stranded on a rewritten sha.

Knowledge compiled: `community/wiki/the-guard-that-reimplements-a-parser-accuses-at-its-authors-bug-rate.md`.

Closes DIVE-3679.
