### PR TITLE
DIVE-3694: tier-1 decision gates clear on the filer's measured track record (ROADMAP #22)

### DIFF
--- a/changelog.d/DIVE-3694.md
+++ b/changelog.d/DIVE-3694.md
@@ -1,0 +1,27 @@
+## Unreleased — feat(gates): when a seat's own recommendations keep coming back, its tier-1 decisions stop asking (DIVE-3694, ROADMAP #22)
+
+A tier-1 `decision` gate filed by a seat whose **own** recent tier-1 decisions have been answered
+with that seat's `--recommend` now applies that recommendation at filing and pings nobody —
+provenance `auto:record`, the same permanent record and digest line a `--tier=0` apply already
+writes, with the record cited on the gate. `5dive task track-record` shows any seat its rate, over
+how many, and exactly what revokes it. `5dive task track-record off` restores the old routing with
+no release.
+
+Promotion is a conjunction and loses on any one term: **≥10** answered tier-1 decisions in the
+window, **≥85 %** of them concordant, and the **last 3 clean**. The streak is the load-bearing half
+— one answer that does not return the recommendation demotes the seat on the very next gate, and it
+stays demoted until three fresh clean answers. An overturn of an auto-applied gate demotes through
+the same path; an `auto:record` answer never feeds the record that produced it.
+
+Refused, not deferred: `approval`, `secret` and `manual` stay human **by type**, every tier-2 gate
+stays human (explicit `--tier=2`, the money/destructive/public-comms subject floor, and any declared
+`--needs=<capability>`), and there is no question-similarity matching anywhere in the path — that
+was ROADMAP #20, measured to fire 0 of 204, and this row must not re-acquire it.
+
+**The measurement, including its cost.** Over the 204 answered tier-1 decision gates the store holds
+(2026-07-21..2026-08-23), 178 = 87.3 % returned the filer's recommendation. Replayed in filing order
+against the shipped threshold, this feature would have removed **15 of those 204 asks (7.4 %)**, and
+**2 of the 15** were in fact answered *against* the recommendation. That second number is the price.
+And the population correction that the release note must carry: only **11 of the 204** were answered
+by a human at all — 193 went to a routed agent lead — so what this removes is overwhelmingly a
+**lead round-trip**, not a human tap.

--- a/src/task/dispatch.sh
+++ b/src/task/dispatch.sh
@@ -271,6 +271,7 @@ cmd_task() {
     clear-recs)      cmd_task_clear_recs "$@" ;;
     precedent)       cmd_task_precedent "$@" ;;
     pfr-autoclear)   cmd_task_pfr_autoclear "$@" ;;   # DIVE-3481 inert push-for-review auto-clear switch
+    track-record)    cmd_task_track_record "$@" ;;   # DIVE-3694 per-filer track-record auto-clear switch + view
     routing)         cmd_task_routing "$@" ;;
     reclaim)         cmd_task_reclaim "$@" ;;   # DIVE-1967 worktree node_modules reclaim
     rm|delete)       cmd_task_rm "$@" ;;

--- a/src/task/need.sh
+++ b/src/task/need.sh
@@ -79,6 +79,55 @@ cmd_task_pfr_autoclear() {
   esac
 }
 
+# DIVE-3694 (ROADMAP #22) — the track-record view and its kill switch.
+# `5dive task track-record [status] [<seat>]` reports what the engine reads: the
+# seat's rate, over how many, and WHAT WOULD REVOKE IT (row scope item 4 — the
+# record must be legible to the seat itself, not only to the gate). Default seat
+# is the caller. `on|off` is the policy write; default ON, because this one is
+# the deliverable rather than an experiment (mirrors `task pfr-autoclear`, not
+# `task precedent`). `off` restores the pre-DIVE-3694 tier-1 routing byte for
+# byte and needs no release to take effect.
+cmd_task_track_record() {
+  tasks_db_init
+  local sub="${1:-status}"
+  case "$sub" in
+    on)
+      _task_pref_set track_record on
+      _task_store_audit_log "task track-record" "on" 0 -- "pref=track_record" || true
+      ok "track-record auto-clear: ON — a tier-1 decision gate from a seat at or above ${_GATE_RECORD_RATE}% over its last ${_GATE_RECORD_MIN}+ answered tier-1 decisions, with the last ${_GATE_RECORD_STREAK} clean, applies its own recommendation and pings nobody (provenance auto:record)" \
+         '{pref:"track_record", value:"on"}'
+      ;;
+    off)
+      _task_pref_set track_record off
+      _task_store_audit_log "task track-record" "off" 0 -- "pref=track_record" || true
+      ok "track-record auto-clear: OFF — every tier-1 decision gate routes as it did before DIVE-3694" \
+         '{pref:"track_record", value:"off"}'
+      ;;
+    status|"")
+      local seat="${2:-}"
+      [[ -n "$seat" ]] || seat=$(task_actor "" 2>/dev/null || printf '')
+      local v; v=$(_task_pref_get track_record 2>/dev/null || printf ''); v="${v:-on}"
+      local c t s pct line
+      read -r c t s <<<"$(_gate_record_stats "$seat")"
+      pct=$(( t > 0 ? (100 * c) / t : 0 ))
+      line=$(_gate_record_line "$seat")
+      local prom=false; _gate_record_promoted "$seat" && prom=true
+      ok "track-record auto-clear: ${v} · ${seat:-<unknown seat>}: ${line}" \
+         '{pref:"track_record", value:$v, seat:$s, concordant:($c|tonumber), total:($t|tonumber),
+           rate:($p|tonumber), streak_clean:($k=="1"), promoted:$pr,
+           threshold:{min_count:($mn|tonumber), min_rate:($mr|tonumber), streak:($st|tonumber), window:($w|tonumber)},
+           summary:$l}' \
+         --arg v "$v" --arg s "$seat" --arg c "$c" --arg t "$t" --arg p "$pct" \
+         --arg k "$s" --argjson pr "$prom" --arg l "$line" \
+         --arg mn "$_GATE_RECORD_MIN" --arg mr "$_GATE_RECORD_RATE" \
+         --arg st "$_GATE_RECORD_STREAK" --arg w "$_GATE_RECORD_WINDOW"
+      ;;
+    *)
+      fail "$E_USAGE" "usage: 5dive task track-record [on|off|status [<seat>]]"
+      ;;
+  esac
+}
+
 # DIVE-1145: ship-gating routing policy switch. `5dive task routing [on|off]`
 # (bare / `status` reports state). When ON, a NON-lead agent's decision gate
 # (tier < 2) routes to the org lead first (see cmd_task_need) instead of pinging
@@ -1372,6 +1421,144 @@ _gate_tapback_stats() {
   printf '%s' "$out"
 }
 
+# ─────────────────────────────────────────────────────────────────────────────
+# DIVE-3694 (ROADMAP #22) — AUTONOMY EARNED BY A MEASURED PER-FILER TRACK RECORD
+#
+# The claim: "when the asker has been right N times running, stop asking". It is
+# the successor to ROADMAP #20 (DIVE-3693 / `task precedent` above), which was
+# demoted because its mechanism keyed on the QUESTION repeating and the questions
+# do not repeat — 322 distinct decision ask_shapes over 333 answered decision
+# gates, so the strictest honest seed rule fires 0 of 204 tier-1 decision gates.
+# Wiki: community/wiki/precedent-needs-a-repeat-rate-not-an-acceptance-rate.md.
+#
+# What DOES transfer is a property of the RECOMMENDATION, not of the question:
+# over the 204 answered tier-1 decision gates carrying a --recommend that the
+# store holds (union of `tasks` + `gate_history`, 2026-07-21..2026-08-23),
+# **178 = 87.3%** came back as the answerer returning the filer's own
+# recommendation. So this keys on the FILER'S TRACK RECORD.
+#
+# THE POPULATION CORRECTION, and it is load-bearing — measure it before you read
+# the release note. Of those 204 tier-1 decision gates, **only 11 were answered
+# by a human at all**; 193 were answered by a ROUTED AGENT LEAD (DIVE-1145
+# builder-gate routing sends a tier<2 decision to the org lead first). Split:
+# agent-answered 169/193 = 87.6%, human-answered 9/11 = 81.8%. So promotion here
+# removes a LEAD ROUND-TRIP in ~19 of every 20 cases, not a human tap. That is
+# still the numerator of `1 - asks/shipped` and still real — an inbound a2a costs
+# the recipient a full context reload (projects/5dive/CLAUDE.md) — but the
+# feature must not be described as "stop asking the human". It is not.
+#
+# ATTRIBUTION IS DELIBERATELY NARROW. `gate_history` carries no filer column, so
+# a history row can only be attributed through its task's CURRENT
+# `tasks.gate_filed_by` — which is the wrong seat whenever a gate was re-filed by
+# someone else. An autonomy grant handed to a seat on ANOTHER seat's record is
+# the exact failure this feature cannot have, so the record reads `tasks` ONLY,
+# where the filer is stamped on the row that carries the answer. Measured cost of
+# that choice, by replay: union attribution would fire 33/204, tasks-only fires
+# 15/204. We take the smaller number.
+#
+# THE RATE IS COMPUTED STARTS-WITH, NEVER `=`. Answers are routinely the
+# recommendation plus commentary (`merge — ALREADY DONE`, `ship — verified in
+# source`), and equality undercounts the same population by ~11-19 points
+# (139/203 = 68.5% vs 177/203 = 87.2%). A threshold set against the equality
+# number would be set against a wrong number.
+#
+# DEMOTION IS THE LOAD-BEARING HALF. Promotion needs THREE things at once and
+# loses on any one of them: rate over the window, a minimum COUNT, and a clean
+# recent streak. The streak is what makes a reversal bite IMMEDIATELY — one
+# answer that does not return the recommendation lands at the head of the window
+# and the streak test fails on the very next gate, without waiting for the
+# windowed rate to drift. It stays failed until the seat has _GATE_RECORD_STREAK
+# fresh concordant answers again.
+#
+# An OVERTURN of an auto-applied gate is covered by the same query and needs no
+# second mechanism: this path never mints a human nonce and never claims a human
+# answered, so if a human or lead later answers that row, `need_answered_by`
+# becomes their stamp, the row enters the window like any other, and a
+# non-concordant overturn breaks the streak exactly as a fresh reversal does.
+#
+# ABSENCE OF A RECORD IS NEVER A GOOD RECORD. The count floor is checked before
+# the rate, and an unknown/empty filer returns "0 0 0" — a new seat is
+# un-promoted by construction, and every error path in the read below FAILS
+# CLOSED to that same value (the opposite posture from `_gate_tapback_stats`,
+# which fails OPEN because a measurement that cannot run must not become a block;
+# here a measurement that cannot run must not become a GRANT).
+_GATE_RECORD_WINDOW=20   # the seat's own last M answered tier-1 decision gates
+_GATE_RECORD_MIN=10      # below this there is no record, whatever the rate says
+_GATE_RECORD_RATE=85     # percent of the window that returned the recommendation
+_GATE_RECORD_STREAK=3    # most-recent answers that must ALL be concordant
+
+# _gate_record_stats <filer> -> "<concordant> <total> <streak_ok>"
+# Window: that seat's last _GATE_RECORD_WINDOW answered tier-1 `decision` gates
+# that carried a --recommend, newest first. `streak_ok` is 1 when the newest
+# _GATE_RECORD_STREAK of them are all concordant (and there are at least that
+# many). Prints "0 0 0" on any error or unknown seat — fail CLOSED.
+_gate_record_stats() {
+  local who="${1:-}" out=""
+  [[ -n "$who" ]] || { printf '0 0 0'; return 0; }
+  out=$(db "SELECT COALESCE(SUM(c),0)||' '||COUNT(*)||' '||
+        CASE WHEN COUNT(*) >= ${_GATE_RECORD_STREAK}
+              AND COALESCE(SUM(CASE WHEN rn <= ${_GATE_RECORD_STREAK} THEN c ELSE 0 END),0)
+                  = ${_GATE_RECORD_STREAK}
+             THEN 1 ELSE 0 END
+      FROM (
+        SELECT CASE WHEN lower(trim(need_answer))
+                         LIKE lower(trim(recommend)) || '%' THEN 1 ELSE 0 END AS c,
+               ROW_NUMBER() OVER (
+                 ORDER BY COALESCE(need_answered_at, need_asked_at, updated_at) DESC) AS rn
+        FROM tasks
+        WHERE gate_filed_by=$(sqlq "$who")
+          AND need_type='decision'
+          AND COALESCE(tier,2)=1
+          AND recommend IS NOT NULL AND trim(recommend) <> ''
+          AND need_answer IS NOT NULL AND trim(need_answer) <> ''
+          AND COALESCE(need_answered_by,'') NOT LIKE 'auto:%'
+        ORDER BY COALESCE(need_answered_at, need_asked_at, updated_at) DESC
+        LIMIT ${_GATE_RECORD_WINDOW});" 2>/dev/null) || out=""
+  [[ "$out" =~ ^[0-9]+\ [0-9]+\ [01]$ ]] || out='0 0 0'
+  printf '%s' "$out"
+}
+
+# _gate_record_promoted <filer> -> rc 0 when this seat is above threshold.
+# THE THREE TESTS ARE A CONJUNCTION and the order is the argument: count first
+# (no record beats a good rate over two gates), then the windowed rate, then the
+# recent streak. Any one failing leaves the gate on the normal routing path,
+# which is exactly today's behaviour.
+_gate_record_promoted() {
+  local c t s
+  read -r c t s <<<"$(_gate_record_stats "${1:-}")"
+  [[ "$t" =~ ^[0-9]+$ && "$c" =~ ^[0-9]+$ ]] || return 1
+  (( t >= _GATE_RECORD_MIN )) || return 1
+  (( t > 0 && (100 * c) / t >= _GATE_RECORD_RATE )) || return 1
+  [[ "$s" == "1" ]] || return 1
+  return 0
+}
+
+# _gate_record_line <filer> -> the one-line legibility string (scope item 4:
+# what my rate is, over how many, and what would revoke it). Shared by the
+# `task track-record` view and the auto-clear's own success message, so the two
+# cannot drift into describing different thresholds.
+_gate_record_line() {
+  local c t s pct
+  read -r c t s <<<"$(_gate_record_stats "${1:-}")"
+  if (( t == 0 )); then
+    printf 'no record yet (0 answered tier-1 decision gates with a recommendation) — un-promoted; a new seat always pings. Needs %d, at >=%d%%, with the last %d clean.' \
+      "$_GATE_RECORD_MIN" "$_GATE_RECORD_RATE" "$_GATE_RECORD_STREAK"
+    return 0
+  fi
+  pct=$(( (100 * c) / t ))
+  if _gate_record_promoted "${1:-}"; then
+    printf 'PROMOTED — %d/%d = %d%% of the last %d answered tier-1 decision gates returned this seat'"'"'s recommendation, last %d clean. Revoked by: ONE answer that does not return the recommendation (breaks the streak immediately), or the rate falling under %d%%, or the count under %d.' \
+      "$c" "$t" "$pct" "$t" "$_GATE_RECORD_STREAK" "$_GATE_RECORD_RATE" "$_GATE_RECORD_MIN"
+  else
+    local why=""
+    (( t >= _GATE_RECORD_MIN )) || why="count ${t} < ${_GATE_RECORD_MIN}"
+    if (( pct < _GATE_RECORD_RATE )); then why="${why:+${why}; }rate ${pct}% < ${_GATE_RECORD_RATE}%"; fi
+    [[ "$s" == "1" ]] || why="${why:+${why}; }last ${_GATE_RECORD_STREAK} not all concordant (a reversal demotes on the next gate)"
+    printf 'not promoted — %d/%d = %d%%; %s. Tier-1 decision gates from this seat route normally.' \
+      "$c" "$t" "$pct" "$why"
+  fi
+}
+
 cmd_task_need() {
   tasks_db_init
   local type="" ask="" options="" recommend="" from="" tier="" secret_key="" connector="" probe="" withdraw="" discusses="" needs="" oob="" rubber_stamp="" gate_mode=""
@@ -2460,7 +2647,7 @@ cmd_task_need() {
         "tapbacks=${_rs_taps}/${_rs_tot}" "reason=tier-2 with a recommendation and no declared capability" || true
       fail "$E_VALIDATION" "$ident: refusing this --tier=2 ${type} gate. You wrote --recommend=\"${recommend}\", which means you have already decided — what is left is asking a person to agree, and that is reassurance, not a gate. (Measured 2026-07-16..08-07: 96 of 107 judgment gates carrying a recommendation came back as the human tapping that same value. Only 7 gates in 346 were floored by category; the rest of tier 2 was typed by hand.) A tier is a CAPABILITY, not a difficulty. Your exits:
   --tier=0    apply \"${recommend}\" NOW. No ping, and still a permanent gate record plus a digest line. This is the exit you want on a decision you have already made — it was used 0 times in the 346 gates measured, which is a discoverability failure, not a missing feature.
-  --tier=1    route to your lead, or to this task's verifier if it carries a loop — except a push-for-review ask, which goes to the LEAD even on a loop, because the verifier cannot read the diff until it is pushed (DIVE-3117); the 48h TTL applies your recommendation if nobody answers, on a decision (NOT on approval/manual/access/secret, which the sweep excludes — DIVE-2235). Use it when you want a second pair of eyes, not a person's authority. DIVE-3481: an --type=approval ask that is an INERT branch push, on a row whose 'Branch:' binding names a non-protected ref, clears at filing instead and pings nobody (\`5dive task pfr-autoclear off\` restores the ping).
+  --tier=1    route to your lead, or to this task's verifier if it carries a loop — except a push-for-review ask, which goes to the LEAD even on a loop, because the verifier cannot read the diff until it is pushed (DIVE-3117); the 48h TTL applies your recommendation if nobody answers, on a decision (NOT on approval/manual/access/secret, which the sweep excludes — DIVE-2235). Use it when you want a second pair of eyes, not a person's authority. DIVE-3694: if YOUR OWN recent tier-1 decisions have been coming back as your recommendation (run \`5dive task track-record\` to see your rate, your count, and what would revoke it), this gate applies itself and pings nobody — one answer against you revokes that. DIVE-3481: an --type=approval ask that is an INERT branch push, on a row whose 'Branch:' binding names a non-protected ref, clears at filing instead and pings nobody (\`5dive task pfr-autoclear off\` restores the ping).
   --needs=human_tap|spend_authority|secret_provision    DECLARE the human-held capability this ask consumes (a person's call on brand/strategy, money, or a credential only a human can issue). Tier 2 by declaration, never refused here.
   --rubber-stamp-ok=\"<why a person must answer this despite your recommendation>\"    the audited exception. Recorded on the gate row and readable afterwards.
 If you cannot name the capability, this is a decision you find uncomfortable, not a human gate."
@@ -2889,6 +3076,88 @@ If you cannot name the capability, this is a decision you find uncomfortable, no
           fi
         fi
       fi
+    fi
+  fi
+
+  # DIVE-3694 (ROADMAP #22) — PROMOTION ON A MEASURED TRACK RECORD.
+  #
+  # Placed HERE, after the tier-0 return, after the T2 floor, after the OSS-21
+  # precedent block and after the main gate write, for the same reason the
+  # precedent block is: it can only ever act on a gate that has ALREADY resolved
+  # to tier 1 by every rule that already existed. Nothing above changes.
+  #
+  # WHAT IS REFUSED, and these are refusals not deferrals (row scope):
+  #   * `approval`, `secret`, `manual` — human BY TYPE. `_gate_human_class` is
+  #     asserted directly rather than inferred from the tier, and the type is
+  #     pinned to `decision` on top of it. A track record is not a CAPABILITY: no
+  #     volume of prior yeses hands an agent a browser tap or spend authority
+  #     (the DIVE-2248 shape).
+  #   * every tier-2 gate — `tier==1` plus `tier_arg != 2` (an explicit
+  #     --tier=2 is the filer's hard-human contract, DIVE-1957) plus
+  #     `tier_floored == 0` (the money/destructive/public-comms subject floor).
+  #     Tier-2 means *an agent cannot*, not *an agent is unsure*.
+  #   * a DECLARED --needs=<capability> (DIVE-2241) — the honest hard gate.
+  #   * question-similarity matching. That is #20, measured to reach ~0, parked
+  #     on DIVE-3693. There is deliberately NO ask_shape read anywhere in this
+  #     block, and there must never be one: this row must not quietly re-acquire
+  #     the mechanism it was opened to replace.
+  #
+  # PROVENANCE IS MINTED, NOT SIDESTEPPED (DIVE-2004): 'auto:record', a value of
+  # its own, never confused with a human's tap (`human:*`), a lead's (`lead:*`),
+  # the TTL's (`auto:ttl`), tier-0's (`auto:t0`) or the push-for-review
+  # auto-clear's (`auto:pfr`). It is not `human:%`, so a loop approval can never
+  # be advanced through it (_task_loop_advance requires human:*), and
+  # `_gate_record_stats` excludes `auto:%` from its own window so an auto-apply
+  # can never feed the record that produced it.
+  #
+  # THE CITATION RIDES THE GATE. The record that licensed the clear is written to
+  # the audit row, the ledger detail and the success line, so a wrong auto-clear
+  # is findable by exactly the query that would have prevented it.
+  #
+  # REVERSIBLE WITHOUT A RELEASE: pref `track_record`, default ON — like
+  # `pfr_autoclear` and unlike `precedent_autoclear`, because this one IS the
+  # deliverable rather than an experiment. `5dive task track-record off` restores
+  # the pre-DIVE-3694 routing byte-for-byte.
+  local _tr_pref; _tr_pref=$(_task_pref_get track_record 2>/dev/null || printf '')
+  if [[ "${_tr_pref:-on}" != "off" && "$type" == "decision" && "$tier" == "1" \
+        && "$tier_floored" == "0" && "$tier_arg" != "2" && "$_needs_human" != "1" \
+        && "$gate_mode" != "confirm-after-send" && -n "$recommend_arg" ]] \
+     && ! _gate_human_class "$type" && _gate_record_promoted "$actor"; then
+    # The recommendation must still be ON THE MENU the filer published. A
+    # promoted seat is trusted about its own judgement, not licensed to apply an
+    # answer its own --options do not offer; an off-menu apply falls through to
+    # the normal route instead.
+    local _tr_ok=1
+    if [[ -n "$options" ]]; then
+      _tr_ok=$(printf '%s' "$options" | jq -Rr --arg r "$recommend_arg" '
+        [ split("|")[] | gsub("^\\s+|\\s+$"; "") | select(length > 0) ]
+        | (($r | gsub("^\\s+|\\s+$"; "")) as $rr | any(.[]; . == $rr)) | if . then "1" else "0" end' 2>/dev/null) || _tr_ok=0
+      [[ "$_tr_ok" == "1" ]] || _tr_ok=0
+    fi
+    if [[ "$_tr_ok" == "1" ]]; then
+      local _tr_c _tr_t _tr_s _tr_pct _tr_ts
+      read -r _tr_c _tr_t _tr_s <<<"$(_gate_record_stats "$actor")"
+      _tr_pct=$(( _tr_t > 0 ? (100 * _tr_c) / _tr_t : 0 ))
+      _tr_ts=$(date -u '+%Y-%m-%d %H:%M:%S')
+      db "UPDATE tasks SET need_answer=$(sqlq "$recommend_arg"), need_answered_at=$(sqlq "$_tr_ts"),
+            need_answered_by='auto:record', need_answered_uid=0
+          WHERE id=${id};
+          UPDATE tasks SET status='todo'
+            WHERE id=${id} AND status='blocked'
+              AND NOT EXISTS (SELECT 1 FROM task_deps WHERE task_id=${id});"
+      # DIVE-2054: an auto-clear applied from task-store data — fenced on store
+      # identity, same primitive as the tier-0, TTL and pfr auto-clears.
+      _task_store_audit_log "task need record-auto" "ok" 0 -- \
+        "task=$ident" "type=$type" "filer=$actor" "applied=$recommend_arg" \
+        "record=${_tr_c}/${_tr_t}" "rate=${_tr_pct}" || true
+      ledger_emit gate.autocleared ident="$ident" task_id="$id" actor="$actor" \
+        policy="record:${type}" \
+        detail="tier-1 decision auto-applied on ${actor}'s track record (${_tr_c}/${_tr_t} = ${_tr_pct}%, last ${_GATE_RECORD_STREAK} clean) — applied: ${recommend_arg}" || true
+      ok "$ident tier-1 decision auto-cleared on your track record — applied: $recommend_arg (record: ${_tr_c}/${_tr_t} = ${_tr_pct}% of your last ${_tr_t} answered tier-1 decision gates returned your recommendation, last ${_GATE_RECORD_STREAK} clean; nobody was pinged, provenance auto:record). ONE answer against your recommendation revokes this. 5dive task track-record off restores the ping." \
+         '{id:($i|tonumber), ident:$id, tier:1, need_type:$ty, auto_applied:$rc, need_answered_by:"auto:record", record_concordant:($c|tonumber), record_total:($t|tonumber), record_rate:($p|tonumber)}' \
+         --arg i "$id" --arg id "$ident" --arg ty "$type" --arg rc "$recommend_arg" \
+         --arg c "$_tr_c" --arg t "$_tr_t" --arg p "$_tr_pct"
+      return
     fi
   fi
 

--- a/tests/gate_parity_smoke.sh
+++ b/tests/gate_parity_smoke.sh
@@ -76,6 +76,7 @@ matrix=(
   "SLA escalation (unanswered gate walks the org chart) | heartbeat gate-escalate | tests/heartbeat_gate_escalate_unit.sh"
   "secret credential-drop fallback | task need --type=secret / secret write | tests/secret_drop_unit.sh"
   "autonomy report | digest --7d autonomy block | tests/digest_autonomy_unit.sh"
+  "track-record promotion (ROADMAP #22) | task need auto:record / task track-record | tests/gate_track_record_unit.sh"
 )
 for row in "${matrix[@]}"; do
   feat="${row%% |*}"

--- a/tests/gate_track_record_unit.sh
+++ b/tests/gate_track_record_unit.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# TIER: nightly — sibling of gate_precedent_unit.sh (same shape, same isolation).
+# DIVE-3694 (ROADMAP #22) isolated unit harness for PROMOTION ON A MEASURED
+# PER-FILER TRACK RECORD: a tier-1 `decision` gate from a seat whose own recent
+# recommendations have been returned at or above threshold applies itself and
+# pings nobody; a reversal demotes the seat on the very next gate.
+#
+# The six arms mirror the row's acceptance list one-for-one:
+#   1  above-threshold seat clears, provenance auto:record, record cited
+#   2  below-threshold / too-few / NO record at all still pings
+#   3  a reversal demotes — the NEXT gate from that seat pings again
+#   4  approval / secret / manual / tier-2 / --needs / floored are untouched
+#   5  the rate is STARTS-WITH: `merge — ALREADY DONE` counts as a MATCH
+#   6  the kill switch restores pre-DIVE-3694 routing
+# Isolation matches the sibling harnesses: source src/ libs against a throwaway
+# STATE_DIR; the live shared tasks.db is NEVER touched. Run:
+#   bash tests/gate_track_record_unit.sh   (no root, no network)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/gate-track-record-unit.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"; set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+eq_t()  { if [[ "$2" == "$3" ]]; then ok_t "$1"; else bad_t "$1" "want [$3] got [$2]"; fi; }
+
+tasks_db_init
+NOTIFIED=""
+task_need_notify() { NOTIFIED="${NOTIFIED} ${1:-}"; }
+audit_log() { :; }
+
+seed_task() { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','$2');"; }
+field() { db "SELECT COALESCE($2,'∅') FROM tasks WHERE ident='$1';"; }
+
+# Seed one ALREADY-ANSWERED tier-1 decision gate onto the seat's record, <age>
+# days old, answered <ans>. Ordering inside the window is by need_answered_at, so
+# a smaller <age> is MORE RECENT — that is what the streak test reads.
+seed_hist() { # <ident> <filer> <recommend> <ans> <age-days>
+  seed_task "$1" "$2"
+  db "UPDATE tasks SET need_type='decision', tier=1, gate_filed_by=$(sqlq "$2"),
+        recommend=$(sqlq "$3"), need_answer=$(sqlq "$4"),
+        need_asked_at=datetime('now','-$5 day'),
+        need_answered_at=datetime('now','-$5 day'),
+        need_answered_by='lead:main', status='todo' WHERE ident='$1';"
+}
+# N concordant gates for a seat, ages descending from <start> days.
+seed_clean() { # <seat> <n> <start-age> <ident-base>
+  local i; for ((i=0;i<$2;i++)); do seed_hist "$4-1$i" "$1" merge merge $(( $3 - i )); done
+}
+
+# ===================== ARM 1: a promoted seat clears ======================
+seed_clean alpha 12 40 TR-A
+eq_t "record: alpha counts 12"             "$(_gate_record_stats alpha | cut -d' ' -f2)" "12"
+eq_t "record: alpha 12/12 concordant"      "$(_gate_record_stats alpha | cut -d' ' -f1)" "12"
+eq_t "record: alpha streak clean"          "$(_gate_record_stats alpha | cut -d' ' -f3)" "1"
+if _gate_record_promoted alpha; then ok_t "record: alpha is promoted"; else bad_t "record: alpha is promoted" "not promoted"; fi
+
+seed_task TR-9001 alpha
+NOTIFIED=""
+( cmd_task_need TR-9001 --type=decision --from=alpha --ask="pick the retry budget" --options="raise|hold" --recommend="raise" ) >/dev/null 2>&1 || true
+eq_t "A1: promoted seat auto-cleared"      "$(field TR-9001 need_answered_by)" "auto:record"
+eq_t "A1: the recommendation was applied"  "$(field TR-9001 need_answer)"      "raise"
+eq_t "A1: row unblocked"                   "$(field TR-9001 status)"           "todo"
+eq_t "A1: nobody was pinged"               "${NOTIFIED// /}"                    ""
+eq_t "A1: provenance is NOT human"         "$(db "SELECT CASE WHEN need_answered_by LIKE 'human:%' THEN 'human' ELSE 'not-human' END FROM tasks WHERE ident='TR-9001';")" "not-human"
+
+# The record must be legible to the seat itself (row scope item 4).
+LINE="$(_gate_record_line alpha)"
+case "$LINE" in *PROMOTED*12/12*) ok_t "A1: track-record line states rate and count" ;;
+  *) bad_t "A1: track-record line states rate and count" "$LINE" ;; esac
+case "$LINE" in *Revoked*) ok_t "A1: track-record line names what revokes it" ;;
+  *) bad_t "A1: track-record line names what revokes it" "$LINE" ;; esac
+
+# An auto:record answer must NEVER feed the record that produced it.
+eq_t "A1: auto:record excluded from own window" "$(_gate_record_stats alpha | cut -d' ' -f2)" "12"
+
+# ============ ARM 2: below threshold / too few / NO record pings ==========
+# 2a — enough gates, rate under the bar (8/12 = 66%).
+seed_clean bravo 8 40 TR-B
+seed_hist TR-B-x0 bravo merge hold 32; seed_hist TR-B-x1 bravo merge hold 31
+seed_hist TR-B-x2 bravo merge hold 30; seed_hist TR-B-x3 bravo merge hold 29
+seed_task TR-9002 bravo
+( cmd_task_need TR-9002 --type=decision --from=bravo --ask="pick the retry budget" --options="raise|hold" --recommend="raise" ) >/dev/null 2>&1 || true
+eq_t "A2a: under-rate seat still pings"    "$(field TR-9002 need_answered_at)" "∅"
+eq_t "A2a: under-rate seat stays blocked"  "$(field TR-9002 status)"           "blocked"
+
+# 2b — a perfect rate over too FEW gates is not a record.
+seed_clean charlie 5 40 TR-C
+seed_task TR-9003 charlie
+( cmd_task_need TR-9003 --type=decision --from=charlie --ask="pick the retry budget" --options="raise|hold" --recommend="raise" ) >/dev/null 2>&1 || true
+eq_t "A2b: 5/5 is too few to promote"      "$(field TR-9003 need_answered_at)" "∅"
+
+# 2c — ABSENCE OF A RECORD IS NEVER A GOOD RECORD. A brand-new seat pings.
+seed_task TR-9004 delta
+( cmd_task_need TR-9004 --type=decision --from=delta --ask="pick the retry budget" --options="raise|hold" --recommend="raise" ) >/dev/null 2>&1 || true
+eq_t "A2c: a new seat starts un-promoted"  "$(field TR-9004 need_answered_at)" "∅"
+eq_t "A2c: new seat stats are 0 0 0"       "$(_gate_record_stats delta)"        "0 0 0"
+
+# ================ ARM 3: a reversal demotes on the NEXT gate ==============
+# echo is promoted on 12 clean gates, then answered AGAINST once, most recently.
+seed_clean echo7 12 40 TR-E
+if _gate_record_promoted echo7; then ok_t "A3: echo7 promoted before the reversal"; else bad_t "A3: echo7 promoted before the reversal" "not promoted"; fi
+seed_hist TR-E-rev echo7 merge "hold — not this cut" 1
+eq_t "A3: rate still over the bar after one reversal" \
+     "$(( 100 * $(_gate_record_stats echo7 | cut -d' ' -f1) / $(_gate_record_stats echo7 | cut -d' ' -f2) >= 85 ? 1 : 0 ))" "1"
+eq_t "A3: but the streak is broken"        "$(_gate_record_stats echo7 | cut -d' ' -f3)" "0"
+if _gate_record_promoted echo7; then bad_t "A3: reversal demotes the seat" "still promoted"; else ok_t "A3: reversal demotes the seat"; fi
+seed_task TR-9005 echo7
+( cmd_task_need TR-9005 --type=decision --from=echo7 --ask="pick the retry budget" --options="raise|hold" --recommend="raise" ) >/dev/null 2>&1 || true
+eq_t "A3: the NEXT gate from that seat pings again" "$(field TR-9005 need_answered_at)" "∅"
+eq_t "A3: and stays blocked"                        "$(field TR-9005 status)"           "blocked"
+case "$(_gate_record_line echo7)" in *reversal*) ok_t "A3: the line explains the demotion" ;;
+  *) bad_t "A3: the line explains the demotion" "$(_gate_record_line echo7)" ;; esac
+
+# ======== ARM 4: the refusals — one test per human-by-type + tier 2 =======
+# alpha is promoted throughout this arm; every row below must still be untouched.
+seed_task TR-9010 alpha
+( cmd_task_need TR-9010 --type=approval --from=alpha --tier=1 --ask="merge the branch" --recommend="merge" ) >/dev/null 2>&1 || true
+eq_t "A4: approval never auto-cleared"     "$(field TR-9010 need_answered_at)" "∅"
+seed_task TR-9011 alpha
+( cmd_task_need TR-9011 --type=secret --from=alpha --ask="provide the token" --recommend="provide" ) >/dev/null 2>&1 || true
+eq_t "A4: secret never auto-cleared"       "$(field TR-9011 need_answered_at)" "∅"
+seed_task TR-9012 alpha
+( cmd_task_need TR-9012 --type=manual --from=alpha --ask="tap the console button" --recommend="tap" ) >/dev/null 2>&1 || true
+eq_t "A4: manual never auto-cleared"       "$(field TR-9012 need_answered_at)" "∅"
+seed_task TR-9013 alpha
+( cmd_task_need TR-9013 --type=decision --from=alpha --tier=2 --ask="pick the retry budget" --options="raise|hold" --recommend="raise" ) >/dev/null 2>&1 || true
+# Nothing is applied. NOTE WHY, because the reason is not this ticket's guard:
+# DIVE-2848's rubber-stamp cap REFUSES a tier-2 decision that carries a
+# --recommend outright, so the gate is never filed at all (tier stays NULL). The
+# assertion that matters either way is that no answer was written.
+eq_t "A4: explicit --tier=2 never auto-cleared" "$(field TR-9013 need_answered_at)" "∅"
+eq_t "A4: explicit --tier=2 was refused at filing, not auto-applied" "$(field TR-9013 tier)" "∅"
+# The T2 SUBJECT floor (money) — the filer cannot lower it and neither can a record.
+seed_task TR-9014 alpha
+( cmd_task_need TR-9014 --type=decision --from=alpha --ask="approve spend of \$4,000 on the new box" --options="raise|hold" --recommend="raise" ) >/dev/null 2>&1 || true
+eq_t "A4: a floored (money) decision never auto-cleared" "$(field TR-9014 need_answered_at)" "∅"
+eq_t "A4: and that gate really WAS filed at tier 2 (a live negative, not a refusal)" "$(field TR-9014 tier)" "2"
+eq_t "A4: and it is still blocked on a human"  "$(field TR-9014 status)" "blocked"
+# A DECLARED capability outranks any record (DIVE-2241).
+seed_task TR-9015 alpha
+( cmd_task_need TR-9015 --type=decision --from=alpha --needs=human_tap --ask="pick the retry budget" --options="raise|hold" --recommend="raise" ) >/dev/null 2>&1 || true
+eq_t "A4: --needs=<capability> never auto-cleared" "$(field TR-9015 need_answered_at)" "∅"
+# A recommendation that is not on the filer's own menu falls through to the ping.
+seed_task TR-9016 alpha
+( cmd_task_need TR-9016 --type=decision --from=alpha --ask="pick the retry budget" --options="raise|hold" --recommend="delete everything" ) >/dev/null 2>&1 || true
+eq_t "A4: off-menu recommendation is not applied" "$(field TR-9016 need_answered_at)" "∅"
+# No recommendation at all: there is nothing to apply.
+seed_task TR-9017 alpha
+( cmd_task_need TR-9017 --type=decision --from=alpha --ask="pick a wholly novel retry budget" --options="raise|hold" ) >/dev/null 2>&1 || true
+eq_t "A4: no recommendation, no auto-clear" "$(field TR-9017 need_answered_at)" "∅"
+
+# ============ ARM 5: STARTS-WITH, not equality — the pinned case ==========
+# `merge — ALREADY DONE` is a MATCH. Equality would score all 12 as reversals and
+# read 0%, and the threshold would have been set against a wrong number.
+for i in 0 1 2 3 4 5 6 7 8 9 10 11; do
+  seed_hist "TR-F-$i" foxtrot merge "merge — ALREADY DONE" $(( 40 - i ))
+done
+eq_t "A5: rec+commentary counts as a MATCH" "$(_gate_record_stats foxtrot | cut -d' ' -f1)" "12"
+if _gate_record_promoted foxtrot; then ok_t "A5: starts-with promotes the seat"; else bad_t "A5: starts-with promotes the seat" "not promoted"; fi
+# The negative control on the same discriminator: a DIFFERENT answer is not a match.
+seed_hist TR-F-neg golf merge "hold — merge later" 3
+eq_t "A5: an answer that merely CONTAINS the rec is not a match" "$(_gate_record_stats golf | cut -d' ' -f1)" "0"
+
+# ==================== ARM 6: the kill switch =============================
+_task_pref_set track_record off
+seed_task TR-9018 alpha
+( cmd_task_need TR-9018 --type=decision --from=alpha --ask="pick the retry budget" --options="raise|hold" --recommend="raise" ) >/dev/null 2>&1 || true
+eq_t "A6: pref off restores the ping"      "$(field TR-9018 need_answered_at)" "∅"
+eq_t "A6: pref off leaves the row blocked" "$(field TR-9018 status)"           "blocked"
+_task_pref_set track_record on
+seed_task TR-9019 alpha
+( cmd_task_need TR-9019 --type=decision --from=alpha --ask="pick the retry budget" --options="raise|hold" --recommend="raise" ) >/dev/null 2>&1 || true
+eq_t "A6: pref on clears again"            "$(field TR-9019 need_answered_by)"  "auto:record"
+
+echo "-------------------------------------"
+echo "gate_track_record_unit: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What this is

ROADMAP #22, the v0.22 headline: **when the asker has been right N times running, stop asking.**
A tier-1 `decision` gate filed by a seat whose own recent tier-1 decisions have been coming back as
that seat's `--recommend` applies that recommendation at filing and pings nobody — provenance
`auto:record`, the same permanent record + digest line a `--tier=0` apply already writes, with the
record cited on the gate, the audit row and the ledger detail.

Successor to DIVE-3693 (ROADMAP #20), which fires **0 of 204** because it keys on the QUESTION
repeating and the questions do not repeat. This keys on the FILER'S RECORD, which is where the 87%
actually lives.

## The threshold, and why it is a conjunction

`>= 10` answered tier-1 decisions in a 20-gate window, `>= 85%` concordant, **and the last 3 clean**.

The streak is the load-bearing half. A rate-only rule cannot demote in time: a 12/12 seat answered
against once still reads **12/13 = 92%**, above any sane bar, and would keep clearing its own gates
through several more reversals. Read positionally, one reversal lands at the head of the window and
the seat is demoted on its very next gate. Live witness on the production store today: `dev3` is at
9/10 = 90%, over the rate bar, and is correctly NOT promoted because its newest answer went the
other way.

An overturn of an auto-applied gate demotes through the same query and needs no second mechanism —
this path never claims a human answered, so a later human/lead answer on that row enters the window
like any other. `auto:%` is excluded from the window, so an auto-clear can never feed the record
that produced it.

**Absence of a record is never a good record.** The count floor is checked before the rate, an
unknown seat returns `0 0 0`, and every error path in the read fails **CLOSED** to that same value —
the opposite posture from `_gate_tapback_stats`, which fails open, because a measurement that cannot
run must not become a GRANT.

## Acceptance criterion 6 — the measured before/after, INCLUDING the cost

Replayed in filing order over the 204 answered tier-1 decision gates the store holds
(`/var/lib/5dive/tasks/tasks.db`, union of `tasks` + `gate_history`, 2026-07-21..2026-08-23),
computed the way DIVE-3693's replay was:

| | |
|---|---|
| population concordance (starts-with) | **178 / 204 = 87.3%** — corroborates main's 81% and dev's 87.2% |
| asks this feature would have REMOVED | **15 / 204 = 7.4%** |
| of those, answered AGAINST the recommendation | **2 / 15 = 13.3%** |

That second number is the price and it is not hidden: 2 rows in thirteen months would have proceeded
on the filer's call where the answerer would have said otherwise. Both would have demoted the seat
immediately afterwards.

Threshold sensitivity, same replay: `min=8/85%/streak=2` → 43 fires; `min=10/85%/streak=3` (shipped,
loose attribution) → 33; `min=10/90%/streak=3` → 19; `min=15/90%/streak=3` → 6; `min=20/95%` → 3.

## THE POPULATION CORRECTION — please read this before writing the release note

**Of the 204 answered tier-1 decision gates, only 11 were answered by a human at all.** 193 went to a
routed agent lead (DIVE-1145 builder-gate routing). Split: agent-answered 169/193 = 87.6%,
human-answered 9/11 = 81.8%.

So what this feature removes is overwhelmingly a **lead round-trip**, not a human tap. That is still
the numerator of `1 - asks/shipped` and still worth shipping — an inbound wakes the recipient into a
full context reload, which our own a2a rules name as the real cost of agent traffic — but the row's
framing ("the rate at which that seat's `--recommend` was returned by the human answer") describes a
population of eleven. **The release note must not say "stop asking the human".** Compiled to
`community/wiki/a-tier-1-gate-is-answered-by-a-lead-not-a-human.md`.

## Attribution: I took the smaller number on purpose

`gate_history` carries no filer column, so attributing a history row means going through its task's
CURRENT `gate_filed_by` — the wrong seat whenever a gate was re-filed. The engine reads `tasks` ONLY.
Measured cost of that choice: loose attribution fires **33/204 with 7 wrong (21.2%)**, exact
attribution fires **15/204 with 2 wrong (13.3%)**. The loose version fires more than twice as often
**and is wronger than the population's own 12.7% base discordance** — which is what misattribution
looks like from outside. An autonomy grant handed to a seat on another seat's record is the one
failure this cannot have.

## Out of scope — refusals, not deferrals

- `approval`, `secret`, `manual` stay human **BY TYPE** (`_gate_human_class` asserted directly, plus
  the type pinned to `decision`). A track record is not a capability: no volume of prior yeses hands
  an agent a browser tap or spend authority (the DIVE-2248 shape).
- Every tier-2 gate stays human — explicit `--tier=2`, the money/destructive/public-comms subject
  floor (`tier_floored`), and any declared `--needs=<capability>` (DIVE-2241).
- **No question-similarity matching.** There is deliberately no `ask_shape` read anywhere in the new
  path. That is #20, measured to reach ~0, parked on DIVE-3693, and this row must not re-acquire it.

## Surfaces

- `5dive task track-record [on|off|status [<seat>]]` — the kill switch and the seat-legible view
  (rate, count, and **what would revoke it**). Default **ON**: this is the deliverable, not an
  experiment (mirrors `task pfr-autoclear`, not `task precedent`). `off` restores pre-DIVE-3694
  routing byte-for-byte with no release.
- The DIVE-2848 rubber-stamp refusal's `--tier=1` help line now names it, because a policy indexed by
  topic never meets the keystroke — that ticket's own lesson.

## Tests

`tests/gate_track_record_unit.sh` — **41 assertions, green**, one arm per acceptance criterion:
promoted seat clears with no ping and a cited record; under-rate, too-few and **no-record-at-all**
seats still ping; a reversal demotes and the NEXT gate pings again; approval / secret / manual /
explicit tier-2 / a live tier-2-floored money decision / `--needs=` / off-menu recommendation / no
recommendation are each provably untouched; **`merge — ALREADY DONE` is pinned as a MATCH** with a
negative control (an answer that merely CONTAINS the rec is not one); the kill switch round-trips.

Also run green, unchanged: `gate_precedent_unit` (74), `gate_class_over_tier_unit` (66),
`gate_recommend_cap_unit` (38), `gate_approval_routing_unit` (9), `gate_parity_smoke` (15, with the
new parity row). `shellcheck -S error -x` clean on the touched files. `5dive task track-record`
exercised end-to-end against a built bundle.

## Disclosure

On the live store today the threshold promotes exactly two seats: `dev2` (15/15) and `dev` (12/13).
**I am `dev`** — the builder of this feature is one of its two first beneficiaries. The threshold was
picked from the replay before I looked at who cleared it, and it is one `_task_pref_set` away from
off, but the verifier should know.

## Residual

- The engine's window is `tasks`-only, so a seat's record grows only as `gate_filed_by` coverage does
  (the column has been populated since 2026-07-29). Reach increases over time; it does not need a
  code change to.
- Nothing here re-evaluates a gate that is ALREADY pending — promotion applies at filing only.
