### PR TITLE
DIVE-3881: pack import resolves the workdir from the registry, and a dropped memory seed says so

### DIFF
--- a/changelog.d/DIVE-3881.md
+++ b/changelog.d/DIVE-3881.md
@@ -1,0 +1,19 @@
+## Unreleased — fix(pack): `agent import` no longer silently drops a pack's memory on the default workdir (DIVE-3881)
+
+`agent export` writes `config.workdir: null` for any agent that was never given an explicit
+`--workdir` — which is every agent on `DEFAULT_WORKDIR`, i.e. the normal way agents are created.
+`cmd_import` read that null into `$workdir`, and the memory-seeding block was guarded on it, so the
+**common** path skipped seeding entirely: the pack carried the facts, the import returned success,
+and the agent came up with an empty memory store. Found running the dashboard export→import end to
+end — 50 distilled facts in the pack, 0 on the imported agent.
+
+Import now resolves the workdir it can always know: the **registry**, read after `cmd_create` has
+run, when the agent's workdir is a fact rather than a guess, falling back to `DEFAULT_WORKDIR`. An
+explicit `--workdir` still wins. The template overlay is deliberately unchanged — it writes files
+into a shared tree and widening it is its own decision.
+
+Second half: the skip had no voice, which is why it survived to a user. `memorySeeded` now reports
+what actually landed (`… (50 of 50 facts)`, or `FAILED (0 of 50 …)` when the copy did not happen —
+every write there is `|| true`, so the reported path used to be an intention, not an outcome), and
+a pack that carries memory and seeds none emits a `warn` on stderr instead of only a parenthetical
+inside the success line.

--- a/src/cmd_pack.sh
+++ b/src/cmd_pack.sh
@@ -2592,6 +2592,30 @@ cmd_import() {
   fi
 
   # Optional template/ bootstrap → a FRESH project dir only (never overlay).
+  # DIVE-3881: resolve the workdir the agent ACTUALLY has, not the one the pack
+  # remembered. A manifest's `config.workdir` is null for every agent that was
+  # never given an explicit --workdir — i.e. every agent on DEFAULT_WORKDIR,
+  # which is the normal way agents are created. So `$workdir` is empty on the
+  # COMMON path, and the memory seeding below is guarded on it: a pack carrying
+  # 50 distilled facts seeded none and the import still returned success (lodar,
+  # dashboard export->import, 2026-09-01).
+  #
+  # The registry is the right source and this is the right MOMENT to read it:
+  # cmd_create has already run, so the agent's workdir is a fact rather than a
+  # guess, and it stays correct even if DEFAULT_WORKDIR later moves. Same read as
+  # the clone path in cmd_agent_runtime.sh. The `// $d` fallback covers the
+  # ordinary case where create recorded no explicit workdir at all.
+  local eff_workdir="$workdir"
+  if [[ -z "$eff_workdir" ]]; then
+    eff_workdir=$(jq -r --arg n "$as" --arg d "$DEFAULT_WORKDIR" \
+      '.agents[$n].workdir // $d' <<<"$(registry_read)" 2>/dev/null) || eff_workdir=""
+    [[ -n "$eff_workdir" && "$eff_workdir" != "null" ]] || eff_workdir="$DEFAULT_WORKDIR"
+  fi
+
+  # Deliberately still on $workdir, not $eff_workdir: an overlay WRITES files, and
+  # pointing it at a resolved default would let a pack lay a template into a shared
+  # projects dir nobody asked it to touch. Seeding memory into the new agent's own
+  # config dir has no such reach. Widening this is its own decision, not this fix.
   local templated="none"
   if [[ -d "$stage/template" && -n "$workdir" ]]; then
     if [[ ! -e "$workdir" ]]; then
@@ -2604,27 +2628,47 @@ cmd_import() {
   fi
 
   # Seed distilled persona memory into the new agent's project memory dir. Memory
-  # is keyed by project slug (the encoded workdir), so we can only place it when a
-  # workdir is known; otherwise report it skipped rather than drop it somewhere
-  # the agent won't read.
+  # is keyed by project slug (the encoded workdir), which is why this needs a
+  # workdir at all — see the DIVE-3881 resolution above for why the manifest's own
+  # value is not one on the common path.
   local mem_seeded="none"
   if [[ "$mem_inc" != "false" && -d "$stage/memory" ]]; then
-    if [[ -n "$workdir" ]]; then
-      local slug mdir
-      slug=$(printf '%s' "$workdir" | sed 's#/#-#g')
+    if [[ -n "$eff_workdir" ]]; then
+      local slug mdir packed landed
+      slug=$(printf '%s' "$eff_workdir" | sed 's#/#-#g')
       mdir="$cdir/projects/${slug}/memory"
+      packed=$(find "$stage/memory" -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l)
       install -d -o "agent-${as}" -g "agent-${as}" "$mdir" 2>/dev/null || true
       cp "$stage"/memory/*.md "$mdir/" 2>/dev/null || true
       chown -R "agent-${as}:agent-${as}" "$cdir/projects" 2>/dev/null || true
-      mem_seeded="$mdir"
+      landed=$(find "$mdir" -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l)
+      # DIVE-3881 (fix B): COUNT what landed instead of assuming the cp worked.
+      # Every write above is `|| true`, so before this the reported path was an
+      # intention, not an outcome — the one string a reader would use to decide
+      # the memory arrived was true even when nothing was written.
+      if (( landed > 0 )); then
+        mem_seeded="$mdir ($landed of $packed facts)"
+      else
+        mem_seeded="FAILED (0 of $packed facts reached $mdir)"
+      fi
       # DIVE-2568: on a claude seat the store IS the loading mechanism; elsewhere
       # it is only the searchable one, and the inline above is what puts the facts
       # in front of the model. Say which happened rather than leaving the reader
       # to infer it from the type.
-      [[ "$mem_effect" == "none" && "$type" == "claude" ]] && mem_effect="auto-loaded from $mdir"
+      [[ "$mem_effect" == "none" && "$type" == "claude" && $landed -gt 0 ]] && mem_effect="auto-loaded from $mdir"
     else
       mem_seeded="skipped (no workdir to resolve the memory slug)"
     fi
+  fi
+
+  # DIVE-3881 (fix B): a pack that CARRIES memory and seeds none must not read as
+  # a plain success. The workdir-null bug survived to a customer because the skip
+  # had no voice: it appeared only inside the ok line's parenthetical and in the
+  # --json `memorySeeded` field, and the API lifts neither. A warn is on stderr,
+  # is not the success sentence, and is what a caller relaying output will show.
+  if [[ "$mem_inc" != "false" && -d "$stage/memory" ]] \
+     && [[ "$mem_seeded" == skipped* || "$mem_seeded" == FAILED* ]]; then
+    warn "this pack carries memory and NONE of it was seeded — $mem_seeded. The agent imported, but the facts you exported are not on it; re-run the import with an explicit --workdir=<path>, or copy the pack's memory/*.md into that agent's project memory dir by hand."
   fi
 
   # Re-add skills best-effort. Config packs record refs, not bodies, so skills not

--- a/tests/pack_import_workdir_memory_unit.sh
+++ b/tests/pack_import_workdir_memory_unit.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# DIVE-3881 — a pack's memory must reach an agent that was created on the DEFAULT
+# workdir, and an import that seeds none must say so.
+#
+# THE BUG THIS GUARDS. `agent export` writes `config.workdir: null` for any agent
+# that was never given an explicit --workdir — which is every agent on
+# DEFAULT_WORKDIR, i.e. the normal way agents are created. cmd_import read that
+# null into $workdir and the memory-seeding block was guarded on it, so the
+# COMMON path skipped seeding entirely. lodar hit it on 2026-09-01 running the
+# dashboard export->import end to end: 50 facts in the pack, 0 on the agent, and
+# the import returned success.
+#
+# WHY IT SURVIVED TO A CUSTOMER is the second half and it is tested here too: the
+# skip had no voice. It appeared inside the ok line's parenthetical and in the
+# --json `memorySeeded` field, and the API lifts neither.
+#
+# The arms below REPLAY the resolution and the seeding against a real temp tree,
+# and arm 2 runs the PRE-FIX guard against the same inputs — a fix that only
+# looked right would leave arm 2 green, so arm 2 is what proves the defect was
+# reproduced before it was closed.
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+
+TMP=""
+trap 'rc=$?; [[ -n "$TMP" ]] && rm -rf "$TMP"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+ROOT=$PWD
+pass=0; fail=0
+ok()  { printf '  ok   %s\n' "$1"; pass=$((pass+1)); }
+no()  { printf '  FAIL %s\n' "$1"; fail=$((fail+1)); }
+is()  { [[ "$2" == "$3" ]] && ok "$1" || no "$1 (got '$2', want '$3')"; }
+
+command -v jq >/dev/null 2>&1 || { echo "  SKIP-as-FAIL — jq missing, arms 1-3 NOT REACHED"; no "jq unavailable"; printf '\n%d passed, %d failed\n' "$pass" "$fail"; exit 1; }
+
+TMP=$(mktemp -d)
+DEFAULT_WORKDIR="/home/claude/projects"
+
+# --- the two lines under test, lifted verbatim in shape from cmd_pack.sh -------
+resolve_eff_workdir() {          # $1 = $workdir (flag or manifest), $2 = registry json, $3 = agent name
+  local workdir="$1" reg="$2" as="$3" eff_workdir="$1"
+  if [[ -z "$eff_workdir" ]]; then
+    eff_workdir=$(jq -r --arg n "$as" --arg d "$DEFAULT_WORKDIR" \
+      '.agents[$n].workdir // $d' <<<"$reg" 2>/dev/null) || eff_workdir=""
+    [[ -n "$eff_workdir" && "$eff_workdir" != "null" ]] || eff_workdir="$DEFAULT_WORKDIR"
+  fi
+  printf '%s' "$eff_workdir"
+}
+
+# Replays the seeding block against a real stage + config dir. Prints
+# "<mem_seeded>|<files landed>". $1 = the workdir the block is guarded on.
+seed_as_import_does() {
+  local guard="$1" stage="$2" cdir="$3"
+  local mem_seeded="none"
+  if [[ -d "$stage/memory" ]]; then
+    if [[ -n "$guard" ]]; then
+      local slug mdir packed landed
+      slug=$(printf '%s' "$guard" | sed 's#/#-#g')
+      mdir="$cdir/projects/${slug}/memory"
+      packed=$(find "$stage/memory" -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l)
+      mkdir -p "$mdir" 2>/dev/null || true
+      cp "$stage"/memory/*.md "$mdir/" 2>/dev/null || true
+      landed=$(find "$mdir" -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l)
+      if (( landed > 0 )); then mem_seeded="$mdir ($landed of $packed facts)"
+      else mem_seeded="FAILED (0 of $packed facts reached $mdir)"; fi
+    else
+      mem_seeded="skipped (no workdir to resolve the memory slug)"
+    fi
+  fi
+  printf '%s|%s' "$mem_seeded" "$(find "$cdir" -type f -name '*.md' 2>/dev/null | wc -l)"
+}
+
+mkstage() {                       # $1 = dir, $2 = number of fact files
+  local d="$1" n="$2" i
+  mkdir -p "$d/memory"
+  for ((i=1;i<=n;i++)); do printf 'fact %d\n' "$i" > "$d/memory/f$i.md"; done
+}
+
+echo "== 1. BEHAVIOURAL: a manifest with workdir:null still seeds the memory =="
+# This is lodar's case exactly: no --workdir flag, config.workdir null, and the
+# registry (read AFTER create) records no explicit workdir either.
+reg_default='{"agents":{"clone1":{"type":"claude"}}}'
+eff=$(resolve_eff_workdir "" "$reg_default" clone1)
+is "null manifest + null registry resolves to DEFAULT_WORKDIR" "$eff" "$DEFAULT_WORKDIR"
+
+mkstage "$TMP/s1" 50
+mkdir -p "$TMP/c1"
+IFS='|' read -r seeded landed < <(seed_as_import_does "$eff" "$TMP/s1" "$TMP/c1")
+is "50 packed facts land"  "$landed" "50"
+[[ "$seeded" == *"50 of 50 facts"* ]] \
+  && ok "memorySeeded names the COUNT, not just an intended path ($seeded)" \
+  || no "memorySeeded does not report a count (got '$seeded')"
+[[ "$seeded" == *"/projects/-home-claude-projects/memory"* ]] \
+  && ok "seeded under the encoded default project slug" \
+  || no "wrong slug (got '$seeded')"
+
+echo "== 2. MUTATION: the PRE-FIX guard, same inputs, drops all 50 =="
+# The defect, reproduced. Guarded on the raw manifest value ("" here) instead of
+# the resolved one. If this arm ever passes memory through, the harness is
+# grading the wrong thing.
+mkstage "$TMP/s2" 50
+mkdir -p "$TMP/c2"
+IFS='|' read -r pre_seeded pre_landed < <(seed_as_import_does "" "$TMP/s2" "$TMP/c2")
+is "pre-fix: zero facts reach the agent" "$pre_landed" "0"
+is "pre-fix: reports a skip"             "$pre_seeded" "skipped (no workdir to resolve the memory slug)"
+
+echo "== 3. an EXPLICIT --workdir still wins over the registry =="
+reg_other='{"agents":{"clone1":{"workdir":"/srv/registry-said-this"}}}'
+is "flag beats registry"      "$(resolve_eff_workdir /srv/flag "$reg_other" clone1)" "/srv/flag"
+is "registry beats default"   "$(resolve_eff_workdir '' "$reg_other" clone1)"        "/srv/registry-said-this"
+is "unknown agent -> default" "$(resolve_eff_workdir '' "$reg_other" nosuch)"        "$DEFAULT_WORKDIR"
+is "unreadable registry -> default" "$(resolve_eff_workdir '' 'not json' clone1)"    "$DEFAULT_WORKDIR"
+
+echo "== 4. a write that fails is reported as FAILED, not as a path =="
+# Every write in the real block is `|| true`, so before DIVE-3881 the reported
+# path was an intention. Force the copy to fail and assert the string flips.
+mkstage "$TMP/s4" 3
+mkdir -p "$TMP/c4/projects"
+: > "$TMP/c4/projects/-x"          # a FILE where the slug dir must go -> mkdir -p fails
+IFS='|' read -r f_seeded f_landed < <(seed_as_import_does "/x" "$TMP/s4" "$TMP/c4")
+is "nothing landed"        "$f_landed" "0"
+[[ "$f_seeded" == FAILED* ]] \
+  && ok "reports FAILED rather than the path it meant to use ($f_seeded)" \
+  || no "a failed seed still reports as success (got '$f_seeded')"
+
+echo "== 5. STRUCTURAL: the source still resolves, and resolves AFTER create =="
+src="$ROOT/src/cmd_pack.sh"
+r=$(grep -n 'local eff_workdir="\$workdir"' "$src" | head -1 | cut -d: -f1)
+c=$(grep -n 'cmd_create "\${cargs\[@\]}"' "$src" | head -1 | cut -d: -f1)
+g=$(grep -n 'if \[\[ -n "\$eff_workdir" \]\]; then' "$src" | head -1 | cut -d: -f1)
+if [[ -z "$r" || -z "$c" || -z "$g" ]]; then
+  no "could not locate the resolve (:$r), the create (:$c) or the seed guard (:$g) — DIVE-3881 regression, or the test is stale"
+else
+  (( c < r )) && ok "resolve at :$r happens after cmd_create at :$c (registry is populated)" \
+               || no "resolve at :$r runs BEFORE cmd_create at :$c — the registry has no row yet"
+  (( r < g )) && ok "seed guard at :$g reads the resolved value from :$r" \
+               || no "seed guard at :$g precedes the resolve at :$r"
+fi
+grep -q 'slug=$(printf '"'"'%s'"'"' "$eff_workdir"' "$src" \
+  && ok "the memory slug is built from the RESOLVED workdir" \
+  || no "the memory slug no longer uses \$eff_workdir (DIVE-3881 regression)"
+# The template overlay is deliberately NOT widened — it writes files.
+grep -q 'if \[\[ -d "\$stage/template" && -n "\$workdir" \]\]' "$src" \
+  && ok "template overlay still guarded on the explicit workdir (deliberate)" \
+  || no "template overlay was widened to the resolved workdir — that was not this fix"
+
+echo "== 6. STRUCTURAL: a seeded-nothing import warns, and only then =="
+if grep -q 'this pack carries memory and NONE of it was seeded' "$src"; then
+  ok "the skip has a voice on stderr"
+  # It must be conditional on the skip, not printed on every import.
+  ctx=$(grep -B4 'this pack carries memory and NONE of it was seeded' "$src")
+  [[ "$ctx" == *'"$mem_seeded" == skipped*'* && "$ctx" == *'"$mem_seeded" == FAILED*'* ]] \
+    && ok "warn is gated on skipped-or-FAILED, so a good import stays quiet" \
+    || no "the warn is not gated on the skip — it would fire on every import"
+else
+  no "no warn when a pack carries memory and seeds none (DIVE-3881 fix B regression)"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## The bug

`agent export` writes `config.workdir: null` for any agent that was never given an explicit
`--workdir` — which is **every agent on `DEFAULT_WORKDIR`, the normal way agents are created**.
`cmd_import` read that null into `$workdir`, and the memory-seeding block was guarded on it:

```bash
if [[ -n "$workdir" ]]; then ... cp "$stage"/memory/*.md "$mdir/" ...
else mem_seeded="skipped (no workdir to resolve the memory slug)"
```

So the failing path is the DEFAULT one. Found by lodar on 2026-09-01 running the dashboard
export→import end to end (CLI 0.25.3): **50 distilled facts in the pack, 0 on the imported agent,
and the import returned success.** Measured at source on the box — the pack's manifest read
`includes.memory = "distilled"` with 52 entries, and the new agent's memory dir held no facts.

## Fix A — resolve a workdir import can always know

Read it from the **registry**, after `cmd_create` has run: by that point the agent exists and its
workdir is a fact, correct even if `DEFAULT_WORKDIR` later moves. Falls back to `DEFAULT_WORKDIR`.
Same read as the clone path in `cmd_agent_runtime.sh`. An explicit `--workdir` still wins.

**The template overlay is deliberately NOT widened.** It *writes files*, and pointing it at a
resolved default would let a pack lay a template into a shared projects tree nobody asked it to
touch. Seeding memory into the new agent's own config dir has no such reach. Arm 5 of the harness
asserts the overlay stayed on `$workdir`, so this stays a decision rather than a drift.

## Fix B — the skip had no voice, which is why it reached a user

- `memorySeeded` now reports what **landed**, not what was intended: `… (50 of 50 facts)`, or
  `FAILED (0 of 50 facts reached …)`. Every write in that block is `|| true`, so the reported path
  was previously an intention — the one string a reader would use to decide the memory arrived was
  true even when nothing was written.
- A pack that **carries** memory and seeds none now emits a `warn` on stderr, gated on
  skipped-or-FAILED so a good import stays quiet. Previously the skip appeared only inside the ok
  line's parenthetical and in the `--json` `memorySeeded` field, and the API lifts neither.

## Evidence

New harness `tests/pack_import_workdir_memory_unit.sh` — **18 passed, 0 failed**:

1. **Behavioural** — null manifest + null registry resolves to `DEFAULT_WORKDIR`; 50 packed facts
   land under the encoded default slug; `memorySeeded` names the count.
2. **Mutation** — the **pre-fix guard**, same inputs, drops all 50 and reports the skip. This is the
   arm that proves the defect was reproduced, not just that the new code looks right.
3. Precedence: flag > registry > default; unknown agent and unparseable registry both fall back.
4. A write that fails flips the string to `FAILED`, rather than reporting the path it meant to use.
5. **Structural** — the resolve is after `cmd_create` and before the seed guard; the slug is built
   from the resolved value; the template overlay is unchanged.
6. **Structural** — the warn exists and is gated on the skip.

Neighbouring harnesses re-run green on this tree: `pack_agents_md` 72/0, `pack_cross_harness` 83/0,
`pack_disclosure` 30/0, `pack_export_memory_dir_missing` 6/0, `pack_import_model_alias` 17/0,
`pack_memory_leakscan` 39/0, `pack_persona_rename` 28/0, `pack_raw_memory` 20/0,
`pack_registry_fetch_errors` 27/0, `pack_secret_tripwire_precision` 36/0,
`pack_skill_source_roundtrip` 41/0, `inherit_memory` 14/0. `bash -n` and `./build.sh` clean;
`registry_read` and `DEFAULT_WORKDIR` are both defined ahead of the new call site in the bundle.

## Not covered by this PR

- **A real on-box `export → import` round trip has not been run.** Every arm above replays the
  resolution and the seeding logic against a temp tree; none of them provisions an agent. That
  residual is what a reviewer should weigh.
- **The API/dashboard half of fix B.** `memorySeeded` still is not lifted by the API and not
  rendered by the dashboard, so a customer importing through the browser still would not see a
  skip. That is `5dive-api` + `5dive-frontend` work and is filed separately.
- Not the same row as DIVE-3877 (the raw LABEL and the raw-onto-non-claude inline). This is the
  workdir-null seeding guard, it hits `distilled` and `raw` equally, and it predates both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
