### PR TITLE
fix(supervisor): mute the FLEET-HEALTH no-output human leg (DIVE-3982)

### DIFF
--- a/src/cmd_supervisor.sh
+++ b/src/cmd_supervisor.sh
@@ -1081,6 +1081,17 @@ _sup_capacity_alert() {  # <name> <class> <detail> [notify_human=true]
 # DIVE-3940's decision.
 _sup_capacity_notify_human() {  # <class> <quotaDeadline> [selfheal_kind] [persisted] -> true|false
   local class="${1:-}" qdl="${2:-}" kind="${3:-no}" persisted="${4:-false}"
+  # DIVE-3982: no-output ("N open row(s), nothing closed in Nd") is never a human
+  # ping — the other half of the FLEET-HEALTH family DIVE-3970 muted. Its remedy is
+  # "reassign or park", which is main/ops triage, NOT lodar's, and it is the
+  # byte-identical false positive an idle on-demand seat produces (an empty queue
+  # closes nothing; a-stalled-signal-is-true-and-names-no-cause). Unlike a quota
+  # wall past its reset, its long duration is not itself an incident, so it is muted
+  # UNCONDITIONALLY — ahead of the persistence escape below. The machine leg in
+  # _sup_capacity_alert stays unconditional, so main still triages every one and the
+  # DIVE-3272 cover is unchanged; a genuinely stuck seat is escalated by main in
+  # plain language, not by re-arming this raw template.
+  [[ "$class" == "no-output" ]] && { printf 'false'; return; }
   # Persistence wins over every mute: this is the hard wall the mute exists to
   # not hide.
   [[ "$persisted" == "true" ]] && { printf 'true'; return; }

--- a/tests/supervisor_escalate_delivery_unit.sh
+++ b/tests/supervisor_escalate_delivery_unit.sh
@@ -437,8 +437,8 @@ t "notify_human: live-deadline quota wall is the one mute" \
   "false" "$(_sup_capacity_notify_human quota-exhausted live)"
 t "notify_human: unknown-deadline (possible hard wall) keeps the human" \
   "true" "$(_sup_capacity_notify_human quota-exhausted unknown)"
-t "notify_human: a non-quota class is never muted by a live deadline" \
-  "true" "$(_sup_capacity_notify_human no-output live)"
+t "notify_human: DIVE-3982 no-output is muted regardless of deadline (not human-actionable)" \
+  "false" "$(_sup_capacity_notify_human no-output live)"
 t "notify_human: quota-exhausted with no deadline defaults to loud" \
   "true" "$(_sup_capacity_notify_human quota-exhausted "")"
 
@@ -478,8 +478,11 @@ t "3940 tick: an unknown-deadline wall keeps the human leg" \
   "ops:true" "$(fld "$(tick_arm "$_HARDWALL_SNAP")" HUMAN)"
 
 _NOOUT_SNAP='[{"name":"ops","type":"claude","classification":"no-output","cause":"no-output","detail":"3 open row(s), nothing closed in 5d"}]'
-t "3940 tick: a no-output stall is unaffected — human leg still fires" \
-  "ops:true" "$(fld "$(tick_arm "$_NOOUT_SNAP")" HUMAN)"
+_noout_out=$(tick_arm "$_NOOUT_SNAP")
+t "3982 tick: a no-output stall MUTES the human leg" \
+  "ops:false" "$(fld "$_noout_out" HUMAN)"
+t "3982 tick: no-output still records the capacity alert (machine leg intact, only the human leg is muted)" \
+  "ops:no-output" "$(fld "$_noout_out" ALERTS)"
 
 # ── DIVE-3970: the OTHER self-healing shapes, and the escape from the mute ───
 # Every string below is a real refusal, copied off supervisor_events
@@ -538,8 +541,10 @@ t "notify_human: persistence overrides the mute" \
   "true" "$(_sup_capacity_notify_human quota-exhausted unknown week true)"
 t "notify_human: persistence overrides the DIVE-3940 live-deadline mute too" \
   "true" "$(_sup_capacity_notify_human quota-exhausted live no true)"
-t "notify_human: a non-quota class is never muted by a self-healing kind" \
-  "true" "$(_sup_capacity_notify_human no-output unknown week)"
+t "notify_human: DIVE-3982 no-output is muted even on a recognised self-healing kind" \
+  "false" "$(_sup_capacity_notify_human no-output unknown week)"
+t "notify_human: DIVE-3982 no-output stays muted even when persisted (its duration is not an incident)" \
+  "false" "$(_sup_capacity_notify_human no-output unknown no true)"
 
 # The horizons. Relative to the FIRST alert for the shapes that name no clock;
 # the clock itself when one was named.


### PR DESCRIPTION
Extends DIVE-3970 to the other FLEET-HEALTH not-transacting class.

**Problem:** `no-output` ("N open row(s), nothing closed in Nd") kept the human leg while DIVE-3970 muted only self-healing quota walls — so lodar still got the byte-identical FLEET-HEALTH DM for a different class, and for the false positive an idle on-demand seat produces (empty queue closes nothing).

**Fix:** `_sup_capacity_notify_human` mutes `no-output` unconditionally, ahead of the persistence escape. The machine leg in `_sup_capacity_alert` stays unconditional, so main still triages every one; a genuinely stuck seat is escalated by main in plain language, not by re-arming the raw template.

**Tests:** three old no-output-pings-human assertions flipped to muted; added a persisted-still-muted case and a machine-leg-intact check. Unit: PASS=127 FAIL=0.

**Release:** rides the same next `5dive-cli` cut as DIVE-3970 (fleet is still on 0.25.10, which predates both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)