### PR TITLE
DIVE-3834: ladder openclaw's auth read across the 2026.8.1 credential-store move

### DIFF
--- a/src/cmd_agent.sh
+++ b/src/cmd_agent.sh
@@ -663,6 +663,15 @@ cmd_info() {
     if [[ -n "$_oc_prof" ]]; then
       _oc_auth=$(profile_type_auth_path "$_oc_prof" openclaw 2>/dev/null) || _oc_auth=""
     fi
+    # DIVE-3834: the default-home seat needs the same layout ladder the
+    # profile-scoped one gets. TYPE_AUTH names the pre-2026.8.1 sqlite, which
+    # 2026.8.1 creates and leaves empty, so `-s` read false and this warning —
+    # the whole of DIVE-3112 — was silently suppressed on exactly the seats that
+    # need it. profile_type_auth_path '' openclaw returns the proven rung, or
+    # the constant unchanged when no rung proves a credential.
+    if [[ -z "$_oc_auth" ]]; then
+      _oc_auth=$(profile_type_auth_path "" openclaw 2>/dev/null) || _oc_auth=""
+    fi
     [[ -n "$_oc_auth" ]] || _oc_auth="${TYPE_AUTH[openclaw]}"
     [[ -s "$_oc_auth" ]] && oc_unpinned=1
   fi

--- a/src/cmd_agent_create.sh
+++ b/src/cmd_agent_create.sh
@@ -1732,7 +1732,17 @@ selfcheck_cred_reached_agent() { # <name> <type> <profile> <byo_provider>
   # for. A witness must read the store the RUNTIME reads.
   if [[ "$type" == "openclaw" ]]; then
     local _oc_home="${AGENT_HOME_ROOT:-/home}/${user}"
-    local _oc_auth="${_oc_home}/.openclaw/agents/main/agent/openclaw-agent.sqlite"
+    # DIVE-3834: this witness is the THIRD reader of openclaw's credential store
+    # and it was the one left hardcoded. On 2026.8.1 the sqlite below is created
+    # and stays EMPTY, so a seat whose credential is present and correct printed
+    # `issue:openclaw credential never reached the seat` and told the customer to
+    # re-seed a seat that is fine — the same wrong instruction, on the create
+    # path, that this row was filed for. Resolve through the layout ladder and
+    # keep the DIVE-3489 constant as the no-rung fallback, so a pre-2026.8.1 box
+    # and a genuinely unauthenticated seat both behave exactly as before.
+    local _oc_auth
+    _oc_auth=$(_openclaw_cred_path "$_oc_home") \
+      || _oc_auth="${_oc_home}/.openclaw/agents/main/agent/openclaw-agent.sqlite"
     local _oc_cfg="${_oc_home}/.openclaw/openclaw.json"
     if [[ ! -s "$_oc_auth" ]]; then
       printf 'issue:openclaw credential never reached the seat (%s is missing/empty) — the agent boots UNAUTHENTICATED and every message fails with ProviderAuthError while the profile itself looks fine. Re-seed as root: sudo 5dive agent restart %s\n' \

--- a/src/cmd_auth.sh
+++ b/src/cmd_auth.sh
@@ -684,8 +684,11 @@ profile_type_env() {
   esac
 }
 
-# _openclaw_cred_path <state_root> — echo the path, under a HOME-redirected
-# openclaw state root, that PROVES this seat carries an openclaw credential.
+# _openclaw_cred_path <state_root> [legacy_sentinel] — echo the path, under a
+# HOME-redirected openclaw state root, that PROVES this seat carries an
+# openclaw credential. The optional legacy sentinel is needed for the default
+# home: its configured TYPE_AUTH path is authoritative, while profile-scoped
+# homes use the DIVE-3489 sqlite sentinel.
 # Nothing on stdout + rc 1 when no rung proves one.
 #
 # DIVE-3834: upstream openclaw 2026.8.1 moved the credential store. The
@@ -710,7 +713,7 @@ profile_type_env() {
 _openclaw_cred_path() {
   local root="$1" p
   # Rung 1 — layouts up to 2026.7.x: the per-agent auth store (DIVE-3489).
-  p="${root}/.openclaw/agents/main/agent/openclaw-agent.sqlite"
+  p="${2:-${root}/.openclaw/agents/main/agent/openclaw-agent.sqlite}"
   [[ -s "$p" ]] && { echo "$p"; return 0; }
   # Rung 2 — 2026.8.1+: auth profiles live in the top-level config under
   # .auth.profiles (measured on box 62.238.11.92, openclaw 2026.8.1 ea80657:
@@ -746,7 +749,7 @@ profile_type_auth_path() {
     if [[ "$type" == openclaw && -n "$_def" ]]; then
       local _root _hit
       if _root=$(_openclaw_state_root "$_def"); then
-        _hit=$(_openclaw_cred_path "$_root") && { echo "$_hit"; return; }
+        _hit=$(_openclaw_cred_path "$_root" "$_def") && { echo "$_hit"; return; }
       fi
     fi
     echo "$_def"

--- a/src/cmd_auth.sh
+++ b/src/cmd_auth.sh
@@ -24,7 +24,9 @@ auth_creds_present() {
   [[ "$sentinel" == *:* ]] && key="${sentinel##*:}"
   # Profile-scoped: swap the default credential path for the profile's. The
   # jq key (for OAuth json sentinels) is unchanged.
-  if [[ -n "$profile" ]]; then
+  # DIVE-3834: openclaw resolves through the layout ladder even with no profile
+  # (the default-home seat is on the same upstream release as the scoped ones).
+  if [[ -n "$profile" || "$type" == openclaw ]]; then
     local ppath
     ppath=$(profile_type_auth_path "$profile" "$type") || ppath=""
     [[ -n "$ppath" ]] && path="$ppath"
@@ -682,6 +684,54 @@ profile_type_env() {
   esac
 }
 
+# _openclaw_cred_path <state_root> — echo the path, under a HOME-redirected
+# openclaw state root, that PROVES this seat carries an openclaw credential.
+# Nothing on stdout + rc 1 when no rung proves one.
+#
+# DIVE-3834: upstream openclaw 2026.8.1 moved the credential store. The
+# DIVE-3489 path (agents/main/agent/openclaw-agent.sqlite) is still CREATED on
+# 2026.8.1 and stays EMPTY, so a single hardcoded path reported every
+# correctly-authenticated BYO seat as `needs_login` and told the customer to run
+# a login that cannot help. We install openclaw UNPINNED, so this landed on
+# every new provision overnight with no change on our side.
+#
+# The ladder is ordered oldest-layout-first so a box on the pre-2026.8.1 layout
+# keeps its exact previous answer, and each rung is a POSITIVE assertion that a
+# credential exists — never "the file the app happens to create is there".
+# That distinction is the whole defect: the empty directory is what made this
+# fail silently instead of loudly.
+#
+# Deliberately NOT a rung: ~/.openclaw/state/openclaw.sqlite. That is the app's
+# own store on 2026.8.1 and it is created lazily by openclaw itself, so a
+# non-empty test on it cannot tell "authenticated" from "openclaw has run once".
+# Admitting it would make this function unable to fire on the ABSENT case —
+# the DIVE-3130 shape (a guard guarded by its own subject). See
+# community/wiki/an-unconfigured-model-authenticates-against-the-wrong-provider.md.
+_openclaw_cred_path() {
+  local root="$1" p
+  # Rung 1 — layouts up to 2026.7.x: the per-agent auth store (DIVE-3489).
+  p="${root}/.openclaw/agents/main/agent/openclaw-agent.sqlite"
+  [[ -s "$p" ]] && { echo "$p"; return 0; }
+  # Rung 2 — 2026.8.1+: auth profiles live in the top-level config under
+  # .auth.profiles (measured on box 62.238.11.92, openclaw 2026.8.1 ea80657:
+  # auth.profiles."google:manual".provider / .mode after a BYO key write).
+  # Gated on the PROFILE MAP being non-empty, not on the file existing —
+  # openclaw.json is written at config time by seats that never authenticated.
+  p="${root}/.openclaw/openclaw.json"
+  if [[ -s "$p" ]] && jq -e '(.auth.profiles // {}) | length > 0' "$p" >/dev/null 2>&1; then
+    echo "$p"; return 0
+  fi
+  return 1
+}
+
+# _openclaw_state_root <path> — the HOME-redirect root implied by an openclaw
+# credential path (everything left of the trailing `/.openclaw/...`).
+_openclaw_state_root() {
+  local p="$1"
+  [[ "$p" == */.openclaw/* ]] || return 1
+  echo "${p%%/.openclaw/*}"
+}
+
 # profile_type_auth_path <profile> <type> — absolute path to the credential
 # sentinel for (profile, type). Empty profile returns TYPE_AUTH's shared
 # default; non-empty returns the per-profile path corresponding to the
@@ -689,7 +739,17 @@ profile_type_env() {
 profile_type_auth_path() {
   local profile="$1" type="$2"
   if [[ -z "$profile" ]]; then
-    echo "${TYPE_AUTH[$type]:-}"
+    local _def="${TYPE_AUTH[$type]:-}"
+    # DIVE-3834: the default-home openclaw seat needs the same layout ladder the
+    # profile-scoped one gets; TYPE_AUTH can only name one path and 2026.8.1
+    # writes a different one. Resolve, and fall back to the constant unchanged.
+    if [[ "$type" == openclaw && -n "$_def" ]]; then
+      local _root _hit
+      if _root=$(_openclaw_state_root "$_def"); then
+        _hit=$(_openclaw_cred_path "$_root") && { echo "$_hit"; return; }
+      fi
+    fi
+    echo "$_def"
     return
   fi
   local dir="${AUTH_PROFILES_DIR}/${profile}/${type}"
@@ -702,7 +762,14 @@ profile_type_auth_path() {
     # sqlite store. This path feeds mtime-based sign-in detection, so pointing it
     # at the JSON watched a file that a successful auth no longer touches — the
     # poll would sit forever on a profile that had in fact authenticated.
-    openclaw)    echo "${dir}/.openclaw/agents/main/agent/openclaw-agent.sqlite" ;;
+    # DIVE-3834: 2026.8.1 moved the store. Return whichever rung PROVES a
+    # credential; with none proven, keep returning the DIVE-3489 path so the
+    # mtime baseline in cmd_auth_poll and the "provably absent" branch in
+    # agent_auth_health behave exactly as they did before this change.
+    openclaw)
+      local _oc
+      _oc=$(_openclaw_cred_path "$dir") && { echo "$_oc"; return; }
+      echo "${dir}/.openclaw/agents/main/agent/openclaw-agent.sqlite" ;;
     antigravity) echo "${dir}/.gemini/antigravity-cli/antigravity-oauth-token" ;;
     grok)        echo "${dir}/.grok/auth.json" ;;
     # claude detection in cmd_auth_poll is log-grep-based, not file-mtime —
@@ -809,7 +876,7 @@ agent_auth_health() {
   # Sentinels are "<path>" or "<path>:<key>"; only the path half is needed here
   # (auth_creds_present owns the key half).
   local path="${sentinel%%:*}"
-  if [[ -n "$profile" ]]; then
+  if [[ -n "$profile" || "$type" == openclaw ]]; then   # DIVE-3834: see auth_creds_present
     local ppath
     ppath=$(profile_type_auth_path "$profile" "$type" 2>/dev/null) || ppath=""
     [[ -n "$ppath" ]] && path="$ppath"

--- a/src/cmd_auth.sh
+++ b/src/cmd_auth.sh
@@ -606,11 +606,30 @@ LOCALBIN
     # still does and dies on the same 401. Say so here, where the version
     # actually moved — this is a NUDGE, not the check: the re-grade shells to
     # openclaw once per provider (~36s) and is not run inline for that reason.
+    # DIVE-3834, scope item 3 — the RECORD half. We install openclaw UNPINNED
+    # from upstream, so an upstream release changes what lands on every new
+    # provision overnight with no change on our side. That is how 2026.8.1
+    # arrived: the credential store moved, our probe kept reading the old path,
+    # and the only signal the next morning was two red smoke arms — the version
+    # that caused it was nowhere in any record we keep. Reading it HERE, where
+    # the install just happened, is what turns the next silent bump into a diff
+    # instead of a morning of triage, and it covers antigravity and grok too:
+    # they are the same HOME-redirect shape and the same class of change.
+    # Best-effort and capped at 5s by resolve_cli_version, so a runtime that
+    # will not answer --version degrades to an empty string and never fails an
+    # install that otherwise succeeded.
+    #
+    # PINNING is the other half of item 3 and is deliberately NOT taken here:
+    # pinning means owning the upgrade cadence for every runtime we ship, which
+    # is a product decision. It is raised on the row, not decided in this diff.
+    local _inst_ver=""
+    _inst_ver=$(resolve_cli_version "$type" 2>/dev/null) || _inst_ver=""
     [[ "$type" == "openclaw" && $verb == "upgraded" ]] \
-      && step "openclaw version changed — model pins were graded against the OLD catalog and nothing re-reads them. Re-grade: sudo 5dive doctor --category=models"
+      && step "openclaw version changed${_inst_ver:+ (now: $_inst_ver)} — model pins were graded against the OLD catalog and nothing re-reads them. Re-grade: sudo 5dive doctor --category=models"
+    [[ -n "$_inst_ver" ]] && step "$type $verb, installed version: $_inst_ver"
     ok "$type $verb at $bin" \
-       '{type:$t, bin:$b, installed:true, alreadyInstalled:false, upgraded:$u}' \
-       --arg t "$type" --arg b "$bin" --argjson u "$ujson"
+       '{type:$t, bin:$b, installed:true, alreadyInstalled:false, upgraded:$u, version:$v}' \
+       --arg t "$type" --arg b "$bin" --argjson u "$ujson" --arg v "$_inst_ver"
   else
     fail "$E_GENERIC" "$type install reported success but $bin still missing — investigate manually"
   fi
@@ -710,6 +729,32 @@ profile_type_env() {
 # Admitting it would make this function unable to fire on the ABSENT case —
 # the DIVE-3130 shape (a guard guarded by its own subject). See
 # community/wiki/an-unconfigured-model-authenticates-against-the-wrong-provider.md.
+#
+# SCOPE ITEM 2 — why this is a path ladder and not a call to openclaw's own auth
+# verb, answered rather than left implicit. The verb exists and we already use
+# it: `openclaw models auth --agent main list` grades the WRITE at
+# cmd_agent_create.sh (a key that openclaw does not list back is refused there).
+# It is not usable as this READ-BACK probe, for four reasons, only the last of
+# which is about our access:
+#   1. COST AND CALLER. auth_creds_present / agent_auth_health are the per-seat
+#      survey behind `agent list`, `auth status` and `agent info` — called in a
+#      loop over every seat. Each verb call is a node process spawn. This repo
+#      has already priced that and refused it inline: cmd_doctor's openclaw pin
+#      re-grade shells to openclaw once per provider at ~36s and is deliberately
+#      NOT run inline for exactly that reason.
+#   2. IT MUST RETURN A PATH, not a verdict. profile_type_auth_path's answer
+#      feeds cmd_auth_poll's MTIME BASELINE for sign-in detection (DIVE-3489).
+#      A verb returns text; swapping the path for a verb deletes the baseline
+#      and the poll can never observe a login.
+#   3. PRIVILEGE. The survey runs from unprivileged seats; reaching another
+#      seat's HOME needs `sudo -u claude -H env HOME=…`, which most seats do not
+#      hold — the reason resolve_cli_version carries a denial back-off at all.
+#   4. UNVERIFIED CONTRACT. Whether 2026.8.1's `models auth ... list` output
+#      shape is stable enough to parse as a verdict was NOT measured: that needs
+#      a box, and the box this row was measured on has self-purged. Claiming it
+#      works would be the thing this row punishes.
+# So the ladder is the fallback item 2 asks for when the verb is not usable, and
+# this comment is the "say so in the row" half of that instruction.
 _openclaw_cred_path() {
   local root="$1" p
   # Rung 1 — layouts up to 2026.7.x: the per-agent auth store (DIVE-3489).

--- a/tests/openclaw_auth_layout_ladder_unit.sh
+++ b/tests/openclaw_auth_layout_ladder_unit.sh
@@ -11,16 +11,22 @@
 #
 # What is graded here is the reported auth STATE, never the existence of any
 # particular file — keying the assertion to a path is exactly what let this
-# defect ride a full upstream release invisibly. Four arms, in both directions:
-#   1. 2026.8.1 layout, credential written  -> ok            (the regression)
-#   2. pre-2026.8.1 layout, credential      -> ok            (fallback intact)
-#   3. 2026.8.1 layout, NO credential       -> needs_login   (the ABSENT case:
+# defect ride a full upstream release invisibly. The arms cover both the
+# shipped default home (profile='') and named-profile HOME redirects:
+#   1. default home, 2026.8.1 credential / no credential -> ok / needs_login,
+#      plus an expired blob proving health reads the resolved credential path
+#   2. default home with the older JSON sentinel and a lazily-created sqlite
+#      only -> needs_login (the configured legacy sentinel stays authoritative)
+#   3. named profile, 2026.8.1 credential -> ok (the reported regression)
+#   4. named profile, pre-2026.8.1 credential -> ok (fallback intact)
+#   5. named profile, 2026.8.1, NO credential -> needs_login (the ABSENT case:
 #      openclaw.json exists and the old dir exists-but-empty, i.e. everything
 #      the tree-shape looks-right test would pass. DIVE-3130's lesson is that a
 #      guard which cannot fire on absence is not a guard.)
-#   4. the app's own lazily-created store alone -> needs_login (it is created by
+#   6. the app's own lazily-created store alone -> needs_login (it is created by
 #      openclaw having RUN, not by having AUTHENTICATED, so it must not be
 #      admitted as a credential rung).
+#   7. an empty .auth.profiles map -> needs_login.
 # Pure, no root, no network:
 #   bash tests/openclaw_auth_layout_ladder_unit.sh
 set -uo pipefail
@@ -43,8 +49,11 @@ AUTH_PROFILES_DIR="$TMP/auth-profiles"
 CONNECTORS_DIR="$TMP/connectors"
 mkdir -p "$CONNECTORS_DIR" "$AUTH_PROFILES_DIR"
 
+default_root="$TMP/home/claude"
 declare -A TYPE_AUTH=(
-  [openclaw]="$TMP/home/claude/.openclaw/agents/main/agent/openclaw-agent.sqlite"
+  # Same relative path as the shipped TYPE_AUTH constant; rooted in TMP so the
+  # unit never reads or writes the real operator home.
+  [openclaw]="$default_root/.openclaw/agents/main/agent/openclaw-agent.sqlite"
 )
 declare -A TYPE_API_FILE=()
 is_known_type() { case "$1" in openclaw) return 0;; *) return 1;; esac; }
@@ -63,7 +72,41 @@ bad()  { printf 'FAIL - %s\n' "$1"; fails=$((fails+1)); }
 # state_of <profile> — the STATE half of agent_auth_health for an openclaw seat.
 state_of() { agent_auth_health openclaw "$1" | cut -d'|' -f1; }
 
-# --- arm 1: openclaw 2026.8.1 layout with a real BYO credential --------------
+# --- arm 1: default-home 2026.8.1 state, with and without a BYO credential ---
+mkdir -p "$default_root/.openclaw/agents/main/agent"
+: > "$default_root/.openclaw/agents/main/agent/openclaw-agent.sqlite"
+cat > "$default_root/.openclaw/openclaw.json" <<'JSON'
+{"auth":{"profiles":{"google:manual":{"provider":"google","mode":"api_key"}}}}
+JSON
+s=$(state_of "")
+[[ "$s" == ok ]] && ok "default home, 2026.8.1 + credential: state=ok" \
+                 || bad "default home, 2026.8.1 + credential: state=$s, want ok"
+echo '{"auth":{"profiles":{}}}' > "$default_root/.openclaw/openclaw.json"
+s=$(state_of "")
+[[ "$s" == needs_login ]] && ok "default home, 2026.8.1 without credential: state=needs_login" \
+                          || bad "default home, 2026.8.1 without credential: state=$s, want needs_login"
+cat > "$default_root/.openclaw/openclaw.json" <<'JSON'
+{"auth":{"profiles":{"oauth:test":{"provider":"openai","mode":"oauth"}}},
+ "expiresAt":1}
+JSON
+s=$(state_of "")
+[[ "$s" == expired ]] && ok "default home ladder feeds credential blob health: state=expired" \
+                      || bad "default home ladder feeds credential blob health: state=$s, want expired"
+
+# --- arm 2: a non-configured legacy default must ignore another sqlite ------
+# The pre-DIVE-3489 default sentinel was auth-profiles.json. A different sqlite
+# appearing beside it must not silently become proof of auth for that layout.
+legacy_root="$TMP/legacy-home/claude"
+TYPE_AUTH[openclaw]="$legacy_root/.openclaw/agents/main/agent/auth-profiles.json"
+mkdir -p "$legacy_root/.openclaw/agents/main/agent"
+printf 'SQLite format 3\0' > "$legacy_root/.openclaw/agents/main/agent/openclaw-agent.sqlite"
+echo '{"auth":{"profiles":{}}}' > "$legacy_root/.openclaw/openclaw.json"
+s=$(state_of "")
+[[ "$s" == needs_login ]] && ok "legacy default + unrelated sqlite: state=needs_login" \
+                          || bad "legacy default + unrelated sqlite: state=$s, want needs_login"
+TYPE_AUTH[openclaw]="$default_root/.openclaw/agents/main/agent/openclaw-agent.sqlite"
+
+# --- arm 3: named-profile 2026.8.1 with a real BYO credential ---------------
 p=new-authed
 root="$AUTH_PROFILES_DIR/$p/openclaw"
 mkdir -p "$root/.openclaw/agents/main/agent" "$root/.openclaw/state"
@@ -80,7 +123,7 @@ s=$(state_of "$p")
 [[ "$s" == ok ]] && ok "2026.8.1 + credential: state=ok" \
                  || bad "2026.8.1 + credential: state=$s, want ok"
 
-# --- arm 2: pre-2026.8.1 layout still passes (fallback intact) ---------------
+# --- arm 4: named-profile pre-2026.8.1 fallback remains intact ---------------
 p=old-authed
 root="$AUTH_PROFILES_DIR/$p/openclaw"
 mkdir -p "$root/.openclaw/agents/main/agent"
@@ -91,7 +134,7 @@ s=$(state_of "$p")
 [[ "$s" == ok ]] && ok "pre-2026.8.1 layout: state=ok" \
                  || bad "pre-2026.8.1 layout: state=$s, want ok"
 
-# --- arm 3: the ABSENT case on 2026.8.1 must still fire ----------------------
+# --- arm 5: named-profile ABSENT case on 2026.8.1 must still fire ------------
 p=new-unauthed
 root="$AUTH_PROFILES_DIR/$p/openclaw"
 mkdir -p "$root/.openclaw/agents/main/agent"
@@ -105,7 +148,7 @@ s=$(state_of "$p")
 [[ "$s" == needs_login ]] && ok "2026.8.1 without credential: state=needs_login" \
                           || bad "2026.8.1 without credential: state=$s, want needs_login"
 
-# --- arm 4: openclaw's own lazily-created store is not a credential ----------
+# --- arm 6: openclaw's own lazily-created store is not a credential ----------
 p=new-ran-only
 root="$AUTH_PROFILES_DIR/$p/openclaw"
 mkdir -p "$root/.openclaw/agents/main/agent" "$root/.openclaw/state"
@@ -113,8 +156,11 @@ printf 'SQLite format 3\0' > "$root/.openclaw/state/openclaw.sqlite"
 if auth_creds_present openclaw "$p"; then
   bad "app store only: reported PRESENT — 'openclaw has run' is not 'openclaw is authed'"
 else ok "app store only: auth_creds_present says absent"; fi
+s=$(state_of "$p")
+[[ "$s" == needs_login ]] && ok "app store only: state=needs_login" \
+                          || bad "app store only: state=$s, want needs_login"
 
-# --- arm 5: an empty auth.profiles map is not a credential -------------------
+# --- arm 7: an empty auth.profiles map is not a credential -------------------
 p=new-empty-map
 root="$AUTH_PROFILES_DIR/$p/openclaw"
 mkdir -p "$root/.openclaw/agents/main/agent"
@@ -122,6 +168,13 @@ echo '{"auth":{"profiles":{}}}' > "$root/.openclaw/openclaw.json"
 if auth_creds_present openclaw "$p"; then
   bad "empty auth.profiles: reported PRESENT — gated on the file, not the map"
 else ok "empty auth.profiles: auth_creds_present says absent"; fi
+s=$(state_of "$p")
+[[ "$s" == needs_login ]] && ok "empty auth.profiles: state=needs_login" \
+                          || bad "empty auth.profiles: state=$s, want needs_login"
 
-if (( fails )); then printf '\nFAIL: %d assertion(s)\n' "$fails"; exit 1; fi
-printf '\nPASS: openclaw auth layout ladder\n'
+if (( fails )); then
+  printf '\nFAIL: %d assertion(s)\n' "$fails"
+else
+  printf '\nPASS: openclaw auth layout ladder\n'
+fi
+(( fails == 0 ))

--- a/tests/openclaw_auth_layout_ladder_unit.sh
+++ b/tests/openclaw_auth_layout_ladder_unit.sh
@@ -27,6 +27,15 @@
 #      openclaw having RUN, not by having AUTHENTICATED, so it must not be
 #      admitted as a credential rung).
 #   7. an empty .auth.profiles map -> needs_login.
+#   8. the CREATE-path witness (selfcheck_cred_reached_agent, witness 1b) on a
+#      2026.8.1-shaped seat -> the "ok:" line, NOT the false
+#      "credential never reached the seat" issue; on a pre-2026.8.1 seat -> ok;
+#      with no credential at all -> the issue still fires. This was the third
+#      reader of the store and the one left hardcoded: a customer provisioning
+#      today was told to re-seed a seat that is fine.
+#   9. the `agent info` unpinned-model warning resolves the default-home seat
+#      through the ladder (structural — see the arm for why an end-to-end
+#      `agent info` is not gradable in a pure unit).
 # Pure, no root, no network:
 #   bash tests/openclaw_auth_layout_ladder_unit.sh
 set -uo pipefail
@@ -40,7 +49,7 @@ TMP="$(mktemp -d /tmp/openclaw-auth-ladder-unit.XXXXXX)"
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
-         lib/agent_setup.sh lib/state.sh; do
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh; do
   # shellcheck source=/dev/null
   source "$SRC/$f"
 done
@@ -171,6 +180,80 @@ else ok "empty auth.profiles: auth_creds_present says absent"; fi
 s=$(state_of "$p")
 [[ "$s" == needs_login ]] && ok "empty auth.profiles: state=needs_login" \
                           || bad "empty auth.profiles: state=$s, want needs_login"
+
+# --- arm 8: the CREATE-path witness (selfcheck_cred_reached_agent) ----------
+#
+# DIVE-3834, second iteration. The ladder was wired into auth_creds_present and
+# agent_auth_health, and there is a THIRD reader: witness 1b in
+# selfcheck_cred_reached_agent hardcoded the pre-2026.8.1 sqlite and tested it
+# with -s. On a 2026.8.1 seat whose credential is present and correct that
+# prints `issue:openclaw credential never reached the seat ... Re-seed as root`
+# — the same defect and the same wrong instruction this row was filed for, on
+# the path a customer provisioning TODAY actually walks. Graded on the emitted
+# verdict, never on a path.
+#
+# `cred_readable_by_agent` is the agent-uid seam; a pure unit cannot shell to
+# `sudo -u`, and a harness that did would grade the runner's sudo policy rather
+# than this code (the reasoning is spelled out in
+# tests/selfcheck_cred_reached_unit.sh).
+# shellcheck source=/dev/null
+source "$SRC/cmd_agent_create.sh"
+set +e   # header.sh enables `set -e`; these arms assert on values, not exits
+cred_readable_by_agent() { return 0; }
+export AGENT_HOME_ROOT="$TMP/agent-homes"
+
+# oc_seat <name> — build a seat home and echo its .openclaw root.
+oc_seat() { local n="$1"; mkdir -p "$AGENT_HOME_ROOT/agent-$n/.openclaw/agents/main/agent"; echo "$AGENT_HOME_ROOT/agent-$n/.openclaw"; }
+
+FALSE_ISSUE='issue:openclaw credential never reached the seat'
+SEAT_OK='ok:openclaw seat has its own credential and model pin'
+
+# 8a — 2026.8.1 shape: old dir created-and-EMPTY, credential + model pin in
+# openclaw.json. This is the reproduction of the reported defect on the create
+# path; before the ladder was wired in here it printed FALSE_ISSUE.
+oc=$(oc_seat new81)
+cat > "$oc/openclaw.json" <<'JSON'
+{"auth":{"profiles":{"google:manual":{"provider":"google","mode":"api_key"}}},
+ "agents":{"defaults":{"model":{"primary":"google/gemini-2.5-pro"}}}}
+JSON
+out=$(selfcheck_cred_reached_agent new81 openclaw "" "" 2>/dev/null)
+[[ "$out" != *"$FALSE_ISSUE"* ]]   && ok "create witness, 2026.8.1 + credential: no false 'never reached the seat'"   || bad "create witness, 2026.8.1 + credential: printed the false issue — the create path still reads the old store"
+[[ "$out" == *"$SEAT_OK"* ]]   && ok "create witness, 2026.8.1 + credential: reports the seat ok"   || bad "create witness, 2026.8.1 + credential: no ok line, got: $out"
+
+# 8b — pre-2026.8.1 shape: the fallback must be unchanged.
+oc=$(oc_seat old81)
+printf 'SQLite format 3\0' > "$oc/agents/main/agent/openclaw-agent.sqlite"
+echo '{"agents":{"defaults":{"model":{"primary":"google/gemini-2.5-pro"}}}}' > "$oc/openclaw.json"
+out=$(selfcheck_cred_reached_agent old81 openclaw "" "" 2>/dev/null)
+[[ "$out" == *"$SEAT_OK"* ]]   && ok "create witness, pre-2026.8.1 + credential: reports the seat ok"   || bad "create witness, pre-2026.8.1 + credential: regressed, got: $out"
+
+# 8c — the ABSENT case must STILL fire. This is the arm that stops the fix from
+# being "make the witness stop complaining": a seat with openclaw.json present
+# (config written) and no auth profile ever created is unauthenticated, and the
+# tree-shape looks right. DIVE-3130.
+oc=$(oc_seat none81)
+echo '{"auth":{"profiles":{}},"agents":{"defaults":{"model":{"primary":"google/gemini-2.5-pro"}}}}' > "$oc/openclaw.json"
+out=$(selfcheck_cred_reached_agent none81 openclaw "" "" 2>/dev/null)
+[[ "$out" == *"$FALSE_ISSUE"* ]]   && ok "create witness, 2026.8.1 without credential: the issue still fires"   || bad "create witness, 2026.8.1 without credential: silent — the witness can no longer fire on absence, got: $out"
+
+# --- arm 9: `agent info`'s unpinned-model warning ----------------------------
+#
+# cmd_agent.sh resolved the DEFAULT-HOME openclaw seat straight from
+# TYPE_AUTH[openclaw] and tested it with -s, so on 2026.8.1 (constant present,
+# EMPTY) the DIVE-3112 unpinned-model warning was silently suppressed on exactly
+# the seats that need it — a seat running on openclaw's built-in default, whose
+# provider prefix selects a credential we never wrote, and 401s while looking
+# configured. Lower stakes than arm 8 (a missing warning, not a wrong
+# instruction) and the same class.
+#
+# Declared limitation, deliberately not papered over: this arm is STRUCTURAL.
+# Grading it behaviourally means running cmd_agent_info, which reads systemd
+# unit state, the on-disk registry and the enforced sudo grant — none of which
+# a pure unit can supply, and stubbing all three would grade the stubs. The
+# behaviour of the resolver it now calls IS graded, on real fixtures, by arm 1.
+blk=$(sed -n '/DIVE-3113: for openclaw, an absent model is not a neutral/,/oc_unpinned=1/p' "$SRC/cmd_agent.sh")
+[[ -n "$blk" ]]   && ok "agent info: the unpinned-model block was located"   || bad "agent info: could not locate the unpinned-model block — this arm graded nothing"
+[[ "$blk" == *'profile_type_auth_path "" openclaw'* ]]   && ok "agent info: default-home seat resolves through the layout ladder"   || bad "agent info: default-home seat still reads TYPE_AUTH directly — suppressed on 2026.8.1"
 
 if (( fails )); then
   printf '\nFAIL: %d assertion(s)\n' "$fails"

--- a/tests/openclaw_auth_layout_ladder_unit.sh
+++ b/tests/openclaw_auth_layout_ladder_unit.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# DIVE-3834 unit: openclaw BYO auth must report the seat AUTHENTICATED on
+# upstream openclaw 2026.8.1, which moved the credential store.
+#
+# The defect (measured on the paid smoke box 62.238.11.92, run
+# smoke-20260831T035510Z, openclaw 2026.8.1 ea80657): the write half succeeded
+# and the read half was pointed at the pre-2026.8.1 path, which 2026.8.1 still
+# CREATES and leaves EMPTY. A correctly-credentialled customer seat rendered
+# `needs_login` with an instruction that cannot help. Nothing on our side
+# changed — we install openclaw unpinned, so an upstream release did it.
+#
+# What is graded here is the reported auth STATE, never the existence of any
+# particular file — keying the assertion to a path is exactly what let this
+# defect ride a full upstream release invisibly. Four arms, in both directions:
+#   1. 2026.8.1 layout, credential written  -> ok            (the regression)
+#   2. pre-2026.8.1 layout, credential      -> ok            (fallback intact)
+#   3. 2026.8.1 layout, NO credential       -> needs_login   (the ABSENT case:
+#      openclaw.json exists and the old dir exists-but-empty, i.e. everything
+#      the tree-shape looks-right test would pass. DIVE-3130's lesson is that a
+#      guard which cannot fire on absence is not a guard.)
+#   4. the app's own lazily-created store alone -> needs_login (it is created by
+#      openclaw having RUN, not by having AUTHENTICATED, so it must not be
+#      admitted as a credential rung).
+# Pure, no root, no network:
+#   bash tests/openclaw_auth_layout_ladder_unit.sh
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; chmod -R u+rwX "${TMP:-}" 2>/dev/null; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/openclaw-auth-ladder-unit.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+AUTH_PROFILES_DIR="$TMP/auth-profiles"
+CONNECTORS_DIR="$TMP/connectors"
+mkdir -p "$CONNECTORS_DIR" "$AUTH_PROFILES_DIR"
+
+declare -A TYPE_AUTH=(
+  [openclaw]="$TMP/home/claude/.openclaw/agents/main/agent/openclaw-agent.sqlite"
+)
+declare -A TYPE_API_FILE=()
+is_known_type() { case "$1" in openclaw) return 0;; *) return 1;; esac; }
+
+# shellcheck source=/dev/null
+source "$SRC/cmd_auth.sh"
+
+# profile_type_dir installs as root:claude on a real host; in the harness we
+# just need the dir to exist under the throwaway root.
+profile_type_dir() { local d="${AUTH_PROFILES_DIR}/$1/$2"; mkdir -p "$d"; echo "$d"; }
+
+fails=0
+ok()   { printf 'ok   - %s\n' "$1"; }
+bad()  { printf 'FAIL - %s\n' "$1"; fails=$((fails+1)); }
+
+# state_of <profile> — the STATE half of agent_auth_health for an openclaw seat.
+state_of() { agent_auth_health openclaw "$1" | cut -d'|' -f1; }
+
+# --- arm 1: openclaw 2026.8.1 layout with a real BYO credential --------------
+p=new-authed
+root="$AUTH_PROFILES_DIR/$p/openclaw"
+mkdir -p "$root/.openclaw/agents/main/agent" "$root/.openclaw/state"
+# 2026.8.1 creates the OLD directory and leaves it empty — reproduce that, it
+# is what made the failure silent.
+: > "$root/.openclaw/state/openclaw.sqlite"
+cat > "$root/.openclaw/openclaw.json" <<'JSON'
+{"auth":{"profiles":{"google:manual":{"provider":"google","mode":"api_key"}}},
+ "agents":{"defaults":{"model":{"primary":"google/gemini-2.5-pro"}}}}
+JSON
+if auth_creds_present openclaw "$p"; then ok "2026.8.1 + credential: auth_creds_present"
+else bad "2026.8.1 + credential: auth_creds_present said ABSENT (the DIVE-3834 defect)"; fi
+s=$(state_of "$p")
+[[ "$s" == ok ]] && ok "2026.8.1 + credential: state=ok" \
+                 || bad "2026.8.1 + credential: state=$s, want ok"
+
+# --- arm 2: pre-2026.8.1 layout still passes (fallback intact) ---------------
+p=old-authed
+root="$AUTH_PROFILES_DIR/$p/openclaw"
+mkdir -p "$root/.openclaw/agents/main/agent"
+printf 'SQLite format 3\0' > "$root/.openclaw/agents/main/agent/openclaw-agent.sqlite"
+if auth_creds_present openclaw "$p"; then ok "pre-2026.8.1 layout: auth_creds_present"
+else bad "pre-2026.8.1 layout: regressed to ABSENT — the fix swapped the path instead of laddering"; fi
+s=$(state_of "$p")
+[[ "$s" == ok ]] && ok "pre-2026.8.1 layout: state=ok" \
+                 || bad "pre-2026.8.1 layout: state=$s, want ok"
+
+# --- arm 3: the ABSENT case on 2026.8.1 must still fire ----------------------
+p=new-unauthed
+root="$AUTH_PROFILES_DIR/$p/openclaw"
+mkdir -p "$root/.openclaw/agents/main/agent"
+# Config written, no auth profile ever created. The tree LOOKS right.
+echo '{"agents":{"defaults":{"model":{"primary":"google/gemini-2.5-pro"}}}}' \
+  > "$root/.openclaw/openclaw.json"
+if auth_creds_present openclaw "$p"; then
+  bad "2026.8.1 without credential: reported PRESENT — the guard cannot fire on absence"
+else ok "2026.8.1 without credential: auth_creds_present says absent"; fi
+s=$(state_of "$p")
+[[ "$s" == needs_login ]] && ok "2026.8.1 without credential: state=needs_login" \
+                          || bad "2026.8.1 without credential: state=$s, want needs_login"
+
+# --- arm 4: openclaw's own lazily-created store is not a credential ----------
+p=new-ran-only
+root="$AUTH_PROFILES_DIR/$p/openclaw"
+mkdir -p "$root/.openclaw/agents/main/agent" "$root/.openclaw/state"
+printf 'SQLite format 3\0' > "$root/.openclaw/state/openclaw.sqlite"
+if auth_creds_present openclaw "$p"; then
+  bad "app store only: reported PRESENT — 'openclaw has run' is not 'openclaw is authed'"
+else ok "app store only: auth_creds_present says absent"; fi
+
+# --- arm 5: an empty auth.profiles map is not a credential -------------------
+p=new-empty-map
+root="$AUTH_PROFILES_DIR/$p/openclaw"
+mkdir -p "$root/.openclaw/agents/main/agent"
+echo '{"auth":{"profiles":{}}}' > "$root/.openclaw/openclaw.json"
+if auth_creds_present openclaw "$p"; then
+  bad "empty auth.profiles: reported PRESENT — gated on the file, not the map"
+else ok "empty auth.profiles: auth_creds_present says absent"; fi
+
+if (( fails )); then printf '\nFAIL: %d assertion(s)\n' "$fails"; exit 1; fi
+printf '\nPASS: openclaw auth layout ladder\n'


### PR DESCRIPTION
## DIVE-3834 — openclaw BYO auth reads "not authenticated" on upstream 2026.8.1

Upstream openclaw **2026.8.1 (ea80657)** moved its credential store. Our probe still read the
DIVE-3489 path — which 2026.8.1 **creates and leaves empty** — so `agent_auth_health`'s "credential
file is provably ABSENT" branch fired and a customer with a present, correct BYO credential was told
`openclaw is not authenticated (needs_login) — run: sudo 5dive agent auth login openclaw`. Running
that does not help.

**Not a 5dive regression.** We install openclaw unpinned, so an upstream release did this overnight,
on every new provision at once: smoke `install-openclaw` 25s → 48s and `failCount` 0 → 2 between
2026-08-30 and 2026-08-31, with every other arm identical.

### The change

`_openclaw_cred_path <state_root>` walks an ordered ladder, **oldest layout first**, and every rung is
a *positive credential assertion*:

1. `.openclaw/agents/main/agent/openclaw-agent.sqlite` non-empty — layouts ≤ 2026.7.x (DIVE-3489)
2. `.openclaw/openclaw.json` with a **non-empty `.auth.profiles` map** — 2026.8.1+

A ladder rather than a path swap: swapping only moves *which release is broken*.

`.openclaw/state/openclaw.sqlite` is **deliberately not a rung.** It is openclaw's own store and it is
created lazily on first run, so a non-empty test on it cannot separate *authenticated* from *has run
once* — admitting it would leave the guard unable to fire on the **absent** case. That is the DIVE-3130
shape (`community/wiki/an-unconfigured-model-authenticates-against-the-wrong-provider.md`), and it is
graded by arm 4 below.

With no rung proven, `profile_type_auth_path` returns the DIVE-3489 path exactly as before, so
`cmd_auth_poll`'s mtime baseline and `agent_auth_health`'s provably-absent branch are byte-for-byte
unchanged in behaviour. openclaw now also resolves through the ladder on the **default-home** seat,
since `TYPE_AUTH` can only name one path.

### Evidence

`tests/openclaw_auth_layout_ladder_unit.sh` — grades the reported auth **STATE**, never the existence
of any file. Keying the assertion to a path is what let this ride a full upstream release invisibly.

| arm | fixture | expected |
| --- | --- | --- |
| 1 | 2026.8.1 layout + BYO credential (old dir present-but-empty, as measured) | `ok` |
| 2 | pre-2026.8.1 layout + credential | `ok` (fallback intact) |
| 3 | 2026.8.1 layout, config written, **no** auth profile | `needs_login` |
| 4 | `state/openclaw.sqlite` alone | `needs_login` |
| 5 | `.auth.profiles` present but **empty** | `needs_login` |

**Mutation control, run against pristine `origin/main` src:** arm 1 fails with exactly the reported
symptom (`auth_creds_present` says ABSENT, `state=needs_login`) and arms 2–5 pass. So the new test
reproduces the defect rather than merely agreeing with the fix.

**Regression, patched tree, all rc=0:** `agent_list_auth_health_unit`,
`auth_status_per_agent_scope_unit`, `auth_session_reaper_unit`, `antigravity_auth_finalize_unit`,
`selfcheck_cred_reached_unit`, `profile_seed_perms_unit`, `dive1762_regression_unit`,
`openclaw_seat_seed_unit`, `openclaw_runtime_unit`, `type_map_registration_contract_unit`.

`shellcheck -S error` clean on the new test; `src/cmd_auth.sh`'s only error is the pre-existing
SC2148 (sourced fragment, no shebang), unchanged by this diff.

### What this PR does NOT do — please read before merging

- **The paid on-box acceptance arm is still owed.** "On a box with openclaw 2026.8.1, `5dive agent
  auth` reports AUTHENTICATED and `openclaw-google` + `openclaw-node-runtime` go green" has **not**
  been run: `agent-olivia` holds no box credential and the preserved smoke box self-purges. Rung 2's
  key path is taken from the row's measurement of that box, not re-measured here. This needs
  `smoke-verified` or a written `smoke-override` from someone who can run it — **`smoke-verified`
  must not be applied on the strength of this PR's unit evidence.**
- **Scope item 2 (ask openclaw instead of reading its files) is not done.** Whether 2026.8.1 exposes a
  supported auth/status verb cannot be established without a box running it. The ladder is the
  fallback ladder that item asks for if no such verb exists; confirming the verb is a follow-up.
- **Scope item 3 (pin the openclaw version) is not done** — the row itself says pinning is a product
  decision to raise, not to decide here. Raised in the delivery result.
- **Named residual:** the interactive device-login leg on 2026.8.1 was not measured, so whether it
  writes `.auth.profiles` is unknown. If it does not, that seat resolves to no proven rung and the
  mtime-poll path (unchanged) is what detects the login. This is the same scope caveat DIVE-3489 wrote
  for its own path, carried forward rather than quietly dropped.
