### PR TITLE
fix(agent): point dispatcher users to agent logs

### DIFF
--- a/src/cmd_agent_config.sh
+++ b/src/cmd_agent_config.sh
@@ -461,7 +461,7 @@ cmd_tui() {
   if [[ "$type" == "codex" ]]; then
     case ",${channels}," in
       *,telegram,*|*,dashboard,*)
-        fail "$E_CONFLICT" "agent '$name' has no interactive Codex TUI: its tmux session is the ${channels} dispatcher. View transport logs with '5dive agent tail $name'; inspect Codex work in /home/agent-${name}/.codex/sessions."
+fail "$E_CONFLICT" "agent '$name' has no interactive Codex TUI: its tmux session is the ${channels} dispatcher. View transport logs with '5dive agent logs $name --tmux'; inspect Codex work in /home/agent-${name}/.codex/sessions."
         ;;
     esac
   fi

--- a/tests/agent_operational_health_unit.sh
+++ b/tests/agent_operational_health_unit.sh
@@ -81,7 +81,7 @@ for seat in dash combo; do
   rc=0; out=$(run_tui "$seat") || rc=$?
   is "$seat dispatcher refuses false TUI attach" "$rc" 5
   has "$seat refusal names no interactive Codex TUI" "$out" "no interactive Codex TUI"
-  has "$seat refusal points to transport logs" "$out" "5dive agent tail $seat"
+  has "$seat refusal points to transport logs" "$out" "5dive agent logs $seat --tmux"
 done
 is "plain Codex still reaches interactive attach" "$(run_tui plain)" \
   "ATTACH:-u agent-plain tmux attach -t agent-plain"


### PR DESCRIPTION
Fixes #793

The dispatcher-only TUI error message referenced the removed [1m5dive agent tail[0m command. Point it at the implemented [1m5dive agent logs <name> --tmux[0m command instead.

Verification:
- bash -n src/cmd_agent_config.sh
- tests/agent_operational_health_unit.sh (26 passed, 0 failed)