### PR TITLE
fix(heartbeat): a start from todo stamps a fresh started_at, so a gate-answered row is not reaped on its first tick (DIVE-4253)

### DIFF
--- a/changelog.d/DIVE-4253.md
+++ b/changelog.d/DIVE-4253.md
@@ -1,0 +1,3 @@
+## Unreleased
+
+- fix(heartbeat): a start from `todo` is a new attempt and gets a fresh `started_at` — both the dispatcher claim and `task start` used to `COALESCE` it, so a row that went blocked on a gate and came back to `todo` on the answer re-entered `in_progress` with its previous attempt's clock, and `_hb_reclaim` reaped it on its FIRST tick (measured 2026-09-10: DIVE-4218 claimed 22:30:21Z, reaped 22:35:09Z; DIVE-4214 gate answered 22:28:11Z, reaped 22:30:13Z — one wasted attempt and one reap per gated row, a direct feeder of the 57% reclaim share DIVE-4206 measured). `first_started_at` still carries the durable history and does not move; `task start` on an already-`in_progress` row is still a no-op. (DIVE-4253)

--- a/src/cmd_heartbeat.sh
+++ b/src/cmd_heartbeat.sh
@@ -1984,8 +1984,16 @@ _hb_ident() {
 #   * WHERE status='todo' AND kind='standard' — never stomps a row something else
 #     already moved between the wake and this stamp, and never touches a
 #     recurring TEMPLATE (starting one silently retires it, DIVE-2055/2059);
-#   * started_at=COALESCE(started_at, ...) — same idempotence as `task start`, so
-#     an agent that DOES run `task start` afterwards is a no-op, not a re-clock.
+#   * started_at=datetime('now') — a claim is only ever made from `todo`, and a
+#     todo row has NO live attempt, so the clock is the claim's, not an older one's.
+#     DIVE-4253: it used to be COALESCE(started_at, now), which kept the started_at
+#     a gate-answered row carried back from its previous attempt (`task need` ->
+#     blocked -> answer -> todo clears nothing). The next claim then inherited an
+#     hours-old clock and _hb_reclaim reaped it on its FIRST tick — measured
+#     2026-09-10: DIVE-4218 claimed 22:30:21Z, reaped 22:35:09Z; DIVE-4214 gate
+#     answered 22:28:11Z, reaped 22:30:13Z. One wasted attempt per gated row.
+#     `task start` on an already-in_progress row stays a no-op (it COALESCEs on
+#     in_progress only), so the DIVE-2244 idempotence arm still holds.
 #
 # Returns nonzero when the claim did not land, so the caller can say so out loud
 # rather than logging a claim it never made. Never exits: the agent is already
@@ -1998,7 +2006,7 @@ _hb_claim_task() {
   # blindness this column exists to remove. Seeded from started_at too, so a row
   # already claimed when this ships keeps its real start.
   db "UPDATE tasks SET status='in_progress',
-        started_at=COALESCE(started_at, datetime('now')),
+        started_at=datetime('now'),
         first_started_at=COALESCE(first_started_at, started_at, datetime('now')),
         updated_at=datetime('now')
       WHERE id=${id} AND status='todo' AND kind='standard';" 2>/dev/null || return 1
@@ -2625,7 +2633,10 @@ _hb_reclaim() {
         #
         # (2) started_at SURVIVED THE PAUSE, and every path back to `todo`
         # COALESCEs it: cmd_task_unblock sets status only, cmd_task_start is
-        # `started_at=COALESCE(started_at, datetime('now'))`. So an unblocked row
+        # `started_at=COALESCE(started_at, datetime('now'))`. (DIVE-4253 later made
+        # the dispatcher claim and `task start` stamp a FRESH clock on any start
+        # from todo, so this clear is now belt-and-braces, not the only defence;
+        # it stays — a pause that hands back a stale clock is still wrong.) So an unblocked row
         # re-entered in_progress carrying a timestamp from hours earlier,
         # `age_min >= budget` was true immediately, and it was reaped on the
         # FIRST tick after the unblock — it never got its ${budget} minutes.

--- a/src/task/status.sh
+++ b/src/task/status.sh
@@ -2185,7 +2185,13 @@ _task_start_preflight() {
 # the nudge path may touch it. Seeded from started_at as well as now(), so a row
 # already in flight when this ships records its real start rather than the moment
 # of its next re-claim. See src/lib/tasks_db.sh for the full rationale.
-cmd_task_start()  { _task_status_cmd in_progress ", started_at=COALESCE(started_at, datetime('now')), first_started_at=COALESCE(first_started_at, started_at, datetime('now'))" start "$@"; }
+# DIVE-4253: from `todo` a start is a NEW attempt, so it gets a fresh clock; only an
+# already-in_progress row keeps its started_at (the DIVE-2244 idempotence: an agent
+# that runs `task start` after the dispatcher claimed for it must not re-clock).
+# The CASE reads the row's PRE-update status, which is what SQLite's SET does.
+# Pre-fix this COALESCEd unconditionally, so a row coming back from a gate kept
+# an hours-old started_at and the reaper took it on its next tick.
+cmd_task_start()  { _task_status_cmd in_progress ", started_at=CASE WHEN status='in_progress' THEN COALESCE(started_at, datetime('now')) ELSE datetime('now') END, first_started_at=COALESCE(first_started_at, started_at, datetime('now'))" start "$@"; }
 # DIVE-2477: COALESCE, not a bare stamp — FIRST close wins. These wrote
 # done_at=datetime('now') unconditionally, so any second close silently moved the
 # original close timestamp forward: measured on a fixture, a row closed at T then

--- a/tests/heartbeat_dispatcher_claim_unit.sh
+++ b/tests/heartbeat_dispatcher_claim_unit.sh
@@ -198,6 +198,41 @@ _hb_claim_task dev "$T4" && bad_t "claim refuses a recurring TEMPLATE (DIVE-2055
 [[ "$(row "$T4")" == "todo|NULL" ]] && ok_t "refused claim left the template firing (still todo)" \
                                     || bad_t "refused claim left the template firing" "got $(row "$T4")"
 
+# --- 3b) DIVE-4253: a claim from todo RE-CLOCKS — the gate-return shape -------
+# A row that was in_progress, went blocked on a gate and came back to todo on the
+# answer still carries its previous attempt's started_at (`task need`, `answer`
+# and `unblock` clear nothing). Pre-fix the claim COALESCEd it, so the reaper's
+# very next tick read `age_min >= budget` and reclaimed a row claimed minutes
+# earlier — measured 2026-09-10: DIVE-4218 claimed 22:30:21Z, reaped 22:35:09Z;
+# DIVE-4214 gate answered 22:28:11Z, reaped 22:30:13Z. One wasted attempt per
+# gated row. first_started_at is the durable history (DIVE-3251) and must NOT move.
+T5=$(mk "came back from a gate")
+db "UPDATE tasks SET started_at=datetime('now','-200 minutes'), first_started_at=datetime('now','-200 minutes') WHERE id=${T5};"
+T5_FIRST=$(db "SELECT first_started_at FROM tasks WHERE id=${T5};")
+_hb_claim_task dev "$T5" >/dev/null 2>&1
+T5_AGE=$(db "SELECT CAST((julianday('now') - julianday(started_at)) * 1440 AS INTEGER) FROM tasks WHERE id=${T5};")
+[[ "$(row "$T5")" == in_progress\|* ]] && (( ${T5_AGE:-999} < 2 )) \
+  && ok_t "[4253] a claim from todo stamps a FRESH started_at (stale clock was 200m old, now ${T5_AGE}m)" \
+  || bad_t "[4253] a claim from todo stamps a FRESH started_at" "row=$(row "$T5") age_min=${T5_AGE:-?}"
+[[ "$(db "SELECT first_started_at FROM tasks WHERE id=${T5};")" == "$T5_FIRST" ]] \
+  && ok_t "[4253] first_started_at is history and does not move on re-claim" \
+  || bad_t "[4253] first_started_at must not move" "was $T5_FIRST now $(db "SELECT first_started_at FROM tasks WHERE id=${T5};")"
+# The consequence that matters: the reaper's next tick does NOT take it back.
+# Same budget as arm 5 (everyMin 30 => 90m); a fresh clock is far under it.
+read -r T5_RC _ < <(_hb_reclaim dev 30)
+[[ "$(row "$T5")" == in_progress\|* ]] && (( ${T5_RC:-0} == 0 )) \
+  && ok_t "[4253] the re-claimed row survives the reaper's next tick (gets its full budget window)" \
+  || bad_t "[4253] re-claimed row must survive the next reap" "row=$(row "$T5") reclaimed=${T5_RC:-?}"
+# Same shape through the agent's own verb: `task start` from todo is a new attempt
+# (arm 4 above holds the other half — on an in_progress row it is still a no-op).
+T6=$(mk "came back from a gate, started by hand")
+db "UPDATE tasks SET started_at=datetime('now','-200 minutes'), first_started_at=datetime('now','-200 minutes') WHERE id=${T6};"
+cmd_task_start "$T6" >/dev/null 2>&1
+T6_AGE=$(db "SELECT CAST((julianday('now') - julianday(started_at)) * 1440 AS INTEGER) FROM tasks WHERE id=${T6};")
+[[ "$(row "$T6")" == in_progress\|* ]] && (( ${T6_AGE:-999} < 2 )) \
+  && ok_t "[4253] 'task start' from todo also stamps a FRESH started_at" \
+  || bad_t "[4253] 'task start' from todo stamps a fresh started_at" "row=$(row "$T6") age_min=${T6_AGE:-?}"
+
 # --- 5) End-to-end reaper, reached ONLY via the dispatcher claim -------------
 # This is the assertion the ticket asked to mutation-grade. Note what is NOT
 # done: the in_progress row is never INSERTed. It is produced by running the


### PR DESCRIPTION
## What this fixes

A row that went **blocked on a gate and came back to `todo` on the answer** kept its previous attempt's `started_at` (`task need`, `answer` and `unblock` clear nothing). Both writers of a start — the dispatcher claim `_hb_claim_task` and `task start` — did `started_at=COALESCE(started_at, now)`, so the next claim inherited an hours-old clock and `_hb_reclaim` reaped it on its **first tick**.

Measured tonight in `/var/log/5dive-heartbeat.log`:

| row | event | reaped |
|---|---|---|
| DIVE-4218 | claimed 22:30:21Z | `overran 45m budget (reap #1)` at 22:35:09Z |
| DIVE-4214 | gate answered 22:28:11Z | 22:30:13Z |

One wasted attempt + one reap per gated row. DIVE-4111 fixed the same shape for the **pause** path (it clears the clock at pause time); the gate path had no equivalent.

## The change

- `_hb_claim_task`: `started_at=datetime('now')`. A claim is only ever made from `todo` (the `WHERE`), and a todo row has no live attempt, so the clock is the claim's.
- `task start`: `CASE WHEN status='in_progress' THEN COALESCE(started_at, now) ELSE now END` — a start from todo is a new attempt; on an already-in_progress row it stays a no-op (the DIVE-2244 idempotence arm, unchanged).
- `first_started_at` is not touched anywhere — it remains the durable history (DIVE-3251).
- DIVE-4111's clear on the pause path stays; its comment now says it is belt-and-braces.

## Evidence

- `tests/heartbeat_dispatcher_claim_unit.sh` **34/0** — new arm 3b: a todo row with a 200-minute-old clock is claimed → `started_at` < 2 min old, `first_started_at` unchanged, and the reaper's next tick leaves it in place; same through `task start`. Red on the pre-fix tree by construction (the stale clock would survive).
- `tests/task_first_started_at_unit.sh` **42/0**, `tests/heartbeat_reap_escalate_latch_unit.sh` **12/0** (DIVE-4111's own arms, including "unblock + re-claim is NOT reaped").
- Full set of harnesses naming `_hb_claim_task` / the start clock, on this head: `heartbeat_reclaim_loop_unit` **33/0**, `heartbeat_reclaim_verifier_handoff_unit` **6/0**, `heartbeat_resume_carryover_unit` **23/0**, `heartbeat_codex_wall_unit` and `task_close_preserves_done_at_unit` green (per-harness lines: 34 passed, 0 failed;42 passed, 0 failed;12 passed, 0 failed;33 passed, 0 failed;6 passed, 0 failed;23 passed, 0 failed;17 passed, 0 failed).
- `scripts/lint-changelog-fragments.sh` → `ok — 1 changelog.d fragment(s) graded, 0 error(s)`.
- `bash -n` clean on all three shell files.

**Not live until the next cut:** the control plane runs the installed bundle (0.30.1); this rides v0.31.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
