### PR TITLE
fix(task): name what the merge-gate SCAN failed on, and stop rendering a failing selftest as a CLI bug (DIVE-4282)

### DIFF
--- a/changelog.d/DIVE-4282.md
+++ b/changelog.d/DIVE-4282.md
@@ -1,0 +1,21 @@
+## Unreleased — fix(task): the merge gate names what the repo SCAN failed on, and a failing `merge-gate-selftest` stops rendering as a CLI bug (DIVE-4282)
+
+On a wizard-provisioned customer box, every `task done` printed *"merge-gate could not query
+GitHub (partial-repo-scan-0-of-11) — this close is UNVERIFIED"* on a seat whose credential read
+that org's issues by hand. The token was never the problem and it was never dropped: the scan
+hands it to `gh` on every repo listing. What was dropped is the **reason** — `_gate_gh` records it
+in a variable and the scan calls it inside `x=$(…)`, a subshell, so every per-repo error died one
+line after it was produced and the scan was left with a count. A count can only be wrapped in the
+sentence you already had, and that sentence blamed the credential — so an always-UNVERIFIED line
+was reasonably read as "agent seats have no GitHub credential" and ignored for weeks.
+
+The per-call reason now crosses the subshell through an opt-in file sink, and a close that HELD a
+rail reads *"merge-gate HELD a rail but the repo scan FAILED (…) — first failure, `<repo>`:
+`<what gh said>`"*, on the terminal and on the audit row. The credential wording is kept for the
+seat it is true of: no rail answered because there was no rail.
+
+Second half, same subsystem: `5dive task merge-gate-selftest` — the command that warning names as
+its remedy — printed its finding and then *"exited 1 without reporting a reason. This is a bug in
+the CLI."* It never crashed; the verb's contract is to exit non-zero WITH a finding and it never
+told the silent-exit backstop it had reported. An operator following the instrument's own advice
+was handed a bug report instead of the diagnosis it had just printed.

--- a/src/task/delivery.sh
+++ b/src/task/delivery.sh
@@ -301,6 +301,17 @@ cmd_task_merge_gate_selftest() {
   fi
   # A failing self-test is a FINDING, not a crash: it is the only surface on which an
   # inert gate announces itself, so it prints the same fields and exits non-zero.
+  #
+  # DIVE-4282: AND IT MUST SAY SO TO THE EXIT-TRAP BACKSTOP. Without `mark_reported`,
+  # lib/output.sh's `_report_silent_exit` sees a non-zero exit with nothing marked and
+  # overprints this verb's own verdict with "5dive task exited 1 without reporting a
+  # reason. This is a bug in the CLI ... Please file it: 5dive bug." Reported from a
+  # customer box 2026-09-11 as a `set -euo pipefail` crash; it is not one — the verb
+  # ran to completion, printed its finding, and returned its verdict. The damage is
+  # that the merge-gate warning tells an operator to run THIS command, and the command
+  # answers with a bug report instead of the diagnosis it just printed. Same fix, same
+  # reason, as cmd_task_merge_unverified's findings exit two functions below.
+  mark_reported
   if (( JSON_MODE )); then
     ok "merge-gate selftest: $detail" \
        '{verdict:$v, seat:$s, controlPr:$p, state:$st, tokenResolved:($tk=="1"), tokenTrace:$tr, botRail:$b, anonRail:$a}' \

--- a/src/task/gate_evidence.sh
+++ b/src/task/gate_evidence.sh
@@ -829,12 +829,38 @@ _gate_gh_blind_err() {
   grep -qiE 'could not resolve to a repository|not found \(http 404\)|http 404|resource not accessible by integration' "$f" 2>/dev/null
 }
 
+# DIVE-4282: _GATE_GH_ERRF — the CALLER'S sink for "why did this call fail".
+#
+# `_GATE_GH_LAST_ERR` is a variable, and every counting caller invokes _gate_gh in a
+# COMMAND SUBSTITUTION, i.e. a subshell — so the variable cannot travel back and the
+# caller is left holding a bare non-zero status. That is exactly how the autodetect
+# scan came to report `partial-repo-scan-0-of-11` on a seat whose token was fine: the
+# scan knew only HOW MANY repos declined, never WHAT any of them said, so the only
+# sentence it could print was "could not query GitHub" — which points the reader at
+# the credential when the credential is not the problem. Measured on a customer box,
+# 2026-09-11 (5dive-exact-swallow): arm 4 RESOLVED, 0 of 11 repos answered, and the
+# reason was unrecoverable from the warning by construction.
+#
+# Same mechanism as DIVE-3496 it.2's `_GATE_GH_NOCRED_ERRF`, one level up: a FILE
+# crosses the subshell boundary a variable cannot. Opt-in — unset, nothing is written
+# and no path changes — which keeps DIVE-2705's decision intact (gh's stderr is still
+# never sprayed on a call that answered; it is published only where a caller has asked
+# for it because it is about to explain a failure).
+_gate_gh_publish_err() {
+  [[ -n "${_GATE_GH_ERRF:-}" ]] || return 0
+  printf '%s' "${_GATE_GH_LAST_ERR:-}" >"$_GATE_GH_ERRF" 2>/dev/null || true
+  return 0
+}
+
 _gate_gh() {
   local tok="${1:-}" secs="${2:-0}"; shift 2
   local -a bound=()
   local _rc=0 _errf
   _GATE_GH_LAST_ERR=""
   _GATE_GH_NOCRED_ERRF=""   # DIVE-3496 it.2: only the escalation below sets a sink
+  # DIVE-4282: truncate the caller's sink at entry, so a call that ANSWERS never
+  # leaves the previous call's failure sitting in it for the caller to misread.
+  [[ -n "${_GATE_GH_ERRF:-}" ]] && { : >"$_GATE_GH_ERRF" 2>/dev/null || true; }
   _errf="${TMPDIR:-/tmp}/.5dive-gate-gh-err.$$"
   if [[ -n "$tok" ]]; then
     [[ "$secs" != "0" ]] && bound=(timeout "${secs}s")
@@ -917,16 +943,23 @@ _gate_gh() {
         return 0
       fi
       _GATE_GH_LAST_ERR="the caller's own credential cannot see this repository (${_blind}); the seat's owner-scoped read token for '${_own:-?}' ${_own:+was ${_otok:+tried and could not answer}${_otok:-not present on this seat}}, and the credential-free rails were tried too and could not answer: ${_esc_err}"
+      _gate_gh_publish_err
       rm -f "$_errf" 2>/dev/null || true
       printf ''
       return "$_rc"
     fi
   else
+    # DIVE-4282: the credential-free rails write their own reason; point them at the
+    # caller's sink so a no-token scan explains itself exactly like a tokened one.
+    local _nc_prev="${_GATE_GH_NOCRED_ERRF:-}"
+    [[ -n "${_GATE_GH_ERRF:-}" ]] && _GATE_GH_NOCRED_ERRF="$_GATE_GH_ERRF"
     _gate_gh_nocred "$secs" "$@" || _rc=$?
+    _GATE_GH_NOCRED_ERRF="$_nc_prev"
     rm -f "$_errf" 2>/dev/null || true
     return "$_rc"
   fi
   [[ -s "$_errf" ]] && _GATE_GH_LAST_ERR="$(cat "$_errf" 2>/dev/null || printf '')"
+  (( _rc != 0 )) && _gate_gh_publish_err
   rm -f "$_errf" 2>/dev/null || true
   return "$_rc"
 }

--- a/src/task/status.sh
+++ b/src/task/status.sh
@@ -1667,6 +1667,10 @@ $_body" 2>/dev/null | sed 's/^.*|/#/' | head -3 | paste -sd, - || true)
     # the refusal messages below, and `set -u` turns an unset one into a crash on
     # the very path (no gh token) this gate is supposed to survive.
     local _ghtok2="" _slug2="" _sc_hit_slug="" _sc_total=0 _sc_ok=0
+    # DIVE-4282: what the SCAN itself failed on, first failing repo wins. The count
+    # alone ("0 of 11") cannot tell a credential problem from a listing/rate-limit/
+    # visibility one, and the warning below was written as if it could.
+    local _sc_err="" _sc_err_slug="" _sc_errf=""
     command -v gh >/dev/null 2>&1 && _ghtok2=$(_gate_gh_token)
     # DIVE-1935: NO TOKEN means the answer is unverified whatever gh prints — do
     # not run the query and then read its empty result as "repo is clean". That
@@ -1688,6 +1692,12 @@ $_body" 2>/dev/null | sed 's/^.*|/#/' | head -3 | paste -sd, - || true)
       # two of three repos. First hit wins and the refusal names WHICH repo. A repo
       # whose listing fails does not count as scanned: partial coverage reported as
       # full is the same succeeding-in-appearance shape DIVE-1935 was about.
+      # DIVE-4282: _gate_gh runs in the command substitution below — a SUBSHELL — so
+      # its `_GATE_GH_LAST_ERR` cannot travel back and every reason this scan had was
+      # being thrown away one line after it was produced. Name a file sink and read it.
+      _sc_errf="${TMPDIR:-/tmp}/.5dive-gate-scan-err.$$"
+      : >"$_sc_errf" 2>/dev/null || true
+      _GATE_GH_ERRF="$_sc_errf"
       while IFS= read -r _slug2; do
         [[ -n "$_slug2" ]] || continue
         _sc_total=$((_sc_total+1))
@@ -1696,8 +1706,18 @@ $_body" 2>/dev/null | sed 's/^.*|/#/' | head -3 | paste -sd, - || true)
                     --state open --limit 200 --json number,headRefName,title \
                     -q "[.[] | select((.title // \"\" | test(\"(^|[^A-Za-z0-9])${ident}([^A-Za-z0-9]|\$)\";\"i\")) or (.headRefName // \"\" | test(\"(^|[^A-Za-z0-9])${ident}([^A-Za-z0-9]|\$)\";\"i\"))) | .number] | .[0] // empty" \
                     2>/dev/null) && _sc_ok=$((_sc_ok+1)) || _hit=""
+        # Keep the FIRST failure's reason: it is the one an operator should read, and
+        # a `timeout`-killed call leaves an empty sink, which is itself the answer
+        # (the call never got far enough to be told anything).
+        if [[ -z "$_hit" && $_sc_ok -lt $_sc_total && -z "$_sc_err" ]]; then
+          _sc_err_slug="$_slug2"
+          _sc_err="$(head -c 400 "$_sc_errf" 2>/dev/null | tr '\n' ' ' || printf '')"
+          [[ -n "$_sc_err" ]] || _sc_err="the call produced no error text (killed by the gate's 5s timeout, or gh exited silently)"
+        fi
         if [[ -n "$_hit" ]]; then _auto_hit="$_hit"; _sc_hit_slug="$_slug2"; break; fi
       done < <(if [[ -n "$_task_slug" ]]; then printf '%s\n' "$_task_slug"; else _gate_repo_slugs; fi)
+      _GATE_GH_ERRF=""
+      rm -f "$_sc_errf" 2>/dev/null || true
       [[ $_sc_ok -eq $_sc_total && $_sc_total -gt 0 ]] && _scan_ran=1
       [[ -n "$_auto_hit" ]] && _scan_ran=1
     fi
@@ -1770,8 +1790,24 @@ $_body" 2>/dev/null | sed 's/^.*|/#/' | head -3 | paste -sd, - || true)
       # which an inert gate announces itself, so it has to say where the instrument
       # stopped. Without the seat, every reader generalises from their own.
       local _uv_why; _uv_why="$(_gate_tok_why)"
-      warn "$ident: merge-gate could not query GitHub ($_scan_why) — this close is UNVERIFIED, not verified-clean (DIVE-1935). Instrument: ${_uv_why}. Grade it with \`5dive task merge-gate-selftest\`."
-      _task_store_audit_log "task.merge-gate-unverified" ok 0 -- "$ident" "reason=$_scan_why" "seat=$(id -un 2>/dev/null || printf '?')"
+      # DIVE-4282: WHEN THE SCAN ITSELF FAILED, SAY WHAT IT FAILED ON. "could not
+      # query GitHub" is a statement about the credential, and on a seat that
+      # resolved one it sends the reader to audit an account that is fine — measured
+      # on a customer box where arm 4 RESOLVED, `gh` read the org's issues by hand,
+      # and the gate still printed 0-of-11 with no other sentence available. The
+      # credential wording is kept for the case it is actually true of: no rail
+      # answered because there was no rail.
+      local _uv_head="merge-gate could not query GitHub ($_scan_why)"
+      [[ -n "$_sc_err" ]] && _uv_head="merge-gate HELD a rail but the repo scan FAILED ($_scan_why) — first failure, ${_sc_err_slug}: ${_sc_err}"
+      warn "$ident: ${_uv_head} — this close is UNVERIFIED, not verified-clean (DIVE-1935). Instrument: ${_uv_why}. Grade it with \`5dive task merge-gate-selftest\`."
+      # The scan's own reason belongs on the AUDIT ROW too — the row is what a later
+      # sweep reads, and a reason that lives only in a warning on someone's terminal
+      # is gone by the time anyone triages the close. Built as an array: the text is
+      # gh's stderr and contains spaces, so an unquoted conditional expansion here
+      # would word-split it into a fistful of bogus audit fields.
+      local -a _uv_fields=("$ident" "reason=$_scan_why" "seat=$(id -un 2>/dev/null || printf '?')")
+      [[ -n "$_sc_err" ]] && _uv_fields+=("scan_err=${_sc_err_slug}: ${_sc_err}")
+      _task_store_audit_log "task.merge-gate-unverified" ok 0 -- "${_uv_fields[@]}"
       _mg_unverified="${_mg_unverified:+$_mg_unverified; }repo scan did not complete ($_scan_why)"
     fi
     # DIVE-1935: the PR reference the maker TYPED is a declaration too. DIVE-1922

--- a/tests/task_merge_gate_autodetect_unit.sh
+++ b/tests/task_merge_gate_autodetect_unit.sh
@@ -47,12 +47,23 @@ TMP="$(mktemp -d /tmp/gate-autodetect-unit.XXXXXX)"
 # an unstubbed harness reaches the HOST's real gh login and asserts against a live
 # credential the fleet does not have. No test here wants a real token.
 mkdir -p "$TMP/bin"
-printf '#!/usr/bin/env bash\nexit 1\n' >"$TMP/bin/sudo"
+# DIVE-4282 needs the OTHER seat shape too — no own gh login, but `sudo -u claude gh
+# auth token` RESOLVES (arm 4). That is the shape every managed customer box has, and
+# it is the one the 0-of-11 report came from. Default stays exit 1, so every arm
+# written before this one keeps the seat it was written against.
+cat >"$TMP/bin/sudo" <<'SUDOSTUB'
+#!/usr/bin/env bash
+[[ "${SUDO_STUB_MODE:-refused}" == "token" ]] || exit 1
+[[ "$*" == *"-l "* ]] && exit 1          # the bot rail stays unavailable
+printf '%s\n' "${SUDO_STUB_TOKEN:-claude-token}"
+SUDOSTUB
 chmod +x "$TMP/bin/sudo"
 cat >"$TMP/bin/gh" <<'STUB'
 #!/usr/bin/env bash
-printf 'ARGS=%s\n' "$*" >>"$GH_ARGS_LOG"
+printf 'TOKEN=%s ARGS=%s\n' "${GH_TOKEN:-}" "$*" >>"$GH_ARGS_LOG"
 if [[ "$1" == "auth" && "$2" == "token" ]]; then printf '%s\n' "${GH_STUB_AUTH_TOKEN:-}"; exit 0; fi
+# DIVE-4282: a repo that DECLINES the listing, with gh's own words on stderr.
+if [[ -n "${GH_STUB_FAIL:-}" ]]; then printf '%s\n' "$GH_STUB_FAIL" >&2; exit 1; fi
 # `pr list ... --json ...`: emit the fixture JSON array, let the caller's -q jq run.
 if [[ "$1" == "pr" && "$2" == "list" ]]; then
   # honour a simulated hang so the gate's `timeout 5s` can be exercised.
@@ -229,6 +240,94 @@ out=$(cmd_task_done DIVE-908 --result="close under test (DIVE-2773: a first clos
 [[ $rc -eq $E_CONFLICT && "$(statusof DIVE-908)" != "done" ]] \
   && ok_t "T8 declared delivery_ref still gated by the DIVE-1830 (fail-closed) path" \
   || bad_t "T8 declared path intact" "rc=$rc status=$(statusof DIVE-908) out=$out"
+
+# ── DIVE-4282: the scan's CREDENTIAL and the scan's FAILURE ────────────────────
+# The customer report was "arm 4 RESOLVED and the scan still returned 0 of 11", and
+# its suggested fix was "check whether the resolved token is handed to the scan, or
+# resolved and then dropped". T10 is that check, standing: it asserts the arm-4 token
+# reaches `gh` on every repo listing. MUTATION (run by hand, DIVE-4282): drop the
+# `"$_ghtok2"` argument at the _gate_gh call site in src/task/status.sh and T10 goes
+# red on the TOKEN= assertion while T11 stays green — the two arms are independent.
+#
+# The identity pin is load-bearing for the same reason the selftest harness carries
+# one: arm 4 only fires for a non-`claude` caller, and without the pin this grades
+# whoever runs it (DIVE-2484).
+_gate_caller_uid()    { printf '%s' "${CALLER_UID_STUB:-990002}"; }
+_gate_passwd_stream() {
+  printf '%s\n' "$(</etc/passwd)"
+  printf 'claude:x:990001:990001::/nonexistent:/bin/false\n'
+  printf 'agent-fixture:x:990002:990002::/nonexistent:/bin/false\n'
+}
+[[ "$(actor_caller_unix_name)" == "agent-fixture" ]] \
+  && ok_t "T10a the caller-identity pin lands (non-claude, so arm 4 is live)" \
+  || bad_t "T10a identity pin" "name=[$(actor_caller_unix_name)]"
+
+# The property is "whatever _gate_gh_token RESOLVED is what `gh` is invoked with",
+# which is independent of WHICH arm resolved it — so it is graded on an arm that runs
+# everywhere (arm 1), and then again on the customer's own arm 4 where the host allows
+# it. tests/lib/env_isolation.sh replaces `sudo` with a refusing FUNCTION on any host
+# whose PAM restores FIVE_* knobs from /etc/environment (DIVE-3096) — that neuters the
+# sudo stub, so the arm-4 case SKIPS WITH ITS REASON PRINTED rather than passing
+# vacuously. (Measured on this dev host 2026-09-11: the guard is installed, which is
+# also why T2/T5 of tests/task_merge_gate_selftest_unit.sh are red here on origin/main.)
+seed DIVE-910
+export GH_STUB_PRLIST='[]'
+export GH_STUB_AUTH_TOKEN=""
+: >"$GH_ARGS_LOG"
+out=$(GH_TOKEN="resolved-tok-4282" cmd_task_done DIVE-910 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
+scanned=$(grep -c 'ARGS=pr list' "$GH_ARGS_LOG")
+tokened=$(grep 'ARGS=pr list' "$GH_ARGS_LOG" | grep -c '^TOKEN=resolved-tok-4282 ')
+{ [[ $rc -eq 0 && "$(statusof DIVE-910)" == "done" ]] && (( scanned > 0 )) && (( tokened == scanned )); } \
+  && ok_t "T10 the RESOLVED token is handed to the scan — $tokened/$scanned repo listings carried it" \
+  || bad_t "T10 resolved token reaches the scan" "rc=$rc scanned=$scanned tokened=$tokened log=$(head -3 "$GH_ARGS_LOG")"
+[[ "$out" != *"UNVERIFIED"* ]] \
+  && ok_t "T10 a scan that answered on every repo closes verified-clean (no UNVERIFIED warning)" \
+  || bad_t "T10 clean close must not warn" "out=$out"
+
+if [[ "$(type -t sudo)" == "function" ]]; then
+  printf 'SKIP - T10b arm-4 hand-off: tests/lib/env_isolation.sh has replaced sudo with a refusing function on this host (DIVE-3096), so the arm-4 fixture cannot be built here. Runs on a host without the PAM knob restore.\n'
+else
+  seed DIVE-9101
+  : >"$GH_ARGS_LOG"
+  out=$(SUDO_STUB_MODE=token SUDO_USER="" cmd_task_done DIVE-9101 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
+  scanned=$(grep -c 'ARGS=pr list' "$GH_ARGS_LOG")
+  tokened=$(grep 'ARGS=pr list' "$GH_ARGS_LOG" | grep -c '^TOKEN=claude-token ')
+  { [[ $rc -eq 0 ]] && (( scanned > 0 )) && (( tokened == scanned )) && [[ "$out" != *"UNVERIFIED"* ]]; } \
+    && ok_t "T10b THE CUSTOMER SEAT: no own gh login, arm 4 (sudo -u claude) resolves — $tokened/$scanned listings carried that token and the close is verified-clean" \
+    || bad_t "T10b arm-4 token reaches the scan" "rc=$rc scanned=$scanned tokened=$tokened out=$out"
+fi
+
+# T11: THE SENTENCE THE OPERATOR READS. A held rail plus a failing listing used to
+# print "merge-gate could not query GitHub (partial-repo-scan-0-of-11)" — a statement
+# about the credential, on a box whose credential read the org's issues by hand. The
+# reason existed (gh wrote it to stderr) and died in the command substitution.
+seed DIVE-911
+: >"$GH_ARGS_LOG"
+out=$(GH_TOKEN="resolved-tok-4282" \
+      GH_STUB_FAIL="HTTP 403: API rate limit exceeded for user ID 4242 (https://api.github.com/repos/x)" \
+      cmd_task_done DIVE-911 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
+[[ $rc -eq 0 && "$(statusof DIVE-911)" == "done" ]] \
+  && ok_t "T11 fail-open intact: a scan whose every listing fails still does not stall the close" \
+  || bad_t "T11 fail-open on scan failure" "rc=$rc status=$(statusof DIVE-911)"
+{ [[ "$out" == *"repo scan FAILED"* ]] && [[ "$out" == *"rate limit exceeded"* ]] \
+  && [[ "$out" == *"partial-repo-scan-0-of-"* ]]; } \
+  && ok_t "T11 the warning NAMES what the scan failed on, not 'could not query GitHub'" \
+  || bad_t "T11 warning names the scan failure" "out=$out"
+[[ "$out" != *"could not query GitHub"* ]] \
+  && ok_t "T11 the credential wording is GONE from a close whose credential resolved" \
+  || bad_t "T11 credential wording must not appear" "out=$out"
+
+# T12: POSITIVE CONTROL for T11's wording swap — a seat with NO rail at all still
+# gets the original credential sentence. That case is the one it is true of, and a
+# fix that relabelled it too would have destroyed the distinction it exists to make.
+seed DIVE-912
+unset GH_STUB_FAIL
+out=$(SUDO_STUB_MODE=refused SUDO_USER="" GH_STUB_AUTH_TOKEN="" \
+      cmd_task_done DIVE-912 --result="close under test (DIVE-2773: a first close must carry a reason)" 2>&1); rc=$?
+{ [[ $rc -eq 0 ]] && [[ "$out" == *"could not query GitHub"* ]] && [[ "$out" == *"no-gh-token"* ]]; } \
+  && ok_t "T12 control: a seat holding NO rail still reads 'could not query GitHub (no-gh-token)'" \
+  || bad_t "T12 no-rail wording preserved" "rc=$rc out=$out"
+export GH_STUB_AUTH_TOKEN="tok"
 
 echo "-----"
 printf 'task_merge_gate_autodetect_unit: %d passed, %d failed\n' "$PASS" "$FAIL"

--- a/tests/task_merge_gate_result_pr_unit.sh
+++ b/tests/task_merge_gate_result_pr_unit.sh
@@ -293,11 +293,22 @@ run_done OK-4 --result='No PR here at all.'
 : >"$AUDIT_CALLS"
 seed LOUD-1
 GH_STUB_LIST_FAIL=1 run_done LOUD-1 --result='no pr named'
-if [[ $RC -eq 0 && "$OUT" == *"could not query GitHub"* ]] && grep -q "merge-gate-unverified" "$AUDIT_CALLS"; then
+# DIVE-4282: this seat HOLDS a token (GH_STUB_AUTH_TOKEN is set at the top of this
+# file) and the listing is the thing that fails, so the announcement is now the
+# scan-failure sentence rather than the credential one — the whole point of that
+# change, and LOUD-2 below still pins the credential wording for the seat it is true
+# of. The graded property is unchanged: ANNOUNCED and AUDITED, never a silent "clean".
+# The stub exits 1 with no stderr, so the named reason is the gate's own "no error
+# text" fallback, which is itself the honest answer for a call killed without a word.
+if [[ $RC -eq 0 && "$OUT" == *"repo scan FAILED"* && "$OUT" == *"partial-repo-scan-0-of-"* ]] \
+   && grep -q "merge-gate-unverified" "$AUDIT_CALLS"; then
   ok_t "a scan that could not run is announced + audited (not silently 'clean')"
 else
   bad_t "unverified scan must be loud + audited" "rc=$RC out=$OUT audit=$(cat "$AUDIT_CALLS")"
 fi
+grep -q "scan_err=" "$AUDIT_CALLS" \
+  && ok_t "DIVE-4282: the scan's own failure reason reaches the AUDIT ROW, not just the terminal" \
+  || bad_t "scan_err on the audit row" "audit=$(cat "$AUDIT_CALLS")"
 : >"$AUDIT_CALLS"
 seed LOUD-2
 GH_STUB_AUTH_TOKEN="" run_done LOUD-2 --result='no pr named'

--- a/tests/task_merge_gate_selftest_unit.sh
+++ b/tests/task_merge_gate_selftest_unit.sh
@@ -202,5 +202,40 @@ grep -q -- 'ls-remote <repo-url> refs/heads/main' "$CODE_NOCOMMENT" \
           "the ls-remote|grep -q form is still emitted" \
   || ok_t "T9 the tip-equality form is gone from the emitted refusal (kept only in a comment)"
 
+# --- T10 (DIVE-4282): A FAILING SELFTEST MUST NOT RENDER AS A CLI BUG. ---------
+# Reported from a customer box as "crashes under set -euo pipefail": the verb printed
+# its warnings and then `error: 5dive task exited 1 without reporting a reason. This
+# is a bug in the CLI`. It never crashed — lib/output.sh's EXIT backstop fires on any
+# non-zero exit that did not `mark_reported`, and this verb's whole contract is to
+# exit non-zero with a finding. So the one diagnostic the merge-gate warning tells an
+# operator to run answered them with a bug report.
+#
+# The assertion is on the FLAG the backstop reads, not on the backstop's text: the
+# trap only runs when the real process exits, which a sourced harness never does.
+JSON_MODE=0
+rm -f "$FIVE_REPORTED_FLAG" 2>/dev/null
+out=$(GH_TOKEN="" GITHUB_TOKEN="" SUDO_USER="" SUDO_STUB_MODE=refused SUDO_STUB_BOT=0 \
+      GH_STUB_STATE="" GH_STUB_AUTH_TOKEN="" cmd_task_merge_gate_selftest --pr="$CTRL" 2>&1); rc=$?
+{ [[ $rc -ne 0 ]] && [[ -e "$FIVE_REPORTED_FLAG" ]] && [[ "$out" == *"merge-gate selftest FAILED"* ]]; } \
+  && ok_t "T10 a blind seat's TEXT-mode finding marks itself reported (no 'bug in the CLI' overprint)" \
+  || bad_t "T10 text-mode finding must mark_reported" "rc=$rc flag=$([[ -e "$FIVE_REPORTED_FLAG" ]] && echo present || echo ABSENT) out=$out"
+
+# T10b: the same for --json, which takes the other return and had the same hole.
+rm -f "$FIVE_REPORTED_FLAG" 2>/dev/null
+out=$(JSON_MODE=1 GH_TOKEN="" GITHUB_TOKEN="" SUDO_USER="" SUDO_STUB_MODE=refused SUDO_STUB_BOT=0 \
+      GH_STUB_STATE="" GH_STUB_AUTH_TOKEN="" cmd_task_merge_gate_selftest --pr="$CTRL" 2>&1); rc=$?
+{ [[ $rc -ne 0 ]] && [[ -e "$FIVE_REPORTED_FLAG" ]]; } \
+  && ok_t "T10b the --json finding exit is marked reported too" \
+  || bad_t "T10b json finding must mark_reported" "rc=$rc out=$out"
+
+# T10c: POSITIVE CONTROL — a PASSING selftest is reported through `ok`, so the flag
+# is not simply always set by this harness's own earlier calls.
+rm -f "$FIVE_REPORTED_FLAG" 2>/dev/null
+out=$(JSON_MODE=1 GH_TOKEN="tok" GH_STUB_STATE="MERGED" cmd_task_merge_gate_selftest --pr="$CTRL" 2>&1); rc=$?
+[[ $rc -eq 0 ]] \
+  && ok_t "T10c control: the passing path still exits 0 (the fix did not change a verdict)" \
+  || bad_t "T10c passing path" "rc=$rc out=$out"
+JSON_MODE=0
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## What this fixes

Reported from `5dive-exact-swallow` (a wizard-provisioned customer box, v0.31.0 shakedown batch 3), two findings in one subsystem.

### 1. The scan's warning blamed the credential, because a count was all it had

Every `task done` on that box printed:

> `merge-gate could not query GitHub (partial-repo-scan-0-of-11) — this close is UNVERIFIED … [4 sudo -u claude gh auth token] RESOLVED`

…while `sudo -u claude gh issue list --repo 5dive-ai/5dive` answered normally from the same seat.

**The row's prescription does not hold on `main`, and that is worth stating plainly.** DO(1) was *"hand the arm-4-resolved token to the repo scan — the same `_gate_gh_token` → `_gate_gh` resolution the delivery-time tripwire uses"*. That is already what happens: `src/task/status.sh:1705` calls `_gate_gh "$_ghtok2" 5 pr list --repo "$_slug2" …` and `_gate_gh` runs `GH_TOKEN="$tok" gh …`. The new arm **T10** pins it — 11 of 11 repo listings carry the resolved token — and the mutation (delete the argument) turns exactly that arm red. So "resolved and then dropped" was a reasonable inference from the only sentence available, and it was wrong.

**What is actually dropped is the reason.** `_gate_gh` records why a call failed in `_GATE_GH_LAST_ERR` — a *variable* — and every counting caller invokes it inside a command substitution, i.e. a subshell. The per-repo error is destroyed one line after it is produced, the scan is left with a bare non-zero status, and from a status you can only derive a count. `0 of 11` then got wrapped in the one sentence that already existed, and that sentence is a claim about the credential.

Fix, and it is DIVE-3496 iteration 2's mechanism one level up (`_GATE_GH_NOCRED_ERRF`): **a file crosses the subshell boundary a variable cannot.**

* `_GATE_GH_ERRF` — opt-in sink, truncated at entry, written only on a failing call. Unset, nothing changes, so DIVE-2705's deliberate decision *not* to spray gh's stderr over healthy multi-repo closes is untouched.
* The scan names the first failing repo: *"merge-gate HELD a rail but the repo scan FAILED (partial-repo-scan-0-of-11) — first failure, `5dive-ai/5dive`: `HTTP 403: API rate limit exceeded …`"*, and the same text lands on the audit row as `scan_err=` (built as an array — it is gh's stderr and it contains spaces).
* A `timeout`-killed call leaves an empty sink; that prints as *"the call produced no error text (killed by the gate's 5s timeout, or gh exited silently)"*, which is the honest answer rather than a blank.
* **The credential wording survives for the seat it is true of** — no rail answered because there was no rail. T12 is the control for that, and it is the distinction the two sentences exist to make.

### 2. `task merge-gate-selftest` is not crashing under `set -euo pipefail`

It printed its diagnosis and then `error: 5dive task exited 1 without reporting a reason. This is a bug in the CLI`. The verb ran to completion and returned its verdict; `lib/output.sh`'s EXIT backstop fires on **any** non-zero exit that did not `mark_reported`, and this verb — whose entire contract is *exit non-zero with a finding* — never did. One line, the same line and the same reasoning `cmd_task_merge_unverified` already carries two functions below.

The cost is not the banner: the merge-gate's UNVERIFIED warning names this command as its remedy, so an operator following the instrument's own advice was handed a bug report — and told the effect was UNKNOWN, about a read-only probe that had just printed its result.

## Evidence

| suite | head | base (`origin/main`, same host) |
|---|---|---|
| `task_merge_gate_autodetect_unit` | **25/0** (+6 arms) | 19/0 |
| `task_merge_gate_selftest_unit` | 12 pass / **2 fail** (+3 arms) | 9 pass / **2 fail** — identical reds |
| `task_merge_gate_result_pr_unit` | 33 pass / **1 fail** (+1 arm) | 32 pass / **1 fail** — identical red |
| `blind_credential` 34/0 · `anon_rail` 31/0 · `repo_scope` 25/0 · `multirepo` 39/0 · `diagnostic` 20/0 · `gh_resolve` 7/0 · `owner_read_token` 33/0 · `deliver_merge_gate` 48/0 · `recorded_proof` 68/0 · `silent_nonzero_exit_backstop` 15/0 | | |

**The pre-existing reds are a host condition, not this diff.** `tests/lib/env_isolation.sh` replaces `sudo` with a refusing *function* on any host whose PAM restores `FIVE_*` from `/etc/environment` (DIVE-3096) — which neuters every sudo-stub arm in the gate family on this dev box. Baselined against a clean `origin/main` archive on the same host: byte-identical arm names fail. It is also why **T10b** — the arm-4 customer seat, no own gh login and `sudo -u claude` resolving — prints `SKIP` with that reason here rather than passing vacuously; it runs for real on a host without the knob restore.

**Mutations** (each restored after):

* delete the `"$_ghtok2"` argument at the scan call site → T10 red (`0/11 listings carried it`), T11 unaffected.
* delete the failure-path `_gate_gh_publish_err` → **only** T11's "names what the scan failed on" goes red; the fail-open and wording-swap arms stay green.

No new shellcheck findings (`-S warning`, diffed against base; the file-level SC2148/SC2140/SC1010 are pre-existing in these fragments).

## Residual, signed

**Why all 11 repos declined on that particular box is still unknown**, and cannot be derived from here — the reason existed only on that machine and the instrument discarded it before anyone could read it. That is what this change fixes rather than a gap in it: the next close on any box prints the scan's own words. The reporter's own "not checked" note (whether some of the 11 are invisible to that token) stays open the same way, and is now one close away from being answered instead of one inference.

The acceptance the row asks for — *`task done` on `5dive-exact-swallow` prints verified-clean* — is **not** claimed here and is not ownable from this seat: it depends on that box's actual failure, which may well be a rate limit or a visibility fact rather than anything in this code. What is claimed and graded: the token reaches the scan, the scan's failure is named, the no-rail wording is preserved, and the selftest completes with its verdict on every arm combination instead of a CLI-bug banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
