### PR TITLE
DIVE-4091 probe: the incident launcher under #801's arm must turn docker-install red (do not merge)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -180,3 +180,85 @@ jobs:
             echo "ERROR: installed 5dive reports '$actual', expected version '$expected'"
             exit 1
           fi
+      # DIVE-4091: nothing in CI ever STARTED an agent. v0.26.1 emptied every box
+      # on 2026-09-07 because `5dive-agent-start` died at line 1687 under
+      # `set -euo pipefail`, and the whole ~1700-line startup path above
+      # `tmux new-session` was executed by no check: the unit corpus sources
+      # functions without running the launcher, and the steps above install the
+      # bundle and ask it for a version string. DIVE-4067 wired
+      # `shellcheck --include=SC2318`, which catches that bug's SYNTACTIC shape
+      # and nothing else. This arm runs the launcher and asserts it reaches the
+      # session it exists to create — the whole class, not one shellcheck code.
+      #
+      # Deterministic by construction: no network, no credential, no sleep the
+      # arm does not bound, and a hard `timeout` so a launcher that hangs turns
+      # this REQUIRED context red in 2 minutes instead of parking the job.
+      - name: Launcher survives its own startup (behavioural, DIVE-4091)
+        run: |
+          cat > /tmp/launcher-arm.sh <<'ARM'
+          #!/bin/bash
+          set -euo pipefail
+          NAME=smoketest
+          CALLS=/tmp/tmux.calls
+
+          # The launcher hard-codes /usr/bin/tmux, so shim THAT path — putting a
+          # stub earlier on PATH would never be consulted.
+          # has-session MUST exit non-zero: the launcher's final statement is
+          #   while /usr/bin/tmux has-session -t "$SESSION"; do sleep 5; done
+          # (it blocks so systemd keeps the unit active), and a stub that exits 0
+          # there would hang this job until the workflow timeout.
+          cat > /usr/bin/tmux <<'STUB'
+          #!/bin/sh
+          printf '%s\n' "$*" >> /tmp/tmux.calls
+          case "$1" in has-session) exit 1 ;; *) exit 0 ;; esac
+          STUB
+          chmod +x /usr/bin/tmux
+
+          # install.sh does not lay down the agent binary, and the launcher
+          # refuses at `[[ -x "$BIN" ]] || exit 3` before it reaches anything
+          # interesting. It only needs to be executable — it is exec'd INSIDE the
+          # tmux session, which is stubbed, so nothing here runs an agent.
+          install -d -m 755 /home/claude/.local/bin /home/claude/projects
+          printf '#!/bin/sh\nexit 0\n' > /home/claude/.local/bin/claude
+          chmod +x /home/claude/.local/bin/claude
+
+          install -d -m 2750 /var/lib/5dive/agents.d
+          printf 'AGENT_TYPE=claude\nAGENT_CHANNELS=none\nAGENT_WORKDIR=/home/claude/projects\n' \
+            > /var/lib/5dive/agents.d/${NAME}.env
+
+          # No credential is seeded, so the launcher takes its degraded-start
+          # branch — the same one a freshly provisioned box takes before its
+          # creds land. CLAUDE_AUTH_WAIT_SECS bounds that wait (default 45s).
+          rc=0
+          CLAUDE_AUTH_WAIT_SECS=1 timeout 120 /usr/local/bin/5dive-agent-start "$NAME" || rc=$?
+
+          echo "--- tmux calls recorded ---"
+          cat "$CALLS" 2>/dev/null || echo "(none)"
+          echo "---------------------------"
+
+          if [ "$rc" -eq 124 ]; then
+            echo "FAIL: 5dive-agent-start did not return within 120s — it hangs during startup" >&2
+            exit 1
+          fi
+          if [ "$rc" -ne 0 ]; then
+            echo "FAIL: 5dive-agent-start exited $rc — the launcher dies during its own startup." >&2
+            echo "      Every managed box runs this file on every agent restart; the nightly" >&2
+            echo "      restarts every agent, so shipping this empties the fleet unattended." >&2
+            exit 1
+          fi
+          # Exit 0 is NOT the assertion. A launcher that returned early because a
+          # precondition was unmet would satisfy an exit-code-only arm forever —
+          # the same green-from-a-filter shape that caused the incident. Assert the
+          # session was actually LAUNCHED. `new-session`, not merely "the stub was
+          # touched": `tmux kill-session` runs ~500 lines earlier and would satisfy
+          # any weaker check while the startup path still died.
+          if ! grep -q '^new-session ' "$CALLS"; then
+            echo "FAIL: launcher exited 0 without ever calling 'tmux new-session' —" >&2
+            echo "      it returned before launching the session it exists to launch." >&2
+            exit 1
+          fi
+          echo "OK: launcher ran its full startup path and launched the session"
+          ARM
+          chmod +x /tmp/launcher-arm.sh
+          docker run --rm -v /tmp/launcher-arm.sh:/arm.sh:ro \
+            --entrypoint /bin/bash 5dive-smoke /arm.sh

--- a/5dive-agent-start
+++ b/5dive-agent-start
@@ -1358,9 +1358,6 @@ if [[ "$TYPE" == "claude" ]]; then
     sleep 1
   done
   if grep -qE "$_creds_re" "$_primary_auth" 2>/dev/null; then
-    # Clear a prior degraded-start verdict only after this boot observed the
-    # credential it will actually export.
-    cred_seed_ok
     # Re-export from disk so the exec'd claude sees the creds systemd read too
     # early (or not at all). Files are systemd EnvironmentFile format: literal
     # KEY=value per line, no shell expansion, unquoted — split on the first '='.
@@ -1373,12 +1370,7 @@ if [[ "$TYPE" == "claude" ]]; then
     done
     [[ "$_waited" == 1 ]] && echo "[5dive] agent=${NAME} claude creds landed during first-boot wait — launching authenticated" >&2
   else
-    # The old text promised this would self-heal on the next restart. It cannot
-    # do that unless a credential is supplied between restarts, and one seat
-    # repeated this branch for 6.5 weeks. Persist the verdict on the same
-    # per-seat breadcrumb every other credential family uses so fleet views can
-    # veto process liveness instead of relying on short-lived journal history.
-    cred_seed_failed "claude credential absent after ${CLAUDE_AUTH_WAIT_SECS:-45}s wait — launched DEGRADED and cannot reach its provider; supply a credential and restart"
+    echo "[5dive] agent=${NAME} WARN: claude creds absent after ${CLAUDE_AUTH_WAIT_SECS:-45}s wait; launching anyway (self-heals on next restart)" >&2
   fi
   unset _primary_auth _creds_re _deadline _waited _af _line 2>/dev/null || :
 fi
@@ -1692,13 +1684,7 @@ write_delivery_declaration() {
   if [[ "$TYPE" == "codex" ]] && codex_dispatcher_enabled "$CHANNELS"; then
     mode="dispatcher-inbox"
   fi
-  # Three statements, not one: `local` is a builtin, so bash expands ALL of its
-  # arguments before performing ANY of the assignments. In a single `local a=X b="$a"`
-  # the `$a` resolves against the ENCLOSING scope, and under this script's `set -u`
-  # that is a fatal unbound-variable exit before the pane ever starts (DIVE-4067).
-  local dir="$HOME/.5dive"
-  local f="$dir/delivery.env"
-  local tmp
+  local dir="$HOME/.5dive" f="$dir/delivery.env" tmp
   mkdir -p "$dir" 2>/dev/null || { echo "warn: cannot create $dir — delivery mode undeclared" >&2; return 0; }
   tmp="${f}.tmp.$$"
   {


### PR DESCRIPTION
Verifier probe for https://github.com/5dive-ai/5dive/pull/801. Same tree as #801's graded head bb204d5 with ONE change: 5dive-agent-start replaced by the v0.26.1 file that emptied every box on 2026-09-07 (the 'line 1687: dir: unbound variable' fatal). Expected: docker-install FAILS in the built image with 'FAIL: 5dive-agent-start exited 1' and a recorded tmux call list that contains kill-session but no new-session. That is the red direction of the arm measured in-image, which #801 could only show on a path-relocated copy. shellcheck going red here (SC2318) is expected and irrelevant. Close after reading.