### PR TITLE
fix(heartbeat): verify the injected submit and never claim a nudge the composer did not accept (DIVE-4242)

### DIFF
--- a/changelog.d/DIVE-4242.md
+++ b/changelog.d/DIVE-4242.md
@@ -1,0 +1,3 @@
+## Unreleased — fix(agent): a read failure on an agent's env file no longer becomes a persisted `admin` tier (DIVE-2218)
+
+- heartbeat: the injector clears the composer (C-u) before typing and VERIFIES the submit — the composer must hold no non-ghost text after Enter; one retry, then a loud `submit UNVERIFIED` and a failed wake so the tick never claims a row the seat did not receive (DIVE-4242).

--- a/changelog.d/DIVE-4242.md
+++ b/changelog.d/DIVE-4242.md
@@ -1,3 +1,3 @@
-## Unreleased — fix(agent): a read failure on an agent's env file no longer becomes a persisted `admin` tier (DIVE-2218)
+## Unreleased — fix(heartbeat): verify the injected submit and never claim a nudge the composer did not accept (DIVE-4242)
 
 - heartbeat: the injector clears the composer (C-u) before typing and VERIFIES the submit — the composer must hold no non-ghost text after Enter; one retry, then a loud `submit UNVERIFIED` and a failed wake so the tick never claims a row the seat did not receive (DIVE-4242).

--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -1670,6 +1670,17 @@ _hb_send_line() {
     fi
     return 1
   }
+  # DIVE-4242: COMPOSER HYGIENE, then the payload. Measured 2026-09-10 15:43Z on
+  # ops: the tick typed a /goal at 15:40:31Z and claimed the row; the pane then
+  # showed `❯ [Pasted text #7]irst (verify before relying...` — the NUDGE's own
+  # tail, NOT dim — sitting unsent in the composer while every later tick read
+  # 'busy — 1 in_progress, skip'. Whatever is already in the composer (a previous
+  # injector's remainder, a human's half-typed line) must not be prepended to
+  # this payload, so clear the line first. C-u, never Escape: Escape on a seat
+  # that is mid-turn ABORTS the turn, C-u only edits the composer. Ghost text
+  # (CC 2.1.267 promptSuggestion, rendered DIM) is not input and is replaced by
+  # typing anyway; it is excluded from the verify below rather than cleared.
+  sudo -u "agent-${name}" tmux send-keys -t "agent-${name}" C-u 2>/dev/null || return 1
   sudo -u "agent-${name}" tmux send-keys -t "agent-${name}" -l -- "$text" 2>/dev/null || return 1
   # DIVE-1217: `send-keys -l` lands as a bracketed PASTE. Claude commits it
   # synchronously so an immediate Enter submits (leave that path alone). Non-claude
@@ -1678,9 +1689,22 @@ _hb_send_line() {
   # starts and the nudge is silently dropped. For those: let the paste settle,
   # Enter, then CONFIRM the turn started (agent left idle), re-sending Enter a few
   # times before giving up.
+  # DIVE-4242: the claude path now VERIFIES the submit instead of assuming it. A
+  # long payload on CC 2.1.267 can leave its tail in the composer after the
+  # Enter (measured above); the caller then claims the row and the dispatcher is
+  # blind to a seat that never received its task. Verify = the composer line holds
+  # no non-dim text. Retry the Enter once; then return failure LOUDLY so
+  # _hb_wake fails and the tick does not claim — the next tick re-nudges, which is
+  # the pre-DIVE-2244 behaviour for exactly this task and strictly better than a
+  # claim on a prompt nobody received.
   if [[ -n "$(_hb_claude_pid "$name")" ]]; then
     sudo -u "agent-${name}" tmux send-keys -t "agent-${name}" Enter 2>/dev/null || return 1
-    return 0
+    _hb_verify_submit "$name" && return 0
+    sleep "${_HB_SUBMIT_RETRY_SEC:-0.5}"
+    sudo -u "agent-${name}" tmux send-keys -t "agent-${name}" Enter 2>/dev/null || return 1
+    _hb_verify_submit "$name" && return 0
+    _hb_log "[$name] submit UNVERIFIED — the composer still holds ${#_HB_COMPOSER_UNSENT} chars of non-ghost text after 2 Enters ('${_HB_COMPOSER_UNSENT:0:60}'); returning failure so nothing is claimed on it (DIVE-4242)" 2>/dev/null || true
+    return 1
   fi
   sleep 0.4
   while (( tries < 5 )); do
@@ -1692,6 +1716,37 @@ _hb_send_line() {
     tries=$((tries+1))
   done
   return 1
+}
+
+# DIVE-4242: the text a seat's composer is holding RIGHT NOW, with ghost text
+# excluded. `capture-pane -e` keeps the SGR codes; CC 2.1.267 renders its prompt
+# suggestion (promptSuggestionEnabled) as a DIM run `ESC[2m...ESC[0m` after the
+# composer glyph, and that run is not input — a plain Enter does nothing to it.
+# Anything else after the last `❯` is real unsent input (a paste placeholder,
+# a half-typed line). Empty output = composer empty (or unreadable: a pane we
+# cannot read is handled by the credential guard before we ever type).
+_hb_composer_unsent() {
+  local name="$1" raw line esc=$'\e'
+  raw=$(sudo -u "agent-${name}" tmux capture-pane -e -p -t "agent-${name}" 2>/dev/null) || { printf ''; return 0; }
+  line=$(grep -a '❯' <<<"$raw" | tail -1)
+  [[ -n "$line" ]] || { printf ''; return 0; }
+  line="${line#*❯}"
+  # 1) drop DIM runs (ghost text); 2) strip every remaining CSI sequence.
+  line=$(sed -E "s/${esc}\[2m[^${esc}]*(${esc}\[0m|${esc}\[22m)//g; s/${esc}\[[0-9;?]*[A-Za-z]//g" <<<"$line")
+  line="${line//[$'\t\r\n']/ }"
+  line=$(sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' <<<"$line")
+  printf '%s' "$line"
+}
+
+# DIVE-4242: did the Enter take? 0 = composer empty of non-ghost text (the
+# payload left it), 1 = text still sitting there (sets _HB_COMPOSER_UNSENT for
+# the caller's log line). Waits a beat first so the TUI has redrawn.
+_HB_COMPOSER_UNSENT=""
+_hb_verify_submit() {
+  local name="$1"
+  sleep "${_HB_SUBMIT_VERIFY_SEC:-0.3}"
+  _HB_COMPOSER_UNSENT=$(_hb_composer_unsent "$name")
+  [[ -z "$_HB_COMPOSER_UNSENT" ]]
 }
 
 # PID of this agent's live inner `claude` process, or empty if not found. This is

--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -1728,7 +1728,7 @@ _hb_send_line() {
 _hb_composer_unsent() {
   local name="$1" raw line esc=$'\e'
   raw=$(sudo -u "agent-${name}" tmux capture-pane -e -p -t "agent-${name}" 2>/dev/null) || { printf ''; return 0; }
-  line=$(grep -a '❯' <<<"$raw" | tail -1)
+  line=$(grep -a '❯' <<<"$raw" | tail -1) || line=""   # no glyph on the pane = empty composer, not a fatal probe
   [[ -n "$line" ]] || { printf ''; return 0; }
   line="${line#*❯}"
   # 1) drop DIM runs (ghost text); 2) strip every remaining CSI sequence.

--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -1733,6 +1733,11 @@ _hb_composer_unsent() {
   line="${line#*❯}"
   # 1) drop DIM runs (ghost text); 2) strip every remaining CSI sequence.
   line=$(sed -E "s/${esc}\[2m[^${esc}]*(${esc}\[0m|${esc}\[22m)//g; s/${esc}\[[0-9;?]*[A-Za-z]//g" <<<"$line")
+  # The composer glyph is followed by a NO-BREAK SPACE (U+00A0, bytes C2 A0),
+  # which [[:space:]] does not match. Measured 2026-09-10 15:58Z on all 13 live
+  # seats: without this line every idle composer read as one leftover character,
+  # i.e. every wake would have failed the verify and nothing would ever be claimed.
+  line="${line//$'\xc2\xa0'/ }"
   line="${line//[$'\t\r\n']/ }"
   line=$(sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' <<<"$line")
   printf '%s' "$line"

--- a/tests/heartbeat_send_line_verify_unit.sh
+++ b/tests/heartbeat_send_line_verify_unit.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# TIER: core
+#
+# DIVE-4242 — the heartbeat injector VERIFIES its submit and clears the composer
+# before typing. Measured 2026-09-10 15:43Z on ops: `_hb_send_line` typed a /goal,
+# fired Enter, returned 0, the tick claimed the row in_progress — and the pane
+# showed `❯ [Pasted text #7]irst (verify before relying...` (the nudge's own tail,
+# NOT dim) sitting unsent, so every later tick read 'busy — 1 in_progress, skip'
+# for a task the seat never received. Correct typing wired to no receipt.
+#
+# Every arm grades an ACTION on a scripted pane: the keys the injector sent and
+# the rc it returned. Ghost text (CC 2.1.267 promptSuggestion, DIM `ESC[2m`) is a
+# fixture too, because reading it as unsent input would make the verify red on
+# every idle seat. A mutation arm proves the failing arm is live: with the verify
+# stubbed to always-pass, the stuck fixture returns 0 again.
+#
+# Reserved-fake values only: seat 'seatx' does not exist; no live pane is touched
+# (sudo is a function here).
+set -uo pipefail
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: one trap, every exit path.
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+SRC=src
+command -v sqlite3 >/dev/null 2>&1 || { echo "SKIP: sqlite3 not present"; exit 0; }
+command -v jq      >/dev/null 2>&1 || { echo "SKIP: jq not present"; exit 0; }
+TMP=$(mktemp -d /tmp/send-line-verify.XXXXXX)
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_agent.sh cmd_heartbeat.sh; do
+  source "$SRC/$f"
+done
+set +e
+STATE_DIR="$TMP"
+KEYS="$TMP/keys"; HBLOG="$TMP/hb.log"; PANE_I="$TMP/pane_i"
+PANES=()
+_reset() { : >"$KEYS"; : >"$HBLOG"; echo 0 >"$PANE_I"; }
+# Fake sudo: `sudo -u agent-x tmux send-keys ...` logs the keystroke; `capture-pane`
+# returns the next scripted pane (the last one repeats). Counter lives in a file
+# because capture-pane is called inside $(...) subshells.
+sudo() {
+  while [ $# -gt 0 ]; do case "$1" in -u) shift 2;; -n|-H) shift;; *) break;; esac; done
+  [[ "${1:-}" == tmux ]] || return 0
+  shift
+  case "${1:-}" in
+    send-keys) shift; while [ $# -gt 0 ]; do case "$1" in -t) shift 2;; -l) shift;; --) shift; break;; *) break;; esac; done
+               printf '%s\n' "$*" >>"$KEYS"; return 0;;
+    capture-pane) local i n; i=$(cat "$PANE_I"); n=${#PANES[@]}; (( i >= n )) && i=$((n-1))
+               echo $(( $(cat "$PANE_I") + 1 )) >"$PANE_I"; printf '%b' "${PANES[$i]}"; return 0;;
+  esac
+  return 0
+}
+_agent_delivery_inbox()  { return 1; }   # no dispatcher inbox: the tmux path under test
+_agent_pane_safe_to_type() { return 0; }
+_hb_claude_pid()         { echo 4242; }  # claude path (immediate Enter + verify)
+_hb_log()                { printf '%s\n' "$1" >>"$HBLOG"; }
+sleep()                  { :; }
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+not_ok(){ FAIL=$((FAIL+1)); printf 'not ok - %s\n' "$1"; }
+grade() { if eval "$2"; then ok_t "$1"; else not_ok "$1"; fi; }
+enters() { grep -cx 'Enter' "$KEYS"; }
+E=$'\e'
+P_EMPTY="${E}[39m❯ ${E}[39m\n  Opus 5 5h: 3%\n"
+P_GHOST="${E}[39m❯ ${E}[2mnext task${E}[0m\n  Opus 5 5h: 3%\n"
+P_STUCK="${E}[38;5;246m❯ ${E}[39m[Pasted text #7]irst (verify before relying)\n  Opus 5 5h: 3%\n"
+P_NOGLYPH="  booting...\n"
+
+# A1 — clean submit: C-u first, payload, one Enter, rc 0.
+_reset; PANES=("$P_EMPTY"); _hb_send_line seatx "/goal do the thing"; rc=$?
+grade "A1 clean submit returns 0 with exactly one Enter" "[[ $rc -eq 0 && $(enters) -eq 1 ]]"
+grade "A2 the injector clears the composer (C-u) BEFORE typing the payload" "[[ \$(sed -n 1p '$KEYS') == 'C-u' && \$(sed -n 2p '$KEYS') == '/goal do the thing' ]]"
+
+# A3 — ghost text after the glyph is NOT unsent input: one Enter, rc 0.
+_reset; PANES=("$P_GHOST"); _hb_send_line seatx "/goal do the thing"; rc=$?
+grade "A3 dim ghost text is not read as unsent input (rc 0, one Enter)" "[[ $rc -eq 0 && $(enters) -eq 1 ]]"
+
+# A4 — tail sits after the first Enter, clears after the retry: rc 0, two Enters, no UNVERIFIED.
+_reset; PANES=("$P_STUCK" "$P_EMPTY"); _hb_send_line seatx "/goal do the thing"; rc=$?
+grade "A4 a tail left after the first Enter is retried once and then accepted (rc 0, two Enters)" "[[ $rc -eq 0 && $(enters) -eq 2 ]] && ! grep -q 'submit UNVERIFIED' '$HBLOG'"
+
+# A5 — tail survives both Enters: rc 1, loud log, exactly two Enters (no loop).
+_reset; PANES=("$P_STUCK" "$P_STUCK"); _hb_send_line seatx "/goal do the thing"; rc=$?
+grade "A5 a tail that survives both Enters returns 1 so the tick does not claim" "[[ $rc -eq 1 && $(enters) -eq 2 ]]"
+grade "A6 ...and logs 'submit UNVERIFIED' naming the leftover text" "grep -q \"submit UNVERIFIED.*Pasted text #7\" '$HBLOG'"
+
+# A7 — _hb_composer_unsent as a function: dim-only -> empty; mixed -> the real text; no glyph -> empty.
+_reset; PANES=("$P_GHOST");   u1=$(_hb_composer_unsent seatx)
+_reset; PANES=("$P_STUCK");   u2=$(_hb_composer_unsent seatx)
+_reset; PANES=("$P_NOGLYPH"); u3=$(_hb_composer_unsent seatx)
+grade "A7 composer reader: ghost-only -> '' ; stuck -> the visible text ; no glyph -> ''" "[[ -z '$u1' && '$u2' == '[Pasted text #7]irst (verify before relying)' && -z '$u3' ]]"
+
+# A8 — MUTATION: with the verify stubbed to always-pass, the stuck fixture returns 0 again.
+_hb_verify_submit() { return 0; }
+_reset; PANES=("$P_STUCK" "$P_STUCK"); _hb_send_line seatx "/goal do the thing"; rc=$?
+grade "A8 mutation: dropping the verify turns A5's rc back to 0 — the arm is live" "[[ $rc -eq 0 && $(enters) -eq 1 ]]"
+
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/heartbeat_send_line_verify_unit.sh
+++ b/tests/heartbeat_send_line_verify_unit.sh
@@ -61,10 +61,11 @@ ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
 not_ok(){ FAIL=$((FAIL+1)); printf 'not ok - %s\n' "$1"; }
 grade() { if eval "$2"; then ok_t "$1"; else not_ok "$1"; fi; }
 enters() { grep -cx 'Enter' "$KEYS"; }
-E=$'\e'
-P_EMPTY="${E}[39m❯ ${E}[39m\n  Opus 5 5h: 3%\n"
-P_GHOST="${E}[39m❯ ${E}[2mnext task${E}[0m\n  Opus 5 5h: 3%\n"
-P_STUCK="${E}[38;5;246m❯ ${E}[39m[Pasted text #7]irst (verify before relying)\n  Opus 5 5h: 3%\n"
+E=$'\e'; NB=$'\xc2\xa0'   # CC renders "❯" + NO-BREAK SPACE (U+00A0), exactly as live panes show it
+P_EMPTY="${E}[39m❯${NB} ${E}[39m\n  Opus 5 5h: 3%\n"
+P_GHOST="${E}[39m❯${NB} ${E}[2mnext task${E}[0m\n  Opus 5 5h: 3%\n"
+P_STUCK="${E}[38;5;246m❯${NB} ${E}[39m[Pasted text #7]irst (verify before relying)\n  Opus 5 5h: 3%\n"
+P_NBSP_ONLY="${E}[38;5;246m❯${NB}${E}[39m\n  Opus 5 5h: 3%\n"
 P_NOGLYPH="  booting...\n"
 
 # A1 — clean submit: C-u first, payload, one Enter, rc 0.
@@ -90,6 +91,11 @@ _reset; PANES=("$P_GHOST");   u1=$(_hb_composer_unsent seatx)
 _reset; PANES=("$P_STUCK");   u2=$(_hb_composer_unsent seatx)
 _reset; PANES=("$P_NOGLYPH"); u3=$(_hb_composer_unsent seatx)
 grade "A7 composer reader: ghost-only -> '' ; stuck -> the visible text ; no glyph -> ''" "[[ -z '$u1' && '$u2' == '[Pasted text #7]irst (verify before relying)' && -z '$u3' ]]"
+
+# A7b — the glyph's trailing NO-BREAK SPACE alone is an EMPTY composer. Measured live
+# 2026-09-10 15:58Z on 13 seats: an ASCII-only trim left one char on every idle seat.
+_reset; PANES=("$P_NBSP_ONLY"); u4=$(_hb_composer_unsent seatx)
+grade "A7b a composer holding only the glyph's U+00A0 reads as empty (live shape on every idle seat)" "[[ -z '$u4' ]]"
 
 # A8 — MUTATION: with the verify stubbed to always-pass, the stuck fixture returns 0 again.
 _hb_verify_submit() { return 0; }


### PR DESCRIPTION
DIVE-4242 items 1–3 (injector hygiene, nudge-claim release, ghost composer vs native state).

**Measured 2026-09-10 15:43Z on ops:** `_hb_send_line` typed a /goal at 15:40:31Z, fired Enter, returned 0, the tick claimed DIVE-4241 in_progress — and `tmux capture-pane -e` showed `❯ [Pasted text #7]irst (verify before relying…` (the nudge's own tail, NOT dim) sitting unsent, so every later tick read `busy — 1 in_progress, skip` for a task the seat never received.

- `_hb_send_line`: `C-u` before typing (never Escape — it aborts a running turn); on the claude path the submit is now VERIFIED: the composer line must hold no non-ghost text after Enter; one retry; then `submit UNVERIFIED` is logged and the function returns 1, so `_hb_wake` fails and the tick does NOT claim (the next tick re-nudges — item 2's "release" by never claiming).
- `_hb_composer_unsent`: reads `capture-pane -e`, drops DIM runs (`ESC[2m…ESC[0m`, CC 2.1.267 prompt suggestions) and every CSI, returns the text after the last `❯`.
- Item 3 measured, no change needed: `_hb_agent_native_state` reads `claude agents --json` (never the pane) and the pane fallback is byte-stability + glyph; a static ghost line reads as idle. Since 14:45Z there were 14 active-defer lines fleet-wide, on seats that were mid-turn.
- `tests/heartbeat_send_line_verify_unit.sh`: 8 arms — clean submit, C-u-first, ghost-not-input, retry-then-accept, stuck→rc 1 + loud log, composer-reader function, and a mutation arm (verify stubbed → the stuck arm's rc flips back to 0).

Not in this PR (owed on DIVE-4242's body): the `agent send` path in cmd_agent_runtime.sh:1070 (same hygiene, human/a2a sender), the post-upgrade probe (rail is `/usr/local/bin/5dive-host-updates.sh` at 04:20 via /etc/cron.d, not 03:00).

🤖 Generated with [Claude Code](https://claude.com/claude-code)