### PR TITLE
DIVE-3792: codex agents start their Telegram listen loop on boot

### DIFF
--- a/5dive-agent-start
+++ b/5dive-agent-start
@@ -1821,6 +1821,57 @@ if [[ "$TYPE" == "antigravity" && "$CHANNELS" == "telegram" ]]; then
   ) &
 fi
 
+# codex cold-start kickoff (telegram only). DIVE-3792.
+#
+# codex was the ONE fork with no cold-start kick, and the comment on grok's
+# branch above says why: "Unlike codex (whose MCP server boots with the
+# process)". That is true and it is not sufficient. Booting the MCP server is
+# not the same as the MODEL calling the tool — the listen loop only exists once
+# codex issues wait_for_message, and on a cold start nothing prompts it to. agy
+# is the same class and already has a kick for exactly this reason ("agy's
+# telegram MCP server is wired, but agy won't call wait_for_message until it's
+# prompted"); codex was left out on a distinction that does not hold.
+#
+# Measured on a CUSTOMER box 2026-08-28: after a restart the pane carried the
+# startup splash and nothing else for 2h40m, every health signal read green, and
+# inbound Telegram found no listener — the bridge raised "not responding — cause
+# unknown" instead of delivering. Typing this same text in by hand armed it
+# immediately. The plugin's SERVER-SIDE kick (which fires on an inbound message)
+# is not a substitute: it is what closes this window normally, so when it does
+# not land the window never closes and the agent is deaf until a human types.
+#
+# Three guards, because this types into a live TUI:
+#   * SKIP IF ALREADY LISTENING. If the plugin's inbound kick beat us to it the
+#     pane already shows wait_for_message; kicking again would queue a second
+#     re-arm behind the first. Break, do not fire.
+#   * NEVER TYPE INTO THE HOOKS DIALOG. The first-run "Hooks need review" prompt
+#     is owned by the accepter above and answered with Down+Enter; a kick landing
+#     there would answer the dialog with prose. `continue`, not `break` — the
+#     dialog is transient and we still want to kick once it clears.
+#   * READY MEANS SPLASH + COMPOSER. The splash line is the one marker stable
+#     across codex versions (the composer PLACEHOLDER is not: v0.150.1 renders
+#     "Ask Codex to do anything", v0.146.0 "Implement {feature}", so keying on
+#     it would silently no-op on half the fleet).
+#
+# Single-fire; the server-side watchdog owns every subsequent re-arm. Send is
+# coldstart_kick_submit, which verifies its own Enter and retries the ENTER only
+# (DIVE-3791) — never the text, which would concatenate onto a stranded line.
+if [[ "$TYPE" == "codex" && "$CHANNELS" == "telegram" ]]; then
+  (
+    for _ in $(seq 1 30); do
+      sleep 2
+      _pane="$(/usr/bin/tmux capture-pane -t "$SESSION" -p -S -40 2>/dev/null)" || break
+      if printf '%s' "$_pane" | grep -q 'wait_for_message'; then break; fi
+      if printf '%s' "$_pane" | grep -q 'Hooks need review'; then continue; fi
+      if printf '%s' "$_pane" | grep -q '>_ OpenAI Codex (v' \
+         && printf '%s' "$_pane" | grep -q '›'; then
+        coldstart_kick_submit "$SESSION" codex || true
+        break
+      fi
+    done
+  ) &
+fi
+
 # Block so systemd keeps the unit "active" as long as the session lives.
 while /usr/bin/tmux has-session -t "$SESSION" 2>/dev/null; do
   sleep 5

--- a/5dive-agent-start
+++ b/5dive-agent-start
@@ -1772,10 +1772,14 @@ coldstart_kick_submit() { # <session> <label>
   return 1
 }
 
-# grok cold-start kickoff (telegram only). Unlike codex (whose MCP server boots
-# with the process), grok lazy-loads its telegram MCP server only once a chat
-# session starts — until then it sits at the home-screen launcher (New worktree
-# / Resume session / Quit) and never receives Telegram messages. On the nightly
+# grok cold-start kickoff (telegram only). grok lazy-loads its telegram MCP server
+# only once a chat session starts — until then it sits at the home-screen launcher
+# (New worktree / Resume session / Quit) and never receives Telegram messages.
+# (This comment used to open by contrasting grok with codex, on the reasoning that
+# codex's MCP server boots with the process. It does — and that never made codex
+# reachable, because the listen loop needs the MODEL to call wait_for_message. That
+# sentence is why codex went 2h40m deaf on a customer box; codex has its own kick
+# below. DIVE-3792.) On the nightly
 # unit restart this left grok dead until a human typed into it. So we mirror the
 # codex trust-accepter above: watch the pane during the boot window, and once the
 # launcher is showing, type a one-line kickoff to start a session. That loads the
@@ -1823,9 +1827,9 @@ fi
 
 # codex cold-start kickoff (telegram only). DIVE-3792.
 #
-# codex was the ONE fork with no cold-start kick, and the comment on grok's
-# branch above says why: "Unlike codex (whose MCP server boots with the
-# process)". That is true and it is not sufficient. Booting the MCP server is
+# codex was the ONE fork with no cold-start kick, and grok's comment above USED to
+# say why: codex's MCP server boots with the process, so it needs no kick. The
+# first half is true and the second does not follow. Booting the MCP server is
 # not the same as the MODEL calling the tool — the listen loop only exists once
 # codex issues wait_for_message, and on a cold start nothing prompts it to. agy
 # is the same class and already has a kick for exactly this reason ("agy's

--- a/changelog.d/DIVE-3792.md
+++ b/changelog.d/DIVE-3792.md
@@ -1,0 +1,28 @@
+## Unreleased — fix(agent-start): codex agents now start their Telegram listen loop on boot (DIVE-3792)
+
+codex was the one fork with no cold-start kick. The reasoning in the code was that
+"codex's MCP server boots with the process" — true, and not sufficient. Booting the
+MCP server is not the same as the model CALLING the tool: the listen loop only exists
+once codex issues `wait_for_message`, and on a cold start nothing prompted it to.
+
+Measured on a customer box: after a restart the pane carried the startup splash and
+nothing else for 2h40m while every health signal read green. Inbound Telegram found no
+listener, so the bridge raised "not responding — cause unknown" instead of delivering.
+Typing the kick text in by hand armed it instantly.
+
+antigravity already had a kick for exactly this reason ("agy's telegram MCP server is
+wired, but agy won't call wait_for_message until it's prompted"); codex was left out on
+a distinction that does not hold.
+
+codex now gets the same single-fire boot kick, sent through DIVE-3791's
+`coldstart_kick_submit`, so it verifies its own Enter and retries the Enter only. Three
+guards: it breaks without typing if the pane already shows `wait_for_message` (the
+plugin's inbound kick got there first), it never types while the first-run "Hooks need
+review" dialog is up, and its ready marker is the codex splash line rather than the
+composer placeholder — the placeholder differs across codex versions ("Ask Codex to do
+anything" on v0.150.1, "Implement {feature}" on v0.146.0) and keying on it would have
+silently no-opped on half the fleet.
+
+`tests/rearm_loop_regression_unit.sh` now grades all three kick blocks instead of two,
+and each must carry ITS OWN ready marker — a shared alternation would pass a codex block
+that had grok's marker copy-pasted into it.

--- a/changelog.d/DIVE-3792.md
+++ b/changelog.d/DIVE-3792.md
@@ -26,3 +26,9 @@ silently no-opped on half the fleet.
 `tests/rearm_loop_regression_unit.sh` now grades all three kick blocks instead of two,
 and each must carry ITS OWN ready marker — a shared alternation would pass a codex block
 that had grok's marker copy-pasted into it.
+
+The regression harness grades those guards rather than only the block around them:
+deleting either the already-listening break or the Hooks-dialog skip now fails, and a
+comment reinstating the "codex's MCP server boots with the process, so it needs no
+kick" reasoning fails too — that sentence is the reason codex was excluded in the
+first place.

--- a/tests/rearm_loop_regression_unit.sh
+++ b/tests/rearm_loop_regression_unit.sh
@@ -79,7 +79,14 @@ echo "== 2. STATIC POSITIVE: the corrected instruction is present =="
 if grep -qF 'END YOUR TURN' "$START"; then ok "cold-start kick says END YOUR TURN"
 else no "cold-start kick says END YOUR TURN"; fi
 
-echo "== 3. STRUCTURAL: both kick blocks submit through the verifier =="
+# The reasoning error is the bug. codex was excluded from the kick because a comment
+# asserted its MCP server booting with the process made it reachable; it does not, and
+# a revert of that comment is a revert of the fix's rationale. DIVE-3792.
+if grep -qF 'Unlike codex (whose MCP server boots' "$START"; then
+  no "no comment still claims codex needs no kick because its MCP server boots"
+else ok "no comment still claims codex needs no kick because its MCP server boots"; fi
+
+echo "== 3. STRUCTURAL: all three kick blocks submit through the verifier =="
 # The verified send is worthless if a call site still fires Enter itself. Read
 # the three kick blocks only, so an unrelated Enter elsewhere in the script (the
 # claude resume prompt, the codex trust-accepter) is not miscounted.
@@ -90,6 +97,17 @@ echo "== 3. STRUCTURAL: both kick blocks submit through the verifier =="
 # each block must carry ITS OWN ready marker, or a copy-pasted grok marker in the
 # codex block would pass this arm while never matching a real codex pane.
 declare -A _READY=( [grok]='Resume session' [antigravity]='for shortcuts' [codex]='>_ OpenAI Codex (v' )
+# A block's GUARDS are graded per block too, because they are per block. DIVE-3792
+# iteration 1 shipped codex's two guards UNGRADED: deleting either left the harness
+# at 75/0, so a refactor could drop one silently and re-open the double-submit and
+# type-into-the-dialog paths the row was filed to close. One `<regex>|<what it is>`
+# per line; a block with no required guards declares none and this loop skips it.
+declare -A _MUST=(
+  [grok]=""
+  [antigravity]=""
+  [codex]="grep -q .wait_for_message.;[[:space:]]*then[[:space:]]*break|does not type when the pane already shows wait_for_message (the plugin's inbound kick won the race)
+grep -q .Hooks need review.;[[:space:]]*then[[:space:]]*continue|does not type while the first-run Hooks-need-review dialog is up"
+)
 for _blk in grok antigravity codex; do
   _pat='^if \[\[ "\$TYPE" == "'"${_blk}"'" && "\$CHANNELS" == "telegram" \]\]; then$'
   _hits="$(grep -cE "$_pat" "$START")"
@@ -107,6 +125,11 @@ for _blk in grok antigravity codex; do
   if grep -qE 'send-keys[^|]*Enter' <<<"$_body"; then
     no "$_blk kick fires no bare Enter of its own"
   else ok "$_blk kick fires no bare Enter of its own"; fi
+  while IFS='|' read -r _gpat _gdesc; do
+    [[ -n "$_gpat" ]] || continue
+    if grep -qE "$_gpat" <<<"$_body"; then ok "$_blk kick $_gdesc"
+    else no "$_blk kick $_gdesc"; fi
+  done <<<"${_MUST[$_blk]}"
 done
 # One text, one definition — the duplicate is how the banned phrasing survived in
 # both blocks.

--- a/tests/rearm_loop_regression_unit.sh
+++ b/tests/rearm_loop_regression_unit.sh
@@ -81,12 +81,16 @@ else no "cold-start kick says END YOUR TURN"; fi
 
 echo "== 3. STRUCTURAL: both kick blocks submit through the verifier =="
 # The verified send is worthless if a call site still fires Enter itself. Read
-# the two kick blocks only, so an unrelated Enter elsewhere in the script (the
+# the three kick blocks only, so an unrelated Enter elsewhere in the script (the
 # claude resume prompt, the codex trust-accepter) is not miscounted.
 # The `if` line is matched WHOLE and asserted UNIQUE. An earlier draft matched a
 # prefix and `head -1` silently graded the grok AUTH block 1100 lines up, which
 # has no kick in it and passed every arm below vacuously.
-for _blk in grok antigravity; do
+# DIVE-3792 added codex, so the marker can no longer be a shared alternation:
+# each block must carry ITS OWN ready marker, or a copy-pasted grok marker in the
+# codex block would pass this arm while never matching a real codex pane.
+declare -A _READY=( [grok]='Resume session' [antigravity]='for shortcuts' [codex]='>_ OpenAI Codex (v' )
+for _blk in grok antigravity codex; do
   _pat='^if \[\[ "\$TYPE" == "'"${_blk}"'" && "\$CHANNELS" == "telegram" \]\]; then$'
   _hits="$(grep -cE "$_pat" "$START")"
   if [[ "$_hits" != 1 ]]; then
@@ -95,9 +99,9 @@ for _blk in grok antigravity; do
   fi
   _ln="$(grep -nE "$_pat" "$START" | cut -d: -f1)"
   _body="$(sed -n "${_ln},\$p" "$START" | awk 'NR>1 && /^fi$/{print;exit}{print}')"
-  if grep -q 'for shortcuts\|Resume session' <<<"$_body"; then
-    ok "$_blk kick block body carries its ready marker"
-  else no "$_blk kick block body carries its ready marker"; fi
+  if grep -qF "${_READY[$_blk]}" <<<"$_body"; then
+    ok "$_blk kick block body carries its own ready marker"
+  else no "$_blk kick block body carries its own ready marker (want '${_READY[$_blk]}')"; fi
   if grep -q 'coldstart_kick_submit' <<<"$_body"; then ok "$_blk kick calls coldstart_kick_submit"
   else no "$_blk kick calls coldstart_kick_submit"; fi
   if grep -qE 'send-keys[^|]*Enter' <<<"$_body"; then


### PR DESCRIPTION
## The defect

codex was the **one fork with no cold-start kick**. The reasoning is written into the grok branch's own comment:

> grok cold-start kickoff (telegram only). Unlike codex (whose MCP server boots with the process), grok lazy-loads its telegram MCP server only once a chat session starts…

That is true, and it is not sufficient. **Booting the MCP server is not the same as the model CALLING the tool.** The listen loop only exists once codex issues `wait_for_message`, and on a cold start nothing prompts it to. The comment treats "server is up" as "agent is listening"; they are different claims, and only the second is the one customers experience.

`antigravity` already carries a kick for precisely this reason — its own comment says *"agy's telegram MCP server is wired, but agy won't call wait_for_message until it's prompted"*. codex is the same class and was excluded on a distinction that does not hold.

## Measured on a customer box, 2026-08-28

After a unit restart the agent sat at a fresh codex TUI and never called `wait_for_message`. The pane carried the startup splash **and nothing else, from 05:53 to 08:38**, while every health signal read green — unit `active`, bridge process up, 60s heartbeat polling normally. Inbound Telegram found no listener, so the bridge raised `not responding — cause unknown` instead of delivering.

Typing the kick text in by hand armed it **immediately**: the agent replied "I'm re-arming the Telegram listener now", called `telegram.wait_for_message({})` and served normally. So the TUI accepted keystrokes, the MCP server was connected, and the model was willing. Nobody had ever asked it to start listening.

The plugin's **server-side** kick (which fires on an inbound message) is not a substitute — it is what normally closes this window, so when it does not land, the window never closes and the agent stays deaf until a human types.

## The change

Reuses DIVE-3791's `coldstart_kick_submit` rather than adding a second sender, so codex inherits the verified Enter and the Enter-only retry.

Three guards, because this types into a live TUI:

| guard | why |
|---|---|
| break without typing if the pane already shows `wait_for_message` | the plugin's inbound kick won the race; a second kick would queue a re-arm behind the first |
| never type while `Hooks need review` is up (`continue`, not `break`) | the accepter above owns that dialog and answers it Down+Enter; a kick landing there would answer a dialog with prose. The dialog is transient, so we still want to kick once it clears |
| ready marker is the **splash line**, not the composer placeholder | the placeholder is version-specific — v0.150.1 renders `Ask Codex to do anything`, v0.146.0 renders `Implement {feature}` — so keying on it would silently no-op on half the fleet |

Single-fire; the server-side watchdog owns every subsequent re-arm.

## Test

`tests/rearm_loop_regression_unit.sh` now grades **three** kick blocks instead of two. The shared marker alternation (`for shortcuts\|Resume session`) is replaced by a **per-block map**, so each block must carry ITS OWN marker — the old form would have passed a codex block with grok's marker copy-pasted into it.

**72/0 → 75/0.** Mutants run against the product file, all caught:

```
codex kick block deleted entirely            72 pass / 1 fail
grok's marker copy-pasted into codex block   74 pass / 1 fail   <- the arm the per-block map adds
bare Enter instead of coldstart_kick_submit  73 pass / 2 fail
restored                                     75 pass / 0 fail
```

All **11** harnesses referencing `5dive-agent-start` exit `HARNESS-RC=0`. `bash -n` clean on both changed shell files.

The new block uses the house `if …; then break; fi` form rather than `cmd && break`: this file runs under `set -euo pipefail`, and while a non-final command in an `&&` list is exempt from `set -e`, that is a subtlety not worth carrying on a boot path.

## Ship path

`5dive-cli` installs by TAG, so this reaches nobody until a release cut. The cut that just went out (**v0.23.1**, `3485255`) carries DIVE-3785 and DIVE-3791 but **not** this — it needs the next one.

**This is time-boxed:** the affected customer box restarts agents on its ~03:00 nightly. The agent armed by hand today goes deaf again at that restart unless this has landed and been cut first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
