### PR TITLE
DIVE-4138: arm the pull-ref-identity branch sweep, nightly

### DIFF
--- a/.github/workflows/branch-hygiene.yml
+++ b/.github/workflows/branch-hygiene.yml
@@ -2,7 +2,10 @@ name: branch-hygiene
 
 on:
   schedule:
-    - cron: '17 5 * * 1'
+    # DIVE-4138 (lodar, 2026-09-09: "Cleanups are daily and automatic?"): daily,
+    # was weekly ('17 5 * * 1'). Cadence alone deletes nothing new -- the widening
+    # that does is BRANCH_HYGIENE_ARM_PULLREF_IDENTITY on the apply step below.
+    - cron: '17 5 * * *'
   workflow_dispatch:
     inputs:
       apply:
@@ -34,11 +37,26 @@ jobs:
           BRANCH_HYGIENE_PRESERVE: ${{ vars.BRANCH_HYGIENE_PRESERVE }}
         run: scripts/branch-hygiene.sh --dry-run
 
-      - name: Delete API-confirmed merged branches
+      # DIVE-4138: the pull-ref-identity widening is armed HERE, in the workflow,
+      # not in the script. DIVE-3490 built the predicate and refused to arm it on
+      # the unattended path until "its first live output [is] a list a human
+      # reads", and said arming must be "a deliberate change to that workflow".
+      # That list ran weekly in the stale-digest job below; lodar read the eight
+      # branches it named on 2026-09-09 and answered DIVE-4138's tier-2 gate
+      # `nightly-for-reviewed-only`. This env var is that deliberate change.
+      #
+      # What it adds: branches whose head is byte-identical to refs/pull/N/head of
+      # their own closed-unmerged PR -- reversible by construction, because GitHub
+      # retains pull refs permanently.
+      # What it does NOT add: branches that never had a PR, and orphan branches
+      # with no common ancestor (the `status` data branch). Those have no recovery
+      # ref, so they stay report-only for a human. Remove this env var to disarm.
+      - name: Delete API-confirmed merged and pull-ref-recoverable branches
         if: github.event_name == 'schedule' || inputs.apply
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH_HYGIENE_PRESERVE: ${{ vars.BRANCH_HYGIENE_PRESERVE }}
+          BRANCH_HYGIENE_ARM_PULLREF_IDENTITY: '1'
         run: scripts/branch-hygiene.sh --apply
 
       # A GitHub-hosted runner cannot inspect or remove worktrees on the 5dive
@@ -58,7 +76,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   stale-digest:
-    # Read-only weekly digest (DIVE-1833): flags unmerged PRs >3d, and classifies
+    # Read-only daily digest (DIVE-1833): flags unmerged PRs >3d, and classifies
     # every other branch by EVIDENCE that its work landed (DIVE-2394) rather than
     # by age. Never deletes/labels/closes, so it runs on every trigger (including
     # the dry-run dispatch) and is not coupled to the merged-branch delete path.

--- a/scripts/branch-hygiene.sh
+++ b/scripts/branch-hygiene.sh
@@ -7,9 +7,12 @@
 # A second predicate (DIVE-3490, `superseded_identity`) reaches branches whose PR
 # was closed UNMERGED, on proof of content identity with the permanent
 # `refs/pull/N/head`. In --report it is the FOURTH ARM of the evidence classifier
-# (DIVE-2394), the one that discharges a finding. On the delete path it is
-# REPORT/DRY-RUN ONLY and deliberately not armed under --apply -- see the comment
-# on the function and at its call sites.
+# (DIVE-2394), the one that discharges a finding.
+#
+# On the delete path it is OFF BY DEFAULT and armed only by the caller setting
+# BRANCH_HYGIENE_ARM_PULLREF_IDENTITY=1 (DIVE-4138). DIVE-3490 conditioned arming
+# on "a deliberate change to that workflow, not a merge of this file", so the
+# switch lives in the workflow env and this file still refuses on its own.
 
 set -euo pipefail
 
@@ -514,6 +517,63 @@ if [[ "$mode" == "report" ]]; then
   exit 0
 fi
 
+# DIVE-4138. Arming the pull-ref-identity predicate on the delete path. The
+# refusal this lifts was NOT arbitrary caution, and the condition it named has
+# now been met, so record both rather than just deleting the comment:
+#
+#   DIVE-3490 armed the predicate in --report/--dry-run only, because "this
+#   predicate's authorisation was explicitly conditioned on its first live
+#   output being a list a human reads."
+#
+# That list exists. The weekly stale-digest arm has been printing
+# `PRESERVED pull-ref-identity #N` lines into the run summary since DIVE-3490
+# merged; on 2026-09-09 a human (lodar) read the eight branches it names,
+# one by one, and answered a tier-2 decision gate on DIVE-4138 with
+# `nightly-for-reviewed-only`: delete nightly the branches that HAVE a
+# recovery ref, leave the ones that do not for a person.
+#
+# The safety property is unchanged and is the whole reason this is armable: a
+# `match` means the branch head is byte-identical to `refs/pull/N/head`, a ref
+# GitHub retains permanently, so the delete is reversible with
+# `git push origin <sha>:refs/heads/<name>`. `mismatch`, `unresolved` and
+# `none` still PRESERVE -- and `none` is what covers every branch that never
+# had a PR at all (including the orphan `status` data branch), which is
+# exactly the class with no undo.
+#
+# Note what is deliberately NOT the predicate: branch AGE. A 7-day tip cutoff
+# would spare `status` only by accident (it is force-pushed daily, so it is
+# never old) and would delete no-PR branches once they aged. Recoverability is
+# the axis; age is not.
+arm_pullref="${BRANCH_HYGIENE_ARM_PULLREF_IDENTITY:-0}"
+
+# Race-guarded delete, shared by both delete predicates so the pull-ref path
+# cannot acquire weaker last-moment checks than the merged-PR path. Fails
+# closed: the ref must still point at the inventoried SHA and must still have
+# no open PR. Returns 0 if deleted, 1 if a recheck preserved it; prints its own
+# DELETED/PRESERVE line either way.
+guarded_delete() { # <branch> <sha> <label>
+  local branch="$1" sha="$2" label="$3"
+  local encoded_branch current_sha open_count encoded_ref
+
+  encoded_branch=$(urlencode "$branch")
+  current_sha=$("$GH_BIN" api "repos/$repo/branches/$encoded_branch" --jq .commit.sha)
+  if [[ "$current_sha" != "$sha" ]]; then
+    echo "PRESERVE changed-since-inventory branch=$branch old=$sha new=$current_sha"
+    return 1
+  fi
+  open_count=$("$GH_BIN" api --method GET "repos/$repo/pulls" \
+    -f state=open -f "head=$owner:$branch" -f per_page=1 --jq length)
+  if [[ "$open_count" != "0" ]]; then
+    echo "PRESERVE newly-open-pr branch=$branch"
+    return 1
+  fi
+
+  encoded_ref=$(urlencode "heads/$branch")
+  "$GH_BIN" api --method DELETE "repos/$repo/git/refs/$encoded_ref" >/dev/null
+  echo "DELETED branch=$branch sha=$sha $label"
+  return 0
+}
+
 declare -A preserve=()
 while IFS= read -r branch; do
   [[ -n "$branch" ]] && preserve["$branch"]=1
@@ -569,12 +629,16 @@ while IFS=$'\t' read -r branch sha protected; do
       < <(superseded_identity "$sha" "$closed_prs")
     case "$ident_state" in
       match)
-        if [[ "$mode" == "apply" ]]; then
+        if [[ "$mode" == "apply" && "$arm_pullref" != "1" ]]; then
           echo "PRESERVE superseded-identity-not-armed branch=$branch sha=$sha pr=#$ident_pr"
           ((skipped_count += 1))
         else
           echo "DELETE-CANDIDATE branch=$branch sha=$sha pr=#$ident_pr via=pullref-identity pullref=$ident_pullref"
           ((candidate_count += 1))
+          if [[ "$mode" == "apply" ]] \
+            && guarded_delete "$branch" "$sha" "pr=#$ident_pr via=pullref-identity"; then
+            ((deleted_count += 1))
+          fi
         fi
         ;;
       mismatch)
@@ -598,26 +662,15 @@ while IFS=$'\t' read -r branch sha protected; do
   ((candidate_count += 1))
   [[ "$mode" == "apply" ]] || continue
 
-  # Fail closed on races: the ref must still point at the inventoried SHA and it
-  # must still have no open PR immediately before deletion.
-  encoded_branch=$(urlencode "$branch")
-  current_sha=$("$GH_BIN" api "repos/$repo/branches/$encoded_branch" --jq .commit.sha)
-  if [[ "$current_sha" != "$sha" ]]; then
-    echo "PRESERVE changed-since-inventory branch=$branch old=$sha new=$current_sha"
-    continue
+  if guarded_delete "$branch" "$sha" "pr=#$pr_number"; then
+    ((deleted_count += 1))
   fi
-  open_count=$("$GH_BIN" api --method GET "repos/$repo/pulls" \
-    -f state=open -f "head=$owner:$branch" -f per_page=1 --jq length)
-  if [[ "$open_count" != "0" ]]; then
-    echo "PRESERVE newly-open-pr branch=$branch"
-    continue
-  fi
-
-  encoded_ref=$(urlencode "heads/$branch")
-  "$GH_BIN" api --method DELETE "repos/$repo/git/refs/$encoded_ref" >/dev/null
-  echo "DELETED branch=$branch sha=$sha pr=#$pr_number"
-  ((deleted_count += 1))
 done < <("$GH_BIN" api --paginate "repos/$repo/branches?per_page=100" \
   --jq '.[] | [.name, .commit.sha, .protected] | @tsv')
 
-echo "SUMMARY candidates=$candidate_count deleted=$deleted_count preserved=$skipped_count mode=$mode"
+# DIVE-4138: name the arming state in SUMMARY. Without it, `deleted=0` reads the
+# same whether nothing qualified or the predicate was simply off -- and
+# `deleted=0` is the SUCCESS case for this job, so nobody re-reads the log to
+# find out which one they are looking at.
+if [[ "$arm_pullref" == "1" ]]; then arm_note=armed; else arm_note=off; fi
+echo "SUMMARY candidates=$candidate_count deleted=$deleted_count preserved=$skipped_count mode=$mode pullref_identity=$arm_note"

--- a/tests/branch_hygiene_unit.sh
+++ b/tests/branch_hygiene_unit.sh
@@ -107,10 +107,24 @@ case "$args" in
   "api repos/acme/demo/branches/changed-head --jq .commit.sha")
     echo NEW-SHA
     ;;
+  # DIVE-4138: the pull-ref-identity path now reaches the same last-moment
+  # rechecks as the merged-PR path, so the mock has to answer them for
+  # superseded-match too. It answers with the branch's own sha and no open PR,
+  # i.e. the recheck PASSES -- otherwise the armed arms below would go green on
+  # a fail-closed preserve and prove nothing about arming.
+  "api repos/acme/demo/branches/superseded-match --jq .commit.sha")
+    echo 1111111111111111111111111111111111111111
+    ;;
   *"-f state=open"*"-f head=acme:merged-old"*)
     echo 0
     ;;
+  *"-f state=open"*"-f head=acme:superseded-match"*)
+    echo 0
+    ;;
   *"--method DELETE repos/acme/demo/git/refs/heads%2Fmerged-old")
+    echo "$args" >>"${GH_MOCK_LOG:?}"
+    ;;
+  *"--method DELETE repos/acme/demo/git/refs/heads%2Fsuperseded-match")
     echo "$args" >>"${GH_MOCK_LOG:?}"
     ;;
   *)
@@ -188,16 +202,57 @@ grep -q 'PRESERVE changed-since-inventory branch=changed-head old=CHANGED new=NE
 [[ $(wc -l <"$TMP/deletes.log") -eq 1 ]]
 grep -q 'heads%2Fmerged-old' "$TMP/deletes.log"
 
-# DIVE-3490: the identity predicate is NOT armed under --apply. The weekly
-# schedule runs --apply unattended, so a branch that PASSES identity must still
-# be preserved there and must not appear in the delete log. This is the arm that
-# would fail if someone later wires the predicate into the unattended path.
+# DIVE-3490 + DIVE-4138: the identity predicate is OFF BY DEFAULT under --apply,
+# and stays off unless the CALLER sets BRANCH_HYGIENE_ARM_PULLREF_IDENTITY=1.
+# DIVE-4138 armed it in branch-hygiene.yml, not here -- so this arm still pins
+# the script's own refusal, which is what makes the workflow env var the single
+# place arming can happen and the single place it can be revoked.
 grep -q 'PRESERVE superseded-identity-not-armed branch=superseded-match sha=1111111111111111111111111111111111111111 pr=#20' <<<"$apply_output"
-refute 'the identity predicate was armed under --apply' 'DELETE-CANDIDATE branch=superseded-match' <<<"$apply_output"
+refute 'the identity predicate self-armed under --apply' 'DELETE-CANDIDATE branch=superseded-match' <<<"$apply_output"
 refute 'an identity-matched branch reached the delete API' superseded <"$TMP/deletes.log"
 # candidates stays 2 under --apply where dry-run saw 3: the identity match is
 # preserved, not counted. That difference IS the guarantee.
 grep -q 'SUMMARY candidates=2 deleted=1' <<<"$apply_output"
+grep -q 'SUMMARY .* pullref_identity=off' <<<"$apply_output"
+
+# --- DIVE-4138: --apply WITH the arm set ----------------------------------------------
+# lodar answered DIVE-4138's gate `nightly-for-reviewed-only`: delete nightly the
+# branches that have a permanent recovery ref, leave the ones that do not.
+# `match` is the ONLY state that widens. The three arms below are the widening,
+# and the four after them are the boundary -- because the failure that matters
+# here is not "it did not delete", it is "arming one state armed the others".
+: >"$TMP/deletes-armed.log"
+armed_output=$(GH_BIN="$TMP/gh" GH_MOCK_LOG="$TMP/deletes-armed.log" \
+  GITHUB_REPOSITORY=acme/demo BRANCH_HYGIENE_PRESERVE=merged-preserved \
+  BRANCH_HYGIENE_ARM_PULLREF_IDENTITY=1 \
+  "$ROOT/scripts/branch-hygiene.sh" --apply)
+
+grep -q 'DELETE-CANDIDATE branch=superseded-match sha=1111111111111111111111111111111111111111 pr=#20 via=pullref-identity' <<<"$armed_output"
+grep -q 'DELETED branch=superseded-match sha=1111111111111111111111111111111111111111 pr=#20 via=pullref-identity' <<<"$armed_output"
+grep -q 'heads%2Fsuperseded-match' "$TMP/deletes-armed.log"
+grep -q 'SUMMARY .* pullref_identity=armed' <<<"$armed_output"
+
+# The boundary. Arming `match` must arm NOTHING else: a pull ref that moved, one
+# that could not be resolved at all, and a recycled branch name whose latest
+# closed PR is not at this head all still have to preserve. `unresolved` is the
+# sharp one -- a network blip reads exactly like "nothing to do", and if it ever
+# fell through to the delete it would destroy the commit it failed to verify.
+refute 'arming match also armed a moved pull ref' 'DELETED branch=superseded-mismatch' <<<"$armed_output"
+refute 'arming match also armed an unresolvable pull ref' 'DELETED branch=superseded-unresolved' <<<"$armed_output"
+refute 'arming match also armed a branch with no matching closed PR' 'DELETED branch=superseded-reused' <<<"$armed_output"
+grep -q 'PRESERVE superseded-identity-mismatch branch=superseded-mismatch' <<<"$armed_output"
+grep -q 'PRESERVE superseded-identity-unresolved branch=superseded-unresolved' <<<"$armed_output"
+grep -q 'PRESERVE no-exact-merged-pr branch=superseded-reused' <<<"$armed_output"
+
+# Arming must not weaken the OTHER preserves either: an open PR head, an
+# explicitly preserved branch, protected branches, and the last-moment
+# changed-since-inventory recheck. The delete log is the tightest statement of
+# that -- exactly two refs, the merged one and the pull-ref-recoverable one.
+grep -q 'PRESERVE open-or-explicit branch=open-live' <<<"$armed_output"
+grep -q 'PRESERVE open-or-explicit branch=merged-preserved' <<<"$armed_output"
+grep -q 'PRESERVE changed-since-inventory branch=changed-head' <<<"$armed_output"
+[[ $(wc -l <"$TMP/deletes-armed.log") -eq 2 ]]
+grep -q 'SUMMARY candidates=3 deleted=2' <<<"$armed_output"
 
 echo "branch_hygiene_unit: PASS"
 


### PR DESCRIPTION
lodar asked for branch cleanup that is "daily and automatic". The job already
existed (.github/workflows/branch-hygiene.yml) and deleted almost nothing,
because DIVE-3490 deliberately built the predicate that reaches closed-unmerged
branches and refused to arm it on the unattended --apply path.

That refusal named its own exit condition: arming was conditioned on "its first
live output being a list a human reads", and had to be "a deliberate change to
that workflow, not a merge of this file". Both are now satisfied — the weekly
stale-digest arm printed the list, lodar read the eight branches in it on
2026-09-09 and answered DIVE-4138's tier-2 gate `nightly-for-reviewed-only`.

So the arming switch is BRANCH_HYGIENE_ARM_PULLREF_IDENTITY, set in the workflow
env, not flipped in the script. The script still refuses on its own, which keeps
the workflow the single place arming can happen and be revoked.

The axis is RECOVERABILITY, not age:
  - head byte-identical to refs/pull/N/head of its own closed-unmerged PR ->
    GitHub retains pull refs permanently, so the delete is reversible with
    `git push origin <sha>:refs/heads/<name>` -> auto-delete.
  - never had a PR, or an orphan with no common ancestor -> no recovery ref ->
    report only, never auto-deleted.
A 7-day tip cutoff was the obvious alternative and is wrong: it spares the
`status` data branch only by accident (force-pushed daily, so never old) and
would eventually delete the no-PR branches that have no undo.

Also: cadence weekly -> daily; the race-guarded delete is now one shared
function so the pull-ref path cannot acquire weaker last-moment checks than the
merged-PR path; and SUMMARY names the arming state, because deleted=0 is the
success case here and otherwise reads the same as "the predicate was off".

Live dry-run, 5dive-ai/5dive, armed: candidates=0 preserved=15 — status,
dive-2214-sibling-tarball-receipt and dive-4081-remedy-text all preserved as
no-exact-merged-pr, which is the intended steady state.

Tests: tests/branch_hygiene_unit.sh — the DIVE-3490 arm still pins the script's
unarmed refusal; new arms cover the armed delete plus the boundary, that arming
`match` arms nothing else (mismatch, unresolved, and no-matching-closed-PR all
still preserve, and the delete log holds exactly two refs).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)