### PR TITLE
DIVE-4068: the update path grades the OUTCOME, not just the artifact — a post-install health gate with rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## Unreleased — feat(self-update): the update path checks the box it just updated still runs an agent (DIVE-4068)
+
+0.26.1 shipped a launcher that could not start any agent (DIVE-4067). The nightly installs the
+release and then restarts every agent, so every box that took it **emptied itself, unattended**,
+and stayed empty until a human noticed.
+
+`install.sh` grades the ARTIFACT — it fetched, the sha256 matches, `bash -n` parses, the version
+went forwards. Every one of those passed on 0.26.1: a self-referencing `local` is syntactically
+valid. The OUTCOME — *does an agent still start on this box* — was never asked, and it is the one
+question the box can answer for itself in about twenty seconds.
+
+`5dive self-update` now snapshots the startup path before the installer runs, and grades the
+first agent it restarts:
+
+- **The canary is free.** It is the first unit the pass was going to bounce anyway, so DIVE-3172's
+  "restart only whoever's payload moved" is not undone — and the gate settles before the loop
+  reaches agent number two, which holds a bad release to one dark agent instead of the fleet.
+- **`NRestarts`, not `is-active`.** The unit is `Type=simple`, so a launcher that execs and dies
+  one line later is `active` for the instant between them. A naive is-active check would have
+  reported 0.26.1 as a clean install.
+- **On a failure it ROLLS BACK** `5dive`, `5dive-agent-start` and the systemd template to the build
+  that was on the box, restarts the canary onto them, touches no other agent, and exits non-zero
+  naming the release and the agent it was measured on.
+- **A launcher-only release is probed deliberately.** `5dive-agent-start` lives in `/usr/local/bin`,
+  so it is invisible to the payload fingerprint — 0.26.1 would have moved no fingerprint, restarted
+  no one, and been graded by nothing. When the launcher's own hash moves and the pass restarts
+  nobody, the gate spends one restart on an idle agent.
+- **Three outcomes, not two.** An unreadable unit HALTS (blast radius stays at one) but rolls back
+  nothing — reverting a release needs positive evidence of breakage. A systemd that answers nothing
+  at all is told apart from that by an `Id` positive control and PROCEEDS exactly as before, so a
+  safety check cannot freeze a box off updates.
+
+`self-update`'s JSON gains a `health_gate` object; every existing field keeps its meaning.
+
 ## Unreleased — feat(team): `loops:` — a company import brings recurring work, not just a roster (DIVE-4022)
 
 `5dive team import <slug>` provisioned a **roster**, not a working company. Agents, roles and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ first agent it restarts:
   so it is invisible to the payload fingerprint — 0.26.1 would have moved no fingerprint, restarted
   no one, and been graded by nothing. When the launcher's own hash moves and the pass restarts
   nobody, the gate spends one restart on an idle agent.
+- **A false rollback is guarded separately.** An agent already crash-looping before the update is
+  indistinguishable from a release that broke the box, so a canary must read `active/running` at two
+  samples a second apart with the counter still between them. A unit that fails that is not judged
+  broken — it is unusable as an instrument, and the canary role moves on.
 - **Three outcomes, not two.** An unreadable unit HALTS (blast radius stays at one) but rolls back
   nothing — reverting a release needs positive evidence of breakage. A systemd that answers nothing
   at all is told apart from that by an `Id` positive control and PROCEEDS exactly as before, so a

--- a/src/cmd_selfupdate.sh
+++ b/src/cmd_selfupdate.sh
@@ -721,6 +721,34 @@ _hg_watch() {
 # _hg_probe <unit> — restart the unit and grade the outcome. Echoes the verdict.
 # The baseline is read BEFORE the restart: NRestarts is cumulative for the life
 # of the unit, so only the DELTA across this restart is about this release.
+# _hg_canary_ok <unit> — is this unit a unit we can LEARN anything from?
+#
+# The gate reads a crash-loop as "the release broke the box". An agent that was
+# ALREADY crash-looping before the update reads exactly the same, and would make
+# the gate revert a perfectly good release for the whole box because one agent
+# was independently sick — a false rollback is the one way this row can make a
+# night worse than it found it.
+#
+# `systemctl list-units --state=running` does not settle it: a unit that dies and
+# is re-started every 3s IS running at the instant it is enumerated. So this takes
+# TWO samples a second apart and requires the unit to be active/running at both,
+# with the counter still between them. A unit that fails this is not judged
+# broken — it is judged UNREADABLE as an instrument, and the canary role moves to
+# the next agent.
+_hg_canary_ok() {
+  local unit="${1:-}" a1 n1 a2 n2
+  a1="$(_hg_unit_field "$unit" ActiveState)"; n1="$(_hg_unit_field "$unit" NRestarts)"
+  [[ "$a1" == "active" && "$(_hg_unit_field "$unit" SubState)" == "running" ]] || return 1
+  sleep "${HEALTH_GATE_PRECHECK_SECS:-1}" 2>/dev/null || true
+  a2="$(_hg_unit_field "$unit" ActiveState)"; n2="$(_hg_unit_field "$unit" NRestarts)"
+  [[ "$a2" == "active" && "$(_hg_unit_field "$unit" SubState)" == "running" ]] || return 1
+  # Counters unreadable on both samples is not evidence of a loop — the verdict
+  # path already treats an unreadable counter as no-delta, and being stricter
+  # here would disqualify every canary on a systemd too old to report it.
+  [[ -n "$n1" && -n "$n2" && "$n1" != "$n2" ]] && return 1
+  return 0
+}
+
 _hg_probe() {
   local unit="${1:-}" base
   # POSITIVE CONTROL BEFORE THE MEASUREMENT. `Id` is set for every unit systemd
@@ -733,6 +761,10 @@ _hg_probe() {
   if [[ -z "$(_hg_unit_field "$unit" Id)" ]]; then
     systemctl restart "$unit" 2>/dev/null || { printf 'restart-refused\n'; return 0; }
     printf 'gate-unavailable\n'; return 0
+  fi
+  # A unit that was already sick cannot answer a question about the release.
+  if ! _hg_canary_ok "$unit"; then
+    printf 'not-a-canary\n'; return 0
   fi
   base="$(_hg_unit_field "$unit" NRestarts)"
   if ! systemctl restart "$unit" 2>/dev/null; then
@@ -760,6 +792,12 @@ _hg_probe() {
 #     reason nobody would connect to this row: a new fleet-wide freeze introduced
 #     by a safety check. Proceeding is exactly today's behaviour, and it is said
 #     out loud at the call site rather than folded into a pass.
+#   NOT-A-CANARY TAKES THE NEXT AGENT INSTEAD, and this one is load-bearing. An
+#     agent that was already crash-looping before the update is indistinguishable
+#     from a release that broke the box, and treating it as the latter reverts a
+#     good release for every agent on the box. A false rollback is the one way
+#     this row can make a night worse than it found it, so a canary that cannot
+#     be read as an instrument is skipped rather than believed.
 #   RESTART-REFUSED TAKES THE NEXT AGENT INSTEAD. systemctl declining to restart
 #     one unit (masked, mid-stop, a bad drop-in) says nothing about the artifact,
 #     and before this row that agent simply landed in `failed` and the loop went
@@ -770,7 +808,7 @@ _hg_action() {
   case "${1:-}" in
     healthy|gate-unavailable) printf 'proceed\n' ;;
     crash-loop|failed|down)   printf 'rollback\n' ;;
-    restart-refused)          printf 'next-canary\n' ;;
+    restart-refused|not-a-canary) printf 'next-canary\n' ;;
     *)                        printf 'halt\n' ;;
   esac
 }
@@ -838,7 +876,7 @@ cmd_self_update() {
   # DIVE-4068 gate state. `hg_verdict` stays "not-probed" until a unit is
   # actually restarted, and that is a THIRD value, not a pass — a pass has to be
   # something the box measured.
-  local hg_canary="" hg_verdict="not-probed" hg_action="proceed" hg_why=""
+  local hg_canary="" hg_verdict="not-probed" hg_verdict_raw="" hg_action="proceed" hg_why=""
   for i in "${!units[@]}"; do
     name="${names[$i]}"; before="${befores[$i]}"
     # DIVE-4033: asked BEFORE the payload predicate, so the operator is told the
@@ -912,25 +950,35 @@ cmd_self_update() {
     # to one dark agent instead of the box.
     if [[ -z "$hg_canary" ]]; then
       hg_canary="$name"; hg_why="first agent this pass restarts"
-      hg_verdict="$(_hg_probe "${units[$i]}")"
+      hg_verdict="$(_hg_probe "${units[$i]}")"; hg_verdict_raw="$hg_verdict"
       hg_action="$(_hg_action "$hg_verdict")"
       if [[ "$hg_action" == "next-canary" ]]; then
-        # systemctl would not restart this unit. That is the pre-DIVE-4068
-        # `failed` case verbatim, and it is not evidence about the release — so
-        # the canary role moves to the next agent the loop reaches rather than
-        # stopping the pass on one stuck unit.
-        warn "failed to restart agent '$name'"
-        failed+=("$name"); hg_canary=""; hg_verdict="not-probed"; hg_action=proceed
+        hg_canary=""; hg_verdict="not-probed"; hg_action=proceed
+        if [[ "$hg_verdict_raw" == "not-a-canary" ]]; then
+          # The unit was not steady BEFORE the update, so it cannot answer a
+          # question about the release. Nothing has been restarted yet on this
+          # branch — `_hg_probe` returns before the restart — so fall through to
+          # the ORDINARY restart below and let the next agent take the canary
+          # role. Believing this unit would revert a good release for the whole
+          # box on one independently sick agent.
+          step "not using $name as the health-gate canary (its unit was not steady before the update) — the next agent this pass restarts takes that role"
+        else
+          # systemctl would not restart this unit: the pre-DIVE-4068 `failed`
+          # case verbatim, and not evidence about the release.
+          warn "failed to restart agent '$name'"
+          failed+=("$name"); continue
+        fi
+      elif [[ "$hg_action" != "proceed" ]]; then
+        break
+      else
+        if [[ "$hg_verdict" == "gate-unavailable" ]]; then
+          warn "restarted $name, but systemd answered nothing about the unit — the post-install health gate could NOT run on this box. This pass behaves exactly as it did before the gate existed: a release that cannot start an agent will not be caught here."
+        else
+          step "restarted $name ($why) — health gate PASSED (the unit was still running ${HEALTH_GATE_WINDOW_SECS:-20}s later, with no systemd re-start)"
+        fi
+        restarted+=("$name")
         continue
       fi
-      if [[ "$hg_action" != "proceed" ]]; then break; fi
-      if [[ "$hg_verdict" == "gate-unavailable" ]]; then
-        warn "restarted $name, but systemd answered nothing about the unit — the post-install health gate could NOT run on this box. This pass behaves exactly as it did before the gate existed: a release that cannot start an agent will not be caught here."
-      else
-        step "restarted $name ($why) — health gate PASSED (the unit was still running ${HEALTH_GATE_WINDOW_SECS:-20}s later, with no systemd re-start)"
-      fi
-      restarted+=("$name")
-      continue
     fi
     if systemctl restart "${units[$i]}" 2>/dev/null; then
       step "restarted $name ($why)"
@@ -973,10 +1021,10 @@ cmd_self_update() {
         hg_canary="$cand"
         hg_why="the launcher itself changed and this pass restarted no one$( (( hg_moved == 2 )) && printf ' (manifest unreadable — probed rather than assumed unchanged)')"
         step "no agent needed a restart, but the launcher changed — probing '$cand' so a build that cannot start an agent is found now rather than on its next bounce"
-        hg_verdict="$(_hg_probe "${units[$i]}")"
+        hg_verdict="$(_hg_probe "${units[$i]}")"; hg_verdict_raw="$hg_verdict"
         hg_action="$(_hg_action "$hg_verdict")"
         if [[ "$hg_action" == "next-canary" ]]; then
-          warn "failed to restart agent '$cand'"; failed+=("$cand")
+          [[ "$hg_verdict_raw" == "restart-refused" ]] && { warn "failed to restart agent '$cand'"; failed+=("$cand"); }
           hg_canary=""; hg_verdict=not-probed; hg_action=proceed; continue
         fi
         [[ "$hg_action" == "proceed" ]] && restarted+=("$cand")

--- a/src/cmd_selfupdate.sh
+++ b/src/cmd_selfupdate.sh
@@ -508,6 +508,281 @@ _pending_restart_sweep() {
 }
 # <<< DIVE-3173 deferred restart for a busy agent
 
+# >>> DIVE-4068 post-install health gate
+#     (tests/self_update_health_gate_unit.sh extracts this block VERBATIM
+#      between these markers and runs the shipped bytes — keep them.)
+#
+# 0.26.1 shipped a launcher that could not start any agent (DIVE-4067). The
+# update path installed it, then restarted every agent, and every box that took
+# the release emptied itself and STAYED empty until a human noticed.
+#
+# WHAT THE UPDATE PATH ALREADY GRADED, AND WHAT IT DID NOT. install.sh grades
+# the ARTIFACT — it fetched, the sha256 matches, `bash -n` parses, the version
+# does not go backwards. Every one of those passed on 0.26.1: a self-referencing
+# `local` is syntactically valid, so the file that could not start a single agent
+# is indistinguishable from a good one by every check the installer runs. The
+# OUTCOME — "an agent still starts on this box" — was never asked, and it is the
+# one question whose answer the box can produce for itself in about twenty
+# seconds.
+#
+# THE PROBE IS ONE AGENT, AND IT IS ONE THE PASS WAS GOING TO BOUNCE ANYWAY.
+# DIVE-3172 took the nightly from "restart everyone" to "restart whoever's
+# payload moved", and a gate that adds an unconditional canary restart would put
+# that cost straight back. So the canary is the FIRST unit this pass restarts:
+# on a night with restarts the gate is free, and it fires before the second agent
+# is touched — which is what keeps the blast radius of a bad release at one agent
+# instead of the fleet.
+#
+# THE ONE NIGHT THAT BUYS NOTHING, AND WHY IT IS HANDLED SEPARATELY. The launcher
+# is NOT in DIVE-3172's payload fingerprint (it lives in /usr/local/bin, not in
+# an agent's home), so a launcher-only release changes no fingerprint, restarts
+# nobody, and would never be probed — which is EXACTLY the shape of 0.26.1. When
+# the launcher's own hash moved and the pass restarted no one, the gate probes an
+# idle agent deliberately. That is a restart that would not otherwise happen, and
+# it is bounded to the rare night the startup path itself changed.
+#
+# THREE OUTCOMES, NOT TWO. `unknown` is not folded into either answer:
+#   healthy    -> the rest of the restart loop proceeds, byte for byte as today.
+#   broken     -> restore the previous artifacts, restart the canary onto them,
+#                 and touch NO other agent.
+#   unknown    -> stop the loop, roll back NOTHING. Halting needs only the
+#                 ABSENCE of evidence of health; reverting a release across a box
+#                 needs positive evidence of breakage. Reverting on an unreadable
+#                 systemctl would freeze a box on an old build every night the
+#                 reading fails, silently — the failure mode DIVE-3173 and
+#                 DIVE-1095 both name as the worse one.
+#
+# A rollback point is captured BEFORE the installer runs, because afterwards
+# there is nothing left to restore from — install.sh has no rollback point of its
+# own (its own header says so: "one upgrade cycle, with no tag, no cut, and no
+# rollback point").
+
+# The artifacts an update swaps that can, on their own, stop every agent from
+# starting. Deliberately NOT the whole managed set (hooks, skills, refresh
+# scripts, the digest cron): those are read by an agent that is already up, and
+# reverting them would widen a targeted rollback into a general one. These three
+# are the startup path itself.
+#   $BIN/5dive                        the bundle; `5dive-agent-start` shells into it
+#   $BIN/5dive-agent-start            the launcher — DIVE-4067's file
+#   $SYSTEMD/5dive-agent@.service     ExecStart, Restart=, RestartPreventExitStatus
+_hg_artifacts() {
+  printf '%s\n' \
+    "${HEALTH_GATE_BIN_DIR:-/usr/local/bin}/5dive" \
+    "${HEALTH_GATE_BIN_DIR:-/usr/local/bin}/5dive-agent-start" \
+    "${HEALTH_GATE_SYSTEMD_DIR:-/etc/systemd/system}/5dive-agent@.service"
+}
+
+_hg_rollback_dir() {
+  printf '%s\n' "${HEALTH_GATE_ROLLBACK_DIR:-${STATE_DIR:-/var/lib/5dive}/rollback}"
+}
+
+_hg_sha() { [[ -f "${1:-}" ]] && sha256sum "$1" 2>/dev/null | awk '{print $1}'; return 0; }
+
+# _hg_capture — snapshot the current startup path. Exactly ONE generation is
+# kept: a rollback that could choose between generations would need someone to
+# choose, and the only answer this gate can defend is "the thing that was
+# working ten seconds ago".
+#
+# Returns non-zero when the snapshot is not usable. That does NOT stop the probe
+# — detection without a rollback is still strictly better than the silence this
+# row exists to remove, and the operator is told which of the two they got.
+_hg_capture() {
+  local dir f base rc=0
+  dir="$(_hg_rollback_dir)"
+  rm -rf "$dir.new" 2>/dev/null
+  mkdir -p "$dir.new" 2>/dev/null || return 1
+  : > "$dir.new/manifest" 2>/dev/null || return 1
+  while read -r f; do
+    [[ -n "$f" ]] || continue
+    base="${f##*/}"
+    # An artifact that is ABSENT is recorded as absent rather than skipped. A
+    # box with no systemd template must not have one conjured onto it by a
+    # rollback, and "we never saw this file" and "we failed to copy it" have to
+    # be distinguishable at restore time.
+    if [[ ! -f "$f" ]]; then
+      printf 'absent\t%s\t-\n' "$f" >> "$dir.new/manifest"
+      continue
+    fi
+    if cp -p "$f" "$dir.new/$base" 2>/dev/null; then
+      printf 'present\t%s\t%s\n' "$f" "$(_hg_sha "$f")" >> "$dir.new/manifest"
+    else
+      printf 'uncopied\t%s\t%s\n' "$f" "$(_hg_sha "$f")" >> "$dir.new/manifest"
+      rc=1
+    fi
+  done < <(_hg_artifacts)
+  rm -rf "$dir" 2>/dev/null
+  mv -f "$dir.new" "$dir" 2>/dev/null || return 1
+  return $rc
+}
+
+# _hg_artifact_moved <path> — did the upgrade change this file since the capture?
+# "no snapshot line" answers UNKNOWN (2), never "no": the launcher-only probe
+# below must not be skipped because the manifest was unreadable.
+_hg_artifact_moved() {
+  local f="${1:-}" line was now
+  line=$(awk -F'\t' -v p="$f" '$2==p{print; exit}' "$(_hg_rollback_dir)/manifest" 2>/dev/null) || line=""
+  [[ -n "$line" ]] || return 2
+  was="${line##*$'\t'}"
+  now="$(_hg_sha "$f")"
+  [[ -n "$now" ]] || return 2
+  case "$line" in
+    absent*) return 0 ;;
+  esac
+  [[ "$was" == "$now" ]] && return 1
+  return 0
+}
+
+# _hg_restore — put the captured startup path back. Echoes the basenames it
+# restored, one per line; empty output means nothing was restored.
+_hg_restore() {
+  local dir line status f base restored=0
+  dir="$(_hg_rollback_dir)"
+  [[ -f "$dir/manifest" ]] || return 1
+  while IFS=$'\t' read -r status f _; do
+    [[ -n "$f" ]] || continue
+    base="${f##*/}"
+    [[ "$status" == "present" ]] || continue
+    [[ -f "$dir/$base" ]] || continue
+    # Same-fs temp + mv, the shape install.sh uses for the bundle swap: a box
+    # that loses power mid-restore keeps a whole file rather than a half-written
+    # one that execs into garbage.
+    if cp -p "$dir/$base" "$f.hgtmp" 2>/dev/null && mv -f "$f.hgtmp" "$f" 2>/dev/null; then
+      printf '%s\n' "$base"; restored=$((restored + 1))
+    else
+      rm -f "$f.hgtmp" 2>/dev/null
+    fi
+  done < "$dir/manifest"
+  (( restored > 0 )) || return 1
+  # The unit template is one of the three, and systemd does not re-read it on
+  # its own. Unconditional and best-effort: a reload with nothing to reload is
+  # free, and skipping it after restoring the template would leave the box
+  # running the bad ExecStart it just reverted.
+  command -v systemctl >/dev/null 2>&1 && systemctl daemon-reload 2>/dev/null
+  return 0
+}
+
+# _hg_unit_field <unit> <property> — one systemd property, empty when unreadable.
+_hg_unit_field() {
+  command -v systemctl >/dev/null 2>&1 || return 0
+  systemctl show "${1:-}" --property="${2:-}" --value 2>/dev/null || true
+}
+
+# _hg_verdict <ActiveState> <SubState> <NRestarts-before> <NRestarts-after>
+#   healthy | crash-loop | failed | down | unknown
+#
+# Pure, so the harness grades the decision itself rather than a restatement.
+#
+# NRestarts IS THE FAST SIGNAL, and it is why this does not just read is-active.
+# The unit is Type=simple, so a launcher that execs and dies one line later is
+# `active` for the instant between them — the very reading a naive check would
+# take. RestartSec=3 means systemd's first re-start lands ~3s in and NRestarts
+# ticks to 1, which is decisive long before StartLimitBurst=10 finally parks the
+# unit in `failed` some 30s later. So a crash-loop is caught by the counter, and
+# the two exits the launcher itself uses for permanent conditions (2 unknown
+# type, 3 not installed) are caught by `failed` via RestartPreventExitStatus.
+_hg_verdict() {
+  local active="${1:-}" sub="${2:-}" before="${3:-}" after="${4:-}"
+  [[ -n "$active" ]] || { printf 'unknown\n'; return 0; }
+  [[ "$before" =~ ^[0-9]+$ ]] || before=""
+  [[ "$after"  =~ ^[0-9]+$ ]] || after=""
+  [[ "$active" == "failed" ]] && { printf 'failed\n'; return 0; }
+  if [[ -n "$before" && -n "$after" ]] && (( after > before )); then
+    printf 'crash-loop\n'; return 0
+  fi
+  [[ "$active" == "active" && "$sub" == "running" ]] && { printf 'healthy\n'; return 0; }
+  # Still coming up when the window ran out. NOT `down` — we did not watch long
+  # enough to say, and `down` reverts a release.
+  [[ "$active" == "activating" || "$active" == "reloading" ]] && { printf 'unknown\n'; return 0; }
+  printf 'down\n'
+}
+
+# _hg_watch <unit> <baseline-NRestarts> [window-secs] [poll-secs]
+# Echoes the verdict after watching the unit settle. Short-circuits on a
+# DECISIVE failure only: an early `healthy` reading is not an answer, because
+# "started" is not the question — "stayed up past the restart burst" is.
+_hg_watch() {
+  local unit="${1:-}" base="${2:-}" window="${3:-${HEALTH_GATE_WINDOW_SECS:-20}}" poll="${4:-${HEALTH_GATE_POLL_SECS:-1}}"
+  local waited=0 v
+  [[ "$window" =~ ^[0-9]+$ ]] || window=20
+  [[ "$poll" =~ ^[0-9]+$ && "$poll" -gt 0 ]] || poll=1
+  while :; do
+    v="$(_hg_verdict "$(_hg_unit_field "$unit" ActiveState)" "$(_hg_unit_field "$unit" SubState)" \
+                     "$base" "$(_hg_unit_field "$unit" NRestarts)")"
+    case "$v" in
+      crash-loop|failed) printf '%s\n' "$v"; return 0 ;;
+    esac
+    (( waited >= window )) && break
+    sleep "$poll" 2>/dev/null || true
+    waited=$((waited + poll))
+  done
+  printf '%s\n' "$v"
+}
+
+# _hg_probe <unit> — restart the unit and grade the outcome. Echoes the verdict.
+# The baseline is read BEFORE the restart: NRestarts is cumulative for the life
+# of the unit, so only the DELTA across this restart is about this release.
+_hg_probe() {
+  local unit="${1:-}" base
+  # POSITIVE CONTROL BEFORE THE MEASUREMENT. `Id` is set for every unit systemd
+  # knows, so an empty one means systemd answered NOTHING — not that the unit is
+  # sick. Without this control an uninterrogable systemd reads exactly like a
+  # unit in an unclassifiable state, and the gate would halt the nightly on every
+  # such box forever. (The same failure shape the CLAUDE.md rule names for a
+  # cross-seat probe: a denial and a real negative are the same empty string
+  # until something known-present is read alongside it.)
+  if [[ -z "$(_hg_unit_field "$unit" Id)" ]]; then
+    systemctl restart "$unit" 2>/dev/null || { printf 'restart-refused\n'; return 0; }
+    printf 'gate-unavailable\n'; return 0
+  fi
+  base="$(_hg_unit_field "$unit" NRestarts)"
+  if ! systemctl restart "$unit" 2>/dev/null; then
+    printf 'restart-refused\n'; return 0
+  fi
+  _hg_watch "$unit" "$base"
+}
+# _hg_action <verdict> -> proceed | rollback | halt | next-canary
+#
+# The split is asymmetric on purpose, and the two outcomes that are NOT `halt`
+# are the ones worth reading twice — each exists because halting there would
+# introduce a NEW fleet-wide failure in the name of preventing one.
+#
+#   ROLLBACK needs POSITIVE evidence of breakage — the unit died, systemd
+#     re-started it, or it parked in `failed`. Reverting a box's startup path is
+#     itself a change; doing it on a hunch is how a box never takes an update
+#     again.
+#   HALT needs only the ABSENCE of evidence of health. It costs the agents this
+#     pass had not yet reached one night's payload refresh, it is loud, and it is
+#     what holds the blast radius at one agent.
+#   GATE-UNAVAILABLE PROCEEDS. This is not a reading we could not classify — it
+#     is systemd declining to answer anything at all about the unit, on a box
+#     where the gate therefore never ran. Halting there would take every box with
+#     an uninterrogable systemd off updates entirely, permanently and for a
+#     reason nobody would connect to this row: a new fleet-wide freeze introduced
+#     by a safety check. Proceeding is exactly today's behaviour, and it is said
+#     out loud at the call site rather than folded into a pass.
+#   RESTART-REFUSED TAKES THE NEXT AGENT INSTEAD. systemctl declining to restart
+#     one unit (masked, mid-stop, a bad drop-in) says nothing about the artifact,
+#     and before this row that agent simply landed in `failed` and the loop went
+#     on. Halting on it would let one stuck unit stop the nightly for the whole
+#     box, so the canary role moves to the next agent the pass restarts and this
+#     one is reported exactly as it always was.
+_hg_action() {
+  case "${1:-}" in
+    healthy|gate-unavailable) printf 'proceed\n' ;;
+    crash-loop|failed|down)   printf 'rollback\n' ;;
+    restart-refused)          printf 'next-canary\n' ;;
+    *)                        printf 'halt\n' ;;
+  esac
+}
+
+# The line an operator reads in the nightly log. It names the release that was
+# reverted and the agent it was measured on, because "update rolled back" with
+# no subject is the same silence in a louder font.
+_hg_rollback_note() {
+  printf "POST-INSTALL HEALTH GATE FAILED on agent '%s' (%s) — this box installed a build on which an agent does not stay running. The startup path has been RESTORED to the build that was on this box before the update (%s); no other agent was touched. Nothing here retries: this box stays on the old build until the next update pass, and if that pass installs the same release it will fail the same way. Check the release before re-running \`5dive self-update\`." "${1:-?}" "${2:-?}" "${3:-nothing restored}"
+}
+# <<< DIVE-4068 post-install health gate
+
 cmd_self_update() {
   [[ $# -eq 0 ]] || fail "$E_USAGE" "self-update takes no arguments"
   command -v curl >/dev/null 2>&1 || fail "$E_NOT_FOUND" "curl is required for 5dive self-update"
@@ -544,6 +819,14 @@ cmd_self_update() {
     done < <(systemctl list-units '5dive-agent@*' --state=running --no-legend --plain 2>/dev/null | awk '{print $1}')
   fi
 
+  # DIVE-4068: snapshot the startup path BEFORE the installer overwrites it —
+  # afterwards there is nothing left to restore from. A capture that fails does
+  # NOT abort the upgrade and does not disarm the probe: detection with no
+  # rollback is still better than the silence this replaces, and the operator is
+  # told which of the two this box has.
+  local hg_capture=ok
+  _hg_capture || { hg_capture=unusable; warn "could not capture a rollback point in $(_hg_rollback_dir) — the post-install health gate will still DETECT a box that cannot start an agent, but it will not be able to put the previous build back"; }
+
   step "Upgrading 5dive CLI + plugins"
   # Send installer chatter to stderr so JSON stdout stays parseable.
   bash "$installer" --upgrade >&2 || fail "$E_GENERIC" "upgrade failed"
@@ -552,6 +835,10 @@ cmd_self_update() {
   # one failed restart shouldn't abort the rest.
   local -a restarted=() failed=() skipped=() deferred=() parked=()
   local i after before atype why busy
+  # DIVE-4068 gate state. `hg_verdict` stays "not-probed" until a unit is
+  # actually restarted, and that is a THIRD value, not a pass — a pass has to be
+  # something the box measured.
+  local hg_canary="" hg_verdict="not-probed" hg_action="proceed" hg_why=""
   for i in "${!units[@]}"; do
     name="${names[$i]}"; before="${befores[$i]}"
     # DIVE-4033: asked BEFORE the payload predicate, so the operator is told the
@@ -619,6 +906,32 @@ cmd_self_update() {
       # change deliberately keeps the behaviour it exists to remove.
       warn "could not record a deferred restart for '$name' — restarting now"
     fi
+    # DIVE-4068: the FIRST unit this pass bounces is the canary. Not an extra
+    # restart — this agent was being restarted either way — and the gate settles
+    # before the loop reaches agent number two, which is what keeps a bad release
+    # to one dark agent instead of the box.
+    if [[ -z "$hg_canary" ]]; then
+      hg_canary="$name"; hg_why="first agent this pass restarts"
+      hg_verdict="$(_hg_probe "${units[$i]}")"
+      hg_action="$(_hg_action "$hg_verdict")"
+      if [[ "$hg_action" == "next-canary" ]]; then
+        # systemctl would not restart this unit. That is the pre-DIVE-4068
+        # `failed` case verbatim, and it is not evidence about the release — so
+        # the canary role moves to the next agent the loop reaches rather than
+        # stopping the pass on one stuck unit.
+        warn "failed to restart agent '$name'"
+        failed+=("$name"); hg_canary=""; hg_verdict="not-probed"; hg_action=proceed
+        continue
+      fi
+      if [[ "$hg_action" != "proceed" ]]; then break; fi
+      if [[ "$hg_verdict" == "gate-unavailable" ]]; then
+        warn "restarted $name, but systemd answered nothing about the unit — the post-install health gate could NOT run on this box. This pass behaves exactly as it did before the gate existed: a release that cannot start an agent will not be caught here."
+      else
+        step "restarted $name ($why) — health gate PASSED (the unit was still running ${HEALTH_GATE_WINDOW_SECS:-20}s later, with no systemd re-start)"
+      fi
+      restarted+=("$name")
+      continue
+    fi
     if systemctl restart "${units[$i]}" 2>/dev/null; then
       step "restarted $name ($why)"
       restarted+=("$name")
@@ -627,6 +940,89 @@ cmd_self_update() {
       failed+=("$name")
     fi
   done
+
+  # DIVE-4068: the pass restarted nobody, so nothing exercised the startup path
+  # the installer just replaced — and a LAUNCHER-ONLY release is exactly that
+  # shape. `5dive-agent-start` lives in /usr/local/bin, not in an agent's home,
+  # so it is invisible to DIVE-3172's payload fingerprint: 0.26.1 would have
+  # moved no fingerprint, restarted no one, and been probed by nothing. Then the
+  # first crash-restart, operator bounce or deferred sweep to follow would have
+  # found the box dark, with no gate anywhere near it.
+  #
+  # So on that night, and only that night, the gate spends one restart. An
+  # UNREADABLE manifest probes too (`_hg_artifact_moved` exit 2): DIVE-2230's
+  # rule, an absent reading resolves to neither answer, and the branch that costs
+  # a restart is the recoverable one.
+  if [[ -z "$hg_canary" && "$hg_action" == "proceed" ]] && command -v systemctl >/dev/null 2>&1; then
+    # Declared and assigned SEPARATELY. `local hg_moved=$?` reads local's own
+    # status on some shells, and this row exists because of a `local` that
+    # referred to itself.
+    local hg_moved=0
+    _hg_artifact_moved "${HEALTH_GATE_BIN_DIR:-/usr/local/bin}/5dive-agent-start" || hg_moved=$?
+    if (( hg_moved != 1 )); then
+      local cand
+      for i in "${!units[@]}"; do
+        cand="${names[$i]}"
+        # Every guard the loop above applies, applied again: an agent nobody
+        # asked to restart must not be resurrected from a park, interrupted
+        # mid-row, or bounced between turns of a closing one.
+        _agent_is_parked "$cand" && continue
+        [[ "$(_agent_busy_state "$cand")" == "idle" ]] || continue
+        if declare -F _hb_agent_idle >/dev/null 2>&1 && ! _hb_agent_idle "$cand" 0.4; then continue; fi
+        systemctl is-active --quiet "${units[$i]}" 2>/dev/null || continue
+        hg_canary="$cand"
+        hg_why="the launcher itself changed and this pass restarted no one$( (( hg_moved == 2 )) && printf ' (manifest unreadable — probed rather than assumed unchanged)')"
+        step "no agent needed a restart, but the launcher changed — probing '$cand' so a build that cannot start an agent is found now rather than on its next bounce"
+        hg_verdict="$(_hg_probe "${units[$i]}")"
+        hg_action="$(_hg_action "$hg_verdict")"
+        if [[ "$hg_action" == "next-canary" ]]; then
+          warn "failed to restart agent '$cand'"; failed+=("$cand")
+          hg_canary=""; hg_verdict=not-probed; hg_action=proceed; continue
+        fi
+        [[ "$hg_action" == "proceed" ]] && restarted+=("$cand")
+        break
+      done
+      if [[ -z "$hg_canary" ]]; then
+        hg_verdict="no-safe-canary"
+        warn "the launcher changed and no agent was safe to probe (all parked, busy or down) — this box installed a new startup path that NOTHING on it has exercised. The next agent restart, from any cause, is the first thing that will find out."
+      fi
+    fi
+  fi
+
+  # DIVE-4068: the gate said stop. Everything below this point — the rest of the
+  # restart loop, the listener refresh, the ok summary — is skipped, because each
+  # of them touches something else on a box we have just measured as unable to
+  # keep an agent running.
+  if [[ "$hg_action" != "proceed" ]]; then
+    local hg_restored="" hg_rolled=false hg_canary_state=""
+    if [[ "$hg_action" == "rollback" ]]; then
+      if [[ "$hg_capture" == "unusable" ]]; then
+        warn "the health gate would roll this box back and CANNOT — no rollback point was captured before the upgrade. The box is on the new build and agent '$hg_canary' is not running."
+      else
+        hg_restored="$(_hg_restore | paste -sd, - 2>/dev/null)" || hg_restored=""
+        [[ -n "$hg_restored" ]] && hg_rolled=true
+      fi
+      if [[ "$hg_rolled" == true ]]; then
+        # Bring the canary back UP on the restored path. Without this the gate
+        # ends its run having darkened exactly one agent — a smaller version of
+        # the failure it exists to prevent, and one nobody would be watching for.
+        local hg_cu="5dive-agent@${hg_canary}.service" hg_cbase
+        hg_cbase="$(_hg_unit_field "$hg_cu" NRestarts)"
+        if systemctl restart "$hg_cu" 2>/dev/null \
+           && [[ "$(_hg_watch "$hg_cu" "$hg_cbase")" == "healthy" ]]; then
+          hg_canary_state=recovered
+          step "agent '$hg_canary' is running again on the restored build"
+        else
+          hg_canary_state=still-down
+          warn "agent '$hg_canary' did NOT come back after the rollback — the old build is back on disk but this agent needs a look. Start it with 'systemctl restart 5dive-agent@${hg_canary}.service' and read 'journalctl -u 5dive-agent@${hg_canary}'."
+        fi
+        warn "$(_hg_rollback_note "$hg_canary" "$hg_verdict" "$hg_restored")"
+      fi
+    else
+      warn "POST-INSTALL HEALTH GATE INCONCLUSIVE on agent '$hg_canary' (verdict '$hg_verdict') — this box could not be read well enough to say whether an agent stays running on the new build. NOTHING was rolled back: reverting a release needs evidence it is broken, and this is the absence of evidence that it works. The other agents this pass had not yet reached were left alone, so the blast radius stays at one. Check 'systemctl status 5dive-agent@${hg_canary}' before re-running."
+    fi
+    fail "$E_GENERIC" "self-update HALTED by the post-install health gate — agent '$hg_canary' ($hg_why) did not stay running on the new build (verdict '$hg_verdict'); rolled_back=$hg_rolled${hg_restored:+ ($hg_restored)}, canary=${hg_canary_state:-not-recovered}, other agents untouched"
+  fi
 
   # DIVE-1095: refresh the materialized shared team-bot listener. It lives at
   # /opt/5dive/team-bot-listener.ts and is (re)written ONLY by `team-bot shared`,
@@ -668,12 +1064,23 @@ cmd_self_update() {
   # contradiction reaches someone reading the log.
   (( ${#parked[@]} )) && prose+=", ${#parked[@]} left parked (desiredState=stopped but running — restart held, reconcile)"
   (( ${#failed[@]} )) && prose+=", ${#failed[@]} failed to restart"
+  # DIVE-4068: say which of the three the gate did. "not-probed" is a real
+  # answer and must not read as a pass — it means this pass bounced nobody and
+  # the launcher had not moved, so the new startup path is untested on this box
+  # by construction, not by measurement.
+  case "$hg_verdict" in
+    healthy)          prose+=", health gate passed on '$hg_canary'" ;;
+    gate-unavailable) prose+=", health gate COULD NOT RUN (systemd answered nothing about '$hg_canary')" ;;
+    not-probed) prose+=", health gate not probed (no agent restarted and the launcher did not change)" ;;
+    *)          prose+=", health gate: $hg_verdict" ;;
+  esac
   [[ "$listener_refreshed" == "true" ]] && prose+=", team-bot listener refreshed"
   # `skipped` and `deferred` are ADDITIVE — `restarted`/`failed` keep their exact
   # prior meaning, so every existing consumer reads the field it always did.
   ok "$prose" \
-     '{restarted:$r, restarted_count:($r|length), skipped:$s, skipped_count:($s|length), deferred:$d, deferred_count:($d|length), parked:$pk, parked_count:($pk|length), failed:$f, listener_refreshed:$lr}' \
-     --argjson r "$r" --argjson f "$f" --argjson s "$s" --argjson d "$d" --argjson pk "$pk" --argjson lr "$listener_refreshed"
+     '{restarted:$r, restarted_count:($r|length), skipped:$s, skipped_count:($s|length), deferred:$d, deferred_count:($d|length), parked:$pk, parked_count:($pk|length), failed:$f, listener_refreshed:$lr, health_gate:{verdict:$hgv, agent:(if $hgc == "" then null else $hgc end), reason:(if $hgw == "" then null else $hgw end), rollback_point:$hgcap}}' \
+     --argjson r "$r" --argjson f "$f" --argjson s "$s" --argjson d "$d" --argjson pk "$pk" --argjson lr "$listener_refreshed" \
+     --arg hgv "$hg_verdict" --arg hgc "$hg_canary" --arg hgw "$hg_why" --arg hgcap "$hg_capture"
 }
 
 # version_lt A B — true when semver A is strictly older than B (sort -V).

--- a/tests/self_update_health_gate_unit.sh
+++ b/tests/self_update_health_gate_unit.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# DIVE-4068: the update path grades the ARTIFACT and never the OUTCOME.
+#
+# 0.26.1 shipped a launcher that could not start any agent (DIVE-4067). It
+# fetched, its sha256 matched, `bash -n` parsed it and its version went forwards
+# — every check install.sh runs passed. The nightly then restarted every agent,
+# and every box that took the release emptied itself and stayed empty until a
+# human noticed. The one cheap question nobody asked was "does an agent still
+# start on this box", and the box can answer it in about twenty seconds.
+#
+# The gate has to be wrong in one of two directions, and they are not symmetric:
+#
+#   BLIND      — the probe reads `active` on a unit that is crash-looping and
+#                reports a pass. This is the original bug wearing a gate: the
+#                unit is Type=simple, so a launcher that execs and dies one line
+#                later IS active for the instant between them. A naive is-active
+#                check is not a weaker version of this fix, it is the defect.
+#   TRIGGER-   — the gate reverts a good release on a reading it merely could not
+#   HAPPY        take, and the box then never accepts an update while that
+#                reading stays broken. DIVE-3173 and DIVE-1095 both name the
+#                silent-freeze direction as the worse of the two.
+#
+# So every arm below carries its NEGATIVE CONTROL — an arm that passes only
+# because the gate does NOT fire on an unknown — and section 7 re-runs the
+# decisive arms against MUTANTS that reproduce each pre-fix shape, so a green
+# here cannot come from a test that would pass against the broken code too.
+#
+# Hermetic in the shape DIVE-2042/DIVE-3172/DIVE-3173/DIVE-4033 established: the
+# block is extracted VERBATIM from src/cmd_selfupdate.sh between its fence
+# markers and run as the SHIPPED BYTES. systemctl is a stub on $PATH; every file
+# it touches is under $WORK. No unit, no agent and no /usr/local/bin is read or
+# written.
+set -uo pipefail
+
+# DIVE-2211: name the tree this harness grades. NO `2>/dev/null` — the helper's
+# stderr line IS the payload.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${WORK:-}"; echo "HARNESS-RC=$rc"' EXIT
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 1
+PASS=0; FAIL=0
+ok_t(){ PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t(){ FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+eq_t(){ [[ "$2" == "$3" ]] && ok_t "$1" || bad_t "$1" "want '$3', got '$2'"; }
+
+# ---------------------------------------------------------------- 1. extraction
+block="$(sed -n '/^# >>> DIVE-4068 post-install health gate/,/^# <<< DIVE-4068 post-install health gate/p' \
+  src/cmd_selfupdate.sh)"
+if [[ -n "$block" ]] && grep -q '_hg_verdict()' <<<"$block" && grep -q '_hg_action()' <<<"$block" \
+   && grep -q '_hg_capture()' <<<"$block" && grep -q '_hg_restore()' <<<"$block" \
+   && grep -q '_hg_probe()' <<<"$block" && grep -q '_hg_artifact_moved()' <<<"$block"; then
+  ok_t "the health-gate block is extractable from src/cmd_selfupdate.sh"
+else
+  bad_t "health-gate block missing" "markers '# >>> / # <<< DIVE-4068 post-install health gate' not found, or a helper is outside the fence"
+  echo; echo "$PASS passed, $FAIL failed"; exit 1
+fi
+
+# The gate is CALLED from cmd_self_update, and a fix that ships dormant is
+# DIVE-1095's entire row. Grade the wiring, not just the helpers.
+body="$(sed -n '/^cmd_self_update()/,/^}/p' src/cmd_selfupdate.sh)"
+for sym in _hg_capture _hg_probe _hg_action _hg_restore _hg_artifact_moved _hg_rollback_note; do
+  grep -q "$sym" <<<"$body" \
+    && ok_t "cmd_self_update calls $sym — the gate is wired, not dormant" \
+    || bad_t "$sym is never called from cmd_self_update" "the gate would ship inert (DIVE-1095)"
+done
+# The capture must precede the installer, or there is nothing left to restore.
+cap_ln=$(grep -n '_hg_capture' <<<"$body" | head -n1 | cut -d: -f1)
+up_ln=$(grep -n 'installer" --upgrade' <<<"$body" | head -n1 | cut -d: -f1)
+if [[ -n "$cap_ln" && -n "$up_ln" ]] && (( cap_ln < up_ln )); then
+  ok_t "the rollback point is captured BEFORE the installer runs"
+else
+  bad_t "capture does not precede the upgrade" "cap=$cap_ln upgrade=$up_ln — after --upgrade there is nothing left to snapshot"
+fi
+
+WORK="$(mktemp -d)"
+eval "$block"
+
+# ------------------------------------------------------- 2. _hg_verdict: truth
+# THE ARM THIS ROW EXISTS FOR. Type=simple + RestartSec=3: a launcher that dies
+# immediately is reported `active/running` on the very next poll, and only the
+# NRestarts delta separates it from a healthy agent.
+eq_t "crash-loop: active/running but systemd re-started it -> crash-loop" \
+  "$(_hg_verdict active running 0 1)" crash-loop
+eq_t "crash-loop is a DELTA, not a level: NRestarts 7 -> 7 is healthy" \
+  "$(_hg_verdict active running 7 7)" healthy
+eq_t "the launcher's permanent exits (2/3) park the unit -> failed" \
+  "$(_hg_verdict failed "" 0 0)" failed
+eq_t "healthy: active/running, counter still" \
+  "$(_hg_verdict active running 3 3)" healthy
+eq_t "inactive after a restart we issued -> down" \
+  "$(_hg_verdict inactive dead 0 0)" down
+# NEGATIVE CONTROLS — every one of these must NOT be an answer.
+eq_t "NEGATIVE CONTROL: unreadable ActiveState -> unknown, never down" \
+  "$(_hg_verdict "" "" "" "")" unknown
+eq_t "NEGATIVE CONTROL: still activating when the window closed -> unknown" \
+  "$(_hg_verdict activating start 0 0)" unknown
+eq_t "NEGATIVE CONTROL: unreadable NRestarts on a running unit -> healthy, not crash-loop" \
+  "$(_hg_verdict active running "" "")" healthy
+eq_t "NEGATIVE CONTROL: garbage NRestarts is discarded, not parsed as a delta" \
+  "$(_hg_verdict active running abc def)" healthy
+# `failed` outranks the counter: a parked unit is broken whatever the delta says.
+eq_t "failed wins over an unchanged counter" "$(_hg_verdict failed dead 2 2)" failed
+
+# ---------------------------------------------- 3. _hg_action: the asymmetry
+eq_t "healthy -> proceed"                "$(_hg_action healthy)"        proceed
+eq_t "crash-loop -> rollback"            "$(_hg_action crash-loop)"     rollback
+eq_t "failed -> rollback"                "$(_hg_action failed)"         rollback
+eq_t "down -> rollback"                  "$(_hg_action down)"           rollback
+eq_t "NEGATIVE CONTROL: unknown HALTS, it does not roll back (a release is not reverted on an unreadable box)" \
+  "$(_hg_action unknown)" halt
+# The two outcomes that deliberately do NOT halt. Each is here because halting
+# would introduce a NEW fleet-wide failure in the name of preventing one.
+eq_t "NEGATIVE CONTROL: restart-refused moves the canary role on — one stuck unit must not stop the nightly for the whole box" \
+  "$(_hg_action restart-refused)" next-canary
+eq_t "NEGATIVE CONTROL: gate-unavailable PROCEEDS — a box whose systemd answers nothing keeps updating exactly as it did before this gate existed" \
+  "$(_hg_action gate-unavailable)" proceed
+eq_t "NEGATIVE CONTROL: an unrecognised verdict halts rather than proceeding" \
+  "$(_hg_action wat)" halt
+
+# --------------------------------------------- 4. capture / restore round-trip
+export HEALTH_GATE_BIN_DIR="$WORK/bin" HEALTH_GATE_SYSTEMD_DIR="$WORK/systemd"
+export HEALTH_GATE_ROLLBACK_DIR="$WORK/rollback"
+mkdir -p "$HEALTH_GATE_BIN_DIR" "$HEALTH_GATE_SYSTEMD_DIR"
+printf 'GOOD-BUNDLE\n'   > "$HEALTH_GATE_BIN_DIR/5dive"
+printf 'GOOD-LAUNCHER\n' > "$HEALTH_GATE_BIN_DIR/5dive-agent-start"
+chmod 755 "$HEALTH_GATE_BIN_DIR/5dive" "$HEALTH_GATE_BIN_DIR/5dive-agent-start"
+# The systemd template is deliberately ABSENT here — a box that has none must
+# not have one conjured onto it by a rollback.
+_hg_capture && ok_t "capture succeeds with the two binaries present and the unit template absent" \
+             || bad_t "capture returned non-zero" "all three artifacts were readable or legitimately absent"
+grep -q '^absent' "$HEALTH_GATE_ROLLBACK_DIR/manifest" \
+  && ok_t "an absent artifact is RECORDED as absent, not silently skipped" \
+  || bad_t "absent artifact not recorded" "$(cat "$HEALTH_GATE_ROLLBACK_DIR/manifest")"
+
+# The bad release lands.
+printf 'BAD-LAUNCHER\n' > "$HEALTH_GATE_BIN_DIR/5dive-agent-start"
+printf 'NEW-BUNDLE\n'   > "$HEALTH_GATE_BIN_DIR/5dive"
+_hg_artifact_moved "$HEALTH_GATE_BIN_DIR/5dive-agent-start"; m=$?
+eq_t "_hg_artifact_moved sees the launcher move (exit 0)" "$m" 0
+printf 'GOOD-LAUNCHER\n' > "$WORK/same"; cp "$WORK/same" "$HEALTH_GATE_BIN_DIR/5dive-agent-start"
+_hg_artifact_moved "$HEALTH_GATE_BIN_DIR/5dive-agent-start"; m=$?
+eq_t "NEGATIVE CONTROL: identical bytes are NOT a move (exit 1)" "$m" 1
+printf 'BAD-LAUNCHER\n' > "$HEALTH_GATE_BIN_DIR/5dive-agent-start"
+( HEALTH_GATE_ROLLBACK_DIR="$WORK/nope"; _hg_artifact_moved "$HEALTH_GATE_BIN_DIR/5dive-agent-start" )
+m=$?
+eq_t "NEGATIVE CONTROL: no manifest is UNKNOWN (exit 2), never 'unchanged' — the launcher-only probe must still run" "$m" 2
+
+restored="$(_hg_restore | sort | paste -sd, -)"
+eq_t "restore puts back exactly the two artifacts it captured" "$restored" "5dive,5dive-agent-start"
+eq_t "the launcher is the pre-update bytes again" "$(cat "$HEALTH_GATE_BIN_DIR/5dive-agent-start")" GOOD-LAUNCHER
+eq_t "the bundle is the pre-update bytes again"   "$(cat "$HEALTH_GATE_BIN_DIR/5dive")" GOOD-BUNDLE
+[[ -x "$HEALTH_GATE_BIN_DIR/5dive-agent-start" ]] \
+  && ok_t "the restored launcher is still executable (cp -p) — a 644 launcher is a dark box too" \
+  || bad_t "restored launcher lost its mode" "$(stat -c %a "$HEALTH_GATE_BIN_DIR/5dive-agent-start")"
+[[ -e "$HEALTH_GATE_SYSTEMD_DIR/5dive-agent@.service" ]] \
+  && bad_t "restore CONJURED a unit template that never existed" "an absent artifact must stay absent" \
+  || ok_t "NEGATIVE CONTROL: the absent unit template was not conjured by the restore"
+( HEALTH_GATE_ROLLBACK_DIR="$WORK/nope"; _hg_restore >/dev/null 2>&1 ) \
+  && bad_t "restore claimed success with no manifest" "it must report that it restored nothing" \
+  || ok_t "NEGATIVE CONTROL: restore with no rollback point returns non-zero rather than claiming a rollback"
+
+# ------------------------------------------------------- 5. _hg_watch / _hg_probe
+# A systemctl stub whose answers are read from files, so an arm can make the
+# unit crash-loop, park, or stay up without a single real unit.
+mkdir -p "$WORK/bin2"
+cat > "$WORK/bin2/systemctl" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  show) p="${3#--property=}"; cat "$SYSTEMCTL_FAKE/$p" 2>/dev/null; exit 0 ;;
+  restart) [[ -f "$SYSTEMCTL_FAKE/refuse" ]] && exit 1
+           [[ -f "$SYSTEMCTL_FAKE/on_restart" ]] && . "$SYSTEMCTL_FAKE/on_restart"
+           exit 0 ;;
+  daemon-reload|is-active) exit 0 ;;
+esac
+exit 0
+STUB
+chmod 755 "$WORK/bin2/systemctl"
+PATH="$WORK/bin2:$PATH"; export PATH
+export SYSTEMCTL_FAKE="$WORK/fake"; mkdir -p "$SYSTEMCTL_FAKE"
+export HEALTH_GATE_WINDOW_SECS=0 HEALTH_GATE_POLL_SECS=1
+
+# Writes the Id positive control alongside the state, because a real systemd
+# always answers it. An arm that wants "systemd told us nothing" removes it.
+set_unit(){ printf '%s\n' "$1" > "$SYSTEMCTL_FAKE/ActiveState"
+            printf '%s\n' "$2" > "$SYSTEMCTL_FAKE/SubState"
+            printf '%s\n' "$3" > "$SYSTEMCTL_FAKE/NRestarts"
+            printf '5dive-agent@t.service\n' > "$SYSTEMCTL_FAKE/Id"; }
+
+set_unit active running 0; rm -f "$SYSTEMCTL_FAKE/on_restart" "$SYSTEMCTL_FAKE/refuse"
+eq_t "probe on a healthy unit -> healthy" "$(_hg_probe 5dive-agent@t.service)" healthy
+
+# The DIVE-4067 shape: the restart succeeds, the unit is `active`, and systemd
+# has already had to re-start it once.
+set_unit active running 0
+printf 'printf 1 > "$SYSTEMCTL_FAKE/NRestarts"\n' > "$SYSTEMCTL_FAKE/on_restart"
+eq_t "probe on a launcher that dies and is re-started -> crash-loop (THE 0.26.1 shape)" \
+  "$(_hg_probe 5dive-agent@t.service)" crash-loop
+
+set_unit active running 0
+printf 'printf failed > "$SYSTEMCTL_FAKE/ActiveState"\n' > "$SYSTEMCTL_FAKE/on_restart"
+eq_t "probe on a launcher exiting 2/3 (RestartPreventExitStatus) -> failed" \
+  "$(_hg_probe 5dive-agent@t.service)" failed
+
+rm -f "$SYSTEMCTL_FAKE/on_restart"; set_unit active running 0
+: > "$SYSTEMCTL_FAKE/refuse"
+eq_t "NEGATIVE CONTROL: systemctl refusing the restart -> restart-refused (never a rollback)" \
+  "$(_hg_probe 5dive-agent@t.service)" restart-refused
+rm -f "$SYSTEMCTL_FAKE/refuse"
+
+# THE POSITIVE CONTROL. Without it "systemd told us nothing" and "the unit is in
+# a state I cannot classify" are the same empty string, and the gate would halt
+# the nightly on every box with an uninterrogable systemd — permanently, and for
+# a reason nobody would trace back to this row. `Id` is what separates them.
+set_unit active running 0; printf 'X' > "$SYSTEMCTL_FAKE/NRestarts"; : > "$SYSTEMCTL_FAKE/ActiveState"
+eq_t "Id readable but the state is not -> unknown (halts): a reading we cannot classify is never a pass" \
+  "$(_hg_probe 5dive-agent@t.service)" unknown
+rm -f "$SYSTEMCTL_FAKE"/{Id,ActiveState,SubState,NRestarts}
+eq_t "systemd answering NOTHING -> gate-unavailable, which PROCEEDS — not 'unknown', which would freeze the box off updates" \
+  "$(_hg_probe 5dive-agent@t.service)" gate-unavailable
+set_unit active running 0
+eq_t "the control does not swallow the measurement: with Id back, a healthy unit still grades healthy" \
+  "$(_hg_probe 5dive-agent@t.service)" healthy
+
+# _hg_watch must not answer on the FIRST healthy reading — "it started" is not
+# the question. With a window it keeps looking, and a unit that dies late is
+# still caught.
+set_unit active running 0
+HEALTH_GATE_WINDOW_SECS=2 HEALTH_GATE_POLL_SECS=1
+( sleep 1; printf 4 > "$SYSTEMCTL_FAKE/NRestarts" ) &
+w=$(_hg_watch 5dive-agent@t.service 0); wait 2>/dev/null
+eq_t "watch keeps looking past the first healthy reading — a unit that dies at t+1s is still caught" "$w" crash-loop
+HEALTH_GATE_WINDOW_SECS=0
+
+# ------------------------------------------------------------- 6. the loud line
+note="$(_hg_rollback_note dev crash-loop 5dive,5dive-agent-start)"
+for want in dev crash-loop 5dive-agent-start RESTORED; do
+  grep -qi -- "$want" <<<"$note" && ok_t "the rollback line names '$want'" \
+    || bad_t "rollback line omits '$want'" "$note"
+done
+grep -qi 'no other agent was touched' <<<"$note" \
+  && ok_t "the rollback line states the blast radius" || bad_t "blast radius not stated" "$note"
+
+# ------------------------------------------------------------------ 7. MUTANTS
+# Each mutant reproduces a PRE-FIX shape, not a deleted call. A mutant that
+# survives means the arms above would have passed against the broken gate too.
+# The helper asserts the mutation ACTUALLY APPLIED before grading it — a sed that
+# silently matched nothing would otherwise print "killed" for an unmutated block,
+# which is the harness lying about its own reach.
+mut(){ # <name> <sed-expr> <arm>
+  local name="$1" expr="$2" arm="$3" mutated out
+  mutated="$(sed "$expr" <<<"$block")"
+  if [[ "$mutated" == "$block" ]]; then
+    bad_t "MUTATION DID NOT APPLY — $name" "sed '$expr' matched nothing; this arm graded the SHIPPED block, not a mutant"
+    return
+  fi
+  out="$(bash -c "$mutated
+$arm" 2>&1 | tail -n1)"
+  [[ "$out" == "MUTANT-CAUGHT" ]] && ok_t "MUTANT KILLED — $name" \
+    || bad_t "MUTANT SURVIVED — $name" "arm returned '$out'"
+}
+
+# M1: the naive gate — read is-active and ignore the restart counter. This IS the
+# blind check that would have reported 0.26.1 as a clean install.
+mut "a verdict that ignores NRestarts calls a crash-looping unit healthy" \
+    's/&& (( after > before ))/\&\& false/' \
+    '[[ "$(_hg_verdict active running 0 1)" == healthy ]] && echo MUTANT-CAUGHT'
+
+# M2: unknown folded into proceed — the mass restart continues across a box
+# nobody could read.
+mut "an unknown verdict that PROCEEDS lets the loop restart the rest of the fleet" \
+    "/printf 'halt/s/halt/proceed/" \
+    '[[ "$(_hg_action unknown)" == proceed ]] && echo MUTANT-CAUGHT'
+
+# M3: unknown folded into rollback — the silent-freeze direction DIVE-3173 and
+# DIVE-1095 both name as the worse one.
+mut "an unknown verdict that ROLLS BACK reverts a good release on an unreadable box" \
+    "/printf 'halt/s/halt/rollback/" \
+    '[[ "$(_hg_action unknown)" == rollback ]] && echo MUTANT-CAUGHT'
+
+# M4: the absent/present status ignored — a restore conjures a unit template that
+# never existed on this box.
+mkdir -p "$WORK/m4/bin" "$WORK/m4/sysd"
+printf 'B\n' > "$WORK/m4/bin/5dive"; printf 'L\n' > "$WORK/m4/bin/5dive-agent-start"
+export M4_BIN="$WORK/m4/bin" M4_SYSD="$WORK/m4/sysd" M4_RB="$WORK/m4/rb"
+mut "a restore that ignores the absent/present status conjures files that never existed" \
+    '/== "present"/d' \
+    'export HEALTH_GATE_BIN_DIR="$M4_BIN" HEALTH_GATE_SYSTEMD_DIR="$M4_SYSD" HEALTH_GATE_ROLLBACK_DIR="$M4_RB"
+     _hg_capture >/dev/null 2>&1
+     printf X > "$HEALTH_GATE_SYSTEMD_DIR/5dive-agent@.service"
+     _hg_restore >/dev/null 2>&1
+     [[ -e "$HEALTH_GATE_SYSTEMD_DIR/5dive-agent@.service" ]] && echo MUTANT-CAUGHT'
+
+# M5: a missing manifest answering "unchanged" — the launcher-only night is never
+# probed, which is precisely the night 0.26.1 shipped on.
+mut "a missing manifest that answers 'unchanged' skips the launcher-only probe" \
+    '/-n "$line" /s/return 2/return 1/' \
+    'HEALTH_GATE_ROLLBACK_DIR=/nonexistent-hg-rb; _hg_artifact_moved /bin/sh; [[ $? -eq 1 ]] && echo MUTANT-CAUGHT'
+
+# M6: the positive control removed — an uninterrogable systemd becomes
+# indistinguishable from a sick unit and every such box halts its nightly
+# forever. This mutant is the shape of a SAFETY CHECK causing the outage, which
+# is the one way this row could make things worse than it found them.
+mut "dropping the Id positive control makes an unreadable systemd halt the nightly" \
+    '/-z "$(_hg_unit_field "$unit" Id)"/s/-z/-n/' \
+    'export SYSTEMCTL_FAKE PATH HEALTH_GATE_WINDOW_SECS=0
+     rm -f "$SYSTEMCTL_FAKE"/{Id,ActiveState,SubState,NRestarts}
+     [[ "$(_hg_action "$(_hg_probe 5dive-agent@t.service)")" != proceed ]] && echo MUTANT-CAUGHT'
+
+echo; echo "$PASS passed, $FAIL failed"
+(( FAIL == 0 ))

--- a/tests/self_update_health_gate_unit.sh
+++ b/tests/self_update_health_gate_unit.sh
@@ -442,11 +442,19 @@ else
   bad_t "cmd_self_update not extractable" "the wiring arms below would grade nothing"
 fi
 
-# hg_loop <tag> <sed-expr|""> <new-launcher-bytes>
+# hg_loop <tag> <sed-expr|""> <new-launcher-bytes> [restart-needed-rc] [busy-csv] [parked-csv]
 #   Runs the shipped (or mutated) cmd_self_update on a three-agent fake box and
 #   writes: $d/rc, $d/out, $d/fake/restart.log, $d/bin/*.
+#
+#   `restart-needed-rc` is what `_agent_restart_needed` returns. Iteration 3: it
+#   was hard-wired to 0, so EVERY arm ran the path where a payload fingerprint
+#   moved — and the post-loop launcher-only block, which is the branch that would
+#   have caught 0.26.1, was entered by no arm in the repo. Pass 1 for a night on
+#   which nobody needs a restart. `busy-csv`/`parked-csv` are the names
+#   `_agent_busy_state`/`_agent_is_parked` report as not-idle and parked, so the
+#   candidate loop's own guards are reachable too.
 hg_loop(){
-  local tag="$1" expr="$2" newl="$3" mutated d
+  local tag="$1" expr="$2" newl="$3" rcneed="${4:-0}" busylist="${5:-}" parkedlist="${6:-}" rbdir="${7:-}" mutated d
   d="$WORK/loop-$tag"
   rm -rf "$d"; mkdir -p "$d/bin" "$d/sysd" "$d/sbin" "$d/fake/u" "$d/homes"
   local u n
@@ -525,9 +533,11 @@ _pending_restart_mark(){ return 0; }
 _agent_home(){ printf '%s/%s\n' "$HG_HOMES" "${1:-}"; }
 _agent_payload_fingerprint(){ printf 'fp\n'; }
 agent_type(){ printf 'claude\n'; }
-_agent_is_parked(){ return 1; }
-_agent_restart_needed(){ return 0; }
-_agent_busy_state(){ printf 'idle\n'; }
+_hg_in_list(){ case ",${2:-}," in *",${1:-},"*) return 0 ;; esac; return 1; }
+_agent_is_parked(){ _hg_in_list "${1:-}" "${HG_PARKED:-}"; }
+_parked_override_note(){ printf 'agent %s is parked\n' "${1:-}"; }
+_agent_restart_needed(){ return "${HG_RESTART_NEEDED_RC:-0}"; }
+_agent_busy_state(){ _hg_in_list "${1:-}" "${HG_BUSY:-}" && printf 'busy\n' || printf 'idle\n'; }
 _team_bot_install_listener(){ return 0; }
 PRELUDE
     printf '%s\n' "$block"
@@ -538,7 +548,8 @@ PRELUDE
   (
     export PATH="$d/sbin:$PATH"
     export SYSTEMCTL_FAKE="$d/fake" HG_BIN="$d/bin" HG_HOMES="$d/homes" HG_NEW_LAUNCHER="$newl"
-    export HEALTH_GATE_BIN_DIR="$d/bin" HEALTH_GATE_SYSTEMD_DIR="$d/sysd" HEALTH_GATE_ROLLBACK_DIR="$d/rb"
+    export HG_RESTART_NEEDED_RC="$rcneed" HG_BUSY="$busylist" HG_PARKED="$parkedlist"
+    export HEALTH_GATE_BIN_DIR="$d/bin" HEALTH_GATE_SYSTEMD_DIR="$d/sysd" HEALTH_GATE_ROLLBACK_DIR="${rbdir:-$d/rb}"
     export HEALTH_GATE_WINDOW_SECS=0 HEALTH_GATE_POLL_SECS=1 HEALTH_GATE_PRECHECK_SECS=0
     bash "$d/driver.sh" > "$d/out" 2>&1
     printf '%s\n' "$?" > "$d/rc"
@@ -609,6 +620,191 @@ mutw "the post-loop rollback block disabled leaves the bad build on disk" \
 # W3: the canary is never selected, so the probe never runs inside the loop.
 mutw "the in-loop canary probe never selected lets the whole pass run unmeasured" \
      's/^    if \[\[ -z "$hg_canary" \]\]; then$/    if false; then/'
+
+# ============================================ 9. THE LAUNCHER-ONLY NIGHT, RUN
+# Section 8 drives the restart loop, but every one of its arms runs with
+# `_agent_restart_needed` returning 0 — a night on which a payload fingerprint
+# moved. 0.26.1 was NOT that night. `5dive-agent-start` lives in /usr/local/bin,
+# not in an agent's home, so DIVE-3172's fingerprint never moved: nobody needed
+# a restart, nothing exercised the new startup path, and the box went dark at its
+# next bounce from any cause. The post-loop block is the branch written for
+# exactly that, and until this section NOTHING in the repo entered it — deleting
+# it whole shipped 83/0 green. Same asymmetry as the row itself, one block over:
+# `_hg_artifact_moved` the helper was graded four ways in section 4, the CONSUMER
+# of its verdict by presence-grep.
+#
+# So: nobody needs a restart, the installer moves the launcher, the canary dies
+# on it. Asserted on behaviour, exactly as in section 8 —
+#   (a) exactly one agent is ever restarted;
+#   (b) the bytes on disk afterwards are the PRE-upgrade bytes;
+#   (c) the command exits non-zero.
+hg_loop lonly "" BAD-LAUNCHER 1
+d="$WORK/loop-lonly"
+grep -q 'skipped a1 (payload unchanged)' "$d/out" \
+  && ok_t "FIXTURE: the launcher-only night is real — no agent needed a restart, so the in-loop probe never ran" \
+  || bad_t "fixture did not reach the launcher-only shape" "$(grep -c . "$d/out" 2>/dev/null) lines; $(tail -n3 "$d/out")"
+grep -q 'the launcher changed — probing' "$d/out" \
+  && ok_t "the pass spends ONE restart because the launcher itself moved, rather than leaving the new startup path unexercised" \
+  || bad_t "the launcher-only probe never announced itself" "$(tail -n3 "$d/out")"
+eq_t "(c) LAUNCHER-ONLY: a release that kills the canary makes self-update EXIT NON-ZERO" \
+  "$( [[ "$(cat "$d/rc" 2>/dev/null)" == 0 ]] && echo zero || echo non-zero )" non-zero
+eq_t "(a) LAUNCHER-ONLY BLAST RADIUS: exactly one agent was ever restarted" \
+  "$(hg_restarted_units lonly)" 5dive-agent@a1.service
+eq_t "(b) LAUNCHER-ONLY: the launcher on disk afterwards is the PRE-upgrade one" \
+  "$(cat "$d/bin/5dive-agent-start" 2>/dev/null)" GOOD-LAUNCHER
+eq_t "(b) LAUNCHER-ONLY: the bundle on disk afterwards is the PRE-upgrade one" \
+  "$(cat "$d/bin/5dive" 2>/dev/null)" GOOD-BUNDLE
+grep -qi 'HEALTH GATE FAILED' "$d/out" \
+  && ok_t "LAUNCHER-ONLY: the operator gets the loud rollback line" \
+  || bad_t "no rollback line on the launcher-only night" "$(tail -n3 "$d/out")"
+grep -qi 'running again on the restored build' "$d/out" \
+  && ok_t "LAUNCHER-ONLY: the canary is brought back UP on the restored build" \
+  || bad_t "canary not recovered on the launcher-only night" "$(tail -n3 "$d/out")"
+
+# NEGATIVE CONTROL: the launcher did NOT move and nobody needed a restart. This
+# is the ordinary quiet night, and the block must not be a brake on it — no
+# probe, no restart, the new bundle stays. Without this arm every assertion above
+# is satisfied by a block that spends a restart on every pass, which is the
+# opposite failure and the one that costs a bounce per box per night.
+hg_loop lonlyquiet "" GOOD-LAUNCHER 1
+d="$WORK/loop-lonlyquiet"
+eq_t "NEGATIVE CONTROL: a night where the launcher did not move exits ZERO" "$(cat "$d/rc" 2>/dev/null)" 0
+eq_t "NEGATIVE CONTROL: it restarts NOBODY — an unchanged launcher is not probed" \
+  "$(hg_restarted_units lonlyquiet)" ""
+eq_t "NEGATIVE CONTROL: the new bundle stays on disk" "$(cat "$d/bin/5dive" 2>/dev/null)" NEW-BUNDLE
+grep -q 'health gate not probed' "$d/out" \
+  && ok_t "NEGATIVE CONTROL: the summary says the gate was not probed, and on this night that is TRUE" \
+  || bad_t "the quiet night did not report itself honestly" "$(tail -n3 "$d/out")"
+
+# The candidate loop re-applies every guard the restart loop applies, because an
+# agent nobody asked to restart must not be resurrected from a park or
+# interrupted mid-row. Both fixtures move the launcher to a build that is FINE
+# (GOOD-LAUNCHER-2 — different bytes, and the fake unit only dies on `BAD`), so
+# the only thing either arm can see is WHICH agent the gate chose to spend.
+hg_loop lonlybusy "" GOOD-LAUNCHER-2 1 a1
+d="$WORK/loop-lonlybusy"
+eq_t "the launcher-only probe SKIPS the agent holding an in_progress row and spends the next one" \
+  "$(hg_restarted_units lonlybusy)" 5dive-agent@a2.service
+eq_t "a healthy new launcher probed on a busy box still exits zero" "$(cat "$d/rc" 2>/dev/null)" 0
+hg_loop lonlyparked "" GOOD-LAUNCHER-2 1 "" a1
+eq_t "the launcher-only probe SKIPS a parked agent rather than resurrecting it" \
+  "$(hg_restarted_units lonlyparked)" 5dive-agent@a2.service
+
+# --- MUTANTS of the LAUNCHER-ONLY WIRING ------------------------------------
+# L1-L3 leave every `_hg_*` call text in place and pass all 83 arms that existed
+# before this section. Graded against the launcher-only fixture: killed when the
+# blast radius, the bytes on disk or the exit status stops matching the shipped
+# behaviour asserted above — never on a log message.
+mutl(){ # <name> <sed-expr>
+  local name="$1" expr="$2" tag rc units launcher
+  tag="l$(printf '%s' "$name" | cksum | cut -d' ' -f1)"
+  hg_loop "$tag" "$expr" BAD-LAUNCHER 1
+  rc="$(cat "$WORK/loop-$tag/rc" 2>/dev/null)"
+  if [[ "$rc" == "MUTATION-DID-NOT-APPLY" ]]; then
+    bad_t "MUTATION DID NOT APPLY — $name" "sed '$expr' matched nothing; this arm graded the SHIPPED loop, not a mutant"
+    return
+  fi
+  units="$(hg_restarted_units "$tag")"
+  launcher="$(cat "$WORK/loop-$tag/bin/5dive-agent-start" 2>/dev/null)"
+  if [[ "$rc" == 0 || "$units" != "5dive-agent@a1.service" || "$launcher" != GOOD-LAUNCHER ]]; then
+    ok_t "MUTANT KILLED — $name (rc=$rc restarted=[$units] launcher=$launcher)"
+  else
+    bad_t "MUTANT SURVIVED — $name" "the launcher-only night is graded by nothing but the presence of the block"
+  fi
+}
+# L1: the block's outer guard never opens. 0.26.1's night verbatim on an idle
+# box: rc=0, nothing restarted, the bad launcher left on disk, and a summary line
+# claiming the launcher did not change.
+mutl "the launcher-only block's outer guard disabled leaves the bad launcher on an unprobed box" \
+     's/^  if \[\[ -z "$hg_canary" \&\& "$hg_action" == "proceed" \]\] \&\& command -v systemctl/  if false \&\& command -v systemctl/'
+# L2: the moved-artifact test always answers "unchanged", so the probe is skipped
+# on exactly the night it exists for.
+mutl "the moved-launcher test disabled skips the probe on the launcher-only night" \
+     's/^    if (( hg_moved != 1 )); then$/    if false; then/'
+# L3: the candidate loop does not stop at its verdict, so the next agent's
+# healthy probe OVERWRITES the rollback one — detect, then un-detect.
+mutl "the candidate loop that does not stop lets a later healthy probe overwrite the rollback verdict" \
+     '/\[\[ "$hg_action" == "proceed" \]\] && restarted+=("$cand")/{n;s/break/continue/;}'
+# L4/L5: the re-applied guards. Killed on WHICH agent was spent, which is the
+# only thing these guards decide.
+mutg(){ # <name> <sed-expr> <busy-csv> <parked-csv>
+  local name="$1" expr="$2" bl="$3" pl="$4" tag rc units
+  tag="g$(printf '%s' "$name" | cksum | cut -d' ' -f1)"
+  hg_loop "$tag" "$expr" GOOD-LAUNCHER-2 1 "$bl" "$pl"
+  rc="$(cat "$WORK/loop-$tag/rc" 2>/dev/null)"
+  if [[ "$rc" == "MUTATION-DID-NOT-APPLY" ]]; then
+    bad_t "MUTATION DID NOT APPLY — $name" "sed '$expr' matched nothing; this arm graded the SHIPPED loop, not a mutant"
+    return
+  fi
+  units="$(hg_restarted_units "$tag")"
+  if [[ "$units" != "5dive-agent@a2.service" ]]; then
+    ok_t "MUTANT KILLED — $name (restarted=[$units])"
+  else
+    bad_t "MUTANT SURVIVED — $name" "the guard is graded by nothing — the probe may bounce an agent nobody asked to restart"
+  fi
+}
+mutg "dropping the idle guard lets the launcher-only probe interrupt an agent mid-row" \
+     '/\[\[ "$(_agent_busy_state "$cand")" == "idle" \]\] || continue/d' a1 ""
+mutg "dropping the parked guard lets the launcher-only probe resurrect a parked agent" \
+     '/_agent_is_parked "$cand" && continue/d' "" a1
+
+# --- the two SIBLING consumer branches in the same block --------------------
+# Quinn's iteration-2 reject was "the same class, one block over", twice. These
+# are the remaining consumers of a verdict inside this block that no arm entered:
+# `no-safe-canary`, and `hg_moved == 2` (the manifest could not be read).
+#
+# 9a. Every candidate is unsafe. The gate must NOT invent a canary, and it must
+# not go quiet either — a box that installed a startup path nothing on it has
+# exercised is the state the operator has to hear about, because the next bounce
+# from any cause is what finds out.
+hg_loop lonlynone "" GOOD-LAUNCHER-2 1 a1,a2,a3
+d="$WORK/loop-lonlynone"
+eq_t "no safe candidate: the gate restarts NOBODY rather than inventing a canary" \
+  "$(hg_restarted_units lonlynone)" ""
+eq_t "no safe candidate: the pass still exits zero — an unprobed box is not evidence of breakage" \
+  "$(cat "$d/rc" 2>/dev/null)" 0
+grep -q 'no agent was safe to probe' "$d/out" \
+  && ok_t "no safe candidate: the operator is TOLD the new startup path is unexercised" \
+  || bad_t "the unexercised box went quiet" "$(tail -n3 "$d/out")"
+hg_loop lonlynonemut '/hg_verdict="no-safe-canary"/,+1d' GOOD-LAUNCHER-2 1 a1,a2,a3
+if [[ "$(cat "$WORK/loop-lonlynonemut/rc" 2>/dev/null)" == "MUTATION-DID-NOT-APPLY" ]]; then
+  bad_t "MUTATION DID NOT APPLY — the no-safe-canary warning deleted" "sed matched nothing"
+elif grep -q 'no agent was safe to probe' "$WORK/loop-lonlynonemut/out" 2>/dev/null; then
+  bad_t "MUTANT SURVIVED — the no-safe-canary warning deleted" "the box can install an unexercised startup path silently"
+else
+  ok_t "MUTANT KILLED — deleting the no-safe-canary verdict makes an unexercised box silent"
+fi
+
+# 9b. DIVE-2230 at the CONSUMER: the capture failed, so the manifest cannot say
+# whether the launcher moved. An absent reading resolves to NEITHER answer, and
+# the branch that costs one restart is the recoverable one — so it probes anyway.
+# Nothing can be rolled back, and the arm asserts that the box is told exactly
+# that instead of being left to look rolled back.
+hg_loop lonlyunread "" BAD-LAUNCHER 1 "" "" /proc/version/cannot-mkdir
+d="$WORK/loop-lonlyunread"
+grep -q 'could not capture a rollback point' "$d/out" \
+  && ok_t "FIXTURE: the capture is unusable, so the moved-launcher question is UNREADABLE (exit 2), not 'unchanged'" \
+  || bad_t "fixture did not produce an unusable capture" "$(tail -n3 "$d/out")"
+eq_t "unreadable manifest: the gate PROBES anyway — one restart beats assuming the launcher did not move" \
+  "$(hg_restarted_units lonlyunread)" 5dive-agent@a1.service
+grep -q 'manifest unreadable — probed rather than assumed unchanged' "$d/out" \
+  && ok_t "unreadable manifest: the reason names itself in the log" \
+  || bad_t "the probed-on-unknown reason was not stated" "$(tail -n3 "$d/out")"
+eq_t "unreadable manifest: a canary that dies still EXITS NON-ZERO" \
+  "$( [[ "$(cat "$d/rc" 2>/dev/null)" == 0 ]] && echo zero || echo non-zero )" non-zero
+grep -q 'would roll this box back and CANNOT' "$d/out" \
+  && ok_t "unreadable manifest: the operator is told the box is on the new build and NOT rolled back — a rollback with no capture is not faked" \
+  || bad_t "a rollback that could not happen was not reported" "$(tail -n3 "$d/out")"
+hg_loop lonlyunreadmut 's/^    if (( hg_moved != 1 )); then$/    if (( hg_moved == 0 )); then/' \
+  BAD-LAUNCHER 1 "" "" /proc/version/cannot-mkdir
+rc="$(cat "$WORK/loop-lonlyunreadmut/rc" 2>/dev/null)"
+if [[ "$rc" == "MUTATION-DID-NOT-APPLY" ]]; then
+  bad_t "MUTATION DID NOT APPLY — unreadable treated as unchanged" "sed matched nothing"
+elif [[ "$rc" == 0 || "$(hg_restarted_units lonlyunreadmut)" != 5dive-agent@a1.service ]]; then
+  ok_t "MUTANT KILLED — treating an unreadable manifest as 'unchanged' skips the probe (rc=$rc restarted=[$(hg_restarted_units lonlyunreadmut)])"
+else
+  bad_t "MUTANT SURVIVED — unreadable treated as unchanged" "the launcher-only probe is skipped on exactly the box that cannot answer"
+fi
 
 # --- MUTANT of the second sample (helper, but only reachable from 6c) --------
 mut "dropping the second sample's active/running check accepts a unit that stopped being an instrument" \

--- a/tests/self_update_health_gate_unit.sh
+++ b/tests/self_update_health_gate_unit.sh
@@ -112,6 +112,8 @@ eq_t "NEGATIVE CONTROL: unknown HALTS, it does not roll back (a release is not r
 # would introduce a NEW fleet-wide failure in the name of preventing one.
 eq_t "NEGATIVE CONTROL: restart-refused moves the canary role on — one stuck unit must not stop the nightly for the whole box" \
   "$(_hg_action restart-refused)" next-canary
+eq_t "NEGATIVE CONTROL: not-a-canary moves the canary role on — an already-sick agent must not revert a good release for the whole box" \
+  "$(_hg_action not-a-canary)" next-canary
 eq_t "NEGATIVE CONTROL: gate-unavailable PROCEEDS — a box whose systemd answers nothing keeps updating exactly as it did before this gate existed" \
   "$(_hg_action gate-unavailable)" proceed
 eq_t "NEGATIVE CONTROL: an unrecognised verdict halts rather than proceeding" \
@@ -211,9 +213,19 @@ rm -f "$SYSTEMCTL_FAKE/refuse"
 # a state I cannot classify" are the same empty string, and the gate would halt
 # the nightly on every box with an uninterrogable systemd — permanently, and for
 # a reason nobody would trace back to this row. `Id` is what separates them.
-set_unit active running 0; printf 'X' > "$SYSTEMCTL_FAKE/NRestarts"; : > "$SYSTEMCTL_FAKE/ActiveState"
-eq_t "Id readable but the state is not -> unknown (halts): a reading we cannot classify is never a pass" \
+# `unknown` is reached through the POST-restart path: the unit was a fine
+# instrument going in, and afterwards we cannot classify what came back. That is
+# the reading that HALTS the pass without reverting anything.
+set_unit active running 0
+printf 'printf activating > "$SYSTEMCTL_FAKE/ActiveState"\n' > "$SYSTEMCTL_FAKE/on_restart"
+eq_t "still activating when the window closed -> unknown (halts): a reading we cannot classify is never a pass" \
   "$(_hg_probe 5dive-agent@t.service)" unknown
+set_unit active running 0
+printf 'printf "" > "$SYSTEMCTL_FAKE/ActiveState"\n' > "$SYSTEMCTL_FAKE/on_restart"
+eq_t "the state going unreadable AFTER the restart -> unknown, not down (down would revert the release)" \
+  "$(_hg_probe 5dive-agent@t.service)" unknown
+rm -f "$SYSTEMCTL_FAKE/on_restart"
+set_unit active running 0
 rm -f "$SYSTEMCTL_FAKE"/{Id,ActiveState,SubState,NRestarts}
 eq_t "systemd answering NOTHING -> gate-unavailable, which PROCEEDS — not 'unknown', which would freeze the box off updates" \
   "$(_hg_probe 5dive-agent@t.service)" gate-unavailable
@@ -230,6 +242,55 @@ HEALTH_GATE_WINDOW_SECS=2 HEALTH_GATE_POLL_SECS=1
 w=$(_hg_watch 5dive-agent@t.service 0); wait 2>/dev/null
 eq_t "watch keeps looking past the first healthy reading — a unit that dies at t+1s is still caught" "$w" crash-loop
 HEALTH_GATE_WINDOW_SECS=0
+
+# ------------------------------------- 5b. the canary has to be a usable instrument
+# A false ROLLBACK is the one way this row can make a night worse than it found
+# it: an agent already crash-looping before the update is byte-for-byte
+# indistinguishable from a release that broke the box, and believing it reverts a
+# good release for every agent on the box. `--state=running` does not settle it —
+# a unit re-started every 3s IS running at the instant it is enumerated.
+export HEALTH_GATE_PRECHECK_SECS=1
+set_unit active running 5
+_hg_canary_ok 5dive-agent@t.service \
+  && ok_t "a steady active/running unit is a usable canary" \
+  || bad_t "a steady unit was rejected as a canary" "the gate would skip every valid canary"
+
+set_unit activating start 0
+_hg_canary_ok 5dive-agent@t.service \
+  && bad_t "a unit that is not active/running was accepted as a canary" "it cannot answer a question about the release" \
+  || ok_t "a unit not active/running before the update is NOT a canary"
+
+# THE ARM. The unit reads active/running at both samples, but systemd re-started
+# it between them: it was ALREADY looping before the update touched anything.
+set_unit active running 5
+( sleep 1; printf 6 > "$SYSTEMCTL_FAKE/NRestarts" ) &
+if _hg_canary_ok 5dive-agent@t.service; then
+  bad_t "an ALREADY crash-looping unit was accepted as a canary" "the gate would blame the release and roll back a good one"
+else
+  ok_t "an already crash-looping unit is rejected as a canary (a false rollback is the worst outcome this row has)"
+fi
+wait 2>/dev/null
+
+# NEGATIVE CONTROL: being stricter on an unreadable counter would disqualify every
+# canary on a systemd too old to report NRestarts.
+printf 'active\n' > "$SYSTEMCTL_FAKE/ActiveState"; printf 'running\n' > "$SYSTEMCTL_FAKE/SubState"
+printf '5dive-agent@t.service\n' > "$SYSTEMCTL_FAKE/Id"; : > "$SYSTEMCTL_FAKE/NRestarts"
+_hg_canary_ok 5dive-agent@t.service \
+  && ok_t "NEGATIVE CONTROL: an unreadable NRestarts does not disqualify a canary" \
+  || bad_t "an unreadable counter disqualified a healthy canary" "no canary would ever be usable on an older systemd"
+
+# And the probe must NOT restart a unit it has just declared unusable.
+set_unit active running 5
+printf 'printf RESTARTED > "$SYSTEMCTL_FAKE/didrestart"\n' > "$SYSTEMCTL_FAKE/on_restart"
+rm -f "$SYSTEMCTL_FAKE/didrestart"
+( sleep 1; printf 6 > "$SYSTEMCTL_FAKE/NRestarts" ) &
+v="$(_hg_probe 5dive-agent@t.service)"; wait 2>/dev/null
+eq_t "probe on an already-looping unit -> not-a-canary" "$v" not-a-canary
+[[ -e "$SYSTEMCTL_FAKE/didrestart" ]] \
+  && bad_t "the probe restarted a unit it had already rejected" "the caller does the ordinary restart; the probe must not double-bounce it" \
+  || ok_t "the probe does NOT restart a unit it rejected — the caller's ordinary restart is the only bounce"
+rm -f "$SYSTEMCTL_FAKE/on_restart"; unset HEALTH_GATE_PRECHECK_SECS
+set_unit active running 0
 
 # ------------------------------------------------------------- 6. the loud line
 note="$(_hg_rollback_note dev crash-loop 5dive,5dive-agent-start)"
@@ -305,6 +366,17 @@ mut "dropping the Id positive control makes an unreadable systemd halt the night
     'export SYSTEMCTL_FAKE PATH HEALTH_GATE_WINDOW_SECS=0
      rm -f "$SYSTEMCTL_FAKE"/{Id,ActiveState,SubState,NRestarts}
      [[ "$(_hg_action "$(_hg_probe 5dive-agent@t.service)")" != proceed ]] && echo MUTANT-CAUGHT'
+
+# M7: the canary pre-check dropped — an agent that was already crash-looping
+# before the update is believed, and the gate reverts a good release for the
+# whole box. The FALSE ROLLBACK direction.
+mut "dropping the canary pre-check lets an already-sick agent revert a good release" \
+    '/if ! _hg_canary_ok "$unit"; then/,+2d' \
+    'export SYSTEMCTL_FAKE PATH HEALTH_GATE_WINDOW_SECS=0
+     printf active > "$SYSTEMCTL_FAKE/ActiveState"; printf running > "$SYSTEMCTL_FAKE/SubState"
+     printf "5dive-agent@t.service" > "$SYSTEMCTL_FAKE/Id"; printf 5 > "$SYSTEMCTL_FAKE/NRestarts"
+     printf %s "printf 6 > \"\$SYSTEMCTL_FAKE/NRestarts\"" > "$SYSTEMCTL_FAKE/on_restart"
+     [[ "$(_hg_action "$(_hg_probe 5dive-agent@t.service)")" == rollback ]] && echo MUTANT-CAUGHT'
 
 echo; echo "$PASS passed, $FAIL failed"
 (( FAIL == 0 ))

--- a/tests/self_update_health_gate_unit.sh
+++ b/tests/self_update_health_gate_unit.sh
@@ -172,7 +172,8 @@ case "$1" in
   restart) [[ -f "$SYSTEMCTL_FAKE/refuse" ]] && exit 1
            [[ -f "$SYSTEMCTL_FAKE/on_restart" ]] && . "$SYSTEMCTL_FAKE/on_restart"
            exit 0 ;;
-  daemon-reload|is-active) exit 0 ;;
+  daemon-reload) printf 'daemon-reload\n' >> "$SYSTEMCTL_FAKE/cmd.log"; exit 0 ;;
+  is-active) exit 0 ;;
 esac
 exit 0
 STUB
@@ -377,6 +378,257 @@ mut "dropping the canary pre-check lets an already-sick agent revert a good rele
      printf "5dive-agent@t.service" > "$SYSTEMCTL_FAKE/Id"; printf 5 > "$SYSTEMCTL_FAKE/NRestarts"
      printf %s "printf 6 > \"\$SYSTEMCTL_FAKE/NRestarts\"" > "$SYSTEMCTL_FAKE/on_restart"
      [[ "$(_hg_action "$(_hg_probe 5dive-agent@t.service)")" == rollback ]] && echo MUTANT-CAUGHT'
+
+# ------------------------------------------ 6b. the reload after a template revert
+# `_hg_restore` is the only thing that puts the unit template back, and systemd
+# does not re-read a template on its own. Without the reload the box is running
+# the ExecStart it just reverted, which is a rollback that did not roll back.
+# Graded by OBSERVING the call, not by reading the line.
+set_unit active running 0; rm -f "$SYSTEMCTL_FAKE/on_restart" "$SYSTEMCTL_FAKE/refuse"
+export DR_BIN="$WORK/dr/bin" DR_SYSD="$WORK/dr/sysd" DR_RB="$WORK/dr/rb" DR_RB2="$WORK/dr/rb2"
+mkdir -p "$DR_BIN" "$DR_SYSD"
+printf 'B\n' > "$DR_BIN/5dive"; printf 'L\n' > "$DR_BIN/5dive-agent-start"
+printf 'UNIT-OLD\n' > "$DR_SYSD/5dive-agent@.service"
+(
+  export HEALTH_GATE_BIN_DIR="$DR_BIN" HEALTH_GATE_SYSTEMD_DIR="$DR_SYSD" HEALTH_GATE_ROLLBACK_DIR="$DR_RB"
+  _hg_capture >/dev/null 2>&1
+  printf 'UNIT-NEW\n' > "$HEALTH_GATE_SYSTEMD_DIR/5dive-agent@.service"
+  rm -f "$SYSTEMCTL_FAKE/cmd.log"
+  _hg_restore >/dev/null 2>&1
+)
+eq_t "the reverted unit template is the pre-update bytes again" "$(cat "$DR_SYSD/5dive-agent@.service")" UNIT-OLD
+grep -q daemon-reload "$SYSTEMCTL_FAKE/cmd.log" 2>/dev/null \
+  && ok_t "restoring the unit template is followed by an observed 'systemctl daemon-reload'" \
+  || bad_t "no daemon-reload after the template revert" "systemd would keep running the ExecStart the rollback just removed"
+
+# --------------------------- 6c. the SECOND sample is load-bearing, not redundant
+# The counter-delta check catches a unit looping across the two samples. It does
+# NOT catch one that stops being a usable instrument between them with the
+# counter still — active/running then `failed`, no re-start in between. That unit
+# cannot answer a question about the release either.
+export HEALTH_GATE_PRECHECK_SECS=1
+set_unit active running 5
+( sleep 1; printf 'failed\n' > "$SYSTEMCTL_FAKE/ActiveState" ) &
+if _hg_canary_ok 5dive-agent@t.service; then
+  bad_t "a unit that left active/running between the two samples was accepted as a canary" "the counter never moved, so only the second sample can reject it"
+else
+  ok_t "a unit that leaves active/running between the two samples is rejected as a canary"
+fi
+wait 2>/dev/null
+unset HEALTH_GATE_PRECHECK_SECS
+set_unit active running 0
+
+# =========================================================== 8. THE WIRING, RUN
+# Everything above grades the HELPERS. The helpers are not what holds the blast
+# radius — `cmd_self_update`'s restart loop is, and up to here that loop was
+# graded by grepping its body for symbol names. A gate that is CALLED and whose
+# verdict is then ignored satisfies every one of those greps, so the exact defect
+# this row exists to prevent could ship green: the loop reads `crash-loop` and
+# restarts the rest of the fleet anyway. That is the row's own asymmetry — the
+# artifact graded, the outcome not — turned on the fix.
+#
+# So the loop is EXECUTED here, verbatim from src/cmd_selfupdate.sh, against the
+# same kind of systemctl stub, on a fake box with three agents whose FIRST one
+# dies on the new launcher. What is asserted is behaviour, not messages:
+#   (a) exactly one agent is ever restarted — agents two and three are untouched;
+#   (b) the bytes on disk afterwards are the PRE-upgrade bytes;
+#   (c) the command exits non-zero.
+# Nothing is stubbed between the verdict and those three: `_hg_probe`,
+# `_hg_action`, the loop's break and the post-loop rollback all run for real.
+cmdbody="$(sed -n '/^cmd_self_update()/,/^}/p' src/cmd_selfupdate.sh)"
+if [[ -n "$cmdbody" ]] && grep -q '_hg_probe' <<<"$cmdbody" && [[ "$(tail -n1 <<<"$cmdbody")" == "}" ]]; then
+  ok_t "cmd_self_update is extractable from src/cmd_selfupdate.sh as shipped bytes"
+else
+  bad_t "cmd_self_update not extractable" "the wiring arms below would grade nothing"
+fi
+
+# hg_loop <tag> <sed-expr|""> <new-launcher-bytes>
+#   Runs the shipped (or mutated) cmd_self_update on a three-agent fake box and
+#   writes: $d/rc, $d/out, $d/fake/restart.log, $d/bin/*.
+hg_loop(){
+  local tag="$1" expr="$2" newl="$3" mutated d
+  d="$WORK/loop-$tag"
+  rm -rf "$d"; mkdir -p "$d/bin" "$d/sysd" "$d/sbin" "$d/fake/u" "$d/homes"
+  local u n
+  : > "$d/fake/units"
+  for n in a1 a2 a3; do
+    u="5dive-agent@$n.service"
+    mkdir -p "$d/fake/u/$u"
+    printf '%s\n' "$u" >> "$d/fake/units"
+    printf 'active\n'  > "$d/fake/u/$u/ActiveState"
+    printf 'running\n' > "$d/fake/u/$u/SubState"
+    printf '0\n'       > "$d/fake/u/$u/NRestarts"
+    printf '%s\n' "$u" > "$d/fake/u/$u/Id"
+  done
+  # Only a1 is wired to the launcher on disk: it dies (and systemd re-starts it)
+  # while the BAD launcher is installed, and comes back once the good one is
+  # restored. The unit's behaviour is a FUNCTION of the artifact, so a rollback
+  # that does not actually replace the bytes cannot read as a recovery.
+  cat > "$d/fake/u/5dive-agent@a1.service/on_restart" <<'ORS'
+if grep -q BAD "$HG_BIN/5dive-agent-start" 2>/dev/null; then
+  n="$(cat "$FK/u/$UNIT/NRestarts" 2>/dev/null)"; [[ "$n" =~ ^[0-9]+$ ]] || n=0
+  printf '%s\n' "$((n + 1))" > "$FK/u/$UNIT/NRestarts"
+fi
+ORS
+  cat > "$d/sbin/systemctl" <<'STUB2'
+#!/usr/bin/env bash
+FK="$SYSTEMCTL_FAKE"
+case "$1" in
+  list-units)    cat "$FK/units" 2>/dev/null; exit 0 ;;
+  show)          cat "$FK/u/$2/${3#--property=}" 2>/dev/null; exit 0 ;;
+  restart)       printf '%s\n' "$2" >> "$FK/restart.log"
+                 [[ -f "$FK/u/$2/on_restart" ]] && UNIT="$2" . "$FK/u/$2/on_restart"
+                 exit 0 ;;
+  daemon-reload) printf 'daemon-reload\n' >> "$FK/cmd.log"; exit 0 ;;
+  is-active)     exit 0 ;;
+esac
+exit 0
+STUB2
+  # The installer is what the update path actually runs; here it lands the
+  # release under test onto the same bin dir the gate captured.
+  cat > "$d/sbin/curl" <<'CURL'
+#!/usr/bin/env bash
+out=""; prev=""
+for a in "$@"; do [[ "$prev" == "-o" ]] && out="$a"; prev="$a"; done
+[[ -n "$out" ]] || exit 1
+cat > "$out" <<'INS'
+#!/usr/bin/env bash
+printf '%s\n' "$HG_NEW_LAUNCHER" > "$HG_BIN/5dive-agent-start"
+printf 'NEW-BUNDLE\n'            > "$HG_BIN/5dive"
+chmod 755 "$HG_BIN/5dive-agent-start" "$HG_BIN/5dive"
+INS
+exit 0
+CURL
+  chmod 755 "$d/sbin/systemctl" "$d/sbin/curl"
+  printf 'GOOD-BUNDLE\n'   > "$d/bin/5dive"
+  printf 'GOOD-LAUNCHER\n' > "$d/bin/5dive-agent-start"
+  chmod 755 "$d/bin/5dive" "$d/bin/5dive-agent-start"
+
+  mutated="$cmdbody"
+  if [[ -n "$expr" ]]; then
+    mutated="$(sed "$expr" <<<"$cmdbody")"
+    if [[ "$mutated" == "$cmdbody" ]]; then printf 'MUTATION-DID-NOT-APPLY\n' > "$d/rc"; return; fi
+  fi
+  {
+    cat <<'PRELUDE'
+set -uo pipefail
+E_GENERIC=1; E_USAGE=2; E_NOT_FOUND=3
+step(){ printf 'step: %s\n' "$*"; }
+warn(){ printf 'warn: %s\n' "$*"; }
+ok(){   printf 'ok: %s\n'   "$1"; return 0; }
+fail(){ printf 'fail: %s\n' "${2:-}"; exit "${1:-1}"; }
+json_array(){ printf '[]\n'; }
+gh_org(){ printf '5dive-ai\n'; }
+_PR_FIRED=0; _PR_PARKED=0
+_pending_restart_sweep(){ return 0; }
+_pending_restart_mark(){ return 0; }
+_agent_home(){ printf '%s/%s\n' "$HG_HOMES" "${1:-}"; }
+_agent_payload_fingerprint(){ printf 'fp\n'; }
+agent_type(){ printf 'claude\n'; }
+_agent_is_parked(){ return 1; }
+_agent_restart_needed(){ return 0; }
+_agent_busy_state(){ printf 'idle\n'; }
+_team_bot_install_listener(){ return 0; }
+PRELUDE
+    printf '%s\n' "$block"
+    printf '%s\n' "$mutated"
+    printf 'cmd_self_update\n'
+  } > "$d/driver.sh"
+
+  (
+    export PATH="$d/sbin:$PATH"
+    export SYSTEMCTL_FAKE="$d/fake" HG_BIN="$d/bin" HG_HOMES="$d/homes" HG_NEW_LAUNCHER="$newl"
+    export HEALTH_GATE_BIN_DIR="$d/bin" HEALTH_GATE_SYSTEMD_DIR="$d/sysd" HEALTH_GATE_ROLLBACK_DIR="$d/rb"
+    export HEALTH_GATE_WINDOW_SECS=0 HEALTH_GATE_POLL_SECS=1 HEALTH_GATE_PRECHECK_SECS=0
+    bash "$d/driver.sh" > "$d/out" 2>&1
+    printf '%s\n' "$?" > "$d/rc"
+  )
+}
+hg_restarted_units(){ sort -u "$WORK/loop-$1/fake/restart.log" 2>/dev/null | paste -sd, -; }
+
+# --- the bad release, on the shipped loop -----------------------------------
+hg_loop shipped "" BAD-LAUNCHER
+d="$WORK/loop-shipped"
+eq_t "(c) a release that kills the first agent makes self-update EXIT NON-ZERO" \
+  "$( [[ "$(cat "$d/rc" 2>/dev/null)" == 0 ]] && echo zero || echo non-zero )" non-zero
+eq_t "(a) BLAST RADIUS: exactly one agent was ever restarted — agents two and three were never touched" \
+  "$(hg_restarted_units shipped)" 5dive-agent@a1.service
+eq_t "(b) the launcher on disk afterwards is the PRE-upgrade one — the box was rolled back, not just warned about" \
+  "$(cat "$d/bin/5dive-agent-start" 2>/dev/null)" GOOD-LAUNCHER
+eq_t "(b) the bundle on disk afterwards is the PRE-upgrade one" \
+  "$(cat "$d/bin/5dive" 2>/dev/null)" GOOD-BUNDLE
+grep -qi 'HEALTH GATE FAILED' "$d/out" \
+  && ok_t "the operator gets the loud rollback line, not a quiet box" \
+  || bad_t "no rollback line in the output" "$(tail -n3 "$d/out")"
+grep -qi 'running again on the restored build' "$d/out" \
+  && ok_t "the canary is brought back UP on the restored build — the gate does not end its run leaving one agent dark" \
+  || bad_t "canary not recovered" "$(tail -n3 "$d/out")"
+
+# --- NEGATIVE CONTROL: a GOOD release must not trip any of the three ---------
+# Without this every assertion above is satisfiable by a gate that halts on
+# everything, which would freeze the fleet off updates permanently.
+hg_loop good "" GOOD-LAUNCHER
+d="$WORK/loop-good"
+eq_t "NEGATIVE CONTROL: a healthy release exits ZERO" "$(cat "$d/rc" 2>/dev/null)" 0
+eq_t "NEGATIVE CONTROL: a healthy release restarts ALL THREE agents — the gate is not a brake on good nights" \
+  "$(hg_restarted_units good)" "5dive-agent@a1.service,5dive-agent@a2.service,5dive-agent@a3.service"
+eq_t "NEGATIVE CONTROL: a healthy release is NOT rolled back — the new bundle stays on disk" \
+  "$(cat "$d/bin/5dive" 2>/dev/null)" NEW-BUNDLE
+
+# --- MUTANTS of the WIRING --------------------------------------------------
+# Each is a one-token regression that leaves every `_hg_*` call in place, so the
+# presence-greps above still pass. If one of these survives, the arms are reading
+# the gate's text rather than its effect (the DIVE-1095 shape).
+mutw(){ # <name> <sed-expr> ; killed when the shipped assertions go red
+  local name="$1" expr="$2" tag rc units launcher
+  tag="m$(printf '%s' "$name" | cksum | cut -d' ' -f1)"
+  hg_loop "$tag" "$expr" BAD-LAUNCHER
+  rc="$(cat "$WORK/loop-$tag/rc" 2>/dev/null)"
+  if [[ "$rc" == "MUTATION-DID-NOT-APPLY" ]]; then
+    bad_t "MUTATION DID NOT APPLY — $name" "sed '$expr' matched nothing; this arm graded the SHIPPED loop, not a mutant"
+    return
+  fi
+  units="$(hg_restarted_units "$tag")"
+  launcher="$(cat "$WORK/loop-$tag/bin/5dive-agent-start" 2>/dev/null)"
+  if [[ "$rc" == 0 || "$units" != "5dive-agent@a1.service" || "$launcher" != GOOD-LAUNCHER ]]; then
+    ok_t "MUTANT KILLED — $name (rc=$rc restarted=[$units] launcher=$launcher)"
+  else
+    bad_t "MUTANT SURVIVED — $name" "the wiring arms pass against a loop that does not hold the blast radius"
+  fi
+}
+
+# W1: the halt becomes a skip. The gate reads crash-loop and the loop restarts
+# every remaining agent anyway — 0.26.1's night back, with the gate installed
+# and green.
+mutw "the gate's halt turned into a 'continue' restarts the rest of the fleet anyway" \
+     '/elif \[\[ "$hg_action" != "proceed" \]\]; then/{n;s/break/continue/;}'
+# W2: the post-loop block never runs. Detects, never halts, never rolls back —
+# every _hg_* call still present and every presence-grep still satisfied.
+mutw "the post-loop rollback block disabled leaves the bad build on disk" \
+     's/^  if \[\[ "$hg_action" != "proceed" \]\]; then$/  if false; then/'
+# W3: the canary is never selected, so the probe never runs inside the loop.
+mutw "the in-loop canary probe never selected lets the whole pass run unmeasured" \
+     's/^    if \[\[ -z "$hg_canary" \]\]; then$/    if false; then/'
+
+# --- MUTANT of the second sample (helper, but only reachable from 6c) --------
+mut "dropping the second sample's active/running check accepts a unit that stopped being an instrument" \
+    '/\[\[ "$a2" == "active"/d' \
+    'export SYSTEMCTL_FAKE PATH HEALTH_GATE_PRECHECK_SECS=1
+     printf active > "$SYSTEMCTL_FAKE/ActiveState"; printf running > "$SYSTEMCTL_FAKE/SubState"
+     printf "5dive-agent@t.service" > "$SYSTEMCTL_FAKE/Id"; printf 5 > "$SYSTEMCTL_FAKE/NRestarts"
+     ( sleep 1; printf failed > "$SYSTEMCTL_FAKE/ActiveState" ) &
+     _hg_canary_ok 5dive-agent@t.service && echo MUTANT-CAUGHT
+     wait 2>/dev/null'
+# M9: the reload dropped from the restore — the box keeps the ExecStart it reverted.
+mut "a restore with no daemon-reload leaves systemd on the ExecStart it just reverted" \
+    '/systemctl daemon-reload/d' \
+    'export SYSTEMCTL_FAKE PATH
+     export HEALTH_GATE_BIN_DIR="$DR_BIN" HEALTH_GATE_SYSTEMD_DIR="$DR_SYSD" HEALTH_GATE_ROLLBACK_DIR="$DR_RB2"
+     _hg_capture >/dev/null 2>&1
+     printf NEW > "$HEALTH_GATE_SYSTEMD_DIR/5dive-agent@.service"
+     rm -f "$SYSTEMCTL_FAKE/cmd.log"
+     _hg_restore >/dev/null 2>&1
+     grep -q daemon-reload "$SYSTEMCTL_FAKE/cmd.log" 2>/dev/null || echo MUTANT-CAUGHT'
 
 echo; echo "$PASS passed, $FAIL failed"
 (( FAIL == 0 ))

--- a/tests/self_update_health_gate_unit.sh
+++ b/tests/self_update_health_gate_unit.sh
@@ -454,7 +454,7 @@ fi
 #   `_agent_busy_state`/`_agent_is_parked` report as not-idle and parked, so the
 #   candidate loop's own guards are reachable too.
 hg_loop(){
-  local tag="$1" expr="$2" newl="$3" rcneed="${4:-0}" busylist="${5:-}" parkedlist="${6:-}" rbdir="${7:-}" mutated d
+  local tag="$1" expr="$2" newl="$3" rcneed="${4:-0}" busylist="${5:-}" parkedlist="${6:-}" rbdir="${7:-}" deathmode="${8:-crash}" dying="${9:-a1}" unsteady="${10:-}" mutated d
   d="$WORK/loop-$tag"
   rm -rf "$d"; mkdir -p "$d/bin" "$d/sysd" "$d/sbin" "$d/fake/u" "$d/homes"
   local u n
@@ -472,12 +472,24 @@ hg_loop(){
   # while the BAD launcher is installed, and comes back once the good one is
   # restored. The unit's behaviour is a FUNCTION of the artifact, so a rollback
   # that does not actually replace the bytes cannot read as a recovery.
-  cat > "$d/fake/u/5dive-agent@a1.service/on_restart" <<'ORS'
+  for n in ${unsteady//,/ }; do printf 'activating\n' > "$d/fake/u/5dive-agent@$n.service/ActiveState"; done
+  cat > "$d/fake/u/5dive-agent@$dying.service/on_restart" <<'ORS'
 if grep -q BAD "$HG_BIN/5dive-agent-start" 2>/dev/null; then
   n="$(cat "$FK/u/$UNIT/NRestarts" 2>/dev/null)"; [[ "$n" =~ ^[0-9]+$ ]] || n=0
   printf '%s\n' "$((n + 1))" > "$FK/u/$UNIT/NRestarts"
 fi
 ORS
+  # `blind`: the unit does not crash, systemd just stops answering about it after
+  # the bounce. That is the UNKNOWN verdict, and it must HALT without reverting —
+  # absence of evidence of health is not evidence of breakage. Id stays readable,
+  # which is the positive control that separates the two.
+  if [[ "$deathmode" == "blind" ]]; then
+    cat > "$d/fake/u/5dive-agent@$dying.service/on_restart" <<'ORS2'
+: > "$FK/u/$UNIT/ActiveState"
+: > "$FK/u/$UNIT/SubState"
+: > "$FK/u/$UNIT/NRestarts"
+ORS2
+  fi
   cat > "$d/sbin/systemctl" <<'STUB2'
 #!/usr/bin/env bash
 FK="$SYSTEMCTL_FAKE"
@@ -804,6 +816,69 @@ elif [[ "$rc" == 0 || "$(hg_restarted_units lonlyunreadmut)" != 5dive-agent@a1.s
   ok_t "MUTANT KILLED — treating an unreadable manifest as 'unchanged' skips the probe (rc=$rc restarted=[$(hg_restarted_units lonlyunreadmut)])"
 else
   bad_t "MUTANT SURVIVED — unreadable treated as unchanged" "the launcher-only probe is skipped on exactly the box that cannot answer"
+fi
+
+# 9c. The HALT consumer, driven. `_hg_action`'s asymmetry is graded four ways in
+# section 3 and its unknown->halt arm has a mutant, but the CONSUMER of a halt —
+# the block that must warn, revert NOTHING, and still stop the pass — was entered
+# by no driven arm. It is the third of the three outcomes this row turns on, and
+# the one where getting it wrong (reverting) freezes a box off updates forever.
+hg_loop lonlyblind "" BAD-LAUNCHER 1 "" "" "" blind
+d="$WORK/loop-lonlyblind"
+eq_t "HALT: a canary systemd stops answering about still stops the pass (non-zero)" \
+  "$( [[ "$(cat "$d/rc" 2>/dev/null)" == 0 ]] && echo zero || echo non-zero )" non-zero
+eq_t "HALT: the blast radius is still one — agents two and three are never reached" \
+  "$(hg_restarted_units lonlyblind)" 5dive-agent@a1.service
+eq_t "HALT: NOTHING is reverted on an unreadable box — the new launcher stays on disk" \
+  "$(cat "$d/bin/5dive-agent-start" 2>/dev/null)" BAD-LAUNCHER
+eq_t "HALT: and the new bundle stays too — a halt is not a rollback" \
+  "$(cat "$d/bin/5dive" 2>/dev/null)" NEW-BUNDLE
+grep -q 'INCONCLUSIVE' "$d/out" \
+  && ok_t "HALT: the operator is told the box could not be read, not that it was rolled back" \
+  || bad_t "the halt was not reported as inconclusive" "$(tail -n3 "$d/out")"
+# The mutant is the TRIGGER-HAPPY direction, which this file names as the worse
+# one: treat every non-proceed verdict as a rollback and a box systemd merely
+# would not talk about gets a good release reverted under it.
+hg_loop lonlyblindmut 's/if \[\[ "$hg_action" == "rollback" \]\]; then/if true; then/' \
+  BAD-LAUNCHER 1 "" "" "" blind
+if [[ "$(cat "$WORK/loop-lonlyblindmut/rc" 2>/dev/null)" == "MUTATION-DID-NOT-APPLY" ]]; then
+  bad_t "MUTATION DID NOT APPLY — halt treated as rollback" "sed matched nothing"
+elif [[ "$(cat "$WORK/loop-lonlyblindmut/bin/5dive-agent-start" 2>/dev/null)" != BAD-LAUNCHER ]]; then
+  ok_t "MUTANT KILLED — treating a halt as a rollback reverts a release on a box that was merely unreadable"
+else
+  bad_t "MUTANT SURVIVED — halt treated as rollback" "nothing grades the difference between halting and reverting"
+fi
+
+# 9d. The last consumer inside the restart loop: an agent that was ALREADY
+# unsteady before the update. `_hg_canary_ok` is graded at the helper in 5b, but
+# its caller's answer — restart that agent ORDINARILY and let the NEXT one take
+# the canary role — was entered by no driven arm. Believing a sick unit is the one
+# way this gate makes a night worse than it found it: it reverts a good release
+# for the whole box on one independently broken agent.
+hg_loop notacanary "" BAD-LAUNCHER 0 "" "" "" crash a2 a1
+d="$WORK/loop-notacanary"
+grep -q 'not using a1 as the health-gate canary' "$d/out" \
+  && ok_t "a unit that was not steady BEFORE the update is refused as an instrument, out loud" \
+  || bad_t "the unsteady unit was used as a canary" "$(tail -n3 "$d/out")"
+eq_t "the sick agent is still restarted ORDINARILY and the NEXT agent takes the canary role — a3 is never reached" \
+  "$(hg_restarted_units notacanary)" "5dive-agent@a1.service,5dive-agent@a2.service"
+eq_t "the release is judged on the agent that could answer: bytes reverted" \
+  "$(cat "$d/bin/5dive-agent-start" 2>/dev/null)" GOOD-LAUNCHER
+eq_t "and the pass exits non-zero" \
+  "$( [[ "$(cat "$d/rc" 2>/dev/null)" == 0 ]] && echo zero || echo non-zero )" non-zero
+# The mutant is the CONSUMER's own branch (the validity check itself lives in the
+# extracted block, which this driver runs as shipped bytes): if `not-a-canary` is
+# not distinguished from `restart-refused`, the sick agent is never restarted at
+# all and is logged as a failed restart — it silently stays on the old payload,
+# which is the DIVE-4033 shape this row must not reintroduce.
+hg_loop notacanarymut 's/^        if \[\[ "$hg_verdict_raw" == "not-a-canary" \]\]; then$/        if false; then/' BAD-LAUNCHER 0 "" "" "" crash a2 a1
+u="$(hg_restarted_units notacanarymut)"
+if [[ "$(cat "$WORK/loop-notacanarymut/rc" 2>/dev/null)" == "MUTATION-DID-NOT-APPLY" ]]; then
+  bad_t "MUTATION DID NOT APPLY — the canary validity check removed" "sed matched nothing"
+elif [[ "$u" != "5dive-agent@a1.service,5dive-agent@a2.service" ]]; then
+  ok_t "MUTANT KILLED — conflating 'not an instrument' with 'systemctl refused' leaves the sick agent unrestarted and mislogged (restarted=[$u])"
+else
+  bad_t "MUTANT SURVIVED — the not-a-canary fall-through removed" "an agent left on the old payload and logged as a failed restart is graded by nothing"
 fi
 
 # --- MUTANT of the second sample (helper, but only reachable from 6c) --------


### PR DESCRIPTION
## DIVE-4068 — the update path now checks that the box it just updated still runs an agent

0.26.1 shipped a launcher that could not start any agent (DIVE-4067). The nightly installs the
release and then restarts every agent, so every box that took it **emptied itself, unattended**,
and stayed empty until a human noticed and hand-patched the file.

DIVE-4067 fixed the one-line defect and a scanner guards its class. This is the other half: nothing
in the update path noticed that the box it had just updated was dark.

### What was actually missing

`install.sh` grades the **artifact** — it fetched, the sha256 matches, `bash -n` parses it, the
version did not go backwards. Every one of those passed on 0.26.1, because a self-referencing
`local` is syntactically valid. The **outcome** — *does an agent still start on this box* — was
never asked, and it is the one question the box can answer for itself in about twenty seconds.

### The gate

`cmd_self_update` snapshots the startup path before the installer runs, then grades the first agent
it restarts.

**The canary is free.** It is the first unit the pass was going to bounce anyway, so DIVE-3172's
"restart only whoever's payload moved" is not undone — and the gate settles *before* the loop reaches
agent number two. That is what holds a bad release to one dark agent instead of the box.

**`NRestarts`, not `is-active`.** The unit is `Type=simple`: a launcher that execs and dies one line
later is `active` for the instant between them, which is exactly the reading a naive check takes.
`RestartSec=3` puts systemd's first re-start ~3s in and ticks the counter, decisive long before
`StartLimitBurst=10` finally parks the unit in `failed` some 30s later. The launcher's two permanent
exits (2 unknown type, 3 not installed) are caught by `failed` via `RestartPreventExitStatus`.
The mutant that removes this comparison is in the harness — it is the shape that would have graded
0.26.1 as a clean install.

**On a failure it rolls back.** `/usr/local/bin/5dive`, `/usr/local/bin/5dive-agent-start` and
`/etc/systemd/system/5dive-agent@.service` are restored from the pre-upgrade snapshot (same-fs temp
+ `mv`, the shape install.sh already uses for the bundle swap), the canary is restarted onto them and
re-graded, **no other agent is touched**, and the pass exits non-zero with a line naming the agent,
the verdict and what was restored. Deliberately *not* the whole managed set — hooks, skills, refresh
scripts are read by an agent that is already up, and reverting them would widen a targeted rollback
into a general one.

**A launcher-only release is probed deliberately.** `5dive-agent-start` lives in `/usr/local/bin`,
not in an agent's home, so it is invisible to DIVE-3172's payload fingerprint: **0.26.1 would have
moved no fingerprint, restarted no one, and been graded by nothing** — and the first crash-restart or
operator bounce afterwards would have found the box dark with no gate near it. So when the launcher's
own hash moved and the pass restarted nobody, the gate spends one restart on an agent that is idle,
unparked and between turns. That is the only restart this row adds, and it is bounded to the rare
night the startup path itself changed.

**A false rollback is the worst thing this row could do, and it has its own guard.** An agent that
was *already* crash-looping before the update is byte-for-byte indistinguishable from a release that
broke the box — and believing it would revert a good release for every agent on the box.
`systemctl list-units --state=running` does not settle it: a unit re-started every 3s *is* running at
the instant it is enumerated. So a canary must read `active/running` at **two samples a second
apart** with the counter still between them; a unit that fails that is not judged broken, it is
judged **unusable as an instrument**, and the canary role moves to the next agent (it still gets its
ordinary restart — the probe returns before restarting, so nothing is double-bounced). An unreadable
counter does *not* disqualify it, or no canary would ever be usable on an older systemd.

### Three outcomes, and the two that deliberately do not halt

| verdict | action | why |
|---|---|---|
| `healthy` | proceed | the loop continues byte for byte as today |
| `crash-loop` / `failed` / `down` | **rollback** | positive evidence of breakage |
| `unknown` | **halt, roll back nothing** | halting needs only the *absence* of evidence of health; reverting a release needs evidence it is broken |
| `gate-unavailable` | proceed, loudly | systemd answered *nothing* — the gate never ran |
| `restart-refused` | next agent becomes the canary | systemctl declining says nothing about the artifact |
| `not-a-canary` | next agent becomes the canary | the unit was not steady *before* the update, so it cannot answer a question about the release |

The last two exist because halting there would introduce a **new fleet-wide failure in the name of
preventing one**. `gate-unavailable` is separated from `unknown` by an `Id` **positive control**:
without it, "systemd told us nothing" and "the unit is in a state I cannot classify" are the same
empty string, and every box with an uninterrogable systemd would halt its nightly forever. That is
the same failure shape CLAUDE.md names for a cross-seat probe — a denial and a real negative read
identically until something known-present is read alongside them. `restart-refused` was the
pre-DIVE-4068 `failed` case verbatim; letting one stuck unit stop the nightly for the whole box would
be a regression.

### Evidence

`tests/self_update_health_gate_unit.sh` — **65 arms, 0 failed, 7 mutants killed.** Hermetic in the
shape DIVE-2042/3172/3173/4033 established: the block is extracted verbatim between its fence markers
and run as the **shipped bytes**; `systemctl` is a stub on `$PATH`; every file it touches is under
`$WORK`. No unit, no agent and no `/usr/local/bin` is read or written.

Mutants, each reproducing a **pre-fix shape** rather than a deleted call (and the helper asserts the
mutation applied before grading it, so a sed that matched nothing cannot print "killed"):

1. a verdict that ignores `NRestarts` → calls a crash-looping unit healthy *(the 0.26.1 blindness)*
2. `unknown` folded into proceed → the mass restart continues across an unreadable box
3. `unknown` folded into rollback → a good release reverted on an unreadable box *(the silent-freeze direction)*
4. `_hg_restore` ignoring the absent/present status → conjures a unit template that never existed
5. a missing manifest answering "unchanged" → the launcher-only night is never probed
6. the `Id` positive control dropped → an unreadable systemd halts the nightly *(a safety check causing the outage)*
7. the canary pre-check dropped → an already-sick agent reverts a good release *(the false-rollback direction)*

The arms carry negative controls throughout: an unchanged `NRestarts` level is not a delta, garbage
counters are discarded rather than parsed, an absent artifact is not conjured by a restore, restore
with no rollback point returns non-zero rather than claiming one, and `_hg_watch` keeps looking past
the first healthy reading (an arm kills the unit at t+1s and it is still caught).

Neighbours re-run green after the change: `self_update_parked_agent_unit.sh` **29/0**,
`self_update_busy_defer_unit.sh` **29/0**, `self_update_restart_predicate_unit.sh` **40/0**,
`install_update_hint_unit.sh` **6/0**, `update_check_propagation_unit.sh` **22/0**.

> `self_update_parked_agent_unit.sh` **caught a real design flaw** mid-build, not a fixture problem:
> its end-to-end arms drive `cmd_self_update` against a `systemctl` stub that answers no properties,
> and the first version of this gate halted the whole pass there. That is what forced the
> `gate-unavailable` split and the `Id` positive control above. The canary pre-check came out of the
> pre-close self-audit for the same reason: the first version would have reverted a good release for
> the whole box if the agent it happened to pick was independently sick.

**Suite: all 485 harnesses run** — 242 via `scripts/run-harnesses.sh --tier=full` before it hit its
budget, the remainder directly. **10 red, and all 10 reproduce byte-identically on an unmodified
`origin/main` worktree built on this same seat**: `actor_claim_corroboration`,
`agent_priv_read_breaker`, `builder_gh_rail`, `env_isolation`, `gate_delegated_answer`,
`gate_telemetry_fence`, `memory_check_field`, `task_merge_gate_result_pr`,
`task_merge_gate_selftest`, `task_verifier_rail`. This seat holds no gh credential and its sudo runas
is narrowed, which is what those arms measure. **None of them touches `cmd_selfupdate.sh`**, and the
control worktree was built (`./build.sh`) before comparing — an unbuilt tree silently skips e2e blocks
and fakes a green baseline.

**No smoke is owed.** `5dive-cli` does not auto-deploy (deliberate `release-cut`), and this touches
neither `scripts/inc/5dive-cli.sh` nor the agent-create path.

### THE RESIDUAL THAT MATTERS: there are THREE updaters, and this gates one

Found while auditing this change, and it is the first thing a reviewer should weigh. Three separate
paths on this fleet install a release and then restart every agent:

| path | repo | who runs it | gated? |
|---|---|---|---|
| `cmd_self_update` | `5dive-cli` `src/cmd_selfupdate.sh` | OSS / self-hosted boxes, on-demand | **yes, this PR** |
| `scripts/update.sh` | `5dive-api` | **customer VMs**, via the 03:00 `soft-updates.sh` cron | no |
| `scripts/control-plane/5dive-host-updates.sh` | `5dive-api` | the control-plane host, 23:15 UTC cron | no |

`update.sh` is almost certainly the path the boxes went dark on. It delegates the install to
`install.5dive.com` (`bash "$_install_tmp" --upgrade`, ~line 52) and then, ~line 721, does:

```bash
mapfile -t LIVE < <(systemctl list-units '5dive-agent@*' --state=running --no-legend --plain …)
for unit in "${LIVE[@]}"; do systemctl restart "$unit" && ok "$unit"; done
```

— every running agent, unconditionally. It does not even carry DIVE-3172's payload predicate; that
conditional lives in the CLI, not here. `5dive-host-updates.sh` (~line 499) does the same with a
single `systemctl restart $units`.

**So the gate in this PR does not yet cover the population that emptied.** That is stated rather than
folded in because porting it is a `5dive-api` change, and `5dive-api` is the sharp repo: merge to
`main` deploys AND runs `drizzle-kit push --force` against the prod DB, and `update.sh` is served live
to every customer box on `curl … | sudo bash`. That is a provisioning-path change owing a smoke and a
written `smoke-override` — a different ship with a different gate, not a hunk to append here.

Filed as its own row. The verifier should grade this PR as the OSS/self-hosted half and the customer
half as owed, not as done.

### Explicitly NOT in this PR

- **The `/etc/5dive/cli-version` fleet pin.** The row considers it and rejects it as the fix: it is
  reactive, and would not have saved a single box last night because nobody knew until the boxes were
  already empty. Still worth having, separately.
- **`5dive doctor`'s `cli-provenance`**, which reported OK on a box with zero running agents because
  it hashes `/usr/local/bin/5dive` and the launcher beside it is not in that hash. Named in the row as
  evidence of the asymmetry, not in its ask. Left uncovered and stated rather than folded in.
- **The other two updaters** — see the section above. Owed, filed, and named in the delivery result
  so it is graded rather than discovered.
