### PR TITLE
DIVE-3872: agent export --memory=distilled|raw

### DIFF
--- a/src/cmd_pack.sh
+++ b/src/cmd_pack.sh
@@ -1426,6 +1426,36 @@ _pack_memory_dir() {
 # (export:false / private:true / share:false) on any fact. Regenerates a clean
 # MEMORY.md index from what survived; the source MEMORY.md is never copied (it
 # indexes private facts too). Echoes "<kept> <excluded>" counts.
+# DIVE-3872 — THE RAW MODE. lodar, 2026-09-01: "some users just want raw memory.
+# but warn them."
+#
+# This is the deliberate complement to _pack_scope_memory, NOT a hole in it. It
+# copies the memory dir verbatim — every type, MEMORY.md included, no opt-out
+# honoured — because the thing being asked for is a BACKUP of an agent, and a
+# backup that silently drops 4 files in 6 is not one. Read the three properties
+# that keep it honest, because they are the whole design:
+#
+#   1. SELF-ONLY, enforced in cmd_export. `--memory=raw --audience=publish`
+#      REFUSES. A distilled pack is a publishable artefact; a raw one never is,
+#      and that is a property of the bytes, not of the operator's intent.
+#   2. THE TRIPWIRE STILL RUNS — it just WARNS instead of refusing (that is the
+#      "but warn them"). The person gets told, by file and line, which facts
+#      look like they carry a credential, and then gets their backup.
+#   3. It counts what it took, so the warning can be specific rather than
+#      atmospheric.
+#
+# Returns "<kept> <0>" to match _pack_scope_memory's contract; nothing is ever
+# excluded here, and the second field exists so callers stay uniform.
+_pack_raw_memory() {
+  local memdir="$1" outdir="$2" kept=0 f base
+  mkdir -p "$outdir"
+  while IFS= read -r f; do
+    base=$(basename "$f")
+    cp "$f" "$outdir/$base"; kept=$((kept+1))
+  done < <(find "$memdir" -maxdepth 1 -name '*.md' 2>/dev/null | sort)
+  printf '%s %s\n' "$kept" 0
+}
+
 _pack_scope_memory() {
   local memdir="$1" outdir="$2" kept=0 excluded=0 f base type optout
   mkdir -p "$outdir"
@@ -1812,9 +1842,12 @@ _agents_md_to_pack() {
 cmd_export() {
   require_root
   local name="" with_memory=0 out="" approve_memory="" format="pack" audience="publish"
+  # DIVE-3872: distilled (deny-by-default knowledge) or raw (verbatim backup).
+  local memory_mode="distilled"
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --with-memory)      with_memory=1 ;;
+      --memory=*)         memory_mode="${1#--memory=}"; with_memory=1 ;;
       --approve-memory=*) approve_memory="${1#--approve-memory=}"; with_memory=1 ;;
       --audience=*)       audience="${1#--audience=}" ;;
       --out=*)            out="${1#--out=}" ;;
@@ -1826,7 +1859,18 @@ cmd_export() {
     esac
     shift
   done
-  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent export <name> [--format=pack|agents-md] [--with-memory] [--approve-memory=<dir>] [--audience=publish|self] [-o <path>]"
+  [[ -n "$name" ]] || fail "$E_USAGE" "usage: 5dive agent export <name> [--format=pack|agents-md] [--with-memory] [--memory=distilled|raw] [--approve-memory=<dir>] [--audience=publish|self] [-o <path>]"
+  case "$memory_mode" in
+    distilled|raw) ;;
+    *) fail "$E_USAGE" "--memory must be 'distilled' (default, {reference,project} knowledge only) or 'raw' (verbatim backup, --audience=self only)" ;;
+  esac
+  # RAW IS SELF-ONLY, and this is a refusal rather than a warning on purpose: a
+  # raw pack carries private {user,feedback} facts about a specific human and
+  # whatever their agent wrote down. "Published" is not a thing it can safely be,
+  # regardless of who is asking, so the audience is checked before any bytes move.
+  if [[ "$memory_mode" == "raw" && "$audience" != "self" ]]; then
+    fail "$E_USAGE" "--memory=raw is a personal backup and cannot be published: re-run with --audience=self (a distilled pack is the publishable one)"
+  fi
   case "$format" in
     pack|agents-md) ;;
     *) fail "$E_USAGE" "unknown --format '$format' (known: pack, agents-md)" ;;
@@ -1858,13 +1902,30 @@ cmd_export() {
       local draft="/home/agent-${name}/.claude/pack-staging/memory-draft"
       rm -rf "$draft"; mkdir -p "$draft"
       local counts kept excluded
-      counts=$(_pack_scope_memory "$memdir" "$draft")
+      if [[ "$memory_mode" == "raw" ]]; then
+        counts=$(_pack_raw_memory "$memdir" "$draft")
+      else
+        counts=$(_pack_scope_memory "$memdir" "$draft")
+      fi
       kept="${counts%% *}"; excluded="${counts##* }"
       if (( kept == 0 )); then
         rm -rf "$draft"
+        if [[ "$memory_mode" == "raw" ]]; then
+          fail "$E_GENERIC" "agent '$name' has no memory files to export. Nothing written."
+        fi
         fail "$E_GENERIC" "nothing shareable: 0 reference/project knowledge facts ($excluded private or opted-out). Only metadata.type 'reference' or 'project' facts are eligible — 'user' and 'feedback' are never exported. Nothing written."
       fi
-      if ! _pack_secret_tripwire "$draft"; then
+      # RAW WARNS, DISTILLED REFUSES (lodar, 2026-09-01: "but warn them"). The
+      # scan is identical; only the consequence differs, because a distilled
+      # pack is publishable and a raw one is the operator's own backup that they
+      # have asked for by name. Warning without naming the files would be
+      # atmospheric, so the tripwire's own file:line output is what they see.
+      if [[ "$memory_mode" == "raw" ]]; then
+        if ! _pack_secret_tripwire "$draft"; then
+          warn "RAW EXPORT: the lines above look like credentials, and they WILL be in this file. It is a personal backup — do not publish it, do not paste it, and rotate anything real that appears there."
+        fi
+        warn "RAW EXPORT: this carries the agent's memory verbatim — including its private notes about you ('user'/'feedback' facts) and any fact tagged private, none of which a distilled pack contains."
+      elif ! _pack_secret_tripwire "$draft"; then
         rm -rf "$draft"
         # DIVE-2679: name the ONE wrong turn this refusal invites. The reporter's next
         # move was --audience=self, because the usage text presents it as the escape
@@ -1896,10 +1957,21 @@ cmd_export() {
         || fail "$E_VALIDATION" "--approve-memory has no .md facts: $approve_memory"
       mem_tmp=$(mktemp -d)
       local scounts skept sexcl
-      scounts=$(_pack_scope_memory "$approve_memory" "$mem_tmp")
+      # The type-gate is re-enforced on seal for DISTILLED no matter what dir is
+      # passed. For RAW the whole point is that it is not, so it copies verbatim
+      # — the protection there is the audience refusal above, which already
+      # guaranteed this pack cannot be a published one.
+      if [[ "$memory_mode" == "raw" ]]; then
+        scounts=$(_pack_raw_memory "$approve_memory" "$mem_tmp")
+      else
+        scounts=$(_pack_scope_memory "$approve_memory" "$mem_tmp")
+      fi
       skept="${scounts%% *}"; sexcl="${scounts##* }"
       (( skept > 0 )) || { rm -rf "$mem_tmp"; fail "$E_GENERIC" "approved dir has 0 shareable knowledge facts after scoping ($sexcl excluded). Nothing sealed."; }
-      if ! _pack_secret_tripwire "$mem_tmp"; then
+      if [[ "$memory_mode" == "raw" ]]; then
+        _pack_secret_tripwire "$mem_tmp" \
+          || warn "RAW EXPORT: sealing anyway — the credential-shaped lines above are going into the pack."
+      elif ! _pack_secret_tripwire "$mem_tmp"; then
         rm -rf "$mem_tmp"
         fail "$E_GENERIC" "approved memory tripped the secret tripwire (file:line: rule above) — refusing to seal. Remove the credential from that fact, or tag it 'private: true', then retry. --audience=self does NOT bypass this (it only skips the operational-detail leak-check)."
       fi

--- a/tests/pack_raw_memory_unit.sh
+++ b/tests/pack_raw_memory_unit.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# DIVE-3872 isolated unit harness for --memory=raw on the EXPORT path.
+#
+# lodar, 2026-09-01: "some users just want raw memory. but warn them." Raw is the
+# deliberate complement to the deny-by-default scoping, so what needs grading is
+# not that it copies files — it is that the THREE properties keeping it honest
+# actually hold, and that the distilled path is untouched by its existence:
+#   1. raw copies VERBATIM — every type, MEMORY.md, opt-outs included.
+#   2. raw is SELF-ONLY — --audience=publish refuses BEFORE any bytes move.
+#   3. distilled still excludes exactly what it always did (the control; without
+#      it this harness would pass on a build where scoping had been deleted).
+#
+# Sources src/ directly (no root, no network). Run: bash tests/pack_raw_memory_unit.sh
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+
+TMP="$(mktemp -d /tmp/pack-raw-unit.XXXXXX)"
+
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+# shellcheck source=/dev/null
+source "$SRC/cmd_pack.sh"
+
+set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# ---- fixture: one of every disposition the scoper cares about --------------
+MEM="$TMP/memory"; mkdir -p "$MEM"
+mk() { printf -- '---\nname: %s\nmetadata:\n  type: %s\n%s---\n\nbody of %s\n' "$1" "$2" "${3:-}" "$1" > "$MEM/$1.md"; }
+mk keep-ref     reference
+mk keep-proj    project
+mk private-user user                       # excluded by type
+mk private-fb   feedback                   # excluded by type
+mk opted-out    reference "export: false\n" # excluded by opt-out
+printf -- '---\nname: no-type\n---\n\nunknown type\n' > "$MEM/no-type.md"   # excluded fail-safe
+printf '# Memory Index\n- [keep-ref](keep-ref.md)\n' > "$MEM/MEMORY.md"     # skipped by scoping
+
+TOTAL_MD=$(find "$MEM" -maxdepth 1 -name '*.md' | wc -l)   # 7
+
+# ---- 1. RAW takes everything ----------------------------------------------
+RAWOUT="$TMP/raw"
+counts=$(_pack_raw_memory "$MEM" "$RAWOUT")
+kept="${counts%% *}"; excl="${counts##* }"
+got=$(find "$RAWOUT" -maxdepth 1 -name '*.md' | wc -l)
+[[ "$got" -eq "$TOTAL_MD" ]] \
+  && ok_t "raw copies every .md ($got of $TOTAL_MD)" \
+  || bad_t "raw copies every .md" "got $got of $TOTAL_MD"
+[[ "$kept" -eq "$TOTAL_MD" && "$excl" -eq 0 ]] \
+  && ok_t "raw reports kept=$kept excluded=0" \
+  || bad_t "raw counts" "kept=$kept excluded=$excl"
+
+for f in private-user private-fb opted-out no-type MEMORY; do
+  [[ -f "$RAWOUT/$f.md" ]] \
+    && ok_t "raw carries $f.md (the whole point of a backup)" \
+    || bad_t "raw carries $f.md" "missing"
+done
+
+# The bytes must be IDENTICAL, not merely present — a backup that rewrites
+# frontmatter on the way out is not one.
+if diff -r "$MEM" "$RAWOUT" >/dev/null 2>&1; then
+  ok_t "raw output is byte-identical to the source dir"
+else
+  bad_t "raw output is byte-identical to the source dir" "$(diff -rq "$MEM" "$RAWOUT" 2>&1 | head -3)"
+fi
+
+# ---- 2. DISTILLED is unchanged — the control -------------------------------
+# Without this arm the suite would still pass on a tree where scoping had been
+# deleted outright, which is the failure raw could plausibly cause.
+DISOUT="$TMP/distilled"
+dcounts=$(_pack_scope_memory "$MEM" "$DISOUT")
+dkept="${dcounts%% *}"
+[[ "$dkept" -eq 2 ]] \
+  && ok_t "distilled still keeps exactly the 2 knowledge facts" \
+  || bad_t "distilled keeps 2" "kept=$dkept"
+for f in private-user private-fb opted-out no-type; do
+  [[ ! -f "$DISOUT/$f.md" ]] \
+    && ok_t "distilled still excludes $f.md" \
+    || bad_t "distilled still excludes $f.md" "leaked"
+done
+# scoping writes its OWN index over only what it kept, so MEMORY.md exists but
+# must not be the source's.
+if ! grep -q 'private-user' "$DISOUT/MEMORY.md" 2>/dev/null; then
+  ok_t "distilled index names no excluded fact"
+else
+  bad_t "distilled index names no excluded fact" "private title leaked via index"
+fi
+
+# ---- 3. RAW IS SELF-ONLY, refused before any bytes move --------------------
+# cmd_export needs root and a real agent; stub only those, so the arm grades the
+# audience guard and nothing else.
+require_root() { :; }
+require_agent() { :; }
+# ASSERT ON THE MESSAGE, NEVER ON rc ALONE. cmd_export exits non-zero here for
+# several reasons (the stubbed agent does not exist, no memory dir, ...), so an
+# rc-only arm passes for the WRONG reason and grades nothing. Mutation-checked:
+# deleting the audience guard left an rc-only arm GREEN.
+refuses_with() { # <expected substring> <label> -- <argv...>
+  local want="$1" label="$2"; shift 3
+  local o rc; o=$(cmd_export "$@" 2>&1); rc=$?
+  if [[ $rc -ne 0 ]] && grep -qi -- "$want" <<<"$o"; then
+    ok_t "$label"
+  else
+    bad_t "$label" "rc=$rc; wanted /$want/; got: $(head -2 <<<"$o" | tr '\n' ' ')"
+  fi
+}
+
+refuses_with 'cannot be published' \
+  "raw + --audience=publish REFUSES, and says why" \
+  -- ceo --memory=raw --audience=publish
+
+# Default audience is publish, so a bare --memory=raw must refuse identically —
+# raw must not escape through the default.
+refuses_with 'cannot be published' \
+  "bare --memory=raw refuses too (publish is the DEFAULT audience)" \
+  -- ceo --memory=raw
+
+refuses_with '--memory must be' \
+  "an unknown --memory mode refuses rather than falling through to a mode" \
+  -- ceo --memory=bogus --audience=self
+
+printf '\n%s\n' "----- pack_raw_memory_unit: PASS=$PASS FAIL=$FAIL -----"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## What

`5dive agent export <name> --memory=distilled|raw`. Default `distilled` — today's behaviour, unchanged.

## Why

lodar, 2026-09-01: *"some users just want raw memory. but warn them."*

Until now **no path anywhere in the CLI** emitted a memory dir verbatim — `_pack_scope_memory` is deny-by-default and is applied unconditionally on both the draft and seal phases. That is correct for a *published* persona pack and wrong for a *backup*: on a realistic memory dir the scoper keeps 2 files in 7, and a backup that silently drops five of them is not a backup.

## Three properties keep raw honest, and they are the design

1. **Self-only, by refusal, before any bytes move.** `--memory=raw` with the publish audience fails — and `publish` is the **default**, so raw cannot escape by omission. A raw pack carries private `user`/`feedback` facts about a named human; "published" is not a thing it can safely be, whoever is asking.
2. **The tripwire still runs, and warns instead of refusing.** That is what *"warn them"* means: the person is told by file and line which facts look like credentials, and then gets their backup. A second warning names what raw carries that distilled never does.
3. **Distilled is untouched.** The seal phase still re-scopes for it, so the type gate holds no matter what directory is passed.

## Evidence

`tests/pack_raw_memory_unit.sh` — 17 assertions. The distilled arms are **controls**: without them the suite would pass on a tree where scoping had been deleted outright, which is the failure raw could plausibly cause. All 11 pack suites green, no regressions.

**Mutation-checked, and it changed the tests rather than confirming them.** The refusal arms originally asserted on exit code, which is over-determined here (`cmd_export` exits non-zero for several unrelated reasons) — so deleting the audience guard left them **green**, and an unknown-mode fallthrough killed **nothing**. Rewritten to assert the message. All four mutants now die:

| mutant | assertions killed |
|---|---|
| drop the raw self-only refusal | 2 |
| raw silently scopes | 7 |
| unknown `--memory` falls through to a mode | 1 |
| raw skips `MEMORY.md` | 4 |

## Delivery note

`5dive-cli` is not auto-deploying and release cuts are cron (37 2 / 43 3 daily), so this reaches no box on merge. The dashboard control for raw is gated on the cut — the API deliberately sends **no** `--memory` flag for distilled, so today's shipped distilled export stays byte-identical on boxes running the older CLI rather than breaking on an unknown flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
