### PR TITLE
fix(supervisor): mute the human leg for the no-output fleet-health class (DIVE-3982)

### DIFF
--- a/src/cmd_supervisor.sh
+++ b/src/cmd_supervisor.sh
@@ -1081,6 +1081,15 @@ _sup_capacity_alert() {  # <name> <class> <detail> [notify_human=true]
 # DIVE-3940's decision.
 _sup_capacity_notify_human() {  # <class> <quotaDeadline> [selfheal_kind] [persisted] -> true|false
   local class="${1:-}" qdl="${2:-}" kind="${3:-no}" persisted="${4:-false}"
+  # DIVE-3982: no-output mutes the human leg UNCONDITIONALLY — ahead of the
+  # persistence escape, unlike quota. Its remedy ("reassign or park") is
+  # main/ops triage, never lodar's, and a long duration is the benign idle case
+  # (an empty queue closes nothing), not an incident like a quota wall past its
+  # reset. The machine leg in _sup_capacity_alert stays unconditional, so main
+  # still triages every one and escalates to a human in plain language if one is
+  # actually stuck. This is the deliberate difference from quota, which DOES
+  # escalate on persistence below.
+  [[ "$class" == "no-output" ]] && { printf 'false'; return; }
   # Persistence wins over every mute: this is the hard wall the mute exists to
   # not hide.
   [[ "$persisted" == "true" ]] && { printf 'true'; return; }

--- a/tests/supervisor_escalate_delivery_unit.sh
+++ b/tests/supervisor_escalate_delivery_unit.sh
@@ -437,8 +437,8 @@ t "notify_human: live-deadline quota wall is the one mute" \
   "false" "$(_sup_capacity_notify_human quota-exhausted live)"
 t "notify_human: unknown-deadline (possible hard wall) keeps the human" \
   "true" "$(_sup_capacity_notify_human quota-exhausted unknown)"
-t "notify_human: a non-quota class is never muted by a live deadline" \
-  "true" "$(_sup_capacity_notify_human no-output live)"
+t "notify_human: no-output is muted regardless of deadline (DIVE-3982)" \
+  "false" "$(_sup_capacity_notify_human no-output live)"
 t "notify_human: quota-exhausted with no deadline defaults to loud" \
   "true" "$(_sup_capacity_notify_human quota-exhausted "")"
 
@@ -478,8 +478,10 @@ t "3940 tick: an unknown-deadline wall keeps the human leg" \
   "ops:true" "$(fld "$(tick_arm "$_HARDWALL_SNAP")" HUMAN)"
 
 _NOOUT_SNAP='[{"name":"ops","type":"claude","classification":"no-output","cause":"no-output","detail":"3 open row(s), nothing closed in 5d"}]'
-t "3940 tick: a no-output stall is unaffected — human leg still fires" \
-  "ops:true" "$(fld "$(tick_arm "$_NOOUT_SNAP")" HUMAN)"
+t "3982 tick: a no-output stall MUTES the human leg" \
+  "ops:false" "$(fld "$(tick_arm "$_NOOUT_SNAP")" HUMAN)"
+t "3982 tick: a no-output stall still fires the machine leg (main triages every one)" \
+  "ops:no-output" "$(fld "$(tick_arm "$_NOOUT_SNAP")" ALERTS)"
 
 # ── DIVE-3970: the OTHER self-healing shapes, and the escape from the mute ───
 # Every string below is a real refusal, copied off supervisor_events
@@ -538,8 +540,12 @@ t "notify_human: persistence overrides the mute" \
   "true" "$(_sup_capacity_notify_human quota-exhausted unknown week true)"
 t "notify_human: persistence overrides the DIVE-3940 live-deadline mute too" \
   "true" "$(_sup_capacity_notify_human quota-exhausted live no true)"
-t "notify_human: a non-quota class is never muted by a self-healing kind" \
-  "true" "$(_sup_capacity_notify_human no-output unknown week)"
+t "notify_human: no-output is muted even with a self-healing kind (DIVE-3982)" \
+  "false" "$(_sup_capacity_notify_human no-output unknown week)"
+# The deliberate difference from quota: persistence escalates a quota wall (asserted
+# above) but NEVER un-mutes no-output — its long duration is the benign idle case.
+t "notify_human: persistence does NOT un-mute no-output (DIVE-3982)" \
+  "false" "$(_sup_capacity_notify_human no-output unknown no true)"
 
 # The horizons. Relative to the FIRST alert for the shapes that name no clock;
 # the clock itself when one was named.


### PR DESCRIPTION
## What

Extends DIVE-3970's human-leg mute to the **second** FLEET-HEALTH class, `no-output`
("N open row(s), nothing closed in Nd"). DIVE-3970 muted only `quota-exhausted`;
`no-output` still DMs lodar with a byte-identical human-facing template, and today's
(dev3, "9d") was a false positive — a healthy idle on-demand seat with an empty queue
(it woke and worked DIVE-3978 the moment work arrived).

## Fix

One clause added to `_sup_capacity_notify_human` (`src/cmd_supervisor.sh`): `no-output`
mutes the human leg **unconditionally**, ahead of the persistence escape.

- **Why unconditional (unlike quota):** `no-output` is not human-actionable — its remedy
  ("reassign or park") is main/ops triage, not lodar's — and its long duration is the
  benign idle case, not an incident the way a quota wall past its reset is. Persistence
  does **not** un-mute it (the deliberate difference from quota, which still escalates).
- **Machine leg unchanged:** `_sup_capacity_alert` stays unconditional, so main still
  triages every one and the DIVE-3272 cover is intact; if a seat is genuinely stuck,
  main escalates to lodar in plain language — exactly what was promised 2026-09-04.

## Tests (`tests/supervisor_escalate_delivery_unit.sh`)

Three existing assertions encoded the old no-output-pings-human behaviour (pure decision,
end-to-end tick, self-healing-kind case) — updated to muted. Added: no-output stays muted
even when `persisted=true`, and the machine leg still fires. Mutation-verified: removing
the guard line reds all four arms. Full harness green (PASS=127 FAIL=0).

## Release / residual

`5dive-cli` ships on release-cut, not on merge. This rides the **same next cut** as
DIVE-3970 (both merged to main, fleet on 0.25.10 predates both) so both classes quiet
lodar's phone together. Until that cut rolls both can still DM; dedup is
per-class-per-window and dev3 is now transacting, so imminent repeats are unlikely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
