### PR TITLE
feat(self-update): resolve the upgrade target through the promoted fleet tag (DIVE-4256)

### DIFF
--- a/changelog.d/DIVE-4256.md
+++ b/changelog.d/DIVE-4256.md
@@ -1,0 +1,14 @@
+## Unreleased — feat(self-update): resolve the upgrade target through the promoted fleet tag (DIVE-4256)
+
+`5dive self-update` now hands the installer the same promoted-tag route the installer
+already defaults to, so the upgrade target for every box comes from one place the fleet
+controls rather than from whatever the newest GitHub tag happens to be.
+
+Practically: when an operator pins a tag on the control plane (a held release, a bad cut
+caught by the nightly smoke), a box's self-update stays on that tag within one route call,
+and removing the pin releases it on the next one. Both directions were rehearsed on a
+scratch sandbox against the shipped resolver.
+
+On a box that already runs the current installer this changes no behaviour today — the
+installer resolves the same route either way. Its value is that the caller can no longer
+drift to a different resolver or a different route without a test going red.

--- a/src/cmd_selfupdate.sh
+++ b/src/cmd_selfupdate.sh
@@ -867,7 +867,13 @@ cmd_self_update() {
 
   step "Upgrading 5dive CLI + plugins"
   # Send installer chatter to stderr so JSON stdout stays parseable.
-  bash "$installer" --upgrade >&2 || fail "$E_GENERIC" "upgrade failed"
+  # >>> DIVE-4140 stable installer handoff
+  # The installer owns target resolution (override/canary/stable/last-known/floor).
+  # Keep the caller explicit about the shared route instead of growing a second,
+  # drifting resolver inside self-update.
+  CLI_VERSION_URL="${CLI_VERSION_URL:-https://api.5dive.com/cli-version}" \
+    bash "$installer" --upgrade >&2 || fail "$E_GENERIC" "upgrade failed"
+  # <<< DIVE-4140 stable installer handoff
 
   # Restart only the agents whose payload actually moved. Best-effort per unit —
   # one failed restart shouldn't abort the rest.

--- a/tests/cli_stable_target_unit.sh
+++ b/tests/cli_stable_target_unit.sh
@@ -14,6 +14,16 @@ block="$(sed -n '/^# >>> DIVE-4140 stable CLI target/,/^# <<< DIVE-4140 stable C
 if [[ -n "$block" ]] && grep -q 'resolve_cli_target()' <<<"$block"; then ok "stable resolver is extractable from install.sh"
 else bad "stable resolver is missing"; echo "$PASS passed, $FAIL failed"; exit 1; fi
 
+handoff="$(sed -n '/^[[:space:]]*# >>> DIVE-4140 stable installer handoff/,/^[[:space:]]*# <<< DIVE-4140 stable installer handoff/p' src/cmd_selfupdate.sh)"
+if [[ -n "$handoff" ]] && grep -q 'CLI_VERSION_URL=' <<<"$handoff" \
+   && grep -q 'bash "$installer" --upgrade' <<<"$handoff"; then
+  ok "self-update installer handoff is extractable from src/cmd_selfupdate.sh"
+else
+  bad "self-update installer handoff is missing"
+  echo "$PASS passed, $FAIL failed"
+  exit 1
+fi
+
 mkdir -p "$TD/bin" "$TD/etc" "$TD/state"
 cat > "$TD/bin/curl" <<'CURL'
 #!/usr/bin/env bash
@@ -74,6 +84,31 @@ printf 'v1.4.0\n' > "$TD/state/known"
 out="$(run_target v1.4.0 1.4.0)"; rc=$?
 [[ $rc -eq 0 && "$out" == v1.4.0 && "$out" != v9.9.9 ]] \
   && ok "held stable tag keeps box self-update put" || bad "held box followed newest" "$out"
+
+# Exercise the real self-update handoff, not only resolve_cli_target in
+# isolation. This fake installer contains the shipped resolver. A fake red
+# smoke writes the one-call brake, then the updater must keep the box on the
+# held tag even while the route advertises a newer release.
+cat > "$TD/bin/fetched-installer" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+resolve_gh_tag(){ printf 'v9.9.9\\n'; }
+$block
+resolve_cli_target
+EOF
+chmod +x "$TD/bin/fetched-installer"
+printf 'v1.4.0\n' > "$TD/etc/override"
+out="$(env -i PATH="$TD/bin:/usr/bin:/bin" FAKE_ROUTE=v9.9.9 FAKE_INSTALLED=1.4.0 \
+  CLI_VERSION_OVERRIDE_FILE="$TD/etc/override" CLI_CANARY_FILE="$TD/etc/canary" \
+  CLI_VERSION_KNOWN_FILE="$TD/state/known" CLI_INSTALLED_BIN="$TD/bin/installed" \
+  bash -c "set -euo pipefail
+installer=\"\$1\"
+$handoff
+" _ "$TD/bin/fetched-installer" 2>&1)"; rc=$?
+[[ $rc -eq 0 && "$out" == v1.4.0 ]] \
+  && ok "fake-red brake holds the real self-update installer handoff" \
+  || bad "fake-red self-update rehearsal failed" "$out"
+rm -f "$TD/etc/override"
 
 mutant="$(sed '/if \[\[ -r "\$known_file"/,/^[[:space:]]*fi/ s/target=""/target="$(resolve_gh_tag)"/' <<<"$block")"
 if [[ "$mutant" == "$block" ]]; then

--- a/tests/cli_stable_target_unit.sh
+++ b/tests/cli_stable_target_unit.sh
@@ -15,7 +15,10 @@ if [[ -n "$block" ]] && grep -q 'resolve_cli_target()' <<<"$block"; then ok "sta
 else bad "stable resolver is missing"; echo "$PASS passed, $FAIL failed"; exit 1; fi
 
 handoff="$(sed -n '/^[[:space:]]*# >>> DIVE-4140 stable installer handoff/,/^[[:space:]]*# <<< DIVE-4140 stable installer handoff/p' src/cmd_selfupdate.sh)"
-if [[ -n "$handoff" ]] && grep -q 'CLI_VERSION_URL=' <<<"$handoff" \
+# DIVE-4256 iteration 2: anchor on the ROUTE, not the presence of the var — a presence
+# grep passes on a repointed literal, which is the value this arm exists to protect.
+if [[ -n "$handoff" ]] \
+   && grep -q 'CLI_VERSION_URL="${CLI_VERSION_URL:-https://api.5dive.com/cli-version}"' <<<"$handoff" \
    && grep -q 'bash "$installer" --upgrade' <<<"$handoff"; then
   ok "self-update installer handoff is extractable from src/cmd_selfupdate.sh"
 else


### PR DESCRIPTION
## What

DIVE-4256, item (2) THE FLOW. Re-lands the self-update half of the canary ring that was
removed from #845 by the 14:06Z ruling ("the flow may not ship before the rehearsal").
The rehearsal (item 1) and the brake end-to-end (item 3) are written on DIVE-4256's row
and were run before this PR was opened.

- `src/cmd_selfupdate.sh` — the installer handoff now names the shared route explicitly,
  inside a marked block, so the caller can never grow a second drifting resolver.
- `tests/cli_stable_target_unit.sh` — a new arm extracts that block and runs it under
  `env -i` against a fake installer carrying the SHIPPED `resolve_cli_target`, with a
  fake red-smoke hold in place. It asserts the box stays on the held tag while the route
  advertises a newer release.

The other flow caller, the nightly fleet soft-updater (`scripts/update.sh` +
`scripts/inc/soft-updates.sh`), already carries `CLI_VERSION_URL` on `5dive-api@origin/main`
and is graded by `src/lib/cli-update-wiring.test.ts`. Nothing was owed there.

## Evidence

`bash tests/cli_stable_target_unit.sh` — **13 passed, 0 failed** at the rebased head
(544f7d8e), including the mutation arm that reds if either resolver falls back to
newest-on-error.

Rehearsal + brake, both directions, observed in one run (full timestamps on DIVE-4256):
writing a concrete tag into the control-plane pin file pins a box's self-update to that
tag within one route call (`Cache-Control: no-store`, no TTL); removing the file releases
it on the next call.

## Stated honestly: what this diff does NOT change

**Runtime behaviour is unchanged.** `install.sh` already defaults `CLI_VERSION_URL` to
`https://api.5dive.com/cli-version`, and `bash "$installer"` inherits the caller's
environment, so a box resolves through the route with or without this line. The value
here is that the handoff is now **explicit and graded** — the marked block plus the new
arm mean a future edit that grows a local resolver in `cmd_selfupdate.sh`, or drops the
route, reds a test instead of shipping silently. Read it as a ratchet, not a behaviour
change.

Consequently the new arm is a **structural** guard: with `CLI_VERSION_OVERRIDE_FILE` set,
the override wins before the route is consulted, so the arm proves the block executes and
honours a hold — it does not prove the route URL itself is what reached the installer.

## Residuals

- No real box ran a real `5dive self-update` against a real `install.sh --upgrade`. The
  installer stand-in carries the shipped resolver but does not download or swap a bundle;
  the bundle-swap/restart path is untouched by this diff.
- The paid Hetzner smoke was not run. This is a CLI *resolution* change, not a
  provisioning-path change, so `smoke-gate` is not the relevant control.
- The row's premise that "DIVE-4114's hold writes the same file the route reads" is
  **false** — a red smoke writes a JSON marker under `$SMOKE_HOLD_DIR` and pages a human;
  it does not write `/var/lib/5dive/cli-version`. The brake rehearsed here is an
  OPERATOR's one call. Automating red-smoke → pin file is a separate row.

Refs DIVE-4256, DIVE-4140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
Pushed and opened by main (lead) after the delegated-push rail returned 403 for this branch (DIVE-4256 gate 02:2xZ); the push itself was approved on the row at 23:25:59Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
