### PR TITLE
feat(task): doctor --fix applies the per-row remedy it already computes (DIVE-3826)

### DIFF
--- a/changelog.d/DIVE-3826.md
+++ b/changelog.d/DIVE-3826.md
@@ -1,0 +1,8 @@
+- `5dive task doctor --fix <id>` applies the per-row remedy `doctor` already computes and prints,
+  by calling the verb named in that row's own report line (`unblock`, `unpark`, or `assign`). It
+  takes one named row — there is no `--all` — and it re-derives the finding at fix time rather than
+  trusting the report you are reading, refusing with the row's actual state if it has since healed.
+  A `dead-lane` row needs `--to=<agent>`, and the destination is checked with the same wakeability
+  test that produced the finding, so the verb that reports dead lanes cannot create one. `--dry-run`
+  prints the command it would run (and any park reason it would drop) and changes nothing. A bare
+  `5dive task doctor` still reports and mutates nothing.

--- a/src/task/dispatch.sh
+++ b/src/task/dispatch.sh
@@ -39,11 +39,16 @@ _task_usage() {
                                                 is NOT the ident number
   orphans [--all]                               rows whose assignee/verifier/creator is not a
                                                 registered agent (undispatchable, DIVE-3344)
-  doctor                                        every open row nothing will dispatch, and WHY —
-                                                no revisit anchor, a stale blocker edge, a park
+  doctor [--fix <id> [--to=<agent>]           every open row nothing will dispatch, and WHY —
+         [--dry-run]]                           no revisit anchor, a stale blocker edge, a park
                                                 past its wake or with none, or a seat nothing
-                                                wakes. Reports, never fixes; each
-                                                finding names the verb that clears it (DIVE-3784)
+                                                wakes. A bare run reports and changes nothing;
+                                                each finding names the verb that clears it
+                                                (DIVE-3784). --fix runs that verb for ONE named
+                                                row, re-deriving the finding first — there is no
+                                                --all. A dead lane needs --to=<agent>, and the
+                                                destination must itself be a seat something wakes
+                                                (DIVE-3826)
   wip-cap-install [--relane=<lane>]             snapshot each lane's actionable count as its
                                                 frozen WIP ceiling (deliberate, once)
   set-budget <id> <tokens|\$cost|none>           record an ADVISORY per-row token budget. Nothing enforces it

--- a/src/task/doctor.sh
+++ b/src/task/doctor.sh
@@ -18,11 +18,15 @@
 # the roster-free classes ALWAYS and degrades only the lane class. `orphans` is
 # kept and is still the verb with the did-you-mean hints.
 #
-# REPORT, NEVER FIX. Mass-clearing a board is its own failure mode: the DIVE-1355
-# heartbeat sweep auto-recovers exactly one class (every blocker closed) because
-# the edges themselves prove it safe, and deliberately only SURFACES the rest. A
-# pull-side command inherits that split — every finding here names the verb the
-# operator should run, and runs none of them.
+# REPORT BY DEFAULT; FIX ONE NAMED ROW ON REQUEST (DIVE-3826). Mass-clearing a
+# board is its own failure mode: the DIVE-1355 heartbeat sweep auto-recovers
+# exactly one class (every blocker closed) because the edges themselves prove it
+# safe, and deliberately only SURFACES the rest. A bare `task doctor` inherits
+# that split exactly — it names the verb per finding and runs none of them.
+# `--fix <id>` runs that one verb for that ONE row, re-deriving the finding
+# first. What is NOT inherited is the retyping: the rail worth keeping is "one
+# row is one decision", not "the operator must be the clipboard". There is no
+# --all and there must never be one. See the --fix block below.
 #
 # WHY A PULL COMMAND WHEN THE HEARTBEAT ALREADY SWEEPS. `_hb_blocked_sweep` pings
 # `ops` at most once per 24h over a2a. That is a push to one seat's inbox, it is
@@ -137,19 +141,199 @@ _task_doctor_explain() {
   esac
 }
 
+# ============================ --fix (DIVE-3826) ==============================
+#
+# THE HOLE THIS CLOSES. `doctor` computes, per row, the exact verb that clears
+# it — and then makes the operator retype it. That is fine for one row and is
+# the whole job for twenty, which is the shape the board was actually in when
+# DIVE-3784 was filed. So the remediation becomes executable, and the rail that
+# made "report only" the right first cut is kept by NARROWING it, not by
+# dropping it:
+#
+#   REPORT IS STILL THE DEFAULT. A bare `task doctor` mutates nothing, exactly
+#   as before. `--fix` is opt-in and it takes ONE NAMED ROW. There is no --all,
+#   and there must never be one: "mass-clearing a board is its own failure mode"
+#   is not a limitation of the first cut, it is the finding. Twenty rows is
+#   twenty decisions; this makes each one one command instead of two.
+#
+#   THE FINDING IS RE-DERIVED AT FIX TIME, never read from the report the
+#   operator is looking at. A printed report is a claim about a board that has
+#   kept moving — the heartbeat tick unparks and the cascade unblocks while you
+#   read it. Fixing off the render would apply a remedy to a row that already
+#   healed, and `unpark` on a healthy row silently drops park state. So `--fix`
+#   classifies the row again itself and REFUSES if it is not a finding now,
+#   naming what the row actually is.
+#
+#   IT APPLIES THE VERB THE TABLE PRINTS, by CALLING that verb. Each class maps
+#   to the command in its own `-> ` slot in _task_doctor_explain and runs it
+#   through the real `cmd_task_*` function, so the semantics cannot drift from
+#   the ones the report promised — the filed symptom was precisely a remedy that
+#   did not match the state (`unblock` over a park, "OK" over a row that did not
+#   move). The parenthetical ALTERNATIVES in that table ("or cancel it if it is
+#   dead", "or re-park with a --wake") are operator judgement and are NOT
+#   automated: one is destructive and the other needs a date only a person has.
+#
+# WHY DEAD-LANE IS THE ONE THAT NEEDED A FLAG. Four of the five remedies are
+# total functions of the row — `unblock`/`unpark` need no argument. `assign`
+# needs a destination, and there is no honest way to derive one: created_by is
+# frequently the seat that is dead, and picking "any live agent" would route
+# real work by coin flip. So `--to=` is required for that class, and the target
+# is checked with the SAME wakeability test that produced the finding — moving a
+# row from one seat nothing wakes to another is the defect, performed by the
+# tool that reports it.
+
+# _task_doctor_row_reason <task-id> — classify ONE row.
+#
+# IT WRITES GLOBALS AND ECHOES NOTHING, deliberately. The obvious shape here is
+# to echo the class and let the caller take it with `$(...)` — and that shape
+# silently loses the second output. A command substitution is a SUBSHELL, so the
+# lane note assigned inside it never reaches the caller, which then reads it
+# under `set -u` and dies. Two return values means two globals.
+#
+#   _TASK_DOCTOR_ROW_REASON     the class, or "" when the row is not a finding
+#   _TASK_DOCTOR_FIX_LANE_NOTE  set when the lane half could not be DECIDED, so
+#                               the caller says "I could not find out" rather
+#                               than "healthy" — the same failure direction
+#                               _task_doctor_lane_wakeable's rc=2 exists for.
+#
+# PRECEDENCE MATCHES THE REPORT: the board classes win over dead-lane, because
+# the report keeps a row's first classification and a row can be both. If the
+# two disagreed, `--fix <ident>` would apply a remedy for a class the operator
+# never saw printed next to that ident.
+_TASK_DOCTOR_ROW_REASON=""
+_TASK_DOCTOR_FIX_LANE_NOTE=""
+_task_doctor_row_reason() {
+  local id="${1:-}" r asg rc
+  _TASK_DOCTOR_ROW_REASON=""
+  _TASK_DOCTOR_FIX_LANE_NOTE=""
+  [[ -n "$id" ]] || return 0
+  r=$(db "SELECT COALESCE(reason,'') FROM ($(_task_doctor_board_sql)) WHERE ident=(SELECT ident FROM tasks WHERE id=${id});" 2>/dev/null || true)
+  if [[ -n "$r" ]]; then _TASK_DOCTOR_ROW_REASON="$r"; return 0; fi
+  asg=$(db "SELECT COALESCE(assignee,'') FROM tasks
+              WHERE id=${id} AND kind='standard' AND status IN ('todo','in_progress','blocked');" 2>/dev/null || true)
+  [[ -n "$asg" ]] || return 0
+  _task_doctor_lane_wakeable "$asg" && rc=0 || rc=$?
+  case "$rc" in
+    1) _TASK_DOCTOR_ROW_REASON="dead-lane" ;;
+    2) _TASK_DOCTOR_FIX_LANE_NOTE="the agent registry (${STATE_DIR:-/var/lib/5dive}/agents.json) could not be read, so whether '${asg}' is a lane anything wakes is UNKNOWN, not healthy" ;;
+  esac
+  return 0
+}
+
+# _task_doctor_fix <ident-or-id> <--to value> <dry-run 0|1>
+_task_doctor_fix() {
+  local target="${1:-}" to="${2:-}" dry="${3:-0}"
+  resolve_task_id "$target"
+  local id="$RESOLVED_TASK_ID" ident="$RESOLVED_TASK_IDENT"
+  local st asg kind park_reason
+  st=$(db "SELECT status FROM tasks WHERE id=${id};")
+  kind=$(db "SELECT COALESCE(kind,'') FROM tasks WHERE id=${id};")
+  asg=$(db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=${id};")
+
+  _task_doctor_row_reason "$id"
+  local reason="$_TASK_DOCTOR_ROW_REASON"
+  if [[ -z "$reason" ]]; then
+    local why="it is not one of the classes doctor reports"
+    [[ "$kind" == "standard" ]] || why="it is a '${kind}' row, and doctor only classifies standard rows"
+    case "$st" in done|cancelled) why="it is already ${st}" ;; esac
+    [[ -z "$_TASK_DOCTOR_FIX_LANE_NOTE" ]] || why="$_TASK_DOCTOR_FIX_LANE_NOTE"
+    fail "$E_VALIDATION" "${ident} is not an undispatchable row right now — ${why} (status=${st}${asg:+, assignee=${asg}}). --fix applies only the remedy doctor computes for a CURRENT finding, and it re-derives that finding rather than trusting a printed report: run '5dive task doctor' for the live list."
+  fi
+
+  # The command for this class, as the report's own `-> ` slot names it.
+  local -a apply=(); local shown=""
+  case "$reason" in
+    no-anchor|stale-edge)
+      [[ -z "$to" ]] || fail "$E_USAGE" "--to is only meaningful for a dead-lane row; ${ident} is '${reason}', whose remedy is '5dive task unblock ${ident}' and takes no destination (re-point the lane separately with '5dive task assign')."
+      apply=(cmd_task_unblock "$ident"); shown="5dive task unblock ${ident}" ;;
+    wake-passed|park-no-wake)
+      [[ -z "$to" ]] || fail "$E_USAGE" "--to is only meaningful for a dead-lane row; ${ident} is '${reason}', whose remedy is '5dive task unpark ${ident}' and takes no destination (re-point the lane separately with '5dive task assign')."
+      park_reason=$(db "SELECT COALESCE(park_reason,'') FROM tasks WHERE id=${id};" 2>/dev/null || true)
+      apply=(cmd_task_unpark "$ident"); shown="5dive task unpark ${ident}" ;;
+    dead-lane)
+      [[ -n "$to" ]] || fail "$E_USAGE" "${ident} is assigned to a lane nothing wakes ('${asg}'), and re-routing needs a destination this command cannot invent — the row's creator is often the dead seat itself. Name one: 5dive task doctor --fix ${ident} --to=<agent>   (roster: 5dive agent list)"
+      # The destination gets the SAME test that produced the finding. Without
+      # this, the verb that reports dead lanes is also the fastest way to make
+      # one, and the row reads as repaired.
+      local trc; _task_doctor_lane_wakeable "$to" && trc=0 || trc=$?
+      if [[ "$trc" == "2" ]]; then
+        fail "$E_GENERIC" "cannot verify --to='${to}': ${STATE_DIR:-/var/lib/5dive}/agents.json could not be read, so this command cannot tell a live seat from another dead one — and moving the row blind is the failure it is meant to repair. Fix the registry first: 5dive doctor"
+      elif [[ "$trc" != "0" ]]; then
+        fail "$E_VALIDATION" "--to='${to}' is itself a lane nothing wakes (no heartbeat enabled, or the seat is operator-stopped) — ${ident} would be exactly as undispatchable at the new address. Pick a live seat: 5dive agent list"
+      fi
+      apply=(cmd_task_assign "$ident" "$to"); shown="5dive task assign ${ident} ${to}" ;;
+    *)
+      fail "$E_GENERIC" "no automatic remedy for class '${reason}' on ${ident} — $(_task_doctor_explain "$reason")" ;;
+  esac
+
+  local detail; detail=$(_task_doctor_explain "$reason")
+  if [[ "$dry" == "1" ]]; then
+    warn "DRY RUN — nothing was changed.
+  ${ident}  [${st}${asg:+ · }${asg}]  ${reason}
+        ${detail}
+  would run: ${shown}${park_reason:+
+  and would DROP the park reason: ${park_reason}}"
+    ok "" '{fix:{ident:$i, reason:$r, command:$c, applied:false, dryRun:true}}' \
+       --arg i "$ident" --arg r "$reason" --arg c "$shown"
+    return 0
+  fi
+
+  # Run the real verb, in a subshell, with its own stdout captured: in JSON mode
+  # each cmd_task_* prints its own envelope and two envelopes on one stdout is
+  # not parseable output. On failure the sibling's envelope and message are the
+  # honest answer, so they are re-emitted rather than swallowed — `fail` exits
+  # the process, and inside the subshell that exit is the rc we read here.
+  local errf; errf=$(mktemp "${TMPDIR:-/tmp}/task-doctor-fix.XXXXXX")
+  local subout rc
+  subout=$( ( "${apply[@]}" ) 2>"$errf" ) && rc=0 || rc=$?
+  if [[ "$rc" != "0" ]]; then
+    cat "$errf" >&2; rm -f "$errf"
+    [[ -z "$subout" ]] || printf '%s\n' "$subout"
+    mark_reported
+    exit "$rc"
+  fi
+  rm -f "$errf"
+
+  warn "${ident} was '${reason}' — applied: ${shown}${park_reason:+
+  park reason dropped: ${park_reason}}
+Re-read the board with '5dive task doctor'; one row was changed and nothing else."
+  ok "${ident}: ${reason} — ran ${shown}" \
+     '{fix:{ident:$i, reason:$r, command:$c, applied:true, dryRun:false}}' \
+     --arg i "$ident" --arg r "$reason" --arg c "$shown"
+}
+
 cmd_task_doctor() {
   tasks_db_init
-  # NO FLAGS, deliberately. The first cut carried a --quiet that suppressed the
-  # census, and the census is the answer to the question the row was filed on
-  # ("31 open, 1 dispatchable") — a flag that hides it is a flag that reproduces
-  # the 42h. It was also accepted and then ignored, which is worse than absent.
+  # NO FLAG HIDES THE REPORT, deliberately. The first cut carried a --quiet that
+  # suppressed the census, and the census is the answer to the question the row
+  # was filed on ("31 open, 1 dispatchable") — a flag that hides it is a flag
+  # that reproduces the 42h. It was also accepted and then ignored, which is
+  # worse than absent, and that is still the bar every flag here is held to:
+  # --to and --dry-run are REFUSED without --fix rather than parsed into
+  # nothing (DIVE-3826).
+  local fix_target="" fix_to="" fix_dry=0 have_fix=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      -*) fail "$E_USAGE" "unknown flag: $1 (usage: 5dive task doctor)" ;;
-      *)  fail "$E_USAGE" "unexpected argument '$1' (usage: 5dive task doctor)" ;;
+      --fix=*)   have_fix=1; fix_target="${1#*=}" ;;
+      --fix)     have_fix=1
+                 [[ $# -ge 2 && "$2" != -* ]] \
+                   || fail "$E_USAGE" "--fix needs the row to repair: 5dive task doctor --fix <id|DIVE-N> [--to=<agent>] [--dry-run]  (there is no --fix-all: one row is one decision)"
+                 fix_target="$2"; shift ;;
+      --to=*)    fix_to="${1#*=}" ;;
+      --dry-run) fix_dry=1 ;;
+      -*) fail "$E_USAGE" "unknown flag: $1 (usage: 5dive task doctor [--fix <id|DIVE-N> [--to=<agent>] [--dry-run]])" ;;
+      *)  fail "$E_USAGE" "unexpected argument '$1' (usage: 5dive task doctor [--fix <id|DIVE-N> [--to=<agent>] [--dry-run]])" ;;
     esac
     shift
   done
+  if [[ "$have_fix" == "0" ]]; then
+    [[ -z "$fix_to" ]] || fail "$E_USAGE" "--to only applies with --fix: 5dive task doctor --fix <id|DIVE-N> --to=<agent>"
+    [[ "$fix_dry" == "0" ]] || fail "$E_USAGE" "--dry-run only applies with --fix — a bare 'doctor' already changes nothing"
+  else
+    [[ -n "$fix_target" ]] || fail "$E_USAGE" "--fix needs the row to repair: 5dive task doctor --fix <id|DIVE-N> [--to=<agent>] [--dry-run]"
+    _task_doctor_fix "$fix_target" "$fix_to" "$fix_dry"
+    return $?
+  fi
 
   # ---- pass 1: the three roster-free classes -------------------------------
   # dbfmt -json prints NOTHING for an empty result set (DIVE-1610), not "[]".
@@ -262,6 +446,7 @@ cmd_task_doctor() {
 
   warn "${n} open row(s) nothing will dispatch — each is counted as work in flight and none of them is:
 ${out}${census_line}
-Nothing above was changed: mass-clearing a board is its own failure mode. Run the named verb per row."
+Nothing above was changed: mass-clearing a board is its own failure mode. Run the named verb per row,
+or have this command run it for ONE row: 5dive task doctor --fix <ident> [--to=<agent> for a dead lane] [--dry-run]"
   ok "" "$payload" "${jargs[@]}"
 }

--- a/tests/task_doctor_unit.sh
+++ b/tests/task_doctor_unit.sh
@@ -24,6 +24,18 @@
 #   T8  a clean board reports zero and still prints the census
 #   T9  an unreadable registry DEGRADES (the roster-free classes still report)
 #       instead of refusing the way `orphans` does
+#   T11..T18 DIVE-3826 `--fix`: the remedy the report NAMES is the one it RUNS,
+#       for ONE named row, re-derived at fix time.
+#   T11  --dry-run prints the command and mutates NOTHING
+#   T12  --fix on each class runs that class's own verb (unblock/unpark/assign)
+#   T13  --fix on a dead lane REFUSES without --to
+#   T14  --fix --to=<another dead lane> is REFUSED — the tool must not create
+#        the defect it reports
+#   T15  --fix on a row that is NOT a current finding is refused, naming its
+#        actual state (the report is a claim about a board that kept moving)
+#   T16  --fix changes exactly ONE row; there is no --all
+#   T17  --to / --dry-run without --fix are REFUSED, not parsed into nothing
+#   T18  --fix with no row argument is refused
 # Run: bash tests/task_doctor_unit.sh   (no root, no network)
 set -uo pipefail
 
@@ -243,6 +255,133 @@ mv "$TMP/agents.json.away" "$TMP/agents.json"; reroster
 { [[ $frc -ne 0 ]] && grep -qi "unknown flag" "$TMP/flag.err"; } \
   && ok_t "an unknown flag is refused rather than accepted and ignored" \
   || bad_t "flag handling" "rc=$frc :: $(cat "$TMP/flag.err")"
+
+# ============================ DIVE-3826: --fix ==============================
+# The fixtures above are consumed by the report arms and are still in their
+# undispatchable states, so they are exactly the population --fix must act on.
+# Each arm below asserts the DATABASE moved (or did not), never the prose: the
+# filed defect was a remedy that printed success over a row that had not moved.
+
+fix() { ( cmd_task_doctor --fix "$@" ) 2>"$TMP/fix.err"; }
+statusof()  { db "SELECT status FROM tasks WHERE id=$1;"; }
+parkedof()  { db "SELECT CASE WHEN parked_at IS NULL THEN 'clear' ELSE 'parked' END FROM tasks WHERE id=$1;"; }
+asgof()     { db "SELECT COALESCE(assignee,'') FROM tasks WHERE id=$1;"; }
+
+# ---- T11: --dry-run names the command and changes NOTHING -------------------
+i_wp=$(ident "$t_wakepast")
+dry=$(fix "$i_wp" --dry-run | tail -n1); drc=$?
+dcmd=$(printf '%s' "$dry" | jq -r '.data.fix.command' 2>/dev/null)
+dapp=$(printf '%s' "$dry" | jq -r '.data.fix.applied' 2>/dev/null)
+{ [[ $drc -eq 0 ]] && [[ "$dcmd" == "5dive task unpark ${i_wp}" ]] && [[ "$dapp" == "false" ]] \
+    && [[ "$(parkedof "$t_wakepast")" == "parked" ]]; } \
+  && ok_t "--dry-run names 'unpark' for a wake-passed row and the row is STILL parked" \
+  || bad_t "--dry-run" "rc=$drc command='${dcmd}' applied='${dapp}' park=$(parkedof "$t_wakepast") :: $(cat "$TMP/fix.err")"
+
+# ---- T12: each class runs ITS OWN verb, and the row actually moves ----------
+# wake-passed -> unpark
+out12a=$(fix "$i_wp" | tail -n1); rc12a=$?
+{ [[ $rc12a -eq 0 ]] && [[ "$(parkedof "$t_wakepast")" == "clear" ]] \
+    && [[ "$(statusof "$t_wakepast")" == "todo" ]] \
+    && [[ "$(printf '%s' "$out12a" | jq -r '.data.fix.applied')" == "true" ]]; } \
+  && ok_t "--fix wake-passed: ran unpark, the row is unparked and back to todo" \
+  || bad_t "--fix wake-passed" "rc=$rc12a park=$(parkedof "$t_wakepast") status=$(statusof "$t_wakepast") :: $(cat "$TMP/fix.err")"
+
+# park-no-wake -> unpark
+i_nw=$(ident "$t_nowake")
+fix "$i_nw" >/dev/null; rc12b=$?
+{ [[ $rc12b -eq 0 ]] && [[ "$(parkedof "$t_nowake")" == "clear" ]]; } \
+  && ok_t "--fix park-no-wake: ran unpark, the row is unparked" \
+  || bad_t "--fix park-no-wake" "rc=$rc12b park=$(parkedof "$t_nowake") :: $(cat "$TMP/fix.err")"
+
+# no-anchor -> unblock
+i_na=$(ident "$t_noanchor")
+fix "$i_na" >/dev/null; rc12c=$?
+{ [[ $rc12c -eq 0 ]] && [[ "$(statusof "$t_noanchor")" == "todo" ]]; } \
+  && ok_t "--fix no-anchor: ran unblock, the row is todo" \
+  || bad_t "--fix no-anchor" "rc=$rc12c status=$(statusof "$t_noanchor") :: $(cat "$TMP/fix.err")"
+
+# stale-edge -> unblock, and the dead EDGE is actually gone (not just the status
+# flipped): a status-only repair leaves the edge to re-block on the next sweep.
+i_se=$(ident "$t_stale")
+fix "$i_se" >/dev/null; rc12d=$?
+edges=$(db "SELECT COUNT(*) FROM task_deps WHERE task_id=${t_stale};")
+{ [[ $rc12d -eq 0 ]] && [[ "$(statusof "$t_stale")" == "todo" ]] && [[ "$edges" == "0" ]]; } \
+  && ok_t "--fix stale-edge: ran unblock, the row is todo AND the dead edge is dropped" \
+  || bad_t "--fix stale-edge" "rc=$rc12d status=$(statusof "$t_stale") edges=$edges :: $(cat "$TMP/fix.err")"
+
+# ---- T13: a dead lane REFUSES without a destination -------------------------
+i_dl=$(ident "$t_dead")
+fix "$i_dl" >/dev/null 2>"$TMP/fix.err"; rc13=$?
+{ [[ $rc13 -ne 0 ]] && grep -qi -- "--to" "$TMP/fix.err" && [[ "$(asgof "$t_dead")" == "zombie" ]]; } \
+  && ok_t "--fix dead-lane with no --to is refused and the row did not move" \
+  || bad_t "dead-lane without --to" "rc=$rc13 assignee=$(asgof "$t_dead") :: $(cat "$TMP/fix.err")"
+
+# ---- T14: --to a lane that is ALSO dead is refused --------------------------
+# The verb that reports dead lanes must not be the fastest way to make one. Both
+# halves of the wakeability test are exercised: 'zombie' (no heartbeat key) was
+# the finding, 'stopped' (heartbeat on, operator-stopped) is the destination.
+fix "$i_dl" --to=stopped >/dev/null 2>"$TMP/fix.err"; rc14=$?
+{ [[ $rc14 -ne 0 ]] && [[ "$(asgof "$t_dead")" == "zombie" ]]; } \
+  && ok_t "--fix --to=<an operator-stopped seat> is refused; the row stays where it was" \
+  || bad_t "--to a dead lane accepted" "rc=$rc14 assignee=$(asgof "$t_dead") :: $(cat "$TMP/fix.err")"
+
+# ...and a WAKEABLE destination is accepted and the row actually moves.
+fix "$i_dl" --to=live >/dev/null 2>"$TMP/fix.err"; rc14b=$?
+{ [[ $rc14b -eq 0 ]] && [[ "$(asgof "$t_dead")" == "live" ]]; } \
+  && ok_t "--fix dead-lane --to=<a wakeable seat>: the row is re-assigned" \
+  || bad_t "--fix dead-lane --to=live" "rc=$rc14b assignee=$(asgof "$t_dead") :: $(cat "$TMP/fix.err")"
+
+# ---- T15: a row that is NOT a current finding is refused ---------------------
+# This is the whole reason --fix re-derives instead of reading the report: the
+# row just repaired above is no longer a finding, and running the remedy again
+# (unpark on a healthy row) would silently drop live park state.
+fix "$i_wp" >/dev/null 2>"$TMP/fix.err"; rc15=$?
+{ [[ $rc15 -ne 0 ]] && grep -qi "not an undispatchable row" "$TMP/fix.err"; } \
+  && ok_t "--fix on an already-repaired row is refused, naming its actual state" \
+  || bad_t "stale finding accepted" "rc=$rc15 :: $(cat "$TMP/fix.err")"
+
+# A healthy row that was NEVER a finding is refused too (the negative control:
+# the arm above could pass merely because the row was touched).
+i_ok=$(ident "$t_todo")
+fix "$i_ok" >/dev/null 2>"$TMP/fix.err"; rc15b=$?
+{ [[ $rc15b -ne 0 ]] && [[ "$(statusof "$t_todo")" == "todo" ]]; } \
+  && ok_t "--fix on a plain healthy row is refused (never-a-finding control)" \
+  || bad_t "healthy row accepted" "rc=$rc15b :: $(cat "$TMP/fix.err")"
+
+# A row waiting on a LIVE human gate is refused: it is correctly in flight, and
+# unblocking it would take the row off the human's inbox without an answer.
+i_gate=$(ident "$t_gate")
+fix "$i_gate" >/dev/null 2>"$TMP/fix.err"; rc15c=$?
+{ [[ $rc15c -ne 0 ]] && [[ "$(statusof "$t_gate")" == "blocked" ]]; } \
+  && ok_t "--fix on a row awaiting a live human gate is refused, and the gate still holds" \
+  || bad_t "live gate cleared by --fix" "rc=$rc15c status=$(statusof "$t_gate") :: $(cat "$TMP/fix.err")"
+
+# ---- T16: there is no --all, and one --fix touched exactly one row ----------
+# t_futurepark is a legitimate hold that sat next to every row repaired above.
+{ [[ "$(parkedof "$t_futurepark")" == "parked" ]] \
+    && [[ "$(statusof "$t_livedep")" == "blocked" ]]; } \
+  && ok_t "the untouched neighbours are untouched — a future park is still parked, a live edge still blocks" \
+  || bad_t "collateral damage" "futurepark=$(parkedof "$t_futurepark") livedep=$(statusof "$t_livedep")"
+( cmd_task_doctor --fix-all ) >/dev/null 2>"$TMP/fix.err"; rc16=$?
+{ [[ $rc16 -ne 0 ]] && grep -qi "unknown flag" "$TMP/fix.err"; } \
+  && ok_t "--fix-all does not exist and is refused as an unknown flag" \
+  || bad_t "--fix-all" "rc=$rc16 :: $(cat "$TMP/fix.err")"
+
+# ---- T17: --to and --dry-run WITHOUT --fix are refused, not ignored ---------
+# Same bar T10 sets: a flag the verb accepts and does not honour is worse than
+# one it rejects.
+( cmd_task_doctor --to=live ) >/dev/null 2>"$TMP/fix.err"; rc17=$?
+[[ $rc17 -ne 0 ]] && r17a=1 || r17a=0
+( cmd_task_doctor --dry-run ) >/dev/null 2>"$TMP/fix.err2"; rc17b=$?
+{ [[ "$r17a" == "1" ]] && [[ $rc17b -ne 0 ]]; } \
+  && ok_t "--to and --dry-run are refused without --fix rather than parsed and ignored" \
+  || bad_t "orphan flags accepted" "--to rc=$rc17 :: --dry-run rc=$rc17b :: $(cat "$TMP/fix.err") $(cat "$TMP/fix.err2")"
+
+# ---- T18: --fix with no row is refused --------------------------------------
+( cmd_task_doctor --fix ) >/dev/null 2>"$TMP/fix.err"; rc18=$?
+{ [[ $rc18 -ne 0 ]] && grep -qi "needs the row" "$TMP/fix.err"; } \
+  && ok_t "--fix with no row argument is refused" \
+  || bad_t "--fix bare" "rc=$rc18 :: $(cat "$TMP/fix.err")"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What

`5dive task doctor --fix <id>` applies the per-row remedy `doctor` already computes and prints.

`doctor` (DIVE-3784) worked out the exact verb that clears each finding and then made the operator
retype it. That is fine for one row and is the whole job for twenty — which is the shape the board
was in when DIVE-3784 was filed, and the shape it was in again on 2026-08-31 (**0 of 21 rows
dispatchable**, which is what put the v0.25 theme on this defect family).

## The anti-mass-clear rail is narrowed, not dropped

"Mass-clearing a board is its own failure mode" is the finding, not a limitation of the first cut.
So:

- **A bare `task doctor` still mutates nothing.** `--fix` is opt-in and takes **one named row**.
  There is no `--all` and there must never be one. Twenty rows is twenty decisions; this makes each
  one *one* command instead of two.
- **The finding is re-derived at fix time**, never read from the report the operator is looking at.
  A printed report is a claim about a board that has kept moving — the heartbeat tick unparks and
  the cascade unblocks while you read it. A row that has since healed is **refused**, naming its
  actual state. Without this, `unpark` on an already-repaired row silently drops live park state.
- **It applies the verb the table PRINTS, by calling that verb.** Semantics cannot drift from what
  the report promised — and the filed symptom of DIVE-3784 was exactly a remedy that did not match
  the state (`unblock` over a park: "OK" printed over a row that did not move).

| class | remedy `--fix` runs |
| --- | --- |
| `no-anchor` | `5dive task unblock <id>` |
| `stale-edge` | `5dive task unblock <id>` |
| `wake-passed` | `5dive task unpark <id>` |
| `park-no-wake` | `5dive task unpark <id>` |
| `dead-lane` | `5dive task assign <id> <--to>` |

The **parenthetical alternatives** in that table ("or cancel it if it is dead", "or re-park with a
`--wake`") are operator judgement and are deliberately **not** automated: one is destructive, the
other needs a date only a person has.

## Why `dead-lane` needed a flag

Four of the five remedies are total functions of the row. `assign` needs a destination and there is
no honest way to derive one — `created_by` is frequently the seat that is dead, and "any live agent"
would route real work by coin flip. So `--to=<agent>` is required for that class, and **the
destination is checked with the same wakeability test that produced the finding**. Otherwise the
verb that reports dead lanes is also the fastest way to make one, and the row reads as repaired.

```
$ 5dive task doctor --fix DIVE-1
error: DIVE-1 is assigned to a lane nothing wakes ('zombie'), and re-routing needs a destination
this command cannot invent — the row's creator is often the dead seat itself. Name one:
5dive task doctor --fix DIVE-1 --to=<agent>   (roster: 5dive agent list)

$ 5dive task doctor --fix DIVE-1 --to=zombie
error: --to='zombie' is itself a lane nothing wakes (no heartbeat enabled, or the seat is
operator-stopped) — DIVE-1 would be exactly as undispatchable at the new address.

$ 5dive task doctor --fix DIVE-1 --to=live --dry-run
warn: DRY RUN — nothing was changed.
  DIVE-1  [todo · zombie]  dead-lane
  would run: 5dive task assign DIVE-1 live
```

`--dry-run` also prints any **park reason the remedy would drop**, which is the one piece of
information `unpark` destroys.

`--to` and `--dry-run` **without** `--fix` are refused rather than parsed into nothing — the same
bar T10 already sets for the `--quiet` that was accepted and ignored in the first cut.

## Bug found and fixed in the writing

`_task_doctor_row_reason` has **two** return values (the class, and a note for when the lane half
could not be *decided* rather than came back healthy). The obvious shape — echo the class, take it
with `$(...)` — is a **subshell**, so the note never reaches the caller, which then reads it under
`set -u` and dies. It writes globals instead. The harness caught this on its first run.

## Tests

`tests/task_doctor_unit.sh`: **31 passed, 0 failed** (8 new arms, T11–T18). Every arm asserts the
**database** moved or did not — never the prose — because the filed defect was a remedy that printed
success over a row that had not moved.

Negative controls: a row that was **never** a finding, a row on a **live human gate** (which must
stay on the human's inbox), and the untouched neighbours next to every repaired row (a future park
is still parked, a live edge still blocks).

**Mutation-graded** — each mutation is caught by the arm that claims to catch it, and by that arm
only:

| mutation | arms that go red |
| --- | --- |
| skip the re-derive (trust the report) | 3 — stale finding, healthy row, live gate |
| accept any `--to` (drop the destination check) | 1 — `--to` a dead lane |
| swap the `dead-lane` remedy to `unblock` | 1 — `--fix dead-lane --to=live` |
| honour `--dry-run` as an apply | 2 — dry-run, and wake-passed |

**End-to-end on the built bundle** (scratch `STATE_DIR`, not the live board): report → dry-run →
refusal without `--to` → refusal on a dead `--to` → apply → clean re-report → refusal on the repeat.
JSON mode emits exactly **one** envelope on every path, including when the sibling verb itself
refuses (`cmd_task_assign`'s own verifier guard propagates with its exact message and code 3, and
the row is unchanged).

Not run: the paid Hetzner smoke — this touches no provisioning path (`src/task/doctor.sh`,
`src/task/dispatch.sh` help text, and the harness only).

Closes DIVE-3826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
