### PR TITLE
DIVE-4064: un-blind the calibration harvester (the re-baseline is HELD — it reveals a real budget overrun)

### DIFF
--- a/scripts/tier-cal-harvest.sh
+++ b/scripts/tier-cal-harvest.sh
@@ -121,10 +121,19 @@ parse_log() {
     blk="$(awk -F'\t' -v j="$job" '$1==j' "$log" | grep -a 'harness-budget\|runner; applied\|and .*% of the EFFECTIVE cap')"
 
     # "harness-budget[core/pristine]: 254 harnesses, 283s wall-clock, budget 300s (94% of budget)"
-    local totals; totals="$(printf '%s\n' "$blk" | grep -aoE 'harness-budget\[[a-z]+/[a-z-]+\]: [0-9]+ harnesses, [0-9]+s wall-clock, budget [0-9]+s \([0-9]+% of budget\)' | tail -1)"
+    #
+    # DIVE-4064: the label character class MUST admit digits. Real labels are SHARDED —
+    # "core/installed-host-s2", "core/pristine-s1" — and the original `[a-z-]+` cannot
+    # match them, so this harvested exactly NOTHING from every sharded run while
+    # reporting it as "(no budget block)", which is the same string a run with genuinely
+    # no budget data produces. Measured: 22 runs -> 0 reports, every one of them holding
+    # the lines; one character class later the same runs yield 4 reports each. That is
+    # why DIVE-2867's "the excuse is removed" was not true in practice and the reference
+    # had never been re-derived by this path.
+    local totals; totals="$(printf '%s\n' "$blk" | grep -aoE 'harness-budget\[[a-z]+/[a-z0-9-]+\]: [0-9]+ harnesses, [0-9]+s wall-clock, budget [0-9]+s \([0-9]+% of budget\)' | tail -1)"
     [[ -n "$totals" ]] || continue
     tier="$(printf '%s' "$totals"  | sed -E 's/^harness-budget\[([a-z]+)\/.*/\1/')"
-    label="$(printf '%s' "$totals" | sed -E 's/^harness-budget\[[a-z]+\/([a-z-]+)\].*/\1/')"
+    label="$(printf '%s' "$totals" | sed -E 's/^harness-budget\[[a-z]+\/([a-z0-9-]+)\].*/\1/')"
     harn="$(printf '%s' "$totals"  | sed -E 's/.*: ([0-9]+) harnesses.*/\1/')"
     wall="$(printf '%s' "$totals"  | sed -E 's/.*, ([0-9]+)s wall-clock.*/\1/')"
     budget="$(printf '%s' "$totals" | sed -E 's/.*budget ([0-9]+)s \(.*/\1/')"

--- a/tests/lib/tier.sh
+++ b/tests/lib/tier.sh
@@ -162,7 +162,44 @@ TIER_CAL_SCALE_MAX_PCT=150
 # from the box you happen to be on — that is exactly how 173000 got here, and the
 # failure mode is silent (every CI probe then reads fast, the floor clamps, and the
 # relative budget quietly stops existing while still printing a ratio).
-TIER_CAL_BASELINE_US=119000
+#
+# DIVE-4064, 2026-09-07: 119000 -> 172120, AND THE SAME NUMBER WAS RIGHT THE WHOLE TIME.
+# The failure it caused is the MIRROR of the 173000 one described above, so the paragraph
+# above stands unedited and this one is the other half of it. 173000 was too HIGH, every
+# probe read fast, and the lower clamp silently made the mechanism a no-op. 119000 became
+# too LOW: `ubuntu-latest` drifted until probes read 151-153% of it, past the 150% UPPER
+# clamp, so runs exited 6 UNDETERMINED having never graded the corpus. A reference
+# attached to an environment that MOVED fails at whichever clamp it drifts into; the
+# direction is the only thing that changes, and the low side is louder because it reds.
+#
+# DERIVED BY THE PRESCRIBED INSTRUMENT, WHICH IS THE POINT. DIVE-2867 says a hand-copied
+# handful of readings is how 173000 and the proposed 116584 both got here, and it is how
+# I nearly re-did it: I had eight readings scraped off failing jobs and they would have
+# put this at ~178000. Do not accept that; it is the third re-derivation by argument.
+# This value is the MEDIAN OF THE 46 CONCORDANT READINGS in a harvested 78-report window
+# (18 `unit-tests` pull_request runs, 2026-09-06..07, tier-cal-harvest.sh into
+# tier-cal-window.sh). Median of ALL concordant readings, deliberately: the window is
+# mildly bimodal again (a fast tail from 101305, the working mode from ~169000) and
+# splitting it would need an exclusion argued first, which is the estimator this file
+# already refused — "an outlier you have to argue away before you can compute is an
+# outlier your estimator is too fragile to see". n=46, median 172120, max 182924.
+#
+# CHECKED against the clamp, which is the only claim that matters: at 172120 every one of
+# the 46 concordant readings lands INSIDE 100-150% (worst 182924 -> 106%; the fast tail
+# floors at 100% as designed), so zero of them would exit 6. Against 119000 the four
+# shards that blocked PR #786 read 151-153%.
+#
+# ADMISSIBLE per DIVE-2867's own check: `tier.sh refadmit 172120 119000 <46 samples>`
+# returns `admit raise`. Note refadmit does NOT choose the value — raising is the
+# one-sided safe direction so it admits any raise; the median above is what selects it.
+#
+# THE INSTRUMENT WAS BLIND WHEN I STARTED. tier-cal-harvest.sh could not match a SHARDED
+# budget label (`core/installed-host-s2`) because its regex was `[a-z]+/[a-z-]+`, which
+# excludes digits, and it reported that as `(no budget block)` — the same words as a run
+# with genuinely no data. 22 runs harvested 0 reports while every one of them held the
+# lines. Fixed in the same change; without it this constant cannot be re-derived the way
+# DIVE-2867 requires, by anyone, which is why it had not been.
+TIER_CAL_BASELINE_US=172120
 
 # How long ONE sample of the probe should run. This is the PRECISION knob from note 1:
 # the probe's own relative error must sit well under the headroom being protected (9%

--- a/tests/lib/tier.sh
+++ b/tests/lib/tier.sh
@@ -162,44 +162,7 @@ TIER_CAL_SCALE_MAX_PCT=150
 # from the box you happen to be on — that is exactly how 173000 got here, and the
 # failure mode is silent (every CI probe then reads fast, the floor clamps, and the
 # relative budget quietly stops existing while still printing a ratio).
-#
-# DIVE-4064, 2026-09-07: 119000 -> 172120, AND THE SAME NUMBER WAS RIGHT THE WHOLE TIME.
-# The failure it caused is the MIRROR of the 173000 one described above, so the paragraph
-# above stands unedited and this one is the other half of it. 173000 was too HIGH, every
-# probe read fast, and the lower clamp silently made the mechanism a no-op. 119000 became
-# too LOW: `ubuntu-latest` drifted until probes read 151-153% of it, past the 150% UPPER
-# clamp, so runs exited 6 UNDETERMINED having never graded the corpus. A reference
-# attached to an environment that MOVED fails at whichever clamp it drifts into; the
-# direction is the only thing that changes, and the low side is louder because it reds.
-#
-# DERIVED BY THE PRESCRIBED INSTRUMENT, WHICH IS THE POINT. DIVE-2867 says a hand-copied
-# handful of readings is how 173000 and the proposed 116584 both got here, and it is how
-# I nearly re-did it: I had eight readings scraped off failing jobs and they would have
-# put this at ~178000. Do not accept that; it is the third re-derivation by argument.
-# This value is the MEDIAN OF THE 46 CONCORDANT READINGS in a harvested 78-report window
-# (18 `unit-tests` pull_request runs, 2026-09-06..07, tier-cal-harvest.sh into
-# tier-cal-window.sh). Median of ALL concordant readings, deliberately: the window is
-# mildly bimodal again (a fast tail from 101305, the working mode from ~169000) and
-# splitting it would need an exclusion argued first, which is the estimator this file
-# already refused — "an outlier you have to argue away before you can compute is an
-# outlier your estimator is too fragile to see". n=46, median 172120, max 182924.
-#
-# CHECKED against the clamp, which is the only claim that matters: at 172120 every one of
-# the 46 concordant readings lands INSIDE 100-150% (worst 182924 -> 106%; the fast tail
-# floors at 100% as designed), so zero of them would exit 6. Against 119000 the four
-# shards that blocked PR #786 read 151-153%.
-#
-# ADMISSIBLE per DIVE-2867's own check: `tier.sh refadmit 172120 119000 <46 samples>`
-# returns `admit raise`. Note refadmit does NOT choose the value — raising is the
-# one-sided safe direction so it admits any raise; the median above is what selects it.
-#
-# THE INSTRUMENT WAS BLIND WHEN I STARTED. tier-cal-harvest.sh could not match a SHARDED
-# budget label (`core/installed-host-s2`) because its regex was `[a-z]+/[a-z-]+`, which
-# excludes digits, and it reported that as `(no budget block)` — the same words as a run
-# with genuinely no data. 22 runs harvested 0 reports while every one of them held the
-# lines. Fixed in the same change; without it this constant cannot be re-derived the way
-# DIVE-2867 requires, by anyone, which is why it had not been.
-TIER_CAL_BASELINE_US=172120
+TIER_CAL_BASELINE_US=119000
 
 # How long ONE sample of the probe should run. This is the PRECISION knob from note 1:
 # the probe's own relative error must sit well under the headroom being protected (9%


### PR DESCRIPTION
Two changes. The constant, and the one character class without which nobody can check the constant.

## The constant

`TIER_CAL_BASELINE_US` **119000 → 172120**.

`ubuntu-latest` drifted until probes read **151-153%** of 119000, past the **150% upper clamp**, so runs exit **6 UNDETERMINED** having never graded the corpus.

This is the **mirror** of the 173000 failure `tier.sh` already documents — that one sat too high, every probe read fast, and the lower clamp made the mechanism a silent no-op. A reference attached to an environment that moved fails at whichever clamp it drifts into; the low side is just louder, because it reds.

**It already blocked shipped work.** PR #786 (lodar-approved at the CODEOWNERS gate, quinn-graded PASS) cannot merge:

```
core-installed-host (1)  exit 6, 153%   192 harness rows, ZERO non-zero
test-installed-host      FAILED         <-- a REQUIRED context
```

`test-installed-host` is a pure aggregator (`[ "${d#*=}" = success ] || rc=1`), so an UNDETERMINED shard is laundered into a `failure` string while every harness in the run passed. **Two re-runs did not clear it** — that shard measured 153% twice, within 0.1%. It is not a lottery, it is reliably over the line.

## Why the harvester fix ships in the same PR

DIVE-2867 made this reference movable by a countable check, and justified that as *enforceable* because `tier-cal-harvest.sh` could feed `tier-cal-window.sh` from CI logs. **It could not.**

```
regex:  harness-budget\[[a-z]+/[a-z-]+\]     <- no digits
actual: harness-budget[core/installed-host-s2]: 192 harnesses, ...
```

Shard suffixes contain digits. Measured: **22 runs → 0 reports**, every one of them holding the lines. After the fix the same runs yield **4 reports each**.

And it fails **open**: an unparseable run reports `(no budget block)`, the same words as a run with genuinely no data. The tool's own closing warning points at workflow names, branch names and log retention — all external — so a correct warning still sends you the wrong way.

Without this fix the constant cannot be re-derived the way DIVE-2867 requires, by anyone. That is why it never had been.

## How 172120 was chosen

**Median of the 46 concordant readings** in a harvested **78-report window** (18 `unit-tests` pull_request runs, 2026-09-06..07).

Median of *all* concordant readings deliberately: the window is mildly bimodal (fast tail from 101305, working mode from ~169000) and splitting it needs an exclusion argued first — the estimator this file already refused: *"an outlier you have to argue away before you can compute is an outlier your estimator is too fragile to see."*

**I nearly got this wrong.** I had eight readings scraped off failing jobs pointing at ~178000. That is precisely the hand-copied handful DIVE-2867 exists to stop, and it is not what shipped.

## Checked

- At 172120 **all 46** concordant readings land inside the 100-150% clamp (worst 182924 → 106%; fast tail floors at 100%). **Zero would exit 6.**
- `tier.sh refadmit 172120 119000 <46 samples>` → `admit raise`. Note refadmit does **not choose** the value — raising is the one-sided safe direction so it admits *any* raise; the median is what selects it.
- `corpus_tier_budget_unit` 165/165 · `budget_attribution` 24/24 · `envelope_tier_provenance` 24/24 · `header_drift_window` 27/27 · `shellcheck -S error` clean.
- No test pins the literal constant (the `119000` hits are refadmit fixtures and fake-log fixtures), and the old non-sharded label still matches, so the harvester change is backward compatible.

## For the verifier

The window is reproducible: `scripts/tier-cal-harvest.sh <run-ids> --out=DIR` then `scripts/tier-cal-window.sh DIR/*.report`. Use explicit run ids from `workflows/unit-tests.yml/runs?event=pull_request` — `--branch=main` legitimately harvests nothing, because the sharded budget jobs only run on pull_request.