### PR TITLE
fix(supervisor): mute the human leg of a self-healing quota-exhausted alert (DIVE-3940)

### DIFF
--- a/src/cmd_supervisor.sh
+++ b/src/cmd_supervisor.sh
@@ -841,8 +841,8 @@ sup_info_for_agent() {  # <name>
 # shape as _sup_verify_alert — both legs best-effort, because one wedged channel
 # must never abort the tick for the rest of the fleet — and the caller owns the
 # dedup window.
-_sup_capacity_alert() {  # <name> <class> <detail>
-  local name="$1" class="$2" detail="$3"
+_sup_capacity_alert() {  # <name> <class> <detail> [notify_human=true]
+  local name="$1" class="$2" detail="$3" notify_human="${4:-true}"
   local msg="[FLEET-HEALTH ${class}] agent '${name}' is UP and REACHABLE but NOT TRANSACTING: ${detail}. Every liveness signal (unit / tmux / poller / registry label) reads healthy — that agreement is the DIVE-3272 defect, not evidence against this alert. Check the seat's model capacity (auth-profile, quota reset) and reassign or park whatever is queued behind it."
   # DIVE-3318: a one-way machine notice nobody replies to is not a round — see
   # a2a_round_guard. NOT a sender exemption; never set this by hand.
@@ -851,9 +851,29 @@ _sup_capacity_alert() {  # <name> <class> <detail>
   # lodar is a human — reached through main's paired channel, same route the
   # verify tripwire uses. Best-effort: a miss still leaves the agent-send leg
   # and the audited alert row.
-  if _task_agent_channel main; then
+  #
+  # DIVE-3940: the human leg is SUPPRESSIBLE. A self-healing quota wall (a shared
+  # profile's 5h window, resume deadline still in the future — quotaDeadline=live)
+  # needs no human ping: the correct response is to let the reset arrive, and on a
+  # shared profile the per-seat alert fans out one ping per seat. The machine leg
+  # above and the audited row are UNCONDITIONAL, so main still triages it and the
+  # DIVE-3272 blind-spot cover is unchanged — only lodar's phone goes quiet for the
+  # confirmed-benign case. The caller sets notify_human=false; every other class
+  # (and quotaDeadline=unknown, a possible hard wall) keeps the human leg.
+  if [[ "$notify_human" == "true" ]] && _task_agent_channel main; then
     _task_send_owner "$msg" >/dev/null 2>&1 || true
   fi
+}
+
+# DIVE-3940: should a capacity alert's HUMAN leg fire? Pure decision, no I/O, so
+# the wiring from classification to the leg is unit-gradeable. The single mute is
+# a confirmed self-healing quota wall — class quota-exhausted with a resume
+# deadline still in the future (quotaDeadline=live). Every other class, and every
+# other deadline state (unknown may be a hard wall; lapsed never reaches here),
+# keeps the human ping. See _sup_capacity_alert for why live is benign noise.
+_sup_capacity_notify_human() {  # <class> <quotaDeadline> -> true|false
+  [[ "$1" == "quota-exhausted" && "$2" == "live" ]] && { printf 'false'; return; }
+  printf 'true'
 }
 
 # DIVE-1127: fire the same-day alert for a tripped account. Both legs are
@@ -1962,10 +1982,16 @@ cmd_supervisor_tick() {
                        AND ts >= datetime('now', '-${_SUP_ALERT_WINDOW_H} hours');" 2>/dev/null || echo 0)
     [[ "$prev_alert" =~ ^[0-9]+$ ]] || prev_alert=0
     (( prev_alert > 0 )) && continue
+    # DIVE-3940: a confirmed self-healing quota wall mutes the human leg only —
+    # the machine leg + audited row still fire (main triages; DIVE-3272 cover
+    # unchanged). The quotaDeadline read is guarded so non-quota rows spend no jq.
+    local qdl="unknown"
+    [[ "$cls" == "quota-exhausted" ]] && qdl=$(jq -r '.signals.quotaDeadline // "unknown"' <<<"$row")
+    local notify_human; notify_human=$(_sup_capacity_notify_human "$cls" "$qdl")
     if [[ "$cls" == "verify-challenge" ]]; then
       _sup_verify_alert "$name" "$excerpt"
     else
-      _sup_capacity_alert "$name" "$cls" "$excerpt"
+      _sup_capacity_alert "$name" "$cls" "$excerpt" "$notify_human"
     fi
     db "INSERT INTO supervisor_events (agent, event, classification, cause, signals)
         VALUES ($(sqlq "$name"), 'alert', $(sqlq "$cls"), $(sqlq "$cause_s"), $(sqlq "$row"));" 2>/dev/null \

--- a/tests/supervisor_escalate_delivery_unit.sh
+++ b/tests/supervisor_escalate_delivery_unit.sh
@@ -197,7 +197,7 @@ tick_arm() {  # <snapshot-json> [armed] [seed-sql] [registry-json] [rotated|no-t
     _sup_snapshot()     { printf "%s" "$SNAP"; }      # the fixture fleet
     registry_read()     { printf "%s" "$FIXTURE_REGISTRY"; }
     _task_agent_channel() { return 1; }               # no telegram anywhere
-    : >"$TMP/sent"; : >"$TMP/restarted"; : >"$TMP/rotated"; : >"$TMP/capacity-alerts"
+    : >"$TMP/sent"; : >"$TMP/restarted"; : >"$TMP/rotated"; : >"$TMP/capacity-alerts"; : >"$TMP/capacity-human"
     cmd_send() { printf "%s\n" "$1" >>"$TMP/sent"; return 0; }
     cmd_restart() { printf "%s\n" "$1" >>"$TMP/restarted"; return 0; }
     # DIVE-3856: rung 4 re-probes the poller after its own restart. Both stubs
@@ -219,7 +219,10 @@ tick_arm() {  # <snapshot-json> [armed] [seed-sql] [registry-json] [rotated|no-t
         *)         return 1 ;;
       esac
     }
-    _sup_capacity_alert() { printf "%s:%s\n" "$1" "$2" >>"$TMP/capacity-alerts"; }
+    # DIVE-3940: capture the 4th arg (notify_human) into its own field so an arm
+    # can grade the classification->human-leg wiring. name:class stays in
+    # capacity-alerts unchanged; the human decision lands in capacity-human.
+    _sup_capacity_alert() { printf "%s:%s\n" "$1" "$2" >>"$TMP/capacity-alerts"; printf "%s:%s\n" "$1" "${4:-true}" >>"$TMP/capacity-human"; }
     # The seed writes BEFORE the tick, so it has to create the schema itself —
     # nothing else has touched this fixture DB yet. Both calls are subshelled:
     # `db` reaches `fail`, and `fail` EXITS, which `|| true` cannot catch.
@@ -232,7 +235,7 @@ tick_arm() {  # <snapshot-json> [armed] [seed-sql] [registry-json] [rotated|no-t
       cmd_supervisor_tick >/dev/null 2>&1 || { printf "TICK-RC=%s|" "$?"; }
       tick_n=$((tick_n + 1))
     done
-    printf "ESC=%s|SENT=%s|ACT=%s|RESTARTED=%s|ROTATED=%s|ALERTS=%s|ALERT_ROWS=%s|NUDGE_ROWS=%s" \
+    printf "ESC=%s|SENT=%s|ACT=%s|RESTARTED=%s|ROTATED=%s|ALERTS=%s|ALERT_ROWS=%s|NUDGE_ROWS=%s|HUMAN=%s" \
       "$(db "SELECT COALESCE(GROUP_CONCAT(signals), \"\") FROM supervisor_events WHERE event=$(sqlq escalate);")" \
       "$(paste -sd, <"$TMP/sent")" \
       "$(db "SELECT COALESCE(GROUP_CONCAT(signals), \"\") FROM supervisor_events WHERE event=$(sqlq action);")" \
@@ -240,7 +243,8 @@ tick_arm() {  # <snapshot-json> [armed] [seed-sql] [registry-json] [rotated|no-t
       "$(paste -sd, <"$TMP/rotated")" \
       "$(paste -sd, <"$TMP/capacity-alerts")" \
       "$(db "SELECT COUNT(*) FROM supervisor_events WHERE event=$(sqlq alert) AND classification=$(sqlq quota-exhausted);")" \
-      "$(db "SELECT COUNT(*) FROM supervisor_events WHERE event=$(sqlq action) AND signals LIKE $(sqlq %\\\"rung\\\":\\\"nudge\\\"%);")"
+      "$(db "SELECT COUNT(*) FROM supervisor_events WHERE event=$(sqlq action) AND signals LIKE $(sqlq %\\\"rung\\\":\\\"nudge\\\"%);")" \
+      "$(paste -sd, <"$TMP/capacity-human")"
   '   # stderr deliberately NOT swallowed: the arm already fails closed (an abort
       # yields an empty receipt, which reds), but a red with no reason costs the
       # next reader a repro. The tick's own warns are silenced at its call above.
@@ -415,6 +419,62 @@ t "text carries the re-check command" \
 # the human re-runs the probe and reads ALIVE as broken.
 t "text warns that a 409 means ALIVE" \
   "yes" "$([[ "$txt" == *"409"* ]] && echo yes || echo no)"
+
+# ── DIVE-3940: the self-healing quota wall mutes ONLY the human leg ──────────
+# lodar 2026-09-03: the [FLEET-HEALTH quota-exhausted] pings are noise when the
+# wall self-heals — a shared profile's 5h window with a resume deadline still in
+# the future (quotaDeadline=live). The machine leg (main triages, DIVE-3272 cover)
+# and the audited row must stay; only lodar's phone goes quiet, and only for the
+# CONFIRMED-benign case.
+
+# (a) the pure decision, graded in isolation — no I/O, so the wiring is exact.
+t "notify_human: live-deadline quota wall is the one mute" \
+  "false" "$(_sup_capacity_notify_human quota-exhausted live)"
+t "notify_human: unknown-deadline (possible hard wall) keeps the human" \
+  "true" "$(_sup_capacity_notify_human quota-exhausted unknown)"
+t "notify_human: a non-quota class is never muted by a live deadline" \
+  "true" "$(_sup_capacity_notify_human no-output live)"
+t "notify_human: quota-exhausted with no deadline defaults to loud" \
+  "true" "$(_sup_capacity_notify_human quota-exhausted "")"
+
+# (b) the guard inside the real _sup_capacity_alert. Both legs are observed: the
+# machine leg (5dive agent send main) must fire UNCONDITIONALLY; the human leg
+# obeys notify_human. `5dive` is a leading-digit function name, which bash allows.
+MACHINE_FIRED=0; HUMAN_FIRED=0
+5dive() { MACHINE_FIRED=1; return 0; }
+_task_agent_channel() { return 0; }
+_task_send_owner() { HUMAN_FIRED=1; return 0; }
+
+MACHINE_FIRED=0; HUMAN_FIRED=0; _sup_capacity_alert ops quota-exhausted "d" true
+t "capacity_alert: notify_human=true fires the human leg"  "1" "$HUMAN_FIRED"
+t "capacity_alert: the machine leg fires regardless (true)" "1" "$MACHINE_FIRED"
+
+MACHINE_FIRED=0; HUMAN_FIRED=0; _sup_capacity_alert ops quota-exhausted "d" false
+t "capacity_alert: notify_human=false MUTES the human leg"  "0" "$HUMAN_FIRED"
+t "capacity_alert: the machine leg still fires when muted"  "1" "$MACHINE_FIRED"
+
+MACHINE_FIRED=0; HUMAN_FIRED=0; _sup_capacity_alert ops quota-exhausted "d"
+t "capacity_alert: default (no 4th arg) preserves the old loud behavior" "1" "$HUMAN_FIRED"
+unset -f 5dive
+
+# (c) end-to-end through the real tick: classification -> deadline -> human leg.
+# Unarmed, so quota-exhausted skips the rotation remedy and reaches the alert.
+_SELFHEAL_SNAP='[{"name":"ops","type":"claude","classification":"quota-exhausted","cause":"quota-exhausted","detail":"pane refusal [resume deadline still in the FUTURE — the refusal is live]","signals":{"quotaDeadline":"live"}}]'
+selfheal_out=$(tick_arm "$_SELFHEAL_SNAP")
+t "3940 tick: a self-healing wall still records the capacity alert" \
+  "ops:quota-exhausted" "$(fld "$selfheal_out" ALERTS)"
+t "3940 tick: a self-healing wall still writes the audited alert row" \
+  "1" "$(fld "$selfheal_out" ALERT_ROWS)"
+t "3940 tick: a self-healing wall MUTES the human leg" \
+  "ops:false" "$(fld "$selfheal_out" HUMAN)"
+
+_HARDWALL_SNAP='[{"name":"ops","type":"claude","classification":"quota-exhausted","cause":"quota-exhausted","detail":"pane refusal [names no resume deadline]","signals":{"quotaDeadline":"unknown"}}]'
+t "3940 tick: an unknown-deadline wall keeps the human leg" \
+  "ops:true" "$(fld "$(tick_arm "$_HARDWALL_SNAP")" HUMAN)"
+
+_NOOUT_SNAP='[{"name":"ops","type":"claude","classification":"no-output","cause":"no-output","detail":"3 open row(s), nothing closed in 5d"}]'
+t "3940 tick: a no-output stall is unaffected — human leg still fires" \
+  "ops:true" "$(fld "$(tick_arm "$_NOOUT_SNAP")" HUMAN)"
 
 echo "PASS=$PASS FAIL=$FAIL"
 (( FAIL == 0 ))


### PR DESCRIPTION
## Why
lodar, 2026-09-03: *"can this template be silent in 5dive. its annoying and noisy"* — re two `[FLEET-HEALTH quota-exhausted]` pings (`ops`, `warm-mark`) that hit his phone within a minute.

Both were the **benign self-healing shape**: `mp-team` is a shared profile (7 seats); its 5h window maxed (account usage `mp-team 5H 100%, 7D 56%`), resume deadline in the **future** (`quotaDeadline=live`), auto-resets 10:40 UTC. Nothing stranded — `ops`'s rows are recurring sweeps; `warm-mark` is a warmer with no queue and `rotation:false`. The correct response to a live-deadline 5h wall is to let the reset arrive, so the human ping is pure noise — and because dedup is per-seat-per-class it **fans out one ping per seat** across a shared profile.

## What
- `_sup_capacity_alert` gains a 4th arg `notify_human` (default `true`); the human (`_task_send_owner`) leg is guarded by it. The `agent send main` **machine leg and the audited alert row are unconditional**.
- New pure `_sup_capacity_notify_human <class> <quotaDeadline>` — returns `false` only for `quota-exhausted` + `quotaDeadline=live`.
- Alert dispatch computes `notify_human` from the row's `signals.quotaDeadline` and passes it through.

## What stays loud (signal preserved)
- `quotaDeadline=unknown` (no parseable resume deadline → possible hard wall) → human still pinged.
- `no-output`, `verify-challenge` → unchanged.
- **DIVE-3272 cover unchanged**: `main` is still told of every quota wall via the machine leg + audited row and triages it. Only lodar's phone goes quiet, and only for the confirmed-benign case.

## Tests
`tests/supervisor_escalate_delivery_unit.sh` +14 arms (70/0 locally): the pure helper; the guard in the **real** `_sup_capacity_alert` with both legs observed (machine fires unconditionally, human obeys `notify_human`, default preserves old behavior); and **end-to-end tick wiring** — a `live` snapshot mutes the human leg while `unknown`/`no-output` stay loud.

Ships on the next CLI release cut (release-cut repo, not auto-deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)