### PR TITLE
feat(install): name the rung that resolved the CLI version (DIVE-4274)

### DIFF
--- a/changelog.d/DIVE-4274.md
+++ b/changelog.d/DIVE-4274.md
@@ -1,0 +1,41 @@
+## Unreleased — feat(install): name the rung that resolved the CLI version (DIVE-4274)
+
+On 2026-09-11 the dashboard's **Update** button was pressed on one of our own boxes, reported
+"Updates started", and the box came back on the version it already had. Twice. It was following the
+fleet pin and behaving exactly as designed, and nothing in the output said so. The question that came
+back — *"why it skipped update?"* — was the right one, and the output could not answer it.
+
+`resolve_cli_target` already knew. It computes a `source` for all four rungs — `local override` >
+`canary opt-in` > `fleet stable route` > `last known stable` — and printed it only on the **error**
+paths. On success it printed the tag alone, and **the four rungs are indistinguishable from their
+result**: a box on the pin and a box on the canary that happen to agree print exactly the same thing.
+
+It now prints on the success path too:
+
+```
+5dive install: CLI target v0.31.0 — source: canary opt-in (/etc/5dive/cli-canary)
+                                    — newest released tag, ahead of the fleet pin
+```
+
+**To stderr, not stdout.** Every caller does `GH_PINNED_TAG="$(resolve_cli_target)"`, so stdout is the
+return value; a human-facing line there would be appended to the tag and installed as a version
+string. The canary rung's source string also names the file and what the opt-in means, so the line
+explains itself to someone who has never read the resolver.
+
+**The harness was strengthened, not loosened, to admit this.** Eight arms in
+`tests/cli_stable_target_unit.sh` went red — not because of the new line, but because `run_target`
+captured `2>&1`, conflating the **return value** with the diagnostics. An arm could not tell
+"returned `v1.2.3`" from "printed something containing `v1.2.3`", so a diagnostic accidentally emitted
+on stdout would have been installed as a version with every arm still green. The streams are graded
+separately now, that property has its own arm, and a mutation anchor strips the `>&2` and requires the
+arm to catch it.
+
+The split also corrected an arm it inherited. The DIVE-4256 self-update rehearsal asserted the tag on
+**stdout**, but the shipped handoff runs `bash "$installer" --upgrade >&2` on purpose — the
+installer's output is log noise for the caller, not a value — so the tag it looked for was never on
+stdout, and only the merged capture made the arm appear to work. It now asserts against the stream the
+product actually uses, and pins the `>&2` besides: a handoff that leaked the installer's output onto
+the caller's stdout would be caught.
+
+Red before / green after: **15 passed / 6 failed at `6ec89c79`, 21 / 0 at head**, the six being exactly
+the new rung-naming arms and the mutation anchor.

--- a/install.sh
+++ b/install.sh
@@ -159,7 +159,7 @@ resolve_cli_target() {
     fi
   elif [[ -e "$canary_file" ]]; then
     target="$(resolve_gh_tag || true)"
-    source="canary newest release"
+    source="canary opt-in ($canary_file) — newest released tag, ahead of the fleet pin"
   else
     target="$(curl -fsSL --max-time 5 "$route" 2>/dev/null | tr -d '[:space:]')" || target=""
     if [[ "$target" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -196,6 +196,20 @@ resolve_cli_target() {
       return 1
     fi
   fi
+
+  # DIVE-4274. Say WHICH RUNG answered, not just what it answered.
+  #
+  # "Updates started", then the same version as before, with no reason given, is
+  # what produced "why it skipped update?" — the box was following the fleet pin
+  # and behaving exactly as designed, and nothing said so. The four rungs are
+  # indistinguishable from their result: a box on the pin and a box on the
+  # canary that happen to agree print the same tag.
+  #
+  # STDERR, not stdout: every caller captures this function with $(...) and the
+  # tag is the return value. A human-facing line on stdout would be appended to
+  # the tag and installed as a version string. It still reaches the operator —
+  # the nightly driver and the dashboard's update both keep stderr in the log.
+  printf '5dive install: CLI target %s — source: %s\n' "$target" "$source" >&2
 
   printf '%s\n' "$target"
 }

--- a/tests/cli_stable_target_unit.sh
+++ b/tests/cli_stable_target_unit.sh
@@ -41,7 +41,15 @@ printf '5dive %s\n' "${FAKE_INSTALLED:-0.0.0}"
 CLI
 chmod +x "$TD/bin/curl" "$TD/bin/installed"
 
-run_target(){ # route [installed] [allow]
+# DIVE-4274. The two streams are graded SEPARATELY now, and that is a
+# strengthening, not an accommodation. resolve_cli_target's stdout is a RETURN
+# VALUE — every caller does GH_PINNED_TAG="$(resolve_cli_target)" — while its
+# diagnostics are stderr. Merging them with 2>&1, as this harness used to, meant
+# an arm could not tell "returned v1.2.3" from "printed something that contains
+# v1.2.3", so a human-facing line accidentally emitted on stdout would have been
+# installed as a version string with every arm still green.
+LOGF="$TD/stderr"
+run_target(){ # route [installed] [allow]   -> stdout only; stderr in $LOGF
   env -i PATH="$TD/bin:/usr/bin:/bin" FAKE_ROUTE="$1" FAKE_INSTALLED="${2:-0.0.0}" \
     FIVE_ALLOW_DOWNGRADE="${3:-0}" CLI_VERSION_OVERRIDE_FILE="$TD/etc/override" \
     CLI_CANARY_FILE="$TD/etc/canary" CLI_VERSION_KNOWN_FILE="$TD/state/known" \
@@ -49,8 +57,9 @@ run_target(){ # route [installed] [allow]
     bash -c "set -euo pipefail
 resolve_gh_tag(){ printf 'v9.9.9\\n'; }
 $block
-resolve_cli_target" 2>&1
+resolve_cli_target" 2>"$LOGF"
 }
+tlog(){ cat "$LOGF" 2>/dev/null; }
 
 printf 'v1.2.3\n' > "$TD/etc/override"
 out="$(run_target v8.0.0)"; rc=$?
@@ -69,7 +78,9 @@ out="$(run_target latest)"; rc=$?
 
 rm -f "$TD/state/known"
 out="$(run_target fail)"; rc=$?
-[[ $rc -ne 0 && "$out" == *"NO STABLE CLI TAG RESOLVED"* ]] && ok "route failure without cache fails closed" || bad "empty fallback did not fail closed" "$out"
+[[ $rc -ne 0 && "$(tlog)" == *"NO STABLE CLI TAG RESOLVED"* && -z "$out" ]] \
+  && ok "route failure without cache fails closed (and returns nothing on stdout)" \
+  || bad "empty fallback did not fail closed" "$out / $(tlog)"
 
 : > "$TD/etc/canary"
 out="$(run_target fail)"; rc=$?
@@ -78,7 +89,9 @@ rm -f "$TD/etc/canary"
 
 printf 'v1.4.0\n' > "$TD/state/known"
 out="$(run_target v1.3.9 1.4.0)"; rc=$?
-[[ $rc -ne 0 && "$out" == *"below installed floor 1.4.0"* ]] && ok "installed version is a downgrade floor" || bad "downgrade floor failed" "$out"
+[[ $rc -ne 0 && "$(tlog)" == *"below installed floor 1.4.0"* && -z "$out" ]] \
+  && ok "installed version is a downgrade floor (and returns nothing on stdout)" \
+  || bad "downgrade floor failed" "$out / $(tlog)"
 out="$(run_target v1.3.9 1.4.0 1)"; rc=$?
 [[ $rc -eq 0 && "$out" == v1.3.9 ]] && ok "explicit rollback hatch permits lower stable tag" || bad "rollback hatch failed" "$out"
 
@@ -107,10 +120,28 @@ out="$(env -i PATH="$TD/bin:/usr/bin:/bin" FAKE_ROUTE=v9.9.9 FAKE_INSTALLED=1.4.
   bash -c "set -euo pipefail
 installer=\"\$1\"
 $handoff
-" _ "$TD/bin/fetched-installer" 2>&1)"; rc=$?
-[[ $rc -eq 0 && "$out" == v1.4.0 ]] \
+" _ "$TD/bin/fetched-installer" 2>"$LOGF")"; rc=$?
+# DIVE-4274: stderr is split out of this capture like every other arm, and for
+# THIS arm that is a correction, not just a tidy-up. The shipped handoff runs
+# `bash "$installer" --upgrade >&2` on purpose — the installer's output is log
+# noise for the self-update caller, not a value — so the tag this arm looks for
+# was never on stdout. Under the old `2>&1` that was invisible: the capture
+# merged the two streams, so the arm could not distinguish "the handoff returned
+# v1.4.0" (which it never does) from "something in the run mentioned v1.4.0".
+# Assert against the stream the product actually uses, and pin the `>&2` while
+# we are here: a handoff that leaked the installer's stdout to the caller would
+# now be caught.
+[[ $rc -eq 0 && "$(tlog)" == *v1.4.0* && "$(tlog)" != *v9.9.9* ]] \
   && ok "fake-red brake holds the real self-update installer handoff" \
-  || bad "fake-red self-update rehearsal failed" "$out"
+  || bad "fake-red self-update rehearsal failed" "rc=$rc out='$out' log='$(tlog)'"
+[[ -z "$out" ]] \
+  && ok "the handoff keeps the installer's output off the caller's stdout" \
+  || bad "the handoff leaked installer output onto stdout" "$out"
+# And the rung that answered is named, so a rehearsal that silently fell through
+# to a different rung cannot read as a held brake.
+[[ "$(tlog)" == *"local override"* ]] \
+  && ok "the held handoff names the rung it resolved from" \
+  || bad "the held handoff did not name its rung" "$(tlog)"
 rm -f "$TD/etc/override"
 
 mutant="$(sed '/if \[\[ -r "\$known_file"/,/^[[:space:]]*fi/ s/target=""/target="$(resolve_gh_tag)"/' <<<"$block")"
@@ -122,9 +153,64 @@ else
   out="$(env -i PATH="$TD/bin:/usr/bin:/bin" FAKE_ROUTE=fail CLI_VERSION_OVERRIDE_FILE="$TD/etc/override" CLI_CANARY_FILE="$TD/etc/canary" CLI_VERSION_KNOWN_FILE="$TD/state/known" CLI_INSTALLED_BIN="$TD/bin/installed" bash -c "set -euo pipefail
 resolve_gh_tag(){ echo v9.9.9; }
 $mutant
-resolve_cli_target" 2>&1)"; rc=$?
+resolve_cli_target" 2>/dev/null)"; rc=$?
   set -e
   [[ $rc -eq 0 && "$out" == v9.9.9 ]] && ok "newest-on-error mutation is caught by the fail-closed assertion" || bad "newest-on-error mutation was not exercised" "$out"
+fi
+
+# --- DIVE-4274: the resolution must SAY which rung answered -----------------
+# "Updates started" followed by the same version, with no reason, is what
+# produced "why it skipped update?". A pinned box and a canary box that happen
+# to agree print the same tag; only the source distinguishes them.
+rm -f "$TD/etc/override" "$TD/etc/canary"; printf 'v1.4.0\n' > "$TD/state/known"
+
+out="$(run_target v1.4.0)"
+[[ "$out" == v1.4.0 && "$(tlog)" == *"CLI target v1.4.0"* && "$(tlog)" == *"fleet stable route"* ]] \
+  && ok "pin rung names itself" || bad "pin rung did not name itself" "$out / $(tlog)"
+
+: > "$TD/etc/canary"
+out="$(run_target fail)"
+[[ "$out" == v9.9.9 && "$(tlog)" == *"canary"* && "$(tlog)" == *"CLI target v9.9.9"* ]] \
+  && ok "canary rung names itself (the word the dashboard shows)" \
+  || bad "canary rung did not name itself" "$out / $(tlog)"
+# The two rungs must be DISTINGUISHABLE when they resolve the same tag —
+# otherwise naming the source buys nothing over printing the version.
+canary_log="$(tlog)"
+rm -f "$TD/etc/canary"
+out="$(run_target v9.9.9)"
+[[ "$out" == v9.9.9 && "$(tlog)" != "$canary_log" && "$(tlog)" != *"canary"* ]] \
+  && ok "same tag from a different rung reads differently" \
+  || bad "pin and canary are indistinguishable on the same tag" "$(tlog)"
+
+printf 'v9.9.9\n' > "$TD/etc/override"
+out="$(run_target fail 0.0.0)"
+[[ "$out" == v9.9.9 && "$(tlog)" == *"local override"* ]] \
+  && ok "override rung names itself" || bad "override rung did not name itself" "$out / $(tlog)"
+rm -f "$TD/etc/override"
+
+# The diagnostic must never reach stdout: stdout is the RETURN VALUE, and a
+# stray line there is installed as a version string.
+out="$(run_target v1.4.0)"
+[[ "$out" == v1.4.0 ]] && ok "stdout carries the tag and nothing else" \
+  || bad "diagnostics leaked onto stdout — the caller would install this" "$out"
+
+# Mutation anchor: move the diagnostic to stdout and the arm above must catch
+# it. Without this, "stdout carries the tag" passes on a function that prints
+# no diagnostic at all.
+leak="${block//>&2/}"
+if [[ "$leak" == "$block" ]]; then
+  bad "stdout-leak mutation applied" "no >&2 redirect found to remove"
+else
+  out="$(env -i PATH="$TD/bin:/usr/bin:/bin" FAKE_ROUTE=v1.4.0 FAKE_INSTALLED=0.0.0 \
+    FIVE_ALLOW_DOWNGRADE=0 CLI_VERSION_OVERRIDE_FILE="$TD/etc/override" \
+    CLI_CANARY_FILE="$TD/etc/canary" CLI_VERSION_KNOWN_FILE="$TD/state/known" \
+    CLI_VERSION_URL=https://control.invalid/cli-version CLI_INSTALLED_BIN="$TD/bin/installed" \
+    bash -c "set -euo pipefail
+resolve_gh_tag(){ printf 'v9.9.9\\n'; }
+$leak
+resolve_cli_target" 2>/dev/null)"
+  [[ "$out" != v1.4.0 ]] && ok "mutation anchor: a diagnostic on stdout is caught" \
+    || bad "mutation anchor: a diagnostic on stdout was NOT caught" "$out"
 fi
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
DIVE-4274 part (3). Parts (1) and (2) are elsewhere — see the bottom.

## The gap

On 2026-09-11 lodar clicked **Update** on the dashboard of one of our boxes, it reported
"Updates started", and the box came back on the version it already had. Twice. The box was following
the fleet pin and behaving exactly as designed, and nothing in the output said so. The question that
came back was *"why it skipped update?"* — which is the right question, and the output could not
answer it.

`resolve_cli_target` already knows the answer. It computes `source` for all four rungs —
`local override` > `canary opt-in` > `fleet stable route` > `last known stable` — and printed it only
on the **error** paths. On success it printed the tag alone, and **the four rungs are
indistinguishable from their result**: a box on the pin and a box on the canary that happen to agree
print exactly the same thing.

## The change

```
5dive install: CLI target v0.31.0 — source: canary opt-in (/etc/5dive/cli-canary)
                                    — newest released tag, ahead of the fleet pin
```

**stderr, not stdout.** Every caller does `GH_PINNED_TAG="$(resolve_cli_target)"`, so stdout is the
**return value**. A human-facing line there would be appended to the tag and installed as a version
string. stderr still reaches the operator: the nightly driver and the dashboard's update both keep it
in the log.

The canary rung's `source` also now names the file and what the opt-in means, so the line explains
itself to someone who has never read the resolver.

## This change would have broken the existing harness, and it was strengthened, not loosened

`tests/cli_stable_target_unit.sh` went **8 arms red** against a 0-fail baseline. The cause was not the
new line — it was that `run_target` captured `2>&1`, conflating the return value with the diagnostics.

So the streams are now graded **separately**, which asserts strictly more than before: an arm could
not previously tell *"returned `v1.2.3`"* from *"printed something containing `v1.2.3`"*. A diagnostic
accidentally emitted on stdout would have been installed as a version, with every arm still green.
That property now has its own arm — **and a mutation anchor** that strips the `>&2` from the extracted
block and requires the arm to catch it. The two error arms additionally assert the message went to
stderr **and** that stdout stayed empty.

New arms: each rung names itself; and the pin and the canary stay **distinguishable when they resolve
the same tag** — otherwise naming the source buys nothing over printing the version.

**Red before / green after: 15 passed / 6 failed against `6ec89c79`, 21 / 0 at head** — the six being
exactly the new rung-naming arms plus the mutation anchor, so nothing else in the file moved.

### It also corrected an arm it inherited, and that is worth reading

Rebasing onto `6ec89c79` (#869, DIVE-4256) brought in a new arm — *"fake-red brake holds the real
self-update installer handoff"* — which went red against this change. Not a conflict: it asserted the
resolved tag on **stdout**, and the shipped handoff runs `bash "$installer" --upgrade >&2` **on
purpose**, because the installer's output is log noise for the self-update caller rather than a value.
So the tag that arm looked for was never on stdout at all; only the merged `2>&1` capture made it
appear to work, and any run that merely *mentioned* `v1.4.0` would have satisfied it.

It now asserts against the stream the product actually uses, and pins the `>&2` besides — a handoff
that leaked the installer's output onto the caller's stdout is now caught, which nothing checked
before. Same lesson as the rest of this PR: merging the two streams is what hid it.

## Blast radius

42 of the 45 suites that mention `install.sh` / `resolve_cli_target` / `cli-version` / `canary` pass at
head (measured before the rebase; the rebase touched only this harness and the changelog fragment). Three fail — **identically at base and at head, same pass/fail counts, so they are pre-existing
and deliberately not touched here**: `agent_priv_read_breaker_unit` (5/4), `install_checksum_unit`
(9/2), `task_merge_gate_result_pr_unit` (32/1).

## Ship note — this DOES reach every box within one nightly, so the last human moment is the merge

`install.5dive.com` is `raw.githubusercontent.com/<org>/5dive/main/install.sh`, and the customer
nightly re-curls that URL and pipes it to `bash` as root. So **merging this puts it on every box at
its next 03:00 run, with no CLI cut** — `5dive-cli` is release-gated for the bundle and `main`-published
for this one file, which is the asymmetry recorded in
`community/wiki/a-repo-that-publishes-by-release-cut-can-still-publish-one-file-from-main.md`.
Re-measured just now with a cache-buster: served `01008d8b2814` == `origin/main:install.sh`.

**Correcting myself, because the first version of this PR body said the opposite.** I wrote "serves the
latest release tag, not main", on a measurement taken at 04:47Z: served bytes were `28a21454bd3a`,
which is `v0.31.0:install.sh`, while `origin/main:install.sh` was already `01008d8b2814`. The URL sits
behind Cloudflare with `cache-control: public, max-age=300`, and the one commit that has touched
`install.sh` since the tag (`809fe7f7`) had merged at 04:36Z — so I read a cached copy of main from
before that merge and inferred a publishing mechanism from it. **One sample through a CDN cannot tell
you which ref a URL serves; bust the cache, or compare against every candidate ref rather than the one
you expect.** Nothing else in this PR depended on it.

Consequences for whoever merges, since this is now a different gate than the one I first described:

- The change is on the `curl | bash`-as-root path of every box. It is two `printf`s to **stderr** and
  one string literal, adds no branch and no network call, and cannot alter the resolved tag — but
  "small" is not the standard here, and the harness evidence above is.
- It is revertible the same way it ships: revert the commit on `main`, and boxes pick the revert up at
  their next nightly.
- No release cut is needed or implied. DIVE-4243's hold on `release-cut.yml` is unrelated to this file.

## Not in this PR

- **Part (2)**, the provision-time canary mark and the ownership config it needs:
  `lodar/5dive-api#159`.
- **Part (1)**, touching `/etc/5dive/cli-canary` on the boxes we already own: needs SSH and an
  inventory of which boxes are ours. Routed to main, who holds both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
