### PR TITLE
DIVE-4071: task doctor dead-lane predicate matches the actual wake path

### DIFF
--- a/src/task/doctor.sh
+++ b/src/task/doctor.sh
@@ -280,7 +280,7 @@ _task_doctor_fix() {
       if [[ "$trc" == "2" ]]; then
         fail "$E_GENERIC" "cannot verify --to='${to}': ${STATE_DIR:-/var/lib/5dive}/agents.json could not be read, so this command cannot tell a live seat from another dead one — and moving the row blind is the failure it is meant to repair. Fix the registry first: 5dive doctor"
       elif [[ "$trc" != "0" ]]; then
-        fail "$E_VALIDATION" "--to='${to}' is itself a lane nothing wakes (no heartbeat enabled, or the seat is operator-stopped) — ${ident} would be exactly as undispatchable at the new address. Pick a live seat: 5dive agent list"
+        fail "$E_VALIDATION" "--to='${to}' is itself a lane nothing wakes (its heartbeat is not enabled, so the tick never iterates it) — ${ident} would be exactly as undispatchable at the new address. Pick a live seat: 5dive agent list"
       fi
       apply=(cmd_task_assign "$ident" "$to"); shown="5dive task assign ${ident} ${to}" ;;
     dead-verifier)
@@ -293,7 +293,7 @@ _task_doctor_fix() {
       if [[ "$vrc" == "2" ]]; then
         fail "$E_GENERIC" "cannot verify --to='${to}': ${STATE_DIR:-/var/lib/5dive}/agents.json could not be read, so this command cannot tell a live seat from another dead one — and re-pointing the grader blind is the failure it is meant to repair. Fix the registry first: 5dive doctor"
       elif [[ "$vrc" != "0" ]]; then
-        fail "$E_VALIDATION" "--to='${to}' is itself a seat nothing wakes (no heartbeat enabled, or the seat is operator-stopped) — ${ident} would strand at handoff exactly as it does now. Pick a live seat: 5dive agent list"
+        fail "$E_VALIDATION" "--to='${to}' is itself a seat nothing wakes (its heartbeat is not enabled, so the tick never iterates it) — ${ident} would strand at handoff exactly as it does now. Pick a live seat: 5dive agent list"
       fi
       apply=(cmd_task_verifier "$ident" "$to"); shown="5dive task verifier ${ident} ${to}" ;;
     *)

--- a/src/task/doctor.sh
+++ b/src/task/doctor.sh
@@ -50,13 +50,23 @@
 # Measured 2026-08-28 on this host: 4 of 17 registered agents carry no heartbeat
 # key at all, and one of them held an open row.
 #
-# THE SECOND HALF: `desiredState`. An operator-stopped seat (`desiredState:
-# "stopped"`) IS iterated by the wake loop and the wake then FAILS — the tick logs
-# "wake failed — will retry next tick" and moves on, forever. That is a different
-# mechanism from the heartbeat key and the same outcome for the row, so it is the
-# same finding. It is deliberately NOT treated as a registry error: an operator
-# stopped that seat on purpose, and the honest report is "these rows are parked on
-# a seat you turned off", not "your registry is broken".
+# `heartbeat.enabled == true` IS THE WHOLE GATE — because it is the whole gate the
+# tick uses. `_hb_wake` (cmd_heartbeat.sh) never reads `desiredState`: on an
+# iterated seat it runs `systemctl is-active` and STARTS a unit that is down. So a
+# seat is woken by the tick if and only if it is in that population, and that
+# population is `heartbeat.enabled == true` alone (DIVE-4071).
+#
+# WHY `desiredState=stopped` IS NOT FOLDED IN HERE (it used to be, and it was
+# wrong). The old comment claimed an operator-stopped seat "IS iterated by the
+# wake loop and the wake then FAILS". It does not fail: the tick still iterates it
+# (`cmd_stop` sets `desiredState=stopped` but leaves `heartbeat.enabled` untouched)
+# and `_hb_wake` STARTS the stopped unit — so the row dispatches. Reporting that as
+# `dead-lane` was a FALSE finding whose printed remedy (`task assign`) re-points a
+# row off a seat that is actively working it. Any seat started outside
+# `5dive agent start` — a manual `systemctl start`, a crash-loop recovery — carries
+# `desiredState=stopped` with a live unit and manufactured that false finding.
+# (The tick overriding an operator's stop is a real anomaly, but a DIFFERENT one:
+# it is not "nothing wakes this lane", so it does not belong in this predicate.)
 #
 # Returns 2 (NOT 1) when the registry could not be read, so the caller can tell
 # "this seat is dead" from "I could not find out" and degrade instead of
@@ -66,12 +76,11 @@ _task_doctor_lane_wakeable() {
   [[ -n "$name" ]] || return 2
   reg="${STATE_DIR:-/var/lib/5dive}/agents.json"
   [[ -r "$reg" ]] || return 2
-  # ONE jq read for both facts: an agent absent from the file yields "false|running",
+  # The tick's exact population: an agent absent from the file yields "false",
   # which is correctly not wakeable and needs no separate existence probe.
-  v=$(jq -r --arg n "$name" '((.agents[$n].heartbeat.enabled // false)|tostring) + "|" + (.agents[$n].desiredState // "running")' "$reg" 2>/dev/null) || return 2
+  v=$(jq -r --arg n "$name" '(.agents[$n].heartbeat.enabled // false)|tostring' "$reg" 2>/dev/null) || return 2
   [[ -n "$v" ]] || return 2
-  [[ "${v%%|*}" == "true" ]] || return 1
-  [[ "${v##*|}" != "stopped" ]]
+  [[ "$v" == "true" ]]
 }
 
 # The four classes, as SQL predicates over open standard rows. Kept as one
@@ -136,7 +145,7 @@ _task_doctor_explain() {
     stale-edge)   printf '%s' "blocked by rows that are ALL closed — a stale edge the cascade missed. -> 5dive task unblock <id>" ;;
     wake-passed)  printf '%s' "parked, and its wake time has already passed — the heartbeat TTL pass should have unparked it. -> 5dive task unpark <id>  (NOT unblock: unblock only drops edges, and a park has none, so it reports success and changes nothing)" ;;
     park-no-wake) printf '%s' "parked with NO wake time — it will never revisit itself. -> 5dive task unpark <id>, or re-park with a --wake" ;;
-    dead-lane)    printf '%s' "assigned to a seat nothing wakes (no heartbeat, or operator-stopped) — nothing will pick it up. -> 5dive task assign <id> <agent>   (roster: 5dive agent list)" ;;
+    dead-lane)    printf '%s' "assigned to a seat the heartbeat tick never wakes (heartbeat disabled or absent) — nothing will pick it up. -> 5dive task assign <id> <agent>   (roster: 5dive agent list)" ;;
     dead-verifier) printf '%s' "GRADER nothing wakes: this row dispatches fine and STRANDS AT HANDOFF, not now — \`task done\` writes assignee=<verifier>, so the maker spends the whole task first and the delivery goes to a seat no tick will ever iterate. -> 5dive task verifier <id> <agent>   (roster: 5dive agent list)" ;;
     *)            printf '%s' "undispatchable" ;;
   esac

--- a/tests/task_doctor_lane_wakeable_unit.sh
+++ b/tests/task_doctor_lane_wakeable_unit.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# DIVE-4071 — task doctor's dead-lane predicate must model the wake path
+# `_hb_wake` actually has. The tick's population is `heartbeat.enabled == true`
+# ALONE (cmd_heartbeat.sh) and `_hb_wake` never reads `desiredState` — it STARTS a
+# down unit. So `_task_doctor_lane_wakeable` must key on heartbeat.enabled only.
+#
+# THE DISCRIMINATING ARM this file exists for: a seat with desiredState=stopped
+# AND heartbeat.enabled=true is WOKEN by the tick (its unit is started), so it is
+# NOT a dead lane. The predicate used to fold desiredState=stopped into "not
+# wakeable" and manufacture a FALSE dead-lane whose remedy (`task assign`)
+# re-points a row off a seat that is actively working it.
+# Run: bash tests/task_doctor_lane_wakeable_unit.sh (no root, no network)
+set -uo pipefail
+# DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
+# Three-state: if the helper is unreachable (a staged copy that did not carry
+# tests/lib/), the log says NO TREE WAS NAMED rather than falling silent, and a
+# `set -e` harness is not killed by a failed source.
+# NOTE the absence of `2>/dev/null`. Redirecting the source's stderr would also
+# swallow the helper's own stderr line, which IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+
+TMP="$(mktemp -d /tmp/doctor-lane-wakeable.XXXXXX)"
+export STATE_DIR="$TMP"
+REG="$STATE_DIR/agents.json"
+
+# shellcheck disable=SC1091
+source src/task/doctor.sh
+set +e
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+eq_t()  { if [[ "$2" == "$3" ]]; then ok_t "$1"; else bad_t "$1" "expected rc=$2, got rc=$3"; fi; }
+
+set_reg() { printf '%s' "$1" >"$REG"; }
+probe()   { _task_doctor_lane_wakeable "$1"; echo $?; }
+
+# ARM 1 — enabled, desiredState absent: the ordinary live seat.
+set_reg '{"agents":{"a":{"type":"claude","heartbeat":{"enabled":true}}}}'
+eq_t "enabled + no desiredState is wakeable" 0 "$(probe a)"
+
+# ARM 2 — THE DISCRIMINATING ARM. enabled AND desiredState=stopped: the tick
+# iterates it (enabled==true) and _hb_wake starts the stopped unit -> wakeable.
+# Before DIVE-4071 this returned rc=1 and printed a false dead-lane.
+set_reg '{"agents":{"a":{"type":"claude","heartbeat":{"enabled":true},"desiredState":"stopped"}}}'
+eq_t "enabled + desiredState=stopped is wakeable (not a dead lane)" 0 "$(probe a)"
+
+# ARM 3 — heartbeat disabled: genuinely outside the tick's population -> dead lane.
+set_reg '{"agents":{"a":{"type":"claude","heartbeat":{"enabled":false}}}}'
+eq_t "heartbeat disabled is a dead lane" 1 "$(probe a)"
+
+# ARM 4 — heartbeat key absent entirely: also never iterated -> dead lane.
+set_reg '{"agents":{"a":{"type":"claude"}}}'
+eq_t "no heartbeat key is a dead lane" 1 "$(probe a)"
+
+# ARM 5 — an agent absent from the registry reads as not-enabled -> dead lane.
+set_reg '{"agents":{"b":{"type":"claude","heartbeat":{"enabled":true}}}}'
+eq_t "agent absent from registry is a dead lane" 1 "$(probe a)"
+
+# ARM 6 — desiredState=stopped WITHOUT an enabled heartbeat stays a dead lane:
+# the fix must not turn desiredState into a wakeability SIGNAL, only stop it being
+# a disqualifier. Absent enabled -> false -> dead lane.
+set_reg '{"agents":{"a":{"type":"claude","desiredState":"stopped"}}}'
+eq_t "desiredState=stopped with no enabled heartbeat is still a dead lane" 1 "$(probe a)"
+
+# ARM 7 — registry unreadable is UNKNOWN (rc=2), never silently "dead".
+rm -f "$REG"
+eq_t "missing registry is unknown, not dead" 2 "$(probe a)"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/task_doctor_unit.sh
+++ b/tests/task_doctor_unit.sh
@@ -14,10 +14,12 @@
 #   T3  wake-passed  parked, wake_at in the past                     -> found
 #   T4  park-no-wake parked, wake_at NULL                            -> found
 #   T5  dead-lane    assignee registered, heartbeat absent               -> found
-#   T5b dead-lane    assignee registered + heartbeat ON but desiredState=stopped -> found
-#                    (the OTHER half: the wake loop DOES iterate it and the wake
-#                     then fails every tick, forever — same outcome for the row)
-#   T6  NEGATIVES    a live gate, a live edge, a future park, a todo -> NOT found
+#   T5b NOT a finding assignee heartbeat ON but desiredState=stopped     -> NOT found
+#                    (DIVE-4071: the wake loop DOES iterate it and STARTS the down
+#                     unit — it is wakeable, so reporting dead-lane was a false
+#                     positive whose `task assign` remedy re-points a live row)
+#   T6  NEGATIVES    a live gate, a live edge, a future park, a todo,
+#                    an operator-stopped-but-enabled seat            -> NOT found
 #   T7  the remedy SLOT for a park holds `unpark` and NOT `unblock` (the filed
 #       symptom: `unblock` on a parked row reports success and changes nothing)
 #   T7c the census prints on the FINDINGS path, not only on a clean board
@@ -65,12 +67,18 @@ tasks_db_init
 
 # The registry fixture. `live` is wakeable; `zombie` is registered and will never
 # be woken (no heartbeat key at all — the measured shape: 4 of 17 agents on the
-# host carry none). Names are fixtures, not real seats.
+# host carry none). `offhb` is registered with heartbeat.enabled=false — the OTHER
+# unwakeable shape, and the only two: the tick's population is `heartbeat.enabled
+# == true` alone. `stopped` is heartbeat-ON but operator-stopped (desiredState=
+# stopped); it IS wakeable, because `_hb_wake` never reads desiredState — it
+# iterates every enabled seat and STARTS the down unit (DIVE-4071). Names are
+# fixtures, not real seats.
 mk_registry() {
   cat > "$TMP/agents.json" <<'JSON'
 {"agents":{
   "live":  {"type":"claude","heartbeat":{"enabled":true}},
   "zombie":{"type":"claude"},
+  "offhb": {"type":"claude","heartbeat":{"enabled":false}},
   "stopped":{"type":"claude","heartbeat":{"enabled":true},"desiredState":"stopped"}
 }}
 JSON
@@ -143,7 +151,7 @@ out=$(doctor)
 
 # ---- T1..T5: each class is found, with its OWN label -------------------------
 for pair in "$t_noanchor:no-anchor" "$t_stale:stale-edge" "$t_wakepast:wake-passed" \
-            "$t_nowake:park-no-wake" "$t_dead:dead-lane" "$t_stopped:dead-lane"; do
+            "$t_nowake:park-no-wake" "$t_dead:dead-lane"; do
   id="${pair%%:*}"; want="${pair##*:}"; i=$(ident "$id"); got=$(reason_of "$out" "$i")
   [[ "$got" == "$want" ]] \
     && ok_t "${want}: ${i} classified ${want}" \
@@ -155,18 +163,19 @@ neg_bad=""
 for pair in "$t_gate:live human gate" "$t_gatedone:an ANSWERED gate" \
             "$t_livedep:live blocker edge" \
             "$t_futurepark:park with a future wake" "$t_todo:plain todo" \
+            "$t_stopped:an operator-stopped-but-enabled seat" \
             "$t_openblocker:the open blocker itself"; do
   id="${pair%%:*}"; what="${pair##*:}"; i=$(ident "$id"); got=$(reason_of "$out" "$i")
   [[ -z "$got" ]] || neg_bad+="${i} (${what}) -> ${got}; "
 done
 [[ -z "$neg_bad" ]] \
-  && ok_t "a live gate / an answered gate / live edge / future park / plain todo are NOT reported undispatchable" \
+  && ok_t "a live gate / an answered gate / live edge / future park / plain todo / an operator-stopped-but-enabled seat are NOT reported undispatchable" \
   || bad_t "false positives" "$neg_bad"
 
 # ---- count is exactly the five --------------------------------------------
 nf=$(printf '%s' "$out" | jq -r '.data.findings')
-[[ "$nf" == "6" ]] && ok_t "findings count is exactly the 6 planted rows" \
-                   || bad_t "findings count" "wanted 6, got '${nf}' (rows: $(printf '%s' "$out" | jq -rc '[.data.rows[]?|{ident,reason}]'))"
+[[ "$nf" == "5" ]] && ok_t "findings count is exactly the 5 planted rows" \
+                   || bad_t "findings count" "wanted 5, got '${nf}' (rows: $(printf '%s' "$out" | jq -rc '[.data.rows[]?|{ident,reason}]'))"
 
 # ---- census counts the rest, and names what clears them ---------------------
 disp=$(printf '%s' "$out" | jq -r '.data.census.dispatchable')
@@ -317,19 +326,23 @@ fix "$i_dl" >/dev/null 2>"$TMP/fix.err"; rc13=$?
   || bad_t "dead-lane without --to" "rc=$rc13 assignee=$(asgof "$t_dead") :: $(cat "$TMP/fix.err")"
 
 # ---- T14: --to a lane that is ALSO dead is refused --------------------------
-# The verb that reports dead lanes must not be the fastest way to make one. Both
-# halves of the wakeability test are exercised: 'zombie' (no heartbeat key) was
-# the finding, 'stopped' (heartbeat on, operator-stopped) is the destination.
-fix "$i_dl" --to=stopped >/dev/null 2>"$TMP/fix.err"; rc14=$?
+# The verb that reports dead lanes must not be the fastest way to make one. The
+# genuinely unwakeable destination is 'offhb' (heartbeat.enabled=false — the tick
+# never iterates it), not an operator-stopped seat: DIVE-4071 established that an
+# operator-stopped-but-enabled seat IS wakeable, exercised as the ACCEPT arm below.
+fix "$i_dl" --to=offhb >/dev/null 2>"$TMP/fix.err"; rc14=$?
 { [[ $rc14 -ne 0 ]] && [[ "$(asgof "$t_dead")" == "zombie" ]]; } \
-  && ok_t "--fix --to=<an operator-stopped seat> is refused; the row stays where it was" \
+  && ok_t "--fix --to=<a seat whose heartbeat is disabled> is refused; the row stays where it was" \
   || bad_t "--to a dead lane accepted" "rc=$rc14 assignee=$(asgof "$t_dead") :: $(cat "$TMP/fix.err")"
 
-# ...and a WAKEABLE destination is accepted and the row actually moves.
-fix "$i_dl" --to=live >/dev/null 2>"$TMP/fix.err"; rc14b=$?
-{ [[ $rc14b -eq 0 ]] && [[ "$(asgof "$t_dead")" == "live" ]]; } \
-  && ok_t "--fix dead-lane --to=<a wakeable seat>: the row is re-assigned" \
-  || bad_t "--fix dead-lane --to=live" "rc=$rc14b assignee=$(asgof "$t_dead") :: $(cat "$TMP/fix.err")"
+# ...and a WAKEABLE destination is accepted and the row actually moves. 'stopped'
+# is operator-stopped but heartbeat-ON: DIVE-4071 says the tick wakes it (it STARTS
+# the down unit), so it is a VALID re-point target — the behaviour change this row
+# lands. Assigning a live row TO an operator-stopped seat is now accepted by design.
+fix "$i_dl" --to=stopped >/dev/null 2>"$TMP/fix.err"; rc14b=$?
+{ [[ $rc14b -eq 0 ]] && [[ "$(asgof "$t_dead")" == "stopped" ]]; } \
+  && ok_t "--fix dead-lane --to=<an operator-stopped-but-enabled seat>: accepted, the row is re-assigned (the wake loop will start it)" \
+  || bad_t "--fix dead-lane --to=stopped" "rc=$rc14b assignee=$(asgof "$t_dead") :: $(cat "$TMP/fix.err")"
 
 # ---- T15: a row that is NOT a current finding is refused ---------------------
 # This is the whole reason --fix re-derives instead of reading the report: the

--- a/tests/verifier_wakeable_routing_unit.sh
+++ b/tests/verifier_wakeable_routing_unit.sh
@@ -70,10 +70,12 @@ ident() { db "SELECT ident FROM tasks WHERE id=$1;"; }
 reroster() { _TASK_ROSTER=""; _TASK_ROSTER_STATE=""; }
 
 # ---- the registry fixture ---------------------------------------------------
-# `deadqa` and `deadlead` are REGISTERED and never woken (no heartbeat key —
-# the measured shape). `livelead` and `livehand` are wakeable. `frozen` is
-# heartbeat-on but operator-stopped: the wake loop iterates it and the wake
-# fails every tick, forever, which is the same outcome for the row.
+# `deadqa`, `deadlead` and `deadcoord` are REGISTERED and never woken (no
+# heartbeat key — the measured shape). `livelead` and `livehand` are wakeable.
+# `frozen` is heartbeat-ON but operator-stopped (desiredState=stopped): it IS
+# wakeable, because `_hb_wake` never reads desiredState — it iterates every
+# enabled seat and STARTS the down unit, so the row dispatches (DIVE-4071). The
+# only unwakeable shape is a missing/disabled heartbeat key.
 mk_registry() {
   cat > "$STATE_DIR/agents.json" <<'JSON'
 {"agents":{
@@ -82,6 +84,7 @@ mk_registry() {
   "livehand": {"type":"claude","heartbeat":{"enabled":true}},
   "deadqa":   {"type":"claude"},
   "deadlead": {"type":"claude"},
+  "deadcoord":{"type":"claude"},
   "frozen":   {"type":"claude","heartbeat":{"enabled":true},"desiredState":"stopped"}
 }}
 JSON
@@ -93,12 +96,17 @@ mk_registry
 # could be green because the fixture is wrong rather than because the code is
 # right: if `deadqa` read wakeable, "skipped" and "never a candidate" render
 # identically.
-_task_doctor_lane_wakeable livelead; rc_live=$?
-_task_doctor_lane_wakeable deadqa;   rc_dead=$?
-_task_doctor_lane_wakeable frozen;   rc_frozen=$?
-{ [[ "$rc_live" == "0" && "$rc_dead" == "1" && "$rc_frozen" == "1" ]]; } \
-  && ok_t "CONTROL: the fixture registry really does make livelead wakeable and deadqa/frozen not (0/1/1)" \
-  || bad_t "CONTROL: fixture wakeability" "livelead=$rc_live (want 0) deadqa=$rc_dead (want 1) frozen=$rc_frozen (want 1)"
+_task_doctor_lane_wakeable livelead;  rc_live=$?
+_task_doctor_lane_wakeable deadqa;    rc_dead=$?
+_task_doctor_lane_wakeable frozen;    rc_frozen=$?
+_task_doctor_lane_wakeable deadcoord; rc_coord=$?
+# DIVE-4071: `frozen` (heartbeat-on, operator-stopped) is WAKEABLE (rc 0), same as
+# livelead — the tick starts its down unit. `deadqa`/`deadcoord` (no heartbeat) are
+# the only unwakeable shape (rc 1). If this control were wrong every arm below could
+# be green because the fixture is wrong rather than because the code is right.
+{ [[ "$rc_live" == "0" && "$rc_dead" == "1" && "$rc_frozen" == "0" && "$rc_coord" == "1" ]]; } \
+  && ok_t "CONTROL: livelead and frozen (operator-stopped-but-enabled) are wakeable; deadqa/deadcoord (no heartbeat) are not (0/1/0/1)" \
+  || bad_t "CONTROL: fixture wakeability" "livelead=$rc_live (want 0) deadqa=$rc_dead (want 1) frozen=$rc_frozen (want 0) deadcoord=$rc_coord (want 1)"
 
 org_seed() {  # <name> [--role=x] [--title=y] [--reports-to=z]
   local n="$1"; shift
@@ -130,11 +138,12 @@ fi
 
 # ---- P2: an end-to-end unwakeable chain returns EMPTY ------------------------
 # Rebuild the chart so EVERY candidate resolves to a seat nothing wakes:
-# QA=deadqa, manager=deadlead, coordinator=frozen (stopped, the other half),
+# QA=deadqa, manager=deadlead, coordinator=deadcoord (all no-heartbeat — the only
+# unwakeable shape; an operator-stopped seat would be woken and is NOT used here),
 # and no org root or deputy that is alive.
 db "DELETE FROM agents_org;"
 org_seed deadlead
-org_seed frozen   --role=coordinator
+org_seed deadcoord --role=coordinator
 org_seed deadqa   --title="Deadqa · Verifier (codex)"
 org_seed maker2   --role=builder --reports-to=deadlead
 got2=$(_task_default_verifier maker2 "")
@@ -179,7 +188,9 @@ reason_of() { printf '%s' "$1" | jq -r --arg i "$2" '.data.rows[]? | select(.ide
 # is wrong today and it cannot be graded tomorrow.
 t_dv=$(addt --assignee=maker --no-verify -- "live lane, grader nothing wakes")
 db "UPDATE tasks SET verifier='deadqa' WHERE id=${t_dv};"
-t_frozenv=$(addt --assignee=maker --no-verify -- "live lane, grader the operator stopped")
+# A grader that is operator-stopped but heartbeat-ON is WAKEABLE (DIVE-4071): the
+# tick starts its unit at handoff, so this is a NEGATIVE, not a dead-verifier row.
+t_frozenv=$(addt --assignee=maker --no-verify -- "live lane, grader is operator-stopped but enabled")
 db "UPDATE tasks SET verifier='frozen' WHERE id=${t_frozenv};"
 # negative: a live grader
 t_okv=$(addt --assignee=maker --no-verify -- "live lane, live grader")
@@ -189,10 +200,19 @@ out=$(doctor)
 i_dv=$(ident "$t_dv"); i_fv=$(ident "$t_frozenv"); i_okv=$(ident "$t_okv")
 
 # ---- D1 ---------------------------------------------------------------------
-r_dv=$(reason_of "$out" "$i_dv"); r_fv=$(reason_of "$out" "$i_fv")
-{ [[ "$r_dv" == "dead-verifier" && "$r_fv" == "dead-verifier" ]]; } \
-  && ok_t "D1: a row with a live assignee and an unwakeable VERIFIER is reported dead-verifier (both halves: no-heartbeat and operator-stopped)" \
-  || bad_t "D1: the verifier column is never scanned" "no-heartbeat grader -> '${r_dv:-<not a finding>}', stopped grader -> '${r_fv:-<not a finding>}' (want dead-verifier for both)"
+r_dv=$(reason_of "$out" "$i_dv")
+{ [[ "$r_dv" == "dead-verifier" ]]; } \
+  && ok_t "D1: a row with a live assignee and an unwakeable VERIFIER (no heartbeat) is reported dead-verifier" \
+  || bad_t "D1: the verifier column is never scanned" "no-heartbeat grader -> '${r_dv:-<not a finding>}' (want dead-verifier)"
+
+# ---- D1b negative: an operator-stopped-but-enabled grader is NOT a finding ---
+# The false belief this row corrects (DIVE-4071/DIVE-3939): folding desiredState
+# into the grader check flagged a grader the tick actually wakes as dead-verifier,
+# whose remedy re-points the grading rail off a live seat.
+r_fv=$(reason_of "$out" "$i_fv")
+[[ -z "$r_fv" ]] \
+  && ok_t "D1b: a grader that is operator-stopped but heartbeat-ON is NOT dead-verifier (the tick wakes it)" \
+  || bad_t "D1b: false dead-verifier on an operator-stopped-but-enabled grader" "${i_fv} -> ${r_fv}"
 
 # ---- D2 negative ------------------------------------------------------------
 r_okv=$(reason_of "$out" "$i_okv")


### PR DESCRIPTION
# DIVE-4071 — task doctor dead-lane predicate matches the actual wake path

## Defect
`_task_doctor_lane_wakeable` (src/task/doctor.sh) failed a lane when the registry
said `desiredState == "stopped"`, on the belief that "an operator-stopped seat IS
iterated by the wake loop and the wake then FAILS." It does not fail. `_hb_wake`
(src/cmd_heartbeat.sh) never reads `desiredState`; the tick's population is
`heartbeat.enabled == true` alone, and `_hb_wake` STARTS a down unit. `cmd_stop`
sets `desiredState=stopped` but leaves `heartbeat.enabled` untouched, so an
operator-stopped seat with an enabled heartbeat is still iterated and its unit
restarted — the row dispatches. Any seat started outside `5dive agent start`
(manual `systemctl start`, crash-loop recovery) carries `desiredState=stopped`
with a live unit and manufactured a FALSE `dead-lane` whose printed remedy
(`5dive task assign`) re-points a row off a seat actively working it.

## Fix
- Predicate now keys on `heartbeat.enabled` ONLY — the tick's exact population.
  desiredState is no longer read (neither as a disqualifier nor a signal).
- `dead-lane` explain text corrected: "heartbeat disabled or absent", drops the
  false "operator-stopped".
- Header comment block rewritten to state the real mechanism.

## Test
New `tests/task_doctor_lane_wakeable_unit.sh` (core tier, <1s, no root/network),
7 arms. The discriminating arm (desiredState=stopped + enabled == wakeable) was
mutation-verified: reverting the predicate to the old desiredState fold-in flips
that arm to FAIL (6 passed / 1 failed).

## Residual (out of scope, needs its own row)
The tick RESTARTING an operator-stopped-but-enabled seat is a real anomaly (tick
overrides operator intent because `cmd_stop` does not disable the heartbeat). It
is a different finding ("registry vs tick disagreement"), not "nothing wakes this
lane", so it is deliberately not in this predicate.
