### PR TITLE
team-templates: key every 5dive-team seat to its character pack

### DIFF
--- a/team-templates/5dive-team.5dive.yaml
+++ b/team-templates/5dive-team.5dive.yaml
@@ -8,10 +8,13 @@
 # out, along with host-specific detail like account profiles and workdirs. Add
 # them when one seat is the bottleneck, not before.
 #
-# Seats with a curated character pack (5dive-ai/character-packs) reference it via
-# `pack:` (DIVE-536): the pack supplies the persona, skills, and model/effort.
-# The rest declare `role`/`model`/`effort` inline. Channels are left off — wire
-# each agent to Telegram afterwards (or add telegram_token: per agent).
+# Every seat is a curated character pack (5dive-ai/character-packs) referenced by
+# `pack:` (DIVE-536): the pack supplies the persona, art, skills, and
+# model/effort, so the spec only declares the org structure. Two seats run under
+# a different name on our own box — our verifier is the `vesper` pack and our
+# DevOps seat is `anton` — and the pack is the identity, not the local name.
+# Channels are left off — wire each agent to Telegram afterwards (or add
+# telegram_token: per agent).
 version: "2"
 
 team:
@@ -36,31 +39,28 @@ agents:
     role: "CTO"
     reports_to: [olivia]
 
-  huck:
+  anton:
+    pack: anton           # keeps it running so nobody notices; runs engineering
     role: "DevOps and Reliability"
-    model: opus
-    effort: high
     instructions: |
-      You own DevOps and reliability, and you run the engineering group. Keep
-      provisioning, deploys and the boxes healthy; take incidents first. The
-      engineer and the verifier report to you — dispatch their work from the task
-      queue (`5dive task`) and reach them with `5dive agent send <name>`.
+      On top of the pack: you run the engineering group. The engineer and the
+      verifier report to you — dispatch their work from the task queue
+      (`5dive task`) and reach them with `5dive agent send <name>`.
     reports_to: [marcus]
 
   dario:
     pack: dario           # heads-down builder
     role: "Engineer"
-    reports_to: [huck]
+    reports_to: [anton]
 
-  quinn:
+  vesper:
+    pack: vesper          # breaks it on purpose so the users do not
     role: "Verifier / QA"
-    model: opus
-    effort: medium
     instructions: |
-      You are the verifier. You grade delivered work at the commit that was
+      On top of the pack: you grade delivered work at the commit that was
       delivered — re-derive the result yourself, never take the maker's word for
       it. Reject with the failing evidence attached, or close it out.
-    reports_to: [huck]
+    reports_to: [anton]
 
   # --- Go-to-market --------------------------------------------------------
   theo:

--- a/team-templates/index.json
+++ b/team-templates/index.json
@@ -12,9 +12,9 @@
       "roster": [
         { "key": "olivia", "role": "CEO", "model": "opus", "reports_to": null },
         { "key": "marcus", "role": "CTO", "model": "opus", "reports_to": "olivia" },
-        { "key": "huck", "role": "DevOps and Reliability", "model": "opus", "reports_to": "marcus" },
-        { "key": "dario", "role": "Engineer", "model": "opus", "reports_to": "huck" },
-        { "key": "quinn", "role": "Verifier / QA", "model": "opus", "reports_to": "huck" },
+        { "key": "anton", "role": "DevOps and Reliability", "model": "opus", "reports_to": "marcus" },
+        { "key": "dario", "role": "Engineer", "model": "opus", "reports_to": "anton" },
+        { "key": "vesper", "role": "Verifier / QA", "model": "opus", "reports_to": "anton" },
         { "key": "theo", "role": "CMO", "model": "opus", "reports_to": "olivia" },
         { "key": "dude", "role": "Head of Community", "model": "sonnet", "reports_to": "theo" },
         { "key": "lilbro", "role": "Creative Director", "model": "opus", "reports_to": "theo" }


### PR DESCRIPTION
## Why

Follow-up to #744. The `5dive-team` card showed real character-pack art for six roles and generated dicebear faces for two, because those two were declared inline rather than by `pack:`.

They are not artless — they run under a different name on our box than the pack they were imported from:

- **Verifier / QA** — our `quinn` seat's `CLAUDE.md` is the **`vesper`** pack text with the name swapped, identical line for line (same "you break everything on purpose so the users don't", same voice bullets, same *How you work* list).
- **DevOps and Reliability** — our `ops` seat's instructions were later replaced by its own charter, so the pack it came from is no longer recorded anywhere in the registry or on disk. **`anton`** is the only DevOps/SRE pack in the registry and the role matches exactly.

Rename-on-import is a supported feature (`tests/pack_persona_rename_unit.sh`), which is why the local name and the pack slug diverge at all.

## Changes

`team-templates/5dive-team.5dive.yaml` and `index.json`:

- `huck` → `anton` (`pack: anton`), `quinn` → `vesper` (`pack: vesper`), and the reporting edges that pointed at them.
- Each keeps its local mandate as an `instructions:` block layered on top of the pack, rather than replacing the persona.
- Header comment updated: every seat is now pack-based, and it says why two run under another name.

## Verification

- YAML parses; keys, roles and reporting lines cross-checked against the index entry; every `reports_to` target resolves inside `agents:`.
- `index.json` parses; `size == len(roster) == 8`.
- **All eight avatars fetched from the live registry — `olivia marcus anton dario vesper theo dude lilbro`, 200 on every one.**

Pairs with the frontend change that makes a card prefer pack art for roster keys that name a pack; without that this is inert, and without this that change leaves two generated faces on our card.
