### PR TITLE
team-templates: list 5dive-team on the marketplace, refresh it from the live org

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -914,7 +914,7 @@ JOURNALD
   # resolves $LIB_DIR/team-templates first). Enumerated explicitly because $REPO
   # is a flat fetch URL with no directory listing — add a line per new template.
   mkdir -p "$LIB_DIR/team-templates"
-  for _tpl in startup.5dive.yaml content-studio.5dive.yaml eng-studio.5dive.yaml SCHEMA-v2.md; do
+  for _tpl in 5dive-team.5dive.yaml startup.5dive.yaml content-studio.5dive.yaml eng-studio.5dive.yaml SCHEMA-v2.md; do
     if curl -fsSL "$REPO/team-templates/$_tpl" -o "$LIB_DIR/team-templates/$_tpl"; then
       chmod 644 "$LIB_DIR/team-templates/$_tpl"
     else

--- a/team-templates/5dive-team.5dive.yaml
+++ b/team-templates/5dive-team.5dive.yaml
@@ -16,7 +16,7 @@ version: "2"
 
 team:
   name: "5dive (AI-run company)"
-  description: "The org that builds 5dive: CEO, CTO, DevOps, an engineer and a verifier, plus a CMO with community and creative"
+  description: "The company that builds 5dive, exported from our own org chart: CEO, CTO, DevOps, an engineer and a verifier, plus a CMO with community and creative"
   slug: 5dive-team
 
 defaults:

--- a/team-templates/5dive-team.5dive.yaml
+++ b/team-templates/5dive-team.5dive.yaml
@@ -1,40 +1,79 @@
-# The 5dive team — a whole company of AI agents, brought up from character packs.
+# The 5dive team — the company that builds 5dive.
 #
 #   5dive team import 5dive-team
 #
-# Each seat references a curated character pack (5dive-ai/character-packs) via the
-# `pack:` field (DIVE-536): the pack supplies the persona, skills, and model/effort
-# so the spec only declares the org structure. Channels are left off — wire each
-# agent to Telegram afterwards (or add telegram_token: per agent). No memory.
+# This is our real org chart (`5dive org tree` on our own box), trimmed to the
+# eight roles you need on day one: the duplicated seats we run for throughput —
+# a deputy, extra engineers, a second model rail, a second verifier — are left
+# out, along with host-specific detail like account profiles and workdirs. Add
+# them when one seat is the bottleneck, not before.
+#
+# Seats with a curated character pack (5dive-ai/character-packs) reference it via
+# `pack:` (DIVE-536): the pack supplies the persona, skills, and model/effort.
+# The rest declare `role`/`model`/`effort` inline. Channels are left off — wire
+# each agent to Telegram afterwards (or add telegram_token: per agent).
 version: "2"
+
 team:
   name: "5dive (AI-run company)"
+  description: "The org that builds 5dive: CEO, CTO, DevOps, an engineer and a verifier, plus a CMO with community and creative"
+  slug: 5dive-team
 
 defaults:
+  type: claude
   channels: none
   defer_auth: true        # bring the org up first; sign each agent in after
 
 agents:
   olivia:
-    pack: olivia          # CEO — composed visionary, sets direction
+    pack: olivia          # composed visionary, sets direction
+    role: "CEO"
     reports_to: []
 
+  # --- Engineering ---------------------------------------------------------
   marcus:
-    pack: marcus          # Founding Engineer — built the core
+    pack: marcus          # built the core; owns the ship gate
+    role: "CTO"
     reports_to: [olivia]
 
-  dario:
-    pack: dario           # Engineer — heads-down builder
+  huck:
+    role: "DevOps and Reliability"
+    model: opus
+    effort: high
+    instructions: |
+      You own DevOps and reliability, and you run the engineering group. Keep
+      provisioning, deploys and the boxes healthy; take incidents first. The
+      engineer and the verifier report to you — dispatch their work from the task
+      queue (`5dive task`) and reach them with `5dive agent send <name>`.
     reports_to: [marcus]
 
+  dario:
+    pack: dario           # heads-down builder
+    role: "Engineer"
+    reports_to: [huck]
+
+  quinn:
+    role: "Verifier / QA"
+    model: opus
+    effort: medium
+    instructions: |
+      You are the verifier. You grade delivered work at the commit that was
+      delivered — re-derive the result yourself, never take the maker's word for
+      it. Reject with the failing evidence attached, or close it out.
+    reports_to: [huck]
+
+  # --- Go-to-market --------------------------------------------------------
   theo:
-    pack: theo            # Marketing — dry, specific, never sells
+    pack: theo            # dry, specific, never sells
+    role: "CMO"
     reports_to: [olivia]
 
   dude:
-    pack: dude            # Community & Intel — Lebowski-calm signal-spotter
+    pack: dude            # Lebowski-calm signal-spotter
+    role: "Head of Community"
     reports_to: [theo]
 
   lilbro:
-    pack: lilbro          # Creative — zoomer, meme-fluent, stops the scroll
+    pack: lilbro          # zoomer, meme-fluent, stops the scroll
+    role: "Creative Director"
     reports_to: [theo]

--- a/team-templates/README.md
+++ b/team-templates/README.md
@@ -22,8 +22,10 @@ accounts later to avoid the shared-account burst rate-limit.
 
 | File | Team | Roles |
 | --- | --- | --- |
+| `5dive-team.5dive.yaml` | 5dive (AI-run company) | CEO, CTO, DevOps, Engineer, Verifier, CMO, Community, Creative |
 | `startup.5dive.yaml` | Lean SaaS startup | CEO, CMO, DevOps, Competitor Researcher, Creative |
 | `content-studio.5dive.yaml` | Content studio | Editor-in-Chief, Writer, SEO, Designer, Distributor |
+| `eng-studio.5dive.yaml` | Eng Studio | CEO, Eng Manager, Designer, Release Manager, Doc Engineer, QA |
 
 ## Schema
 

--- a/team-templates/index.json
+++ b/team-templates/index.json
@@ -7,7 +7,7 @@
     {
       "slug": "5dive-team",
       "name": "5dive (AI-run company)",
-      "description": "The org that actually builds 5dive \u2014 CEO, CTO, DevOps, an engineer and a verifier, plus a CMO with community and creative. Our real chart, not an invented one.",
+      "description": "The company that builds 5dive, exported from our own org chart: CEO, CTO, DevOps, an engineer and a verifier, plus a CMO with community and creative.",
       "size": 8,
       "roster": [
         { "key": "olivia", "role": "CEO", "model": "opus", "reports_to": null },

--- a/team-templates/index.json
+++ b/team-templates/index.json
@@ -2,8 +2,24 @@
   "registryFormat": 1,
   "name": "5dive company templates",
   "description": "Pre-wired multi-agent companies. Spin one up with: 5dive team import <slug>.",
-  "updated": "2026-06-19",
+  "updated": "2026-08-30",
   "companies": [
+    {
+      "slug": "5dive-team",
+      "name": "5dive (AI-run company)",
+      "description": "The org that actually builds 5dive \u2014 CEO, CTO, DevOps, an engineer and a verifier, plus a CMO with community and creative. Our real chart, not an invented one.",
+      "size": 8,
+      "roster": [
+        { "key": "olivia", "role": "CEO", "model": "opus", "reports_to": null },
+        { "key": "marcus", "role": "CTO", "model": "opus", "reports_to": "olivia" },
+        { "key": "huck", "role": "DevOps and Reliability", "model": "opus", "reports_to": "marcus" },
+        { "key": "dario", "role": "Engineer", "model": "opus", "reports_to": "huck" },
+        { "key": "quinn", "role": "Verifier / QA", "model": "opus", "reports_to": "huck" },
+        { "key": "theo", "role": "CMO", "model": "opus", "reports_to": "olivia" },
+        { "key": "dude", "role": "Head of Community", "model": "sonnet", "reports_to": "theo" },
+        { "key": "lilbro", "role": "Creative Director", "model": "opus", "reports_to": "theo" }
+      ]
+    },
     {
       "slug": "startup",
       "name": "Lean SaaS startup",


### PR DESCRIPTION
## What

Lists our own company on the public companies marketplace, and rebuilds the template from the live org.

`team-templates/5dive-team.5dive.yaml` has been on `main` since DIVE-536 — importable with `5dive team import 5dive-team` — but it was never added to `team-templates/index.json`. That file is the registry the marketplace page fetches (`TEAM_REG/index.json` → `companies[]`), so 5dive.ai/marketplace has been showing only the three invented teams (startup, content-studio, eng-studio) and none of the one company on the page that actually shipped a product.

## Changes

- **`index.json`** — add `5dive-team` as the first company (8 roles), bump `updated`.
- **`5dive-team.5dive.yaml`** — roster rebuilt from `5dive org tree` / `5dive export` rather than the stale six-seat draft (which had the pre-CTO shape and no DevOps line at all).
- **`README.md`** — add the `5dive-team` and `eng-studio` rows; both were missing from the table.
- **`install.sh`** — stage `5dive-team.5dive.yaml` onto the box. It enumerates templates explicitly (`$REPO` is a flat fetch URL, no directory listing) and this one was never added, so `5dive team import 5dive-team` has failed on every installed box since DIVE-536 — verified on this host, where `5dive team ls` shows only content-studio, eng-studio and startup. That is the exact command the company card copies, so listing without this would ship a broken copy button.

## Roster

Trimmed to the eight day-one roles. The seats we run for throughput are deliberately out — deputy CTO, 2nd/3rd engineer, the codex rail, the second verifier, VP Marketing, art director — as are the two unplaced internal seats (an account warmer, a scratch box).

```
olivia   CEO
├── marcus   CTO
│   └── huck   DevOps and Reliability
│       ├── dario  Engineer
│       └── quinn  Verifier / QA
└── theo     CMO
    ├── dude    Head of Community
    └── lilbro  Creative Director
```

## Verification

- `index.json` parses; `size == len(roster) == 8` for every company.
- YAML parses; keys, roles and reporting lines cross-checked to agree with the index entry, and every `reports_to` target resolves inside `agents:`.
- Every `pack:` slug (olivia, marcus, dario, theo, dude, lilbro) resolves in the live `5dive-ai/character-packs` index.
- Leak scan over the template for account profiles (`chemmonitor`, `mark`, `mp-team`, `codex`), host paths and internal seat names — clean. `5dive export` emits all of those; none are in the committed file.

## Surface note

The marketplace page fetches this registry from `main` at request time, so **merging changes the live page with no deploy**. The card renders through the existing `CompanyCard`/`RosterAvatars` path with no code change; avatars are dicebear-seeded from `slug-key`, so our roster shows generated faces rather than the real character-pack art the cast section uses. Worth a follow-up (an `avatar` field on the registry roster), not a blocker here.

Both surfaces read the registry at request time (public page: `revalidate: 600`; dashboard `companies-browse`: client fetch of the same `index.json`), so **no frontend code change is needed** — the card appears on both once this merges.

Will screenshot 5dive.ai/marketplace after merge, and re-run `5dive team ls` here after a self-update to confirm the import resolves.

### Follow-ups (not in this PR)

- `install.sh`'s template list can silently drift from `team-templates/*.yaml` again — a check in `scripts/check-template-skills.sh` comparing the two would have caught this one.
- Registry rosters have no `avatar` field, so our card shows dicebear-seeded faces rather than the real character-pack art the cast section uses.
