### PR TITLE
DIVE-4072: give the manual cut the hotfix lane its own header already promises

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -78,6 +78,11 @@ on:
           - patch
           - minor
           - major
+      required_only:
+        description: 'HOTFIX LANE (DIVE-4072). Grade the sha against the NINE REQUIRED contexts only, instead of every check-run on it. For an incident, when a non-required job (a sweep shard, a nightly-only guard) is red or undetermined and the release cannot wait for it. The reason above is published with the release and must say which one and why. Ignored on the nightly.'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: release-cut
@@ -100,6 +105,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           MANUAL_REASON: ${{ inputs.reason }}
           RELEASE_LEVEL: ${{ inputs.level }}
+          REQUIRED_ONLY: ${{ inputs.required_only }}
         run: |
           set -uo pipefail
 
@@ -266,8 +272,72 @@ jobs:
             git merge-base --is-ancestor "$1" "$_t" 2>/dev/null || return 0
             printf '%s\n' "$_t"
           }
+          # DIVE-4072: the REQUIRED contexts, read LIVE from branch protection.
+          # Outside the fence for exactly the reason _ci_fetch_runs is: the block below is
+          # extracted and executed by tests/release_cut_guards_unit.sh, which supplies its own
+          # stub. NEVER a hand-copied list in this file — release-cut and branch protection
+          # disagreeing about what "required" means is the DIVE-2144 "one rule implemented
+          # twice" trap this workflow already carries a warning about, and the failure would be
+          # silent in the dangerous direction: publishing against a list that has drifted SHORT.
+          _required_contexts() {
+            gh api "repos/${GITHUB_REPOSITORY}/branches/main/protection" \
+              --jq '.required_status_checks.contexts[]' 2>/dev/null
+          }
           runs=$(_ci_fetch_runs)
           # >>> DIVE-2144 release-cut guard block (extracted verbatim by tests/release_cut_guards_unit.sh)
+          # DIVE-4072 — THE HOTFIX LANE, and its three refusals.
+          #
+          # This workflow grades the sha against EVERY check-run on it. Branch protection
+          # requires NINE. So a red on a job nothing gates merges on — a sweep shard, a
+          # nightly-only guard — blocks the publish act while main merges happily around it.
+          # Measured: the v0.26.2 incident cut sat 45 minutes on two shards that exited 6
+          # UNDETERMINED with zero non-zero harness rows, while every box on that night's
+          # update ran no agents at all.
+          #
+          # `workflow_dispatch` already exists and already demands a written reason, and the
+          # header of this file already calls it "a manual cut for hotfixes" — it just never
+          # escaped anything, because it applied the identical predicate. This is that escape.
+          #
+          # WHAT IT DOES NOT DO, and these are the load-bearing bounds:
+          #   - it is REFUSED on schedule and on push, so the nightly keeps the strict rule;
+          #   - it never relaxes ANYTHING else — completeness, ancestry, the sort assertion
+          #     and the incomplete-run wait all still run over the filtered set;
+          #   - it refuses outright if the required list comes back EMPTY, because "no
+          #     contexts required" and "the API call failed" are the same empty string, and
+          #     one of them means publish-with-no-gate.
+          REQUIRED_ONLY="${REQUIRED_ONLY:-false}"
+          _REQ_LIST=""
+          if [[ "$REQUIRED_ONLY" == "true" ]]; then
+            if [[ "${GITHUB_EVENT_NAME:-}" != "workflow_dispatch" ]]; then
+              echo "::error::required_only is a MANUAL lane and this run is '${GITHUB_EVENT_NAME:-unknown}'. The scheduled and push cuts grade every check-run, deliberately. Refusing."
+              exit 1
+            fi
+            _REQ_LIST=$(_required_contexts)
+            if [[ -z "$_REQ_LIST" ]]; then
+              echo "::error::required_only was requested but branch protection returned NO required contexts for main. That is indistinguishable from a failed read, and grading against an empty list is publishing with no gate at all. Refusing."
+              exit 1
+            fi
+            echo "DIVE-4072 HOTFIX LANE: grading ${sha:0:12} against the $(printf '%s\n' "$_REQ_LIST" | grep -c .) REQUIRED context(s) only."
+            printf '%s\n' "$_REQ_LIST" | sed 's/^/  required: /'
+          fi
+          # Keep only the required contexts when the lane is on; a no-op otherwise, so every
+          # pre-existing arm of the harness drives exactly the code it always did.
+          _filter_required() {
+            if [[ "$REQUIRED_ONLY" != "true" ]]; then cat; return 0; fi
+            awk -F'\t' -v req="$_REQ_LIST" '
+              BEGIN { n = split(req, a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") R[a[i]] = 1 }
+              ($1 in R)'
+          }
+          # The complement, kept rather than discarded: what the lane SKIPPED goes in the
+          # release notes. A hotfix that publishes without saying what it did not wait for is
+          # the same unattributable green this file spends 200 lines refusing elsewhere.
+          _filter_dropped() {
+            if [[ "$REQUIRED_ONLY" != "true" ]]; then return 0; fi
+            awk -F'\t' -v req="$_REQ_LIST" '
+              BEGIN { n = split(req, a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") R[a[i]] = 1 }
+              !($1 in R) && $3 != "success" && $3 != "skipped" && $3 != "neutral"'
+          }
+          _DROPPED=$(printf '%s\n' "$runs" | _filter_dropped); runs=$(printf '%s\n' "$runs" | _filter_required)
           # DIVE-2238: DROP THIS RUN'S OWN CHECK-RUNS BEFORE COUNTING ANYTHING.
           # This job runs against main's tip, so its own `cut` job is a check-run on
           # the very sha it is grading — permanently `in_progress` for as long as it
@@ -542,6 +612,7 @@ jobs:
                 printf '%s\n' "$bad" | sed 's/^/  abandoned: /'
                 sha="$_newtip"
                 runs=$(_ci_fetch_runs)
+          _DROPPED=$(printf '%s\n' "$runs" | _filter_dropped); runs=$(printf '%s\n' "$runs" | _filter_required)
                 continue
               fi
               echo "::error::CI is RED on ${sha:0:12} — refusing to cut ${tag}. Failing:"
@@ -570,6 +641,7 @@ jobs:
             fi
             sleep "$_poll_int"
             runs=$(_ci_fetch_runs)
+          _DROPPED=$(printf '%s\n' "$runs" | _filter_dropped); runs=$(printf '%s\n' "$runs" | _filter_required)
           done
           # <<< DIVE-2144 release-cut guard block
 
@@ -595,6 +667,17 @@ jobs:
           # --- publish -----------------------------------------------------------
           note="nightly auto-cut: main changed and CI is green (lodar 2026-07-27, cadence option A)"
           [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]] && note="manual cut: ${MANUAL_REASON}"
+          # DIVE-4072: a hotfix-lane cut says so IN THE RELEASE, and names what it did not wait
+          # for. A later reader must not have to reconstruct that from workflow logs that age out.
+          if [[ "$REQUIRED_ONLY" == "true" ]]; then
+            note="${note} [HOTFIX LANE: graded against required contexts only"
+            if [[ -n "${_DROPPED:-}" ]]; then
+              note="${note}; NOT waited for: $(printf '%s\n' "$_DROPPED" | awk -F'\t' '{printf "%s(%s) ", $1, $3}')"
+            else
+              note="${note}; every non-required check was green anyway"
+            fi
+            note="${note}]"
+          fi
 
           git config user.name  'lodar'
           git config user.email 'markounik@gmail.com'

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -24,6 +24,16 @@
 # that can defeat protection. version-assign.yml is retired; this job is now the ONLY
 # writer of a version anywhere in the repo, which is also what retires the collision
 # race it used to be possible to lose (see the derivation block below).
+#
+# WHAT READS WHAT (DIVE-4072). The manual cut has a HOTFIX LANE (`required_only`) that
+# grades the sha against the contexts REQUIRED on main instead of every check-run on it,
+# because this job used to publish on nine-plus-everything while main merges on nine. That
+# lane reads that list LIVE from the two authorities that actually gate a merge, and grades
+# against their UNION: `repos/:owner/:repo/branches/main` (`.protection.required_status_checks`
+# — CLASSIC branch protection, and NOT admin-class, whatever `branches/main/protection` says)
+# and `repos/:owner/:repo/rules/branches/main` (the rulesets view). Never a list copied into
+# this file: that is the same "one rule implemented twice" trap as the sort above, and it
+# would fail in the loose direction. Full argument at `_required_contexts` below.
 name: release-cut
 on:
   schedule:
@@ -272,17 +282,79 @@ jobs:
             git merge-base --is-ancestor "$1" "$_t" 2>/dev/null || return 0
             printf '%s\n' "$_t"
           }
-          # DIVE-4072: the REQUIRED contexts, read LIVE from branch protection.
-          # Outside the fence for exactly the reason _ci_fetch_runs is: the block below is
-          # extracted and executed by tests/release_cut_guards_unit.sh, which supplies its own
-          # stub. NEVER a hand-copied list in this file — release-cut and branch protection
-          # disagreeing about what "required" means is the DIVE-2144 "one rule implemented
-          # twice" trap this workflow already carries a warning about, and the failure would be
-          # silent in the dangerous direction: publishing against a list that has drifted SHORT.
-          _required_contexts() {
-            gh api "repos/${GITHUB_REPOSITORY}/branches/main/protection" \
-              --jq '.required_status_checks.contexts[]' 2>/dev/null
+          # >>> DIVE-4072 required-contexts block (extracted verbatim by tests/release_cut_guards_unit.sh)
+          # DIVE-4072: the contexts REQUIRED on main, read LIVE from the same authorities that
+          # gate the merge. NEVER a hand-copied list in this file — release-cut and the merge gate
+          # disagreeing about what "required" means is the DIVE-2144 "one rule implemented twice"
+          # trap this workflow already carries a warning about, and it fails SILENTLY in the
+          # dangerous direction: publishing against a list that has drifted SHORT.
+          #
+          # WHY NOT branches/main/protection (quinn, iteration 1). The first revision read
+          # `repos/:owner/:repo/branches/main/protection`, which needs the Administration:read
+          # repo permission — and `administration` is NOT a scope a workflow `permissions:` block
+          # can grant at all, so no edit to this job's own permissions could have fixed it; the
+          # endpoint had to change. Measured on this repo with an installation token:
+          # /commits/main/check-runs returns 60 rows, /branches/main/protection returns 403
+          # "Resource not accessible by integration". The lane therefore refused on EVERY real
+          # invocation while the harness stayed 83/0, because this read was the one link stubbed.
+          #
+          # WHAT IS READ INSTEAD — TWO ENDPOINTS, AND THE UNION OF THEM:
+          #   1. `repos/:owner/:repo/branches/main` -> `.protection.required_status_checks.contexts`
+          #      This is CLASSIC branch protection itself — the merge gate, not a proxy for it —
+          #      and it is NOT admin-class. Measured 200 with all nine contexts UNAUTHENTICATED on
+          #      2026-09-08, i.e. strictly below the floor github.token has, and independently as
+          #      `5dive-bot` on 2026-08-11 (DIVE-3244, wiki:
+          #      a-check-run-is-not-a-commit-status-and-protection-is-readable-without-admin).
+          #      That page is why this revision does not need the ruleset workaround: the 403 was
+          #      an artefact of WHICH URL was picked for a question that has a non-privileged
+          #      answer.
+          #   2. `repos/:owner/:repo/rules/branches/main` -> the RULESETS view (also 200
+          #      unauthenticated). Ruleset 22522554 ('main-required-checks', active) was created
+          #      2026-09-08 while classic protection was believed unreadable, and it holds the
+          #      same nine.
+          # A PR must satisfy BOTH mechanisms, so the honest predicate is their UNION, and taking
+          # the union is also what makes the redundancy safe in the only direction that matters:
+          # a context that lives in only one of the two still gates this cut. Grading against
+          # either one ALONE would be the loose direction the moment they diverge — which is the
+          # residual an earlier revision of this block signed rather than closed, and it did not
+          # have to be signed at all.
+          #
+          # BOTH HALVES OF THE CLASSIC PAYLOAD ARE READ. `required_status_checks` carries the same
+          # list twice — the flat `contexts` array, which GitHub documents as DEPRECATED, and
+          # `checks[].context`, its replacement — and the response measured 2026-09-08 carries both,
+          # identical. Reading only `contexts` would go EMPTY the day GitHub drops it; reading only
+          # `checks` would go empty on any older shape. Unioned, either field alone still answers,
+          # and if both ever vanish the empty list is a refusal rather than a publish.
+          #
+          # EITHER READ FAILING IS A REFUSAL, WITH THE HTTP STATUS NAMED, and stderr is not
+          # swallowed. The first revision ended in `2>/dev/null`, which turns a 403 into an empty
+          # list — byte-identical to "nothing is required" — and hands the operator "returned NO
+          # required contexts" in the middle of an incident. A read that 200s and legitimately
+          # names nothing stays a SUCCESS with an empty list, refused one layer up in different
+          # words, so the two can never be confused again.
+          _req_read_one() {   # $1 = api path under the repo, $2 = jq filter, $3 = what it is
+            local _out _rc _status
+            _out=$(gh api "repos/${GITHUB_REPOSITORY}/$1" --jq "$2" 2>&1); _rc=$?
+            if (( _rc != 0 )); then
+              _status=$(printf '%s\n' "$_out" | sed -n 's/.*HTTP \([0-9][0-9][0-9]\).*/\1/p' | head -1)
+              echo "::error::DIVE-4072: could not READ $3 from repos/${GITHUB_REPOSITORY}/$1 — HTTP ${_status:-unknown} (gh exit ${_rc}). A failed read is NOT 'nothing is required'. gh said: $(printf '%s' "$_out" | tr '\n' ' ' | cut -c1-300)" >&2
+              return 1
+            fi
+            printf '%s\n' "$_out"
+            return 0
           }
+          _required_contexts() {
+            local _classic _rules
+            _classic=$(_req_read_one 'branches/main' \
+                       '(.protection.required_status_checks.contexts[]?, .protection.required_status_checks.checks[]?.context)' \
+                       "main's CLASSIC branch-protection contexts") || return 1
+            _rules=$(_req_read_one 'rules/branches/main' \
+                     '.[]? | select(.type == "required_status_checks") | .parameters?.required_status_checks[]? | .context' \
+                     "main's RULESET-required contexts") || return 1
+            printf '%s\n%s\n' "$_classic" "$_rules" | grep -v '^[[:space:]]*$' | sort -u
+            return 0
+          }
+          # <<< DIVE-4072 required-contexts block
           runs=$(_ci_fetch_runs)
           # >>> DIVE-2144 release-cut guard block (extracted verbatim by tests/release_cut_guards_unit.sh)
           # DIVE-4072 — THE HOTFIX LANE, and its three refusals.
@@ -312,9 +384,12 @@ jobs:
               echo "::error::required_only is a MANUAL lane and this run is '${GITHUB_EVENT_NAME:-unknown}'. The scheduled and push cuts grade every check-run, deliberately. Refusing."
               exit 1
             fi
-            _REQ_LIST=$(_required_contexts)
+            if ! _REQ_LIST=$(_required_contexts); then
+              echo "::error::required_only was requested but the READ of main's required contexts FAILED (the HTTP status is in the error immediately above). Refusing: a tag published against an unknown gate is worse than a late tag."
+              exit 1
+            fi
             if [[ -z "$_REQ_LIST" ]]; then
-              echo "::error::required_only was requested but branch protection returned NO required contexts for main. That is indistinguishable from a failed read, and grading against an empty list is publishing with no gate at all. Refusing."
+              echo "::error::required_only was requested but main's rules report NO required contexts. Grading against an empty list is publishing with no gate at all. Refusing."
               exit 1
             fi
             echo "DIVE-4072 HOTFIX LANE: grading ${sha:0:12} against the $(printf '%s\n' "$_REQ_LIST" | grep -c .) REQUIRED context(s) only."
@@ -337,7 +412,6 @@ jobs:
               BEGIN { n = split(req, a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") R[a[i]] = 1 }
               !($1 in R) && $3 != "success" && $3 != "skipped" && $3 != "neutral"'
           }
-          _DROPPED=$(printf '%s\n' "$runs" | _filter_dropped); runs=$(printf '%s\n' "$runs" | _filter_required)
           # DIVE-2238: DROP THIS RUN'S OWN CHECK-RUNS BEFORE COUNTING ANYTHING.
           # This job runs against main's tip, so its own `cut` job is a check-run on
           # the very sha it is grading — permanently `in_progress` for as long as it
@@ -478,6 +552,21 @@ jobs:
                 { if ($2 == "completed" && $3 == "cancelled" && ($1 in v)) next; print }
               ' <(printf '%s\n' "$runs") <(printf '%s\n' "$runs"))
             fi
+            # DIVE-4072: SPLIT THE BOARD HERE, NOT AT THE FETCH (quinn, iteration 1).
+            # These two filters used to run immediately after every `_ci_fetch_runs`, i.e. BEFORE
+            # the DIVE-2238/2466 self-and-sibling drop above — so this run's own `cut` row
+            # (permanently pending, and never a required context) landed in `_DROPPED` and then in
+            # the release note as "NOT waited for: cut(pending)", naming as skipped a check that
+            # was never a gate. The row asked the notes to name what was skipped; this is what
+            # makes that list true.
+            # It repairs a second, quieter thing in the same move: our own row is not a required
+            # context either, so the old order deleted the very row `_self_name` is learned off,
+            # and under the lane the unattributable-red deferral could never clear — a required
+            # red would have been waited out to the deadline and then refused with the wrong
+            # message. Filtering after the drop means the lane grades exactly the board every
+            # pre-existing arm grades, minus the non-required rows and nothing else.
+            _DROPPED=$(printf '%s\n' "$runs" | _filter_dropped)
+            runs=$(printf '%s\n' "$runs" | _filter_required)
             total=$(printf '%s' "$runs" | grep -c . || true)
             incomplete=$(awk -F'\t' '$2 != "completed"' <<<"$runs")
             bad=$(awk -F'\t' '$3 != "success" && $3 != "skipped" && $3 != "neutral"' <<<"$runs" | awk -F'\t' '$2 == "completed"')
@@ -612,7 +701,6 @@ jobs:
                 printf '%s\n' "$bad" | sed 's/^/  abandoned: /'
                 sha="$_newtip"
                 runs=$(_ci_fetch_runs)
-          _DROPPED=$(printf '%s\n' "$runs" | _filter_dropped); runs=$(printf '%s\n' "$runs" | _filter_required)
                 continue
               fi
               echo "::error::CI is RED on ${sha:0:12} — refusing to cut ${tag}. Failing:"
@@ -641,7 +729,6 @@ jobs:
             fi
             sleep "$_poll_int"
             runs=$(_ci_fetch_runs)
-          _DROPPED=$(printf '%s\n' "$runs" | _filter_dropped); runs=$(printf '%s\n' "$runs" | _filter_required)
           done
           # <<< DIVE-2144 release-cut guard block
 
@@ -670,7 +757,7 @@ jobs:
           # DIVE-4072: a hotfix-lane cut says so IN THE RELEASE, and names what it did not wait
           # for. A later reader must not have to reconstruct that from workflow logs that age out.
           if [[ "$REQUIRED_ONLY" == "true" ]]; then
-            note="${note} [HOTFIX LANE: graded against required contexts only"
+            note="${note} [HOTFIX LANE (DIVE-4072): graded against the contexts required on main only, read live from branch protection and the repo rules"
             if [[ -n "${_DROPPED:-}" ]]; then
               note="${note}; NOT waited for: $(printf '%s\n' "$_DROPPED" | awk -F'\t' '{printf "%s(%s) ", $1, $3}')"
             else

--- a/tests/release_cut_guards_unit.sh
+++ b/tests/release_cut_guards_unit.sh
@@ -38,14 +38,20 @@ pass=0; fail=0
 ok(){ if [[ "$2" == "$3" ]]; then pass=$((pass+1)); echo "ok   - $1"; else fail=$((fail+1)); echo "FAIL - $1: got '$2' want '$3'"; fi; }
 
 # Extract a fenced block verbatim and strip the workflow's 10-space run: indent.
-extract(){ # $1 = fence name
-  sed -n "/# >>> DIVE-2144 $1/,/# <<< DIVE-2144 $1/p" "$WF" \
+# DIVE-4072: the label is now the WHOLE marker, ticket included, because not every fence in
+# this file belongs to DIVE-2144 any more. `extract` keeps its old one-argument meaning so the
+# two pre-existing call sites read exactly as they did.
+extract_fence(){ # $1 = full fence label, e.g. 'DIVE-4072 required-contexts block'
+  sed -n "/# >>> $1/,/# <<< $1/p" "$WF" \
     | sed '1d;$d' | sed 's/^          //'
 }
+extract(){ extract_fence "DIVE-2144 $1"; }
 
 GUARD=$(extract 'release-cut guard block')
 SORTA=$(extract 'sort-assertion block')
+REQBLK=$(extract_fence 'DIVE-4072 required-contexts block')
 [[ -n "$GUARD" && -n "$SORTA" ]] || { echo "FAIL - could not extract the fenced blocks from $WF"; exit 1; }
+[[ -n "$REQBLK" ]] || { echo "FAIL - could not extract the DIVE-4072 required-contexts block from $WF"; exit 1; }
 
 # --- harness: run the extracted bytes against a fixture -----------------------
 # DIVE-2466: the guard now POLLS. RELEASE_CUT_POLL_SECONDS=0 pins these two helpers
@@ -663,6 +669,343 @@ if m=$(mutate '/MANUAL lane and this run is/d' GUARD); then
 else
   vacuous "drop the event guard"
 fi
+
+# ── DIVE-4072 iteration 2: GRADE THE READ, NOT ONLY THE FILTER ────────────────
+# quinn's iteration-1 reject: every arm above stubs `_required_contexts`, so the one link
+# that decides whether the lane works at all — the API read — was the one link never
+# exercised. It read branches/main/protection, which needs Administration:read, a scope no
+# workflow `permissions:` block can grant; it 403s, `2>/dev/null` swallowed that, and the
+# empty-list guard then refused EVERY real invocation. The suite was 83/0 throughout, and the
+# arm "an EMPTY required list refuses" PASSED for the wrong reason, which is the tell.
+#
+# So these arms extract the REAL `_required_contexts` from the workflow and stub only the
+# TRANSPORT (`gh`). The two fixture bodies are the verbatim 200 responses measured on this
+# repo 2026-09-08, and the stub 403s on any path but the two the function is supposed to
+# read — so re-pointing a read at an endpoint the token cannot reach REDS here instead of
+# shipping green.
+echo
+echo "== DIVE-4072 the READ (unstubbed _required_contexts, gh transport stubbed) =="
+
+# Verbatim `.protection` subtree of GET repos/5dive-ai/5dive/branches/main, 2026-09-08, HTTP
+# 200 UNAUTHENTICATED. This is CLASSIC branch protection — the merge gate itself — and the
+# whole point of the endpoint swap is that it is not admin-class. Siblings the filter does not
+# read are trimmed; `.protection` is byte-for-byte what the API returned, `checks[]` included,
+# because a fixture reshaped to the author's model is the defect this section exists to catch.
+BRANCH_JSON='{
+  "name": "main",
+  "protected": true,
+  "protection": {
+    "enabled": true,
+    "required_status_checks": {
+      "enforcement_level": "non_admins",
+      "contexts": [
+        "test", "test-installed-host", "shellcheck", "docker-install", "scan",
+        "check", "supply-chain-guard", "test-confirm", "test-installed-host-confirm"
+      ],
+      "checks": [
+        { "context": "test", "app_id": 15368 },
+        { "context": "test-installed-host", "app_id": 15368 },
+        { "context": "shellcheck", "app_id": 15368 },
+        { "context": "docker-install", "app_id": 15368 },
+        { "context": "scan", "app_id": 15368 },
+        { "context": "check", "app_id": 15368 },
+        { "context": "supply-chain-guard", "app_id": 15368 },
+        { "context": "test-confirm", "app_id": 15368 },
+        { "context": "test-installed-host-confirm", "app_id": 15368 }
+      ]
+    }
+  }
+}'
+# Verbatim body of GET repos/5dive-ai/5dive/rules/branches/main, 2026-09-08 (HTTP 200):
+# ruleset 22522554, created while classic protection was believed unreadable, same nine.
+RULES_JSON='[
+  {
+    "type": "required_status_checks",
+    "parameters": {
+      "strict_required_status_checks_policy": false,
+      "do_not_enforce_on_create": false,
+      "required_status_checks": [
+        { "context": "test" },
+        { "context": "test-installed-host" },
+        { "context": "shellcheck" },
+        { "context": "docker-install" },
+        { "context": "scan" },
+        { "context": "check" },
+        { "context": "supply-chain-guard" },
+        { "context": "test-confirm" },
+        { "context": "test-installed-host-confirm" }
+      ]
+    },
+    "ruleset_source_type": "Repository",
+    "ruleset_source": "5dive-ai/5dive",
+    "ruleset_id": 22522554
+  }
+]'
+# The same rulesets body plus a TENTH context that classic protection does not carry. A PR must
+# satisfy both mechanisms, so this context gates merges — and it is how the arms below tell a
+# UNION from "whichever endpoint I happened to read first".
+RULES_JSON_EXTRA=$(printf '%s' "$RULES_JSON" | sed 's|{ "context": "test" },|{ "context": "test" }, { "context": "ruleset-only-guard" },|')
+
+# `_required_contexts` emits a SORTED union, so the expectation is sorted too — the order the
+# API returns is not part of the contract (the filter builds a set from it).
+REQ_NINE_SORTED=$(printf '%s\n' "$REQ_NINE" | sort -u)
+
+# A transport that serves those bodies for the two READABLE paths and answers anything else
+# with the 403 the real API gives an installation token on branch protection. gh applies --jq
+# itself, so the stub does too: the filters under test stay the workflow's own bytes.
+_GH_DISPATCH='
+  local f="" path=""
+  [[ "$1" == "api" ]] || { echo "gh: unexpected subcommand: $1" >&2; return 1; }
+  shift
+  while (( $# )); do
+    case "$1" in
+      --jq) f="$2"; shift 2 ;;
+      -*)   shift ;;
+      *)    path="$1"; shift ;;
+    esac
+  done
+'
+GH_403='{ echo "gh: HTTP 403: Resource not accessible by integration (https://api.github.com/$path)" >&2; return 1; }'
+GH_STUB_LIVE="$_GH_DISPATCH"'
+  case "$path" in
+    repos/5dive-ai/5dive/branches/main)       printf "%s" "$BRANCH_JSON" | jq -r "$f" ;;
+    repos/5dive-ai/5dive/rules/branches/main) printf "%s" "$RULES_JSON"  | jq -r "$f" ;;
+    *) '"$GH_403"' ;;
+  esac
+'
+# Same, but the ruleset carries the tenth context.
+GH_STUB_UNION="$_GH_DISPATCH"'
+  case "$path" in
+    repos/5dive-ai/5dive/branches/main)       printf "%s" "$BRANCH_JSON"      | jq -r "$f" ;;
+    repos/5dive-ai/5dive/rules/branches/main) printf "%s" "$RULES_JSON_EXTRA" | jq -r "$f" ;;
+    *) '"$GH_403"' ;;
+  esac
+'
+# Classic protection unreadable, rulesets fine — and vice versa. Either is a refusal.
+GH_STUB_403_CLASSIC="$_GH_DISPATCH"'
+  case "$path" in
+    repos/5dive-ai/5dive/rules/branches/main) printf "%s" "$RULES_JSON" | jq -r "$f" ;;
+    *) '"$GH_403"' ;;
+  esac
+'
+GH_STUB_403_RULES="$_GH_DISPATCH"'
+  case "$path" in
+    repos/5dive-ai/5dive/branches/main) printf "%s" "$BRANCH_JSON" | jq -r "$f" ;;
+    *) '"$GH_403"' ;;
+  esac
+'
+# Both endpoints 200 and both genuinely name nothing: an UNPROTECTED main with no rulesets.
+# A real answer, not a failed read — and the caller refuses it in different words.
+GH_STUB_EMPTY_200="$_GH_DISPATCH"'
+  case "$path" in
+    repos/5dive-ai/5dive/branches/main)       printf "%s" "{\"name\":\"main\",\"protected\":false}" | jq -r "$f" ;;
+    repos/5dive-ai/5dive/rules/branches/main) printf "%s" "[]" | jq -r "$f" ;;
+    *) '"$GH_403"' ;;
+  esac
+'
+
+REQ_OUT=""; REQ_ERR=""; REQ_RC=0
+req_run(){ # $1 = gh transport stub ; sets REQ_OUT / REQ_ERR / REQ_RC
+  local errf; errf=$(mktemp)
+  REQ_OUT=$(GITHUB_REPOSITORY=5dive-ai/5dive _GH_STUB="$1" \
+            BRANCH_JSON="$BRANCH_JSON" RULES_JSON="$RULES_JSON" RULES_JSON_EXTRA="$RULES_JSON_EXTRA" bash -c '
+    set -uo pipefail
+    gh(){ eval "$_GH_STUB"; }
+    '"$REQBLK"'
+    _required_contexts
+  ' 2>"$errf"); REQ_RC=$?
+  REQ_ERR=$(cat "$errf"); rm -f "$errf"
+}
+
+# 1. THE READ ITSELF: the real gh calls and the real --jq filters, against the real 200 bodies,
+#    must yield exactly the nine contexts that gate a merge to main.
+req_run "$GH_STUB_LIVE"
+ok "the READ returns the nine required contexts from the real 200 bodies" "$REQ_OUT" "$REQ_NINE_SORTED"
+ok "the READ exits 0 on a 200" "$REQ_RC" "0"
+
+# 2. IT IS A UNION, NOT A FAVOURITE. A context required by only ONE of the two mechanisms still
+#    gates the merge, so it must still gate this cut. Without this arm, reading either endpoint
+#    alone passes arm 1 — the two fixtures agree today, which is exactly why agreement cannot be
+#    the evidence.
+req_run "$GH_STUB_UNION"
+ok "a context required by the RULESET only is in the union" \
+   "$(grep -cx 'ruleset-only-guard' <<<"$REQ_OUT")" "1"
+ok "the union does not lose the classic nine" \
+   "$(comm -23 <(printf '%s\n' "$REQ_NINE_SORTED") <(printf '%s\n' "$REQ_OUT" | sort -u) | wc -l | tr -d ' ')" "0"
+
+# 2b. THE CLASSIC PAYLOAD CARRIES THE LIST TWICE — the flat `contexts` array (which GitHub
+#     documents as DEPRECATED) and `checks[].context`. Both are read, so either field alone still
+#     answers. These two fixtures drop one field each; without them, the day GitHub retires
+#     `contexts` the lane reads an empty list and refuses every hotfix again.
+GH_STUB_CHECKS_ONLY="$_GH_DISPATCH"'
+  case "$path" in
+    repos/5dive-ai/5dive/branches/main)       printf "%s" "$BRANCH_JSON" | jq -r "del(.protection.required_status_checks.contexts) | $f" ;;
+    repos/5dive-ai/5dive/rules/branches/main) printf "%s" "$RULES_JSON"  | jq -r "$f" ;;
+    *) '"$GH_403"' ;;
+  esac
+'
+GH_STUB_CONTEXTS_ONLY="$_GH_DISPATCH"'
+  case "$path" in
+    repos/5dive-ai/5dive/branches/main)       printf "%s" "$BRANCH_JSON" | jq -r "del(.protection.required_status_checks.checks) | $f" ;;
+    repos/5dive-ai/5dive/rules/branches/main) printf "%s" "$RULES_JSON"  | jq -r "$f" ;;
+    *) '"$GH_403"' ;;
+  esac
+'
+req_run "$GH_STUB_CHECKS_ONLY"
+ok "classic protection with checks[] but no deprecated contexts[] still yields the nine" "$REQ_OUT" "$REQ_NINE_SORTED"
+req_run "$GH_STUB_CONTEXTS_ONLY"
+ok "classic protection with contexts[] but no checks[] still yields the nine" "$REQ_OUT" "$REQ_NINE_SORTED"
+
+# 3. EITHER READ FAILING IS ITS OWN REFUSAL, and it names the status. This is the arm whose
+#    absence let a lane that 403s on every invocation ship as 83/0.
+for arm in "classic:$GH_STUB_403_CLASSIC" "rulesets:$GH_STUB_403_RULES"; do
+  req_run "${arm#*:}"
+  ok "a 403 on the ${arm%%:*} read exits NON-zero (never an empty list)" \
+     "$([[ "$REQ_RC" != 0 ]] && echo nonzero || echo zero)" "nonzero"
+  ok "a 403 on the ${arm%%:*} read names the HTTP status in its error" \
+     "$(grep -q 'HTTP 403' <<<"$REQ_ERR" && echo named || echo "unnamed:$REQ_ERR")" "named"
+done
+req_run "$GH_STUB_403_CLASSIC"
+ok "a failed read prints NOTHING on stdout — a partial list is not a gate" "$REQ_OUT" ""
+
+# 4. AND THE OTHER SIDE OF THAT DISTINCTION: two 200s that genuinely require nothing must NOT
+#    look like a failed read. They succeed with an empty list, and the lane's own empty-list
+#    refusal (arm above) is what stops the cut. Without this arm, "always refuse" would pass 3.
+req_run "$GH_STUB_EMPTY_200"
+ok "an unprotected main with no rulesets exits 0 with an empty list, not as a read failure" \
+   "$REQ_RC:$REQ_OUT" "0:"
+
+# 5. READ AND FILTER COMPOSE. The lane is driven with the list the REAL read produced rather
+#    than with REQ_NINE typed into this file, so a parse that lost or mangled a context shows
+#    up as a verdict change and not merely as a string mismatch above.
+req_run "$GH_STUB_LIVE"
+ok "read -> lane: the incident board is GREEN on the list the read actually produced" \
+   "$(lane "$INCIDENT" "$REQ_OUT" workflow_dispatch)" "GREEN"
+ok "read -> lane: a REQUIRED red on that same list still refuses" \
+   "$(lane "$INCIDENT_REQ" "$REQ_OUT" workflow_dispatch)" "RED"
+
+# 6. MUTANT — the iteration-1 defect, put back. Re-point the classic read at the admin-only
+#    endpoint (the one the workflow token gets 403 on) and this section must fail.
+if m=$(mutate "s|'branches/main' \\\\|'branches/main/protection' \\\\|" REQBLK); then
+  REQ_SAVE="$REQBLK"; REQBLK="$m"
+  req_run "$GH_STUB_LIVE"
+  ok "MUTANT read an endpoint the token cannot reach: the read stops returning the nine" \
+     "$([[ "$REQ_OUT" == "$REQ_NINE_SORTED" ]] && echo caught-nothing || echo mutant-detected)" "mutant-detected"
+  REQBLK="$REQ_SAVE"
+else
+  vacuous "read an endpoint the token cannot reach"
+fi
+
+# 7. MUTANT — swallow the failure again (drop the read's non-zero return), which is what made a
+#    403 indistinguishable from "nothing is required".
+if m=$(mutate '/^    return 1$/d' REQBLK); then
+  REQ_SAVE="$REQBLK"; REQBLK="$m"
+  req_run "$GH_STUB_403_CLASSIC"
+  ok "MUTANT drop the read's refusal: a 403 stops being distinguishable from an empty list" \
+     "$([[ "$REQ_RC" != 0 ]] && echo caught-nothing || echo mutant-detected)" "mutant-detected"
+  REQBLK="$REQ_SAVE"
+else
+  vacuous "drop the read's refusal"
+fi
+
+# 8. MUTANT — read only classic protection (drop the rulesets read), the loose direction the
+#    union exists to close.
+if m=$(mutate '/RULESET-required contexts/d' REQBLK); then
+  REQ_SAVE="$REQBLK"; REQBLK="$m"
+  req_run "$GH_STUB_UNION"
+  ok "MUTANT drop the rulesets read: a ruleset-only required context stops gating the cut" \
+     "$(grep -qx 'ruleset-only-guard' <<<"$REQ_OUT" && echo caught-nothing || echo mutant-detected)" "mutant-detected"
+  REQBLK="$REQ_SAVE"
+else
+  vacuous "drop the rulesets read"
+fi
+
+# ── DIVE-4072 iteration 2: THE RELEASE NOTE MUST NOT NAME A NON-GATE ──────────
+# quinn's second finding: `_DROPPED` was computed at the fetch, BEFORE the DIVE-2238/2466
+# self-and-sibling drop, so this run's own permanently-pending `cut` row — not a required
+# context, so never filtered out as one — was reported as something the hotfix "did not wait
+# for". The row asked the notes to name what was skipped; that named a check that was never a
+# gate, and it would have appeared in every hotfix release ever cut.
+echo
+echo "== DIVE-4072 what the release note says was skipped =="
+
+# The board a real hotfix sees: nine green, one red sweep shard, plus THIS run's own `cut`
+# row. Column 4 carries the run id the self-filter matches on.
+SELFRUN=987654321
+BOARD_SELF=$(printf '%s\ncut\tin_progress\tpending\thttps://github.com/o/r/actions/runs/%s/job/1\n' "$INCIDENT" "$SELFRUN")
+
+dropped(){ # $1 = board, $2 = required list, $3 = GITHUB_RUN_ID ; echoes the note fragment
+  runs="$1" sha=deadbeefcafe tag=v9.9.9 RELEASE_CUT_POLL_SECONDS=0 \
+  REQUIRED_ONLY=true GITHUB_EVENT_NAME=workflow_dispatch _REQ_FIXTURE="$2" GITHUB_RUN_ID="$3" \
+  bash -c '
+    set -uo pipefail
+    _required_contexts(){ printf "%s\n" "$_REQ_FIXTURE"; }
+    # The guard block itself is loud; its own verdict is graded by lane()/lane_run() above.
+    # Here only the note fragment is under test, so the block keeps its verbatim bytes and it
+    # is the GROUP that is silenced — an `exit` inside it still exits, so a refusal still
+    # yields an empty fragment rather than a stale one.
+    {
+    '"$GUARD"'
+    } >/dev/null
+    printf "%s\n" "$_DROPPED" | awk -F"\t" "{printf \"%s(%s) \", \$1, \$3}"
+  ' 2>/dev/null
+}
+
+ok "the note names the non-required red that was skipped" \
+   "$(dropped "$BOARD_SELF" "$REQ_NINE" "$SELFRUN")" "full-pristine (2)(failure) "
+ok "the note does NOT name this run's own pending cut row" \
+   "$(dropped "$BOARD_SELF" "$REQ_NINE" "$SELFRUN" | grep -c 'cut(pending)')" "0"
+
+# MUTANT — put the computation back before the self drop and the corpse returns to the note.
+if m=$(mutate 's|^  _DROPPED=.*_filter_dropped)$|  _DROPPED=""|' GUARD); then
+  GUARD_SAVE="$GUARD"; GUARD="$m"
+  ok "MUTANT delete the relocated _DROPPED: the note stops naming what was skipped" \
+     "$([[ "$(dropped "$BOARD_SELF" "$REQ_NINE" "$SELFRUN")" == "full-pristine (2)(failure) " ]] && echo caught-nothing || echo mutant-detected)" "mutant-detected"
+  GUARD="$GUARD_SAVE"
+else
+  vacuous "delete the relocated _DROPPED"
+fi
+
+# NEGATIVE CONTROL for the two arms above, and it reproduces the PRE-FIX SHAPE rather than
+# merely deleting the fixed line: disable the self-row drop entirely (both the id filter and
+# the name it is learned from) and the board reaching the filters is the board the old order
+# handed them — our own pending `cut` row included. The note must then name it again. Without
+# this arm "does NOT name cut(pending)" would also pass on a board that never had the row.
+if m=$(mutate '/_found/d; /index($4, self) == 0/d' GUARD); then
+  GUARD_SAVE="$GUARD"; GUARD="$m"
+  ok "PRE-FIX SHAPE (self row never dropped): the note names cut(pending) again" \
+     "$(dropped "$BOARD_SELF" "$REQ_NINE" "$SELFRUN" | grep -c 'cut(pending)')" "1"
+  GUARD="$GUARD_SAVE"
+else
+  vacuous "self row never dropped"
+fi
+
+# And the sibling repair the same move bought: under the lane, our own row is not a required
+# context, so the OLD order deleted the row `_self_name` is learned from — leaving every red
+# unattributable and a required red waited out to the deadline instead of refused. With the
+# split after the drop, the required red refuses as RED on a board that also carries our row.
+lane_run(){ # $1 = board, $2 = required list, $3 = GITHUB_RUN_ID ; echoes like lane()
+  local out rc
+  out=$(runs="$1" sha=deadbeefcafe tag=v9.9.9 RELEASE_CUT_POLL_SECONDS=0 \
+        REQUIRED_ONLY=true GITHUB_EVENT_NAME=workflow_dispatch _REQ_FIXTURE="$2" \
+        GITHUB_RUN_ID="$3" bash -c '
+    set -uo pipefail
+    _required_contexts(){ printf "%s\n" "$_REQ_FIXTURE"; }
+    '"$GUARD"'
+  ' 2>&1); rc=$?
+  if (( rc != 0 )); then
+    grep -q 'CI is RED'         <<<"$out" && { echo RED;       return; }
+    grep -q 'CI still IN FLIGHT'<<<"$out" && { echo IN-FLIGHT; return; }
+    grep -q 'CI NOT REACHED'    <<<"$out" && { echo NOT-REACHED; return; }
+    echo "OTHER-FAIL:$out"; return
+  fi
+  grep -q 'CI green on' <<<"$out" && echo GREEN || echo "OTHER-OK:$out"
+}
+BOARD_SELF_REQRED=$(printf '%s\ncut\tin_progress\tpending\thttps://github.com/o/r/actions/runs/%s/job/1\n' "$INCIDENT_REQ" "$SELFRUN")
+ok "lane ON, our own row on the board: a REQUIRED red is REFUSED, not waited out" \
+   "$(lane_run "$BOARD_SELF_REQRED" "$REQ_NINE" "$SELFRUN")" "RED"
+ok "lane ON, our own row on the board: an all-green board still cuts" \
+   "$(lane_run "$BOARD_SELF" "$REQ_NINE" "$SELFRUN")" "GREEN"
 
 echo
 echo "$pass passed, $fail failed"

--- a/tests/release_cut_guards_unit.sh
+++ b/tests/release_cut_guards_unit.sh
@@ -561,6 +561,109 @@ else
   vacuous "drop the re-read"
 fi
 
+# ── DIVE-4072: THE HOTFIX LANE ────────────────────────────────────────────────
+# `required_only` grades the sha against the NINE contexts branch protection
+# actually requires, instead of every check-run on it. The v0.26.2 incident cut sat
+# 45 minutes on two sweep shards that exited 6 UNDETERMINED with zero non-zero
+# harness rows, while every box on that night's update ran no agents.
+#
+# The lane is the dangerous kind of change — it makes a gate accept LESS — so each
+# arm below is paired with the refusal that bounds it.
+echo
+echo "== DIVE-4072 hotfix lane =="
+
+# Nine contexts as branch protection actually returns them (2026-09-08).
+REQ_NINE='test
+test-installed-host
+shellcheck
+docker-install
+scan
+check
+supply-chain-guard
+test-confirm
+test-installed-host-confirm'
+
+lane(){ # $1 = check-runs TSV, $2 = required-context list, $3 = event name
+  local out rc
+  out=$(runs="$1" sha=deadbeefcafe tag=v9.9.9 RELEASE_CUT_POLL_SECONDS=0 \
+        REQUIRED_ONLY=true GITHUB_EVENT_NAME="$3" _REQ_FIXTURE="$2" bash -c '
+    set -uo pipefail
+    _required_contexts(){ printf "%s\n" "$_REQ_FIXTURE"; }
+    '"$GUARD"'
+  ' 2>&1); rc=$?
+  if (( rc != 0 )); then
+    grep -q 'MANUAL lane'      <<<"$out" && { echo REFUSED-EVENT;  return; }
+    grep -q 'NO required contexts' <<<"$out" && { echo REFUSED-EMPTY; return; }
+    grep -q 'CI is RED'        <<<"$out" && { echo RED;            return; }
+    grep -q 'CI still IN FLIGHT'<<<"$out" && { echo IN-FLIGHT;     return; }
+    grep -q 'CI NOT REACHED'   <<<"$out" && { echo NOT-REACHED;    return; }
+    echo "OTHER-FAIL:$out"; return
+  fi
+  grep -q 'CI green on' <<<"$out" && echo GREEN || echo "OTHER-OK:$out"
+}
+
+# A board shaped like the incident: every required context green, one sweep shard
+# UNDETERMINED. Nothing gates merges on that shard; it blocked the publish anyway.
+INCIDENT=$(printf 'test\tcompleted\tsuccess\ntest-installed-host\tcompleted\tsuccess\nshellcheck\tcompleted\tsuccess\ndocker-install\tcompleted\tsuccess\nscan\tcompleted\tsuccess\ncheck\tcompleted\tsuccess\nsupply-chain-guard\tcompleted\tsuccess\ntest-confirm\tcompleted\tsuccess\ntest-installed-host-confirm\tcompleted\tsuccess\nfull-pristine (2)\tcompleted\tfailure')
+
+ok "lane ON: a NON-required red no longer blocks the cut" \
+   "$(lane "$INCIDENT" "$REQ_NINE" workflow_dispatch)" "GREEN"
+
+# THE BOUND. Same lane, same board, but the red is one of the nine.
+INCIDENT_REQ=$(printf '%s\n' "$INCIDENT" | sed 's/^scan\tcompleted\tsuccess$/scan\tcompleted\tfailure/')
+ok "lane ON: a REQUIRED red still refuses" \
+   "$(lane "$INCIDENT_REQ" "$REQ_NINE" workflow_dispatch)" "RED"
+
+# And with the lane OFF the same board must still block, or the arm above is
+# measuring nothing.
+ok "lane OFF: that same non-required red DOES block (control)" \
+   "$(verdict "$INCIDENT")" "RED"
+
+ok "lane is refused on the nightly (schedule)" \
+   "$(lane "$INCIDENT" "$REQ_NINE" schedule)" "REFUSED-EVENT"
+ok "lane is refused on push" \
+   "$(lane "$INCIDENT" "$REQ_NINE" push)" "REFUSED-EVENT"
+
+# An empty required list and a failed API read are the same empty string, and one of
+# them means publishing with no gate at all.
+ok "an EMPTY required list refuses rather than grading against nothing" \
+   "$(lane "$INCIDENT" "" workflow_dispatch)" "REFUSED-EMPTY"
+
+# Incompleteness is NOT relaxed: a required context still in flight still waits.
+INCOMPLETE_REQ=$(printf '%s\n' "$INCIDENT" | sed 's/^check\tcompleted\tsuccess$/check\tin_progress\tpending/')
+ok "lane ON: an in-flight REQUIRED context still waits" \
+   "$(lane "$INCOMPLETE_REQ" "$REQ_NINE" workflow_dispatch)" "IN-FLIGHT"
+
+# A non-required context still in flight must NOT hold the hotfix.
+INCOMPLETE_OPT=$(printf '%s\n' "$INCIDENT" | sed 's/^full-pristine (2)\tcompleted\tfailure$/full-pristine (2)\tin_progress\tpending/')
+ok "lane ON: an in-flight NON-required context does not hold it" \
+   "$(lane "$INCOMPLETE_OPT" "$REQ_NINE" workflow_dispatch)" "GREEN"
+
+# If the lane filtered EVERYTHING away it would publish against an empty board, which
+# the completeness guard must still catch as NOT-REACHED rather than as green.
+ok "lane ON: a board with no required context at all is NOT-REACHED, never GREEN" \
+   "$(lane "$(printf 'full-pristine (2)\tcompleted\tsuccess')" "$REQ_NINE" workflow_dispatch)" "NOT-REACHED"
+
+# MUTANT: make the filter keep everything (the lane becomes a lie that reports success).
+if m=$(mutate 's/^ *(\$1 in R)'"'"'$/  1/' GUARD); then
+  GUARD_SAVE="$GUARD"; GUARD="$m"
+  ok "MUTANT filter keeps every row: the incident board blocks again" \
+     "$([[ "$(lane "$INCIDENT" "$REQ_NINE" workflow_dispatch)" == "GREEN" ]] && echo caught-nothing || echo mutant-detected)" "mutant-detected"
+  GUARD="$GUARD_SAVE"
+else
+  vacuous "filter keeps every row"
+fi
+
+# MUTANT: drop the event guard, so the nightly could take the lane.
+if m=$(mutate '/MANUAL lane and this run is/d' GUARD); then
+  GUARD_SAVE="$GUARD"; GUARD="$m"
+  ok "MUTANT drop the event guard: the nightly stops refusing the lane" \
+     "$([[ "$(lane "$INCIDENT" "$REQ_NINE" schedule)" == "REFUSED-EVENT" ]] && echo caught-nothing || echo mutant-detected)" "mutant-detected"
+  GUARD="$GUARD_SAVE"
+else
+  vacuous "drop the event guard"
+fi
+
 echo
 echo "$pass passed, $fail failed"
 exit $(( fail > 0 ))


### PR DESCRIPTION
Closes DIVE-4072.

`release-cut` grades a sha against **every** check-run on it. Branch protection requires **nine**. So a red on a job nothing gates merges on — a sweep shard, a nightly-only guard — blocks the *publish act* while main merges happily around it.

Measured 2026-09-08: the v0.26.2 incident cut sat **45 minutes** on two shards that exited 6 UNDETERMINED with **zero** non-zero harness rows, while every box that took the previous night's update was running no agents at all.

`workflow_dispatch` already exists, already demands a written `reason`, and this file's own header already calls it *"a manual cut for hotfixes"*. It never escaped anything, because it applied the identical predicate. This is that escape.

## The bounds are the point

This makes a gate accept **less**, so each is graded:

- **Refused on `schedule` and on `push`** — the nightly keeps the strict predicate.
- **Refuses on an empty required list.** "Nothing is required" and "the API read failed" are the same empty string; one of them means publishing with no gate at all.
- **Read LIVE from `branches/main/protection`**, never a hand-copied list — that is the "one rule implemented twice" trap DIVE-2144 already warns about in this very file, and it would fail silently in the dangerous direction (a list that drifted short).
- **Relaxes nothing else.** Completeness, the in-flight wait, the unattributable-red deferral, ancestry and the sort assertion all still run, over the filtered set.
- **What it skipped goes in the release notes**, named, with each conclusion. A hotfix that publishes without saying what it did not wait for is the same unattributable green this workflow spends 200 lines refusing.

## Tests — `tests/release_cut_guards_unit.sh`, 83 passed, 0 failed

The **72 pre-existing arms are unchanged and still green** — the lane is a strict no-op when off, which is what lets them stand as the regression evidence. Plus 11 new:

| arm | asserts |
|---|---|
| incident board, lane ON | cuts GREEN |
| same board, red is one of the nine | still RED |
| **same board, lane OFF** | still RED — so the first arm is not vacuous |
| lane on `schedule` / on `push` | REFUSED |
| empty required list | REFUSED |
| in-flight **required** context | still waits |
| in-flight non-required context | does not hold it |
| board with no required context at all | NOT-REACHED, never GREEN |
| MUTANT: filter keeps every row | caught |
| MUTANT: event guard deleted | caught |

## Not done, deliberately

Scheduled and push predicates untouched. The sweep shards are **not** made required — that makes the freeze worse, not better. Does not supersede #796 (DIVE-4064): with the baseline repaired the lane stops being needed weekly and stays available for an incident.