### PR TITLE
feat(plugin): dispatch a plugin's declared verb — contract §2's live half (DIVE-4035)

### DIFF
--- a/changelog.d/DIVE-4035.md
+++ b/changelog.d/DIVE-4035.md
@@ -1,0 +1,42 @@
+## Unreleased — feat(plugin): a declared plugin verb is now dispatched (DIVE-4035)
+
+Contract v1 §2 let a plugin declare a `verb` capability and the enforcer validated the declaration
+— but nothing dispatched it. `plugins/voice` named the verb `voice`, `5dive plugin add voice@5dive`
+succeeded, no warning was printed, and `5dive voice` was still **unknown command**. One clause
+checked and not honoured, in the direction a publisher cannot see: §2's stated half ("an undeclared
+surface is inert") was enforced, its unstated half ("a DECLARED surface is live") was false.
+
+**What a plugin verb is invoked as** — the design call, now fixed and written into the contract. A
+verb resolves to an **executable file at a path 5dive computes**: `<plugin>/bin/<verb>`, `exec`'d
+with the caller's argv as an argument **vector**. The manifest supplies the NAME and nothing else.
+No command line, interpreter or entry-point path out of `plugin.json` ever reaches a shell — that is
+the arbitrary-code-execution door contract §5 keeps shut, and which DIVE-4020 already refused once
+for `fivedive.setup` (printed, never executed). Verb dispatch does not reopen it from the other
+side. Running the file at all is a different thing from that door: it happens because the **user
+typed the verb**, after a consent screen, at a path we chose — not because the publisher said so.
+
+**Collisions cannot shadow, and are refused anyway.** Dispatch hangs off `main()`'s `*)` branch, the
+last thing before "unknown command", so all 47 builtin verbs have already matched by the time a
+plugin is consulted — a plugin structurally cannot take `5dive task` from you. But a verb that
+installs and can never run is the same silent inertness this row removes, so a manifest declaring a
+builtin's name is **refused at install**, naming it; so is a second plugin claiming a verb another
+already holds, naming the incumbent. `verbs` declared without the `verb` capability still installs
+(that is honestly inert under §2) and now **says so out loud**. The converse — the capability with
+no verbs named — is refused as incoherent.
+
+**Fixed on the way, and it was the real box defect:** `installed.json` was mode 0600. Every writer
+built the document in a `mktemp` (always 0600) and moved it into place, which was invisible for the
+whole of DIVE-4020 because every `5dive plugin` subverb is root-gated and the only readers were
+root. Verb dispatch is the registry's first **unprivileged** reader — so on a real install `plugin
+add` announced a live verb and `5dive voice` answered "unknown command". The store is now 0644/0755,
+which is the mode that matches what it holds (names, versions, publishers, declared grants; never a
+secret).
+
+**Cost:** the registry read happens only on the unknown-command path — a command that was about to
+die anyway. A successful `5dive task ls` never opens `installed.json` and never shells `jq`, so the
+parse tax every heartbeat tick already pays is unchanged.
+
+`plugins/voice` now declares `verb` and ships `bin/voice`: it reports whether the host-level voice
+engine is installed and warm, and names the one command that installs it. It deliberately does not
+hold a conversation — the speak/listen loop is the voice runtime's job, and a stub wearing that
+name would be worse than the missing verb.

--- a/install.sh
+++ b/install.sh
@@ -938,11 +938,21 @@ JOURNALD
   #
   # Enumerated per file for the same reason team-templates is: $REPO is a flat
   # fetch URL with no directory listing. Add a line per new bundled plugin file.
-  mkdir -p "$LIB_DIR/plugins/.claude-plugin" "$LIB_DIR/plugins/voice/.claude-plugin"
+  #
+  # DIVE-4035 — MODE IS PART OF THE STAGE, not a detail. A plugin verb resolves
+  # to <plugin>/bin/<verb> and 5dive refuses to dispatch a file that is not
+  # executable, so a blanket `chmod 644` here would stage a voice that installs
+  # and then cannot run — the exact silent-inertness DIVE-4035 removed,
+  # reintroduced by the installer. Anything under a plugin's bin/ is staged 755.
+  mkdir -p "$LIB_DIR/plugins/.claude-plugin" "$LIB_DIR/plugins/voice/.claude-plugin" \
+           "$LIB_DIR/plugins/voice/bin"
   _plug_ok=1
-  for _pf in .claude-plugin/marketplace.json voice/.claude-plugin/plugin.json voice/README.md; do
+  for _pf in .claude-plugin/marketplace.json voice/.claude-plugin/plugin.json voice/README.md voice/bin/voice; do
     if curl -fsSL "$REPO/plugins/$_pf" -o "$LIB_DIR/plugins/$_pf"; then
-      chmod 644 "$LIB_DIR/plugins/$_pf"
+      case "$_pf" in
+        */bin/*) chmod 755 "$LIB_DIR/plugins/$_pf" ;;
+        *)       chmod 644 "$LIB_DIR/plugins/$_pf" ;;
+      esac
     else
       _plug_ok=0
       echo "warn: failed to stage bundled plugin file $_pf — '5dive plugin add voice' won't resolve until the next refresh" >&2

--- a/plugins/voice/.claude-plugin/plugin.json
+++ b/plugins/voice/.claude-plugin/plugin.json
@@ -17,7 +17,8 @@
   "fivedive": {
     "contract": "1",
     "capabilities": [
-      "channel"
+      "channel",
+      "verb"
     ],
     "verbs": [
       {

--- a/plugins/voice/README.md
+++ b/plugins/voice/README.md
@@ -7,7 +7,8 @@ every other plugin:
 5dive market --kind=plugin        # see what exists
 5dive plugin add voice            # read who published it and what it is handed, then agree
 sudo 5dive-setup-voice            # the host-level engine — you run this, not us (see below)
-5dive plugin list                 # voice 1.0.0  official  channel
+5dive plugin list                 # voice 1.0.0  official  channel,verb
+5dive voice                       # the verb the plugin registers
 ```
 
 ## What the voice runtime actually is
@@ -57,11 +58,20 @@ written — it is here because "installed — now what?" is the same dead end th
 }
 ```
 
-- **`capabilities: ["channel"]`** is the whole point. Contract §2: *an undeclared
-  surface is inert.* The installer registers what this array names and nothing
-  else. If voice later ships an MCP server without adding `"mcp"` here, that
-  server is not registered — and `plugin add` says so out loud rather than
-  dropping it silently.
+- **`capabilities: ["channel", "verb"]`** is the whole point. Contract §2: *an
+  undeclared surface is inert.* The installer registers what this array names and
+  nothing else. If voice later ships an MCP server without adding `"mcp"` here,
+  that server is not registered — and `plugin add` says so out loud rather than
+  dropping it silently. `verb` arrived in DIVE-4035; before it, this manifest
+  named a verb without declaring the capability, so `5dive voice` did not exist
+  — correct under §2, and silent about it, which is the half the amendment fixed.
+- **`bin/voice`** is where the verb resolves, and 5dive picked that path, not the
+  manifest. The manifest names `voice`; it never says what to run. A command line
+  out of `plugin.json` would be arbitrary code chosen by the publisher — the same
+  door `setup` is printed rather than executed to keep shut. `5dive voice` runs
+  `bin/voice` with your argv as a vector, and it can only ever be reached after
+  every builtin 5dive command has already had its chance, so a plugin cannot take
+  `5dive task` from you.
 - **`grants`** is the consent list, not documentation. `plugin add` prints it
   back in plain English ("your microphone and speakers") and will not install
   until you agree. A plugin that asks for nothing gets nothing beyond its own

--- a/plugins/voice/bin/voice
+++ b/plugins/voice/bin/voice
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# `5dive voice` — the reference implementation of a plugin VERB (DIVE-4035).
+#
+# 5dive found this file by convention: the manifest declares the `verb`
+# capability and the name `voice`, and the dispatcher looks at
+# <installed-plugin-dir>/bin/voice. The manifest never said what to run. That is
+# the point — a command line out of plugin.json would be arbitrary code chosen by
+# the publisher, which contract §5 keeps shut.
+#
+# WHAT IT DOES, AND WHAT IT DELIBERATELY DOES NOT. It reports whether the
+# host-level voice engine this plugin needs is actually present, and names the
+# one command that installs it. It does NOT hold a conversation: the interactive
+# speak/listen loop is the voice runtime's job, not the verb's, and pretending
+# otherwise here would be a stub wearing a feature's name.
+set -uo pipefail
+
+VOICE_SERVICE_PORT="${VOICE_SERVICE_PORT:-8765}"
+SETUP_CMD="sudo 5dive-setup-voice"
+
+usage() {
+  cat <<'USAGE'
+5dive voice — speech-to-text and text-to-speech on your own box
+
+  5dive voice              # is the voice engine installed and warm?
+  5dive voice --help
+
+  Speech never leaves the box: transcription runs locally against a warm
+  whisper service. Install the engine with:  sudo 5dive-setup-voice
+USAGE
+}
+
+case "${1:-}" in
+  -h|--help|help) usage; exit 0 ;;
+  "") ;;
+  *) printf 'unknown: 5dive voice %s (see: 5dive voice --help)\n' "$1" >&2; exit 64 ;;
+esac
+
+missing=0
+report() {  # report <label> <ok?> <detail>
+  if [[ "$2" == yes ]]; then printf '  %-22s %s\n' "$1" "$3"
+  else printf '  %-22s MISSING (%s)\n' "$1" "$3"; missing=1; fi
+}
+
+printf 'voice — plugin %s\n' "${FIVEDIVE_PLUGIN_KEY:-voice}"
+
+if command -v ffmpeg >/dev/null 2>&1; then report ffmpeg yes "$(command -v ffmpeg)"
+else report ffmpeg no "audio conversion"; fi
+
+if command -v 5dive-transcribe >/dev/null 2>&1; then report 5dive-transcribe yes "$(command -v 5dive-transcribe)"
+else report 5dive-transcribe no "the wrapper an agent pre-allows"; fi
+
+# A listening socket is the only honest test of "warm": the unit can be enabled
+# and the model still not loaded, and a `systemctl is-active` would call that up.
+if (exec 3<>"/dev/tcp/127.0.0.1/$VOICE_SERVICE_PORT") 2>/dev/null; then
+  report "whisper-service" yes "listening on :$VOICE_SERVICE_PORT"
+else
+  report "whisper-service" no "nothing listening on :$VOICE_SERVICE_PORT"
+fi
+
+if (( missing )); then
+  printf '\nThe engine is not fully installed. 5dive does not install it behind your back:\n  %s\n' "$SETUP_CMD"
+  exit 1
+fi
+printf '\nReady. Send your agent a voice message and it will hear you.\n'

--- a/src/cmd_plugin.sh
+++ b/src/cmd_plugin.sh
@@ -51,6 +51,27 @@ _plugin_cache_dir() { echo "$(_plugin_root)/cache"; }
 _plugin_enabled_dir() { echo "$(_plugin_root)/enabled"; }
 _plugin_installed_json() { echo "$(_plugin_root)/installed.json"; }
 
+# _plugin_publish_json <tmp> <dest> — the ONLY way these two files are replaced.
+#
+# DIVE-4035, and it is a real box defect rather than tidiness. Every writer here
+# builds the new document in a `mktemp` and moves it into place, and mktemp
+# creates 0600 — so `installed.json` ended up ROOT-ONLY on a real install. That
+# was invisible for the whole of DIVE-4020 because every `5dive plugin` subverb
+# is root-gated, so the only readers were root. Verb dispatch is the first
+# UNPRIVILEGED reader of this registry: a normal user typing `5dive voice` could
+# not read it, `_plugin_verb_claims` came back empty, and the verb fell through
+# to "unknown command" — install said the verb was live and the box disagreed,
+# which is precisely the failure this row exists to remove, one layer down.
+#
+# The registry holds names, versions, publishers and declared grants. No secret
+# has ever been written here and none may be; 0644 is the mode that matches what
+# it is, and the directories above it are 0755 for the same reason.
+_plugin_publish_json() {
+  local tmp="$1" dest="$2"
+  mv "$tmp" "$dest" || return 1
+  chmod 644 "$dest"
+}
+
 # The capability and grant enums are contract §1. They are declared here as the
 # single source of truth because THREE places need them to agree: validation
 # (refuse an unknown value), the consent screen (render a grant in English), and
@@ -95,6 +116,13 @@ _plugin_usage() {
 
   Discovery lives in `5dive market --kind=plugin`, not here — one front door for
   "what can I add?" whether the answer is a plugin, a persona or a skill.
+
+  A plugin that declares the `verb` capability adds a top-level command. It is
+  reached only AFTER every builtin one, so a plugin can never take `5dive task`
+  from you — a manifest naming a builtin, or a verb a second plugin already
+  claims, is refused at install rather than installed dead. 5dive runs
+  <plugin>/bin/<verb> and nothing else: the manifest names the verb, it never
+  supplies a command line.
 
   Installing a plugin is installing CODE that runs with your agent's access.
   `add` prints who published it and exactly what it will be handed, and waits
@@ -196,6 +224,31 @@ _plugin_validate_manifest() {
     # not declare does not get it registered — but silently dropping it is how a
     # publisher discovers the rule in a bug report, so name it at install time.
     local caps; caps=$(jq -r '(.capabilities // []) | join(" ")' <<<"$fd")
+
+    # DIVE-4035 — the `verb` capability, both directions.
+    #
+    # DECLARED-BUT-NOT-DISPATCHED is the shape this whole row exists to kill, so
+    # it is said out loud here rather than left for the publisher to discover as
+    # a bug report. It is a warning and not a refusal on purpose: `verbs` without
+    # the capability is a manifest that is honestly inert under §2, and refusing
+    # it would make §2's own rule uninstallable.
+    #
+    # The converse IS a refusal, because it is not inert — it is incoherent. A
+    # manifest claiming the `verb` capability while naming no verbs asks for a
+    # surface and then declines to say what goes on it, and every later step
+    # (collision check, entry-point check, dispatch) has nothing to read.
+    local vnames; vnames=$(jq -r '(.verbs // []) | map(.name? // empty) | join(" ")' <<<"$fd")
+    if [[ " $caps " == *" verb "* ]]; then
+      [[ -n "$vnames" ]] \
+        || fail "$E_VALIDATION" "$name declares the 'verb' capability but names no verbs — add fivedive.verbs: [{\"name\": \"...\"}] (contract §2)"
+      local vn
+      for vn in $vnames; do
+        _plugin_verb_name_ok "$vn" \
+          || fail "$E_VALIDATION" "verb name '$vn' must be lowercase kebab-case — it becomes a top-level '5dive' command (contract §2)"
+      done
+    elif [[ -n "$vnames" ]]; then
+      warn "$name names verbs ($vnames) but does not declare the 'verb' capability — they will NOT be dispatched, and '5dive $(cut -d' ' -f1 <<<"$vnames")' stays an unknown command (contract §2: an undeclared surface is inert)"
+    fi
     [[ -f "$dir/.mcp.json" && " $caps " != *" mcp "* ]] \
       && warn "$name ships .mcp.json but does not declare the 'mcp' capability — it will NOT be registered (contract §2: an undeclared surface is inert)"
     [[ -d "$dir/skills" && " $caps " != *" skill "* ]] \
@@ -337,7 +390,7 @@ _plugin_register_bundled() {
   local tmp; tmp=$(mktemp)
   jq --arg s "$src" --arg t "$(date -u +%FT%TZ)" \
      '.["5dive"] = {source:$s, kind:"local", ref:"", added_at:$t, bundled:true}' \
-     "$(_plugin_mkt_json)" > "$tmp" && mv "$tmp" "$(_plugin_mkt_json)"
+     "$(_plugin_mkt_json)" > "$tmp" && _plugin_publish_json "$tmp" "$(_plugin_mkt_json)"
   # Explicit, because this function's last command is a CONDITIONAL and would
   # otherwise supply its exit status: every caller is `_plugin_ensure_store`,
   # which runs under errexit, so a failed jq here would take the whole verb down
@@ -350,8 +403,12 @@ _plugin_register_bundled() {
 _plugin_ensure_store() {
   require_root
   mkdir -p "$(_plugin_mkt_dir)" "$(_plugin_cache_dir)" "$(_plugin_enabled_dir)"
+  # DIVE-4035: the store is written by root and READ by whoever types a plugin
+  # verb, so its traversal has to survive a tight umask on the installing shell.
+  chmod 755 "$(_plugin_root)" "$(_plugin_mkt_dir)" "$(_plugin_cache_dir)" "$(_plugin_enabled_dir)" 2>/dev/null || true
   [[ -f "$(_plugin_mkt_json)" ]]       || echo '{}' > "$(_plugin_mkt_json)"
   [[ -f "$(_plugin_installed_json)" ]] || echo '{}' > "$(_plugin_installed_json)"
+  chmod 644 "$(_plugin_mkt_json)" "$(_plugin_installed_json)" 2>/dev/null || true
   _plugin_register_bundled
 }
 
@@ -430,7 +487,7 @@ _plugin_mkt_add() {
   local tmp; tmp=$(mktemp)
   jq --arg n "$name" --arg s "$src" --arg k "$kind" --arg r "$ref" --arg t "$(date -u +%FT%TZ)" \
      '.[$n] = {source:$s, kind:$k, ref:$r, added_at:$t}' "$(_plugin_mkt_json)" > "$tmp" \
-     && mv "$tmp" "$(_plugin_mkt_json)"
+     && _plugin_publish_json "$tmp" "$(_plugin_mkt_json)"
 
   local n; n=$(_plugin_mkt_plugins "$name" | jq 'length' 2>/dev/null || echo 0)
   ok "marketplace '$name' added ($kind) — $n plugin(s) available" \
@@ -544,7 +601,7 @@ _plugin_mkt_remove() {
 
   rm -rf "$(_plugin_mkt_dir)/$name"
   local tmp; tmp=$(mktemp)
-  jq --arg n "$name" 'del(.[$n])' "$(_plugin_mkt_json)" > "$tmp" && mv "$tmp" "$(_plugin_mkt_json)"
+  jq --arg n "$name" 'del(.[$n])' "$(_plugin_mkt_json)" > "$tmp" && _plugin_publish_json "$tmp" "$(_plugin_mkt_json)"
   ok "marketplace '$name' removed" '{marketplace:$n}' --arg n "$name"
 }
 
@@ -647,6 +704,15 @@ cmd_plugin_add() {
   _plugin_trust_gate "$plugin" "$review"
 
   local key="${plugin}@${mkt}"
+
+  # DIVE-4035, and it runs BEFORE the consent screen and before anything is
+  # copied. A verb that cannot be dispatched — because it collides with a
+  # builtin, because another plugin holds it, or because the plugin ships no
+  # executable for it — must not reach the point where the user has agreed to
+  # install it. Refusing here costs the publisher one message; refusing later
+  # would leave a half-installed plugin whose verb silently does not exist,
+  # which is the state this row was filed to remove.
+  _plugin_verb_install_check "$srcdir" "$plugin" "$key" "$caps" "$j"
   local dest; dest="$(_plugin_cache_dir)/$mkt/$plugin/$version"
 
   # §4, and this is the trap the atom
@@ -689,11 +755,22 @@ cmd_plugin_add() {
      '.[$k] = {plugin:$p, marketplace:$m, version:$v, enabled:true, review:$r,
                publisher:$pub, capabilities:$caps, grants:$grants, verbs:$verbs,
                installed_at:$t}' \
-     "$(_plugin_installed_json)" > "$tmp" && mv "$tmp" "$(_plugin_installed_json)"
+     "$(_plugin_installed_json)" > "$tmp" && _plugin_publish_json "$tmp" "$(_plugin_installed_json)"
 
   if [[ -z "$caps" ]]; then
     echo "  Note: $plugin declares no 5dive capabilities, so it registers no surfaces." >&2
     echo "  It is installed and inert (contract §2)." >&2
+  fi
+
+  # §2's live half, stated. The publisher's next question after "installed" is
+  # "so what do I type", and the answer is now a fact about this box rather than
+  # documentation.
+  if [[ " $caps " == *" verb "* ]]; then
+    local _v
+    while IFS= read -r _v; do
+      [[ -z "$_v" ]] && continue
+      echo "  '5dive $_v' now runs this plugin ($PLUGIN_VERB_BINDIR/$_v)." >&2
+    done < <(_plugin_verbs_of_manifest "$j")
   fi
 
   # `fivedive.setup` — a PROPOSED addendum to contract §6, and the whole of its
@@ -763,7 +840,7 @@ cmd_plugin_remove() {
   rm -f  "$(_plugin_enabled_dir)/$key"
   rm -rf "$(_plugin_cache_dir)/$mkt/$plugin"
   local tmp; tmp=$(mktemp)
-  jq --arg k "$key" 'del(.[$k])' <<<"$j" > "$tmp" && mv "$tmp" "$(_plugin_installed_json)"
+  jq --arg k "$key" 'del(.[$k])' <<<"$j" > "$tmp" && _plugin_publish_json "$tmp" "$(_plugin_installed_json)"
   ok "$key removed — every version, its pointer and its grants are gone" '{plugin:$k}' --arg k "$key"
 }
 
@@ -815,7 +892,7 @@ cmd_plugin_upgrade() {
      --argjson caps "$(jq -c '(.fivedive.capabilities // [])' <<<"$nj")" \
      --argjson grants "$(jq -c '(.fivedive.grants // [])' <<<"$nj")" \
      '.[$k].version = $v | .[$k].capabilities = $caps | .[$k].grants = $grants | .[$k].upgraded_at = $t' \
-     <<<"$j" > "$tmp" && mv "$tmp" "$(_plugin_installed_json)"
+     <<<"$j" > "$tmp" && _plugin_publish_json "$tmp" "$(_plugin_installed_json)"
 
   ok "$key upgraded $cur -> $new (roll back: 5dive plugin rollback $key)" \
      '{plugin:$k, from:$f, to:$t, changed:true}' --arg k "$key" --arg f "$cur" --arg t "$new"
@@ -865,7 +942,7 @@ _plugin_set_enabled() {
 
   local tmp; tmp=$(mktemp)
   jq --arg k "$key" --argjson e "$want" '.[$k].enabled = $e' <<<"$j" > "$tmp" \
-    && mv "$tmp" "$(_plugin_installed_json)"
+    && _plugin_publish_json "$tmp" "$(_plugin_installed_json)"
   if [[ "$want" == true ]]; then
     ok "$key enabled ($version)" '{plugin:$k, enabled:true, changed:true}' --arg k "$key"
   else
@@ -916,8 +993,182 @@ cmd_plugin_rollback() {
     ln -sfn "$base/$want" "$(_plugin_enabled_dir)/$key"
   fi
   local tmp; tmp=$(mktemp)
-  jq --arg k "$key" --arg v "$want" '.[$k].version = $v' <<<"$j" > "$tmp" && mv "$tmp" "$(_plugin_installed_json)"
+  jq --arg k "$key" --arg v "$want" '.[$k].version = $v' <<<"$j" > "$tmp" && _plugin_publish_json "$tmp" "$(_plugin_installed_json)"
   ok "$key rolled back $cur -> $want" '{plugin:$k, from:$f, to:$t}' --arg k "$key" --arg f "$cur" --arg t "$want"
+}
+
+# ---- contract §2, the other half: a DECLARED verb is LIVE (DIVE-4035) -------
+#
+# DIVE-4020 shipped one half of §2 and quinn signed the other half as a residual.
+# The enforcer got "an undeclared surface is inert" right; the unstated converse,
+# "a DECLARED surface is live", was false. A manifest could name a verb, install
+# cleanly, print no warning — and `5dive <verb>` was still "unknown command".
+# One clause checked and not honoured, in the more surprising direction: the
+# publisher gets no signal at all.
+#
+# ---- THE DESIGN CALL: WHAT A VERB IS INVOKED AS ----------------------------
+#
+# A verb resolves to an EXECUTABLE FILE AT A PATH 5DIVE COMPUTES, exec'd with the
+# caller's argv as an argument VECTOR. The manifest supplies one thing: the NAME.
+# It never supplies a command line, an interpreter, an entry-point path or any
+# other string that reaches a shell.
+#
+# That is the whole of it, and the alternative is the reason it is written down.
+# The obvious shape — `"verbs": [{"name": "voice", "command": "..."}]` and a
+# `$command "$@"` in the dispatcher — is arbitrary code execution chosen by the
+# publisher, which is the door contract §5 keeps shut and which DIVE-4020 already
+# refused once for `fivedive.setup` (printed, never executed). Verb dispatch must
+# not reopen it from the other side. With the path fixed by us, a plugin can only
+# ship a file where we look; `exec "$entry" "$@"` passes a vector, so no argument
+# is ever word-split or glob-expanded, and nothing from plugin.json is evaluated.
+#
+# WHY RUNNING THE FILE AT ALL IS NOT THE SAME DOOR. `plugin add` already copies
+# the publisher's whole directory onto the box after a consent screen that names
+# the publisher and the grants. What §5 keeps shut is code that runs because the
+# publisher said so — at install, before the user has seen what they installed. A
+# verb runs because the USER TYPED IT. That is the distinction, and it is the
+# only one doing work here: user-initiated, after consent, at a path we chose.
+#
+# ---- COLLISIONS: STRUCTURALLY IMPOSSIBLE, THEN REFUSED ANYWAY --------------
+#
+# Dispatch hangs off main()'s `*)` branch — the last thing before "unknown
+# command". A plugin therefore CANNOT shadow a builtin: by the time we are
+# consulted the 47 builtin verbs have already matched. That is the strong form of
+# the guarantee (a bug in the list below cannot cost a user their `5dive task`),
+# and it is why the list is a refusal aid rather than a security boundary.
+#
+# But "cannot shadow" would leave a publisher with a verb that installs and never
+# runs — the exact silent-inertness this row exists to remove. So a colliding
+# verb is REFUSED AT INSTALL, naming the builtin. Same for a second plugin
+# claiming a verb the first already holds: refused, naming the incumbent, because
+# picking a winner is a decision the box should not make on the user's behalf.
+#
+# ---- COST -----------------------------------------------------------------
+#
+# ~73% of every 5dive invocation is already bash parsing one 91k-line bundle, and
+# that is paid by every heartbeat tick fleet-wide. So the registry read happens
+# ONLY on the unknown-command path — a command that was about to die anyway. A
+# successful `5dive task ls` never reaches _plugin_dispatch_verb, never opens
+# installed.json and never shells jq.
+
+# Where a plugin's verb entry points live inside its own directory. A constant
+# rather than an inline literal because three places must agree: the install-time
+# check (source dir), the dispatcher (installed dir) and the error text that
+# tells a publisher where to put the file.
+readonly PLUGIN_VERB_BINDIR="bin"
+
+# Every label main()'s dispatch table already answers to. Kept as data because it
+# is read at install time, when the dispatcher itself is not a thing we can ask.
+# It is NOT hand-maintained on trust: tests/plugin_verb_dispatch_unit.sh
+# re-extracts the case labels from src/main.sh and asserts set equality, so a new
+# builtin verb that forgets this line reds the suite rather than silently
+# becoming claimable by a plugin.
+readonly FIVEDIVE_BUILTIN_VERBS="a2a account acp activity agent _audit_append bug buzz company constitution cost council crew deploy _deploy_do digest doctor down export fire fleet gate-proof gh _gh_do goal -h heartbeat --help help hire host human humans init liveness loop market memory _merge_do models objective objectives org paperclip-seed plugin project projects proof ps push _push_do run runs secret selfcheck self-update self_update supervisor task _task_answer team trace trigger triggers ui uninstall up update usage -v --version version watch whoami"
+
+_plugin_verb_name_ok()   { [[ "$1" =~ ^[a-z0-9][a-z0-9-]{0,63}$ ]]; }
+_plugin_verb_is_builtin(){ [[ " $FIVEDIVE_BUILTIN_VERBS " == *" $1 "* ]]; }
+
+# _plugin_verb_claims <verb> [<key-to-ignore>]
+# Prints the installed.json key of every ENABLED plugin that declared the `verb`
+# capability AND names <verb>. Empty output means unclaimed.
+#
+# Both halves of the select are §2: the capability is the declaration, the verbs
+# array is the content, and a plugin that ships one without the other registers
+# nothing. Reading the RECORD and never the directory is DIVE-4020's rule — a
+# file dropped into bin/ after install cannot mint a verb the manifest never
+# named.
+_plugin_verb_claims() {
+  local verb="$1" skip="${2:-}" f
+  f=$(_plugin_installed_json)
+  [[ -r "$f" ]] || return 0
+  jq -r --arg v "$verb" --arg skip "$skip" '
+    to_entries[]
+    | select(.key != $skip)
+    | select(.value.enabled == true)
+    | select((.value.capabilities // []) | index("verb"))
+    | select((.value.verbs // []) | map(.name? // empty) | index($v))
+    | .key' "$f" 2>/dev/null || true
+}
+
+# _plugin_verb_entry_in <dir> <verb> — echoes the entry path, rc 1 if unusable.
+# One function for both callers so the convention cannot drift between the check
+# that gates the install and the lookup that runs the verb.
+_plugin_verb_entry_in() {
+  local dir="$1" verb="$2" entry="$1/$PLUGIN_VERB_BINDIR/$2"
+  [[ -d "$dir" ]] || return 1
+  [[ -f "$entry" && -x "$entry" ]] || return 1
+  printf '%s\n' "$entry"
+}
+
+# _plugin_verbs_of_manifest <manifest-json> — one verb name per line.
+_plugin_verbs_of_manifest() {
+  jq -r '(.fivedive.verbs // []) | map(.name? // empty)[]' <<<"$1" 2>/dev/null || true
+}
+
+# _plugin_verb_install_check <srcdir> <plugin> <key> <caps> <manifest-json>
+# Every refusal a declared verb can earn, run BEFORE anything is copied. Called
+# from cmd_plugin_add; separate so the suite can drive it without an install.
+_plugin_verb_install_check() {
+  local srcdir="$1" plugin="$2" key="$3" caps="$4" j="$5" v other
+  [[ " $caps " == *" verb "* ]] || return 0
+  while IFS= read -r v; do
+    [[ -z "$v" ]] && continue
+    _plugin_verb_is_builtin "$v" \
+      && fail "$E_VALIDATION" "$plugin declares the verb '$v', which is already a 5dive command — a plugin verb is only ever reached AFTER the builtin table, so this one could never run. Rename it in plugin.json (contract §2)."
+    other=$(_plugin_verb_claims "$v" "$key")
+    [[ -n "$other" ]] \
+      && fail "$E_VALIDATION" "$plugin declares the verb '$v', which is already claimed by $(tr '\n' ' ' <<<"$other" | sed 's/ $//') — 5dive will not pick between them. Remove or disable that plugin first, or rename this verb (contract §2)."
+    _plugin_verb_entry_in "$srcdir" "$v" >/dev/null \
+      || fail "$E_VALIDATION" "$plugin declares the verb '$v' but ships no executable at $PLUGIN_VERB_BINDIR/$v — that is the only place 5dive looks, and a verb it cannot run must not install as if it could. Add the file and chmod +x it (contract §2)."
+  done < <(_plugin_verbs_of_manifest "$j")
+  return 0
+}
+
+# _plugin_dispatch_verb <verb> [args...]
+# EXECS on success and therefore does not return. Returns 1 — quietly, with
+# nothing printed — only when no installed, enabled plugin claims <verb>, which
+# is the caller's signal to carry on to "unknown command".
+#
+# Quiet is the contract with main(): every other outcome here is a plugin problem
+# worth a sentence, but "no plugin claims it" is the overwhelmingly common case
+# (a typo) and must read exactly as it did before this row existed.
+_plugin_dispatch_verb() {
+  local verb="${1:-}"; [[ $# -gt 0 ]] && shift
+  _plugin_verb_name_ok "$verb" || return 1
+  # Belt to the structural brace: main() has already matched every builtin before
+  # we are called, so this can only fire on a hand-edited installed.json. It
+  # still refuses, because "a plugin cannot shadow a builtin" should not depend
+  # on the reader knowing where the call site sits.
+  _plugin_verb_is_builtin "$verb" && return 1
+  command -v jq >/dev/null 2>&1 || return 1
+
+  local claims; claims=$(_plugin_verb_claims "$verb")
+  [[ -n "$claims" ]] || return 1
+
+  if [[ "$(wc -l <<<"$claims")" -gt 1 ]]; then
+    fail "$E_VALIDATION" "verb '$verb' is claimed by more than one enabled plugin ($(tr '\n' ' ' <<<"$claims" | sed 's/ $//')) — 5dive will not pick between them. Disable all but one: 5dive plugin disable <plugin>"
+  fi
+
+  local key="$claims" dir entry
+  dir="$(_plugin_enabled_dir)/$key"
+  entry=$(_plugin_verb_entry_in "$dir" "$verb") \
+    || fail "$E_NOT_FOUND" "$key declares the verb '$verb' but $dir/$PLUGIN_VERB_BINDIR/$verb is missing or not executable. Reinstall it: 5dive plugin upgrade $key"
+
+  # The child gets its own location and identity and nothing else invented for
+  # it. STATE_DIR and the rest of the environment pass through untouched, which
+  # is what lets the suite run a real dispatch against a throwaway tree.
+  export FIVEDIVE_PLUGIN_DIR="$dir"
+  export FIVEDIVE_PLUGIN_KEY="$key"
+  export FIVEDIVE_VERB="$verb"
+
+  # DIVE-2797: `exec` replaces the process, so the dispatcher's EXIT trap never
+  # fires and AUDIT_CMD would be lost. Same fix cmd_acp uses — write the row
+  # here, before the exec, rather than pretending the trap will.
+  if declare -F audit_log >/dev/null 2>&1 && [[ -n "${AUDIT_LOG:-}" ]]; then
+    audit_log "plugin-verb" "start" 0 -- "verb=$verb" "plugin=$key" || true
+  fi
+
+  exec "$entry" "$@"
 }
 
 cmd_plugin() {

--- a/src/main.sh
+++ b/src/main.sh
@@ -1288,7 +1288,27 @@ main() {
       # trap can fire (DIVE-2797), so the row is written inside cmd_acp instead.
       cmd_acp "$@" ;;
     -h|--help|help) usage ;;
-    *) fail "$E_USAGE" "unknown command: $top" ;;
+    *)
+      # DIVE-4035 — contract §2's live half, and the ONLY place a plugin verb is
+      # reachable. Sitting last is the whole guarantee: every builtin above has
+      # already matched, so an installed plugin cannot shadow one no matter what
+      # its manifest says. It is also the cost argument — a registry read here is
+      # paid only by a command that was about to die anyway, never by the
+      # heartbeat's `task ls`.
+      #
+      # _plugin_dispatch_verb EXECS when a plugin claims $top, so control does
+      # not come back. It returns non-zero, silently, only when nothing claims
+      # it — and then this reads exactly as it did before the row.
+      # The `if !` is load-bearing under header.sh's errexit: a bare call
+      # returning 1 would exit the CLI right here with a silent 1 instead of
+      # reaching fail(), so the "no plugin claims it" path would print nothing at
+      # all. Attaching the condition also exempts the function's body from
+      # errexit — deliberate, because every refusal inside it goes through
+      # fail(), which exits on its own, and every other non-zero (no jq, no
+      # store, unreadable json) is meant to fall through to "unknown command".
+      if ! _plugin_dispatch_verb "$top" "$@"; then
+        fail "$E_USAGE" "unknown command: $top"
+      fi ;;
   esac
 }
 

--- a/tests/plugin_contract_unit.sh
+++ b/tests/plugin_contract_unit.sh
@@ -325,8 +325,15 @@ t "T7f ...and voice resolves from it" "yes" \
   "$(_plugin_source_dir 5dive voice >/dev/null 2>&1 && echo yes || echo no)"
 t "T7g ...as an official plugin, so it is the one thing that installs today" "official" \
   "$(jq -r '.fivedive.trust.review' "$(_plugin_source_dir 5dive voice)/.claude-plugin/plugin.json")"
-t "T7h ...declaring channel, the shape browser will copy" '["channel"]' \
+# DIVE-4035 added `verb` here. Kept as an EXACT set rather than an `index("channel")`
+# containment check on purpose: voice is the reference implementation, so the arm's
+# job is to notice when the reference shape changes at all, and a containment check
+# would have let `verb` in silently — which is the drift a reference implementation
+# is least able to afford.
+t "T7h ...declaring channel + verb, the shape browser will copy" '["channel","verb"]' \
   "$(jq -c '.fivedive.capabilities' "$(_plugin_source_dir 5dive voice)/.claude-plugin/plugin.json")"
+t "T7i ...and shipping the executable its verb resolves to (DIVE-4035)" "yes" \
+  "$([[ -x "$(_plugin_source_dir 5dive voice)/bin/voice" ]] && echo yes || echo no)"
 
 # =============================================================================
 # §7.2 — discovery folds into `market`; it does not become a fourth silo

--- a/tests/plugin_verb_dispatch_unit.sh
+++ b/tests/plugin_verb_dispatch_unit.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# DIVE-4035 — contract §2's live half: a DECLARED verb is dispatched.
+#
+# The row's grading mutant is "a plugin declares a verb that is NOT dispatched:
+# install must either make it work or say out loud that it did not". Every arm
+# below drives the real functions against a real store on a throwaway STATE_DIR;
+# none of them greps the source for a line, with ONE deliberate exception (T5,
+# the builtin-list guard) whose whole subject IS a source-derived list.
+#
+# THE DISPATCH ARMS RUN A REAL EXEC. _plugin_dispatch_verb ends in `exec`, which
+# replaces the process — so every arm that reaches it runs inside `run()`'s
+# subshell and reads what the child left behind, never a return value. T4b is the
+# positive control for that mechanism: if the sentinel scheme were broken, every
+# "did not execute" assertion below would pass for the wrong reason, which is
+# exactly the trap DIVE-4020's suite documents at its own `set +e`.
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+ROOT="$PWD"
+
+# shellcheck source=/dev/null
+source src/lib/error_codes.sh
+# shellcheck source=/dev/null
+source src/lib/output.sh
+# shellcheck source=/dev/null
+source src/header.sh
+# shellcheck source=/dev/null
+source src/cmd_plugin.sh
+
+# header.sh:14 is `set -euo pipefail`; sourcing it turns errexit on in THIS
+# shell, where the `( ... )` in run() would take the harness down with the first
+# refusal it is meant to grade. Same reason, same fix, as plugin_contract_unit.
+set +e -o pipefail
+
+require_root() { :; }
+
+TMP="$(mktemp -d)"
+export STATE_DIR="$TMP/state"
+SENTINEL="$TMP/EXECUTED"
+export SENTINEL
+
+PASS=0; FAIL=0
+t()  { if [[ "$2" == "$3" ]]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); printf 'FAIL: %s\n   expected: %s\n   got:      %s\n' "$1" "$2" "$3"; fi; }
+tc() { if [[ "$3" == *"$2"* ]]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); printf 'FAIL: %s\n   expected to contain: %s\n   got: %s\n' "$1" "$2" "$3"; fi; }
+tn() { if [[ "$3" != *"$2"* ]]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); printf 'FAIL: %s\n   expected NOT to contain: %s\n   got: %s\n' "$1" "$2" "$3"; fi; }
+
+OUT=""; ERR=""; RC=0
+run() {
+  local o="$TMP/.o" e="$TMP/.e"
+  ( "$@" ) >"$o" 2>"$e"; RC=$?
+  OUT=$(cat "$o"); ERR=$(cat "$e")
+  return 0
+}
+
+# ---- fixtures ---------------------------------------------------------------
+MKT="$TMP/fixture-mkt"
+mkdir -p "$MKT/.claude-plugin"
+
+# The entry point every runnable fixture ships. It records that it RAN and the
+# argv it was handed, so an arm can assert both "it executed" and "the vector
+# survived" from one file.
+mkentry() {  # mkentry <plugin-dir-name> <verb>
+  mkdir -p "$MKT/$1/bin"
+  cat > "$MKT/$1/bin/$2" <<'ENTRY'
+#!/usr/bin/env bash
+{ printf 'RAN=%s\n' "${FIVEDIVE_VERB:-?}"
+  printf 'KEY=%s\n' "${FIVEDIVE_PLUGIN_KEY:-?}"
+  printf 'DIR=%s\n' "${FIVEDIVE_PLUGIN_DIR:-?}"
+  printf 'ARGC=%s\n' "$#"
+  for a in "$@"; do printf 'ARG=[%s]\n' "$a"; done
+} > "$SENTINEL"
+echo "voice-fixture-stdout"
+ENTRY
+  chmod +x "$MKT/$1/bin/$2"
+}
+
+mkplugin() {  # mkplugin <dir-name> <manifest-json>
+  mkdir -p "$MKT/$1/.claude-plugin"
+  printf '%s\n' "$2" > "$MKT/$1/.claude-plugin/plugin.json"
+}
+mkindex() {
+  local arr="[]" d n
+  for d in "$MKT"/*/; do
+    n=$(basename "${d%/}"); [[ "$n" == .* ]] && continue
+    arr=$(jq -c --arg n "$n" '. + [{name:$n, description:("fixture " + $n), category:"test", source:("./" + $n)}]' <<<"$arr")
+  done
+  jq -n --argjson p "$arr" '{name:"fixture", description:"test fixture", owner:{name:"t"}, plugins:$p}' \
+    > "$MKT/.claude-plugin/marketplace.json"
+}
+
+# manifest <name> <caps-json> <verbs-json>
+manifest() {
+  jq -cn --arg n "$1" --argjson caps "$2" --argjson verbs "$3" \
+     '{name:$n, version:"1.0.0", description:"fixture", author:{name:"t"},
+       fivedive:{contract:"1", capabilities:$caps, verbs:$verbs, grants:[],
+                 trust:{publisher:"t", did:"did:key:t", review:"official"}}}'
+}
+V() { jq -cn --arg n "$1" '[{name:$n, summary:"fixture verb", installs:"channel"}]'; }
+
+# runnable, correctly declared
+mkplugin sings   "$(manifest sings '["verb"]' "$(V sing)")";        mkentry sings sing
+# names a verb but never declares the capability — inert under §2, and the whole
+# point is that it must SAY so
+mkplugin mutters "$(manifest mutters '["channel"]' "$(V mutter)")"; mkentry mutters mutter
+# declares the capability and names nothing
+mkplugin empty   "$(manifest empty '["verb"]' '[]')"
+# verb name that is not kebab-case
+mkplugin shouty  "$(manifest shouty '["verb"]' "$(V SING)")"
+# collides with a real 5dive builtin
+mkplugin usurper "$(manifest usurper '["verb"]' "$(V task)")";      mkentry usurper task
+# declares a verb and ships no bin/ at all
+mkplugin hollow  "$(manifest hollow '["verb"]' "$(V hum)")"
+# ships the file but forgets chmod +x
+mkplugin limp    "$(manifest limp '["verb"]' "$(V whistle)")"
+  mkdir -p "$MKT/limp/bin"; echo '#!/bin/sh' > "$MKT/limp/bin/whistle"
+# a SECOND plugin claiming `sing`
+mkplugin rival   "$(manifest rival '["verb"]' "$(V sing)")";        mkentry rival sing
+# §5 negative control: the manifest carries strings that WOULD write a sentinel
+# if anything ever evaluated them. Nothing may.
+mkplugin sneaky  "$(manifest sneaky '["verb"]' "$(V sneak)")";      mkentry sneaky sneak
+  jq --arg c 'touch '"$TMP/MANIFEST-STRING-RAN" \
+     '.fivedive.setup = {hint:"h", command:$c} | .fivedive.verbs[0].command = $c' \
+     "$MKT/sneaky/.claude-plugin/plugin.json" > "$TMP/x" && mv "$TMP/x" "$MKT/sneaky/.claude-plugin/plugin.json"
+mkindex
+
+run cmd_plugin_marketplace add "$MKT" --as=fixture
+t  'setup: marketplace add rc' 0 "$RC"
+
+# ---- T1  §2 both directions, at validation time -----------------------------
+run cmd_plugin_add mutters@fixture --yes
+t  'T1a mutters installs (verbs without the capability are inert, not invalid)' 0 "$RC"
+tc 'T1a mutters says the verb will not be dispatched' 'will NOT be dispatched' "$ERR"
+tc 'T1a mutters names the dead command'               "5dive mutter" "$ERR"
+
+run cmd_plugin_add empty@fixture --yes
+t  'T1b verb capability with no verbs is refused' "$E_VALIDATION" "$RC"
+tc 'T1b names the missing declaration' 'names no verbs' "$ERR"
+
+run cmd_plugin_add shouty@fixture --yes
+t  'T1c non-kebab verb name refused' "$E_VALIDATION" "$RC"
+tc 'T1c names the offending verb' "'SING'" "$ERR"
+
+# ---- T2  install-time collision + entry-point refusals ----------------------
+run cmd_plugin_add usurper@fixture --yes
+t  'T2a verb colliding with a builtin is refused' "$E_VALIDATION" "$RC"
+tc 'T2a names the builtin'      "verb 'task'" "$ERR"
+tc 'T2a explains it could never run' 'could never run' "$ERR"
+
+run cmd_plugin_add hollow@fixture --yes
+t  'T2b declared verb with no executable is refused' "$E_VALIDATION" "$RC"
+tc 'T2b names where 5dive looks' 'bin/hum' "$ERR"
+
+run cmd_plugin_add limp@fixture --yes
+t  'T2c non-executable entry point is refused' "$E_VALIDATION" "$RC"
+tc 'T2c names the chmod'  'chmod +x' "$ERR"
+
+run cmd_plugin_add sings@fixture --yes
+t  'T2d a correctly declared verb installs' 0 "$RC"
+tc 'T2d says the verb is now live' "'5dive sing' now runs this plugin" "$ERR"
+t  'T2d record carries the verb capability' 'true' \
+   "$(jq -r '.["sings@fixture"].capabilities | index("verb") != null' "$STATE_DIR/plugins/installed.json")"
+t  'T2d record carries the verb name' 'sing' \
+   "$(jq -r '.["sings@fixture"].verbs[0].name' "$STATE_DIR/plugins/installed.json")"
+
+run cmd_plugin_add rival@fixture --yes
+t  'T2e a second claimant is refused' "$E_VALIDATION" "$RC"
+tc 'T2e names the incumbent' 'sings@fixture' "$ERR"
+
+# ---- T3  resolution reads the RECORD, and honours enable/disable ------------
+t 'T3a an enabled declared verb resolves to its plugin' 'sings@fixture' "$(_plugin_verb_claims sing)"
+t 'T3b an undeclared verb resolves to nothing'          ''              "$(_plugin_verb_claims mutter)"
+t 'T3c an unknown verb resolves to nothing'             ''              "$(_plugin_verb_claims nosuch)"
+
+run cmd_plugin_disable sings@fixture
+t 'T3d disable makes the verb stop resolving' '' "$(_plugin_verb_claims sing)"
+run cmd_plugin_enable sings@fixture
+t 'T3e enable brings it back' 'sings@fixture' "$(_plugin_verb_claims sing)"
+
+_plugin_verb_entry_in "$STATE_DIR/plugins/enabled/sings@fixture" sing >/dev/null; t 'T3f entry resolves when executable' 0 "$?"
+_plugin_verb_entry_in "$MKT/limp" whistle >/dev/null;                            t 'T3g entry refuses a non-executable file' 1 "$?"
+_plugin_verb_entry_in "$MKT/hollow" hum >/dev/null;                              t 'T3h entry refuses a missing file' 1 "$?"
+
+# ---- T4  dispatch: the real exec -------------------------------------------
+rm -f "$SENTINEL"
+run _plugin_dispatch_verb sing one "two three" '*'
+t  'T4a dispatch execs the entry point'   0 "$RC"
+tc 'T4a the child ran'          'RAN=sing'          "$(cat "$SENTINEL" 2>/dev/null)"
+tc 'T4a the child was told its key' 'KEY=sings@fixture' "$(cat "$SENTINEL" 2>/dev/null)"
+tc 'T4a the child stdout reaches the caller' 'voice-fixture-stdout' "$OUT"
+t  'T4a argv arrived as a VECTOR, not a string' 'ARGC=3' \
+   "$(grep '^ARGC=' "$SENTINEL")"
+tc 'T4a an argument with spaces survived intact' 'ARG=[two three]' "$(cat "$SENTINEL")"
+tc 'T4a a glob argument was not expanded'        'ARG=[*]'         "$(cat "$SENTINEL")"
+
+# POSITIVE CONTROL for every "did not run" assertion below.
+rm -f "$SENTINEL"
+( SENTINEL="$SENTINEL" "$STATE_DIR/plugins/enabled/sings@fixture/bin/sing" probe >/dev/null 2>&1 )
+t 'T4b positive control: the sentinel mechanism works' 'yes' \
+  "$([[ -f "$SENTINEL" ]] && echo yes || echo no)"
+
+rm -f "$SENTINEL"
+run _plugin_dispatch_verb nosuch
+t  'T4c an unclaimed verb returns 1 for main() to turn into unknown command' 1 "$RC"
+t  'T4c and says nothing at all' '' "$ERR$OUT"
+t  'T4c and executed nothing' 'no' "$([[ -f "$SENTINEL" ]] && echo yes || echo no)"
+
+# A builtin name hand-written into the store cannot be dispatched, independent of
+# where the call site sits in main().
+jq '.["usurper@fixture"] = {plugin:"usurper", marketplace:"fixture", version:"1.0.0",
+      enabled:true, review:"official", publisher:"t", capabilities:["verb"],
+      grants:[], verbs:[{name:"task"}], installed_at:"x"}' \
+  "$STATE_DIR/plugins/installed.json" > "$TMP/x" && mv "$TMP/x" "$STATE_DIR/plugins/installed.json"
+run _plugin_dispatch_verb task ls
+t 'T4d a builtin name is never dispatched, even when the store claims it' 1 "$RC"
+t 'T4d and it printed nothing'                                           '' "$ERR$OUT"
+
+# Two enabled claimants: refuse, do not pick.
+jq '.["rival@fixture"] = {plugin:"rival", marketplace:"fixture", version:"1.0.0",
+      enabled:true, review:"official", publisher:"t", capabilities:["verb"],
+      grants:[], verbs:[{name:"sing"}], installed_at:"x"}' \
+  "$STATE_DIR/plugins/installed.json" > "$TMP/x" && mv "$TMP/x" "$STATE_DIR/plugins/installed.json"
+rm -f "$SENTINEL"
+run _plugin_dispatch_verb sing
+t  'T4e two claimants refuse rather than pick' "$E_VALIDATION" "$RC"
+tc 'T4e names both'  'sings@fixture' "$ERR"
+tc 'T4e names both'  'rival@fixture' "$ERR"
+t  'T4e and ran neither' 'no' "$([[ -f "$SENTINEL" ]] && echo yes || echo no)"
+jq 'del(.["rival@fixture"]) | del(.["usurper@fixture"])' \
+  "$STATE_DIR/plugins/installed.json" > "$TMP/x" && mv "$TMP/x" "$STATE_DIR/plugins/installed.json"
+
+# Claimed, but the entry point has gone missing since install.
+mv "$STATE_DIR/plugins/cache/fixture/sings/1.0.0/bin/sing" "$TMP/sing.parked"
+run _plugin_dispatch_verb sing
+t  'T4f a claimed verb with no runnable entry fails loudly' "$E_NOT_FOUND" "$RC"
+tc 'T4f names the path it looked at' 'bin/sing' "$ERR"
+mv "$TMP/sing.parked" "$STATE_DIR/plugins/cache/fixture/sings/1.0.0/bin/sing"
+
+run cmd_plugin_disable sings@fixture
+rm -f "$SENTINEL"
+run _plugin_dispatch_verb sing
+t 'T4g a disabled plugin does not dispatch'  1 "$RC"
+t 'T4g and executed nothing' 'no' "$([[ -f "$SENTINEL" ]] && echo yes || echo no)"
+run cmd_plugin_enable sings@fixture
+
+# §5 stays shut: install AND dispatch a plugin whose manifest carries command
+# strings, and assert nothing ever evaluated one.
+rm -f "$TMP/MANIFEST-STRING-RAN"
+run cmd_plugin_add sneaky@fixture --yes
+t  'T4h sneaky installs' 0 "$RC"
+tc 'T4h the setup command is PRINTED' 'Run it yourself' "$ERR"
+run _plugin_dispatch_verb sneak
+t  'T4h dispatch runs the file, not the manifest string' 0 "$RC"
+t  'T4h no string out of plugin.json was ever executed (contract §5)' 'no' \
+   "$([[ -f "$TMP/MANIFEST-STRING-RAN" ]] && echo yes || echo no)"
+
+# ---- T6  the registry is READABLE by the unprivileged caller ----------------
+# The defect this row surfaced on a real box: every writer builds the document in
+# a `mktemp` and moves it into place, and mktemp is 0600, so installed.json was
+# root-only. Invisible for all of DIVE-4020 (every `plugin` subverb is
+# root-gated, so the only readers were root) and fatal to dispatch, whose reader
+# is whoever typed the verb. These arms grade the MODE of the artifact rather
+# than the presence of a chmod line, so they red on any writer that forgets to
+# route through _plugin_publish_json.
+t 'T6a installed.json is world-readable after an install' '644' \
+  "$(stat -c %a "$STATE_DIR/plugins/installed.json")"
+t 'T6b marketplaces.json is world-readable' '644' \
+  "$(stat -c %a "$STATE_DIR/plugins/marketplaces.json")"
+t 'T6c the store root is traversable' '755' "$(stat -c %a "$STATE_DIR/plugins")"
+t 'T6d the enabled/ pointer dir is traversable' '755' "$(stat -c %a "$STATE_DIR/plugins/enabled")"
+# Every mutating subverb must LEAVE it readable, not just `add`.
+run cmd_plugin_disable sings@fixture
+t 'T6e ...and still readable after disable rewrites it' '644' \
+  "$(stat -c %a "$STATE_DIR/plugins/installed.json")"
+run cmd_plugin_enable sings@fixture
+t 'T6f ...and after enable' '644' "$(stat -c %a "$STATE_DIR/plugins/installed.json")"
+run cmd_plugin_remove sneaky@fixture
+t 'T6g ...and after remove' '644' "$(stat -c %a "$STATE_DIR/plugins/installed.json")"
+
+# ---- T5  the builtin list is not hand-maintained on trust -------------------
+# The ONE source-derived arm in this file, because the subject IS the source: a
+# new top-level verb added to main.sh without a line here would silently become
+# claimable by a plugin, and no behavioural arm can see a verb that does not
+# exist yet.
+declared=$(printf '%s\n' $FIVEDIVE_BUILTIN_VERBS | sort -u)
+actual=$(awk 'f&&/^}$/{exit} /^main\(\) \{$/{f=1} f' "$ROOT/src/main.sh" \
+         | grep -oE '^    [a-z0-9_|*-]+\)' | tr -d ' )' | tr '|' '\n' | grep -v '^\*$' | sort -u)
+t 'T5 FIVEDIVE_BUILTIN_VERBS matches main.sh case labels exactly' "$actual" "$declared"
+
+# ---- T7  the WIRING in main.sh, graded through the real binary --------------
+# Every arm above calls _plugin_dispatch_verb directly, which is exactly the
+# blind spot a maker builds for themselves: delete the call site from main.sh's
+# `*)` branch and all 62 of them stay green while `5dive voice` goes back to
+# being an unknown command. So these run the BUILT CLI.
+#
+# The store is assembled BY HAND here rather than through cmd_plugin_add,
+# because every `5dive plugin` subverb is root-gated and a suite must not need
+# root. That is not a shortcut past the install path — T1/T2 grade that — it is
+# the only way to reach the dispatcher as an ordinary user.
+#
+# NO SKIP IF ./5dive IS ABSENT. An unbuilt tree would silently drop the only
+# arms that can see the wiring, and a suite that is green because it did not run
+# is the failure mode this corpus has been bitten by before. Build first.
+E2E="$TMP/e2e"; mkdir -p "$E2E/plugins/enabled" "$E2E/plugins/cache/fixture/sings/1.0.0/bin"
+cat > "$E2E/plugins/cache/fixture/sings/1.0.0/bin/sing" <<'E2EENTRY'
+#!/usr/bin/env bash
+printf 'E2E-RAN verb=%s key=%s argc=%s\n' "${FIVEDIVE_VERB:-?}" "${FIVEDIVE_PLUGIN_KEY:-?}" "$#"
+for a in "$@"; do printf 'E2E-ARG=[%s]\n' "$a"; done
+E2EENTRY
+chmod +x "$E2E/plugins/cache/fixture/sings/1.0.0/bin/sing"
+ln -sfn "$E2E/plugins/cache/fixture/sings/1.0.0" "$E2E/plugins/enabled/sings@fixture"
+jq -n '{"sings@fixture":{plugin:"sings", marketplace:"fixture", version:"1.0.0",
+        enabled:true, review:"official", publisher:"t", capabilities:["verb"],
+        grants:[], verbs:[{name:"sing"}], installed_at:"x"}}' \
+  > "$E2E/plugins/installed.json"
+echo '{}' > "$E2E/plugins/marketplaces.json"
+
+if [[ ! -x "$ROOT/5dive" ]]; then
+  FAIL=$((FAIL+1))
+  printf 'FAIL: T7-precondition ./5dive is not built — run ./build.sh; the wiring arms cannot run\n'
+else
+  e2e() { ( STATE_DIR="$E2E" "$ROOT/5dive" "$@" ) 2>"$TMP/.e2ee"; }
+  out=$(e2e sing alpha "two words"); rc=$?
+  t  'T7a the built CLI dispatches a plugin verb' 0 "$rc"
+  tc 'T7a ...running the entry point'      'E2E-RAN verb=sing' "$out"
+  tc 'T7a ...with its key'                 'key=sings@fixture' "$out"
+  tc 'T7a ...and argv as a vector'         'E2E-ARG=[two words]' "$out"
+  t  'T7a ...exactly two arguments'        'argc=2' "$(grep -o 'argc=[0-9]*' <<<"$out")"
+
+  out=$(e2e definitely-not-a-verb); rc=$?
+  t  'T7b an unclaimed command still fails as usage' 2 "$rc"
+  tc 'T7b ...with the unchanged message' 'unknown command: definitely-not-a-verb' "$(cat "$TMP/.e2ee")"
+
+  # A builtin still wins, with the plugin store present and claiming nothing
+  # relevant — the structural guarantee, measured rather than reasoned.
+  out=$(e2e --version); rc=$?
+  t  'T7c builtins are untouched by the new branch' 0 "$rc"
+  tc 'T7c ...and still answer'                     '5dive' "$out"
+
+  # Disabled means gone, through the real binary too.
+  jq '.["sings@fixture"].enabled = false' "$E2E/plugins/installed.json" > "$TMP/x" \
+    && mv "$TMP/x" "$E2E/plugins/installed.json"
+  e2e sing >/dev/null; rc=$?
+  t  'T7d a disabled plugin is not dispatched by the built CLI' 2 "$rc"
+  tc 'T7d ...and reads as an unknown command' 'unknown command: sing' "$(cat "$TMP/.e2ee")"
+fi
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Replaces #785, which I made unmergeable.

## What happened

#785 carried #779 (DIVE-4020) as a merge commit. I **squash**-merged #779, so its five commits are not ancestors of `main` — main has one equivalent-but-different commit instead. #785 therefore still carried them and went `CONFLICTING`. quinn's "land #779 and #785 shrinks to its own commit" assumed a merge, not a squash. My mistake, not the maker's.

## What this branch is

`87cff8dd` — the single DIVE-4035 commit quinn graded — cherry-picked onto current `main`. Nothing else.

## The check that makes it safe

The tree cannot be compared against the old branch (main has since gained #782 and #784, which that branch never had). So the invariant is on the **delta**, not the tree:

    git diff 87cff8dd^ 87cff8dd      ->  9 files, +776/-20
    git diff origin/main fix785      ->  9 files, +776/-20

Byte-identical except **4 lines of git blob index hashes**, all in `src/main.sh` — whose base moved because #782 touched it. Same textual change, applied cleanly to the newer base, no conflict.

So this branch introduces **exactly the delta quinn graded at `87cff8dd`**, and nothing more.

quinn: the grade transfers on that invariant, but the resolved tree is new — re-grade or confirm at your discretion.