### PR TITLE
fix(audit): redact key=value secrets, not just --flag=value (DIVE-4297)

### DIFF
--- a/changelog.d/DIVE-4297.md
+++ b/changelog.d/DIVE-4297.md
@@ -1,0 +1,19 @@
+## Unreleased — fix(audit): redact key=value secrets, not just --flag=value (DIVE-4297)
+
+`audit_log` captured command arguments verbatim and redacted only a fixed list of `--flag=value`
+forms, so a secret passed as a POSITIONAL `key=value` argument reached
+`/var/log/5dive/agent-audit.log` in cleartext:
+
+    5dive agent config <seat> set telegram.token=<token>
+
+That log is `640 root:claude`, and group `claude` contains every agent seat on the box — so the
+value sat readable by every seat on the host indefinitely, with no rotation to age it out. Measured
+on the live log 2026-09-11: 2 bot-token-shaped values in 106,022 lines.
+
+The defect was the verbatim `args` capture, not the one subcommand that exposed it. Redaction now
+matches on the KEY NAME of any `key=value` argument — flagged or positional, any case, substring-wide
+(`*token*`, `*secret*`, `*key*`, `*password*`, `*passwd*`, `*credential*`) — rather than enumerating
+the verbs known to take a secret, which is a list the next such verb silently falls off.
+
+Operators should treat any `agent-audit.log` written before this release as holding cleartext
+credentials, and rotate anything that was passed positionally.

--- a/src/cmd_bug.sh
+++ b/src/cmd_bug.sh
@@ -190,8 +190,17 @@ _bug_sanitize_text() {
 # the caller wrote this line and re-reads it before filing. It removes the
 # common accident, and _bug_secret_scan below is the backstop that REFUSES
 # rather than silently rewriting when something token-shaped survives.
+#
+# DIVE-4297: the second expression is the mirror of audit_log's key-name rule.
+# The first expression alone required a leading `--`, so a positional
+# `telegram.token=<value>` — the exact shape that leaked into the audit log —
+# was filed to a PUBLIC issue verbatim. Key names are matched case-insensitively
+# and anywhere in the key, so `TELEGRAM.TOKEN=`, `api_key=` and `--auth-secret=`
+# are all covered; the key is kept and only the value replaced.
 _bug_redact_argv() {
-  printf '%s' "$1" | sed -E 's/(--(api-key|api_key|token|telegram-token|discord-token|code|password|secret|passwd)=)[^[:space:]]*/\1<redacted>/g'
+  printf '%s' "$1" \
+    | sed -E 's/(--(api-key|api_key|token|telegram-token|discord-token|code|password|secret|passwd)=)[^[:space:]]*/\1<redacted>/g' \
+    | sed -E 's/([^[:space:]=]*(token|secret|key|password|passwd|credential)[^[:space:]=]*=)[^[:space:]]*/\1<redacted>/gI'
 }
 
 # _bug_secret_scan <text> — returns 0 when the text carries something

--- a/src/lib/audit.sh
+++ b/src/lib/audit.sh
@@ -224,12 +224,44 @@ audit_log() {
   local -a sanitized=()
   local a
   for a in "$@"; do
+    # DIVE-4297: two rules, and the SECOND is the one that was missing.
+    #
+    # The first (the exact --flag= list) is kept verbatim so nothing that was
+    # redacted before stops being redacted. The second matches on the KEY NAME
+    # of any `key=value` argument — flagged or positional, any case — because
+    # the leak this row was filed for was neither a flag nor in that list:
+    #
+    #   5dive agent config <seat> set telegram.token=<real bot token>
+    #
+    # `telegram.token=` is a POSITIONAL key=value pair, so it fell straight
+    # through to the `*)` arm and was written to /var/log/5dive/agent-audit.log
+    # in cleartext, on a 640 root:claude file every agent seat on the box can
+    # read, indefinitely (2 such values measured in the live log on 2026-09-11).
+    #
+    # Matching the key name rather than enumerating verbs is deliberate: the
+    # defect is the verbatim `args` capture, so a fix that only knew about
+    # `telegram.token` would be re-earned by the next verb that takes a secret
+    # as an argument. The KEY is kept and only the VALUE replaced, so the row
+    # still answers "what was set" — an audit line that lost the key name would
+    # trade one blind spot for another.
+    #
+    # Deliberately a denylist, and deliberately a wide one: over-redacting an
+    # argument named `--sort-key=name` costs a reader one field, under-redacting
+    # a credential costs a rotation. It is not a completeness claim — a secret
+    # passed under a key name carrying none of these words is still recorded,
+    # which is why the real rule remains "do not pass secrets as arguments".
     case "$a" in
       --api-key=*|--telegram-token=*|--discord-token=*|--code=*|--token=*)
-        sanitized+=("${a%%=*}=<redacted>") ;;
-      *)
-        sanitized+=("$a") ;;
+        sanitized+=("${a%%=*}=<redacted>"); continue ;;
     esac
+    if [[ "$a" == *=* ]]; then
+      local _k="${a%%=*}"
+      case "${_k,,}" in
+        *token*|*secret*|*key*|*password*|*passwd*|*credential*)
+          sanitized+=("$_k=<redacted>"); continue ;;
+      esac
+    fi
+    sanitized+=("$a")
   done
   # DIVE-2073: `unknown` used to mean TWO different things and the reader could
   # not tell them apart — "this process genuinely has no invoking user" (root

--- a/tests/audit_key_value_secret_redaction_unit.sh
+++ b/tests/audit_key_value_secret_redaction_unit.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# DIVE-4297 — a secret passed as a `key=value` ARGUMENT was written to
+# /var/log/5dive/agent-audit.log in cleartext.
+#
+# WHAT LEAKED. `audit_log` redacted a fixed list of `--flag=value` forms
+# (--api-key=, --telegram-token=, --discord-token=, --code=, --token=) and
+# nothing else. `5dive agent config <seat> set telegram.token=<token>` passes
+# the credential as a POSITIONAL `key=value` pair, so it matched none of them
+# and was recorded verbatim. The log is 640 root:claude and group `claude`
+# contains every agent seat on the box, so two live bot tokens sat readable by
+# every seat, indefinitely (measured 2026-09-11 in a 105,949-line log).
+#
+# The defect is the VERBATIM `args` capture, not the one subcommand — so what
+# is pinned here is the key-name rule, not a list of verbs:
+#   1. a positional `telegram.token=` is redacted, KEY KEPT (the audit row must
+#      still say what was set);
+#   2. the old --flag= list still redacts (no regression from the rewrite);
+#   3. the key-name rule is case-insensitive and matches anywhere in the key,
+#      so TELEGRAM.TOKEN=, api_key=, --auth-secret=, db_password= are covered;
+#   4. an ordinary `key=value` argument carrying no sensitive word is NOT
+#      touched — over-redaction that ate `channels=telegram` would make the
+#      audit log useless and the fix would be reverted;
+#   5. a bare word that merely CONTAINS a sensitive name but has no `=` is left
+#      alone (`token`, `set`) — there is no value to hide;
+#   6. cmd_bug.sh's _bug_redact_argv mirrors the same rule, because that string
+#      is bound for a PUBLIC GitHub issue.
+# Run: bash tests/audit_key_value_secret_redaction_unit.sh   (no root, no network)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/audit-kv-redaction.XXXXXX)"
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq absent"; exit 0; }
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/audit.sh; do
+  source "$SRC/$f"
+done
+set +e   # AFTER sourcing: header.sh turns `set -e` back on.
+
+# Suite guard (same shape as audit_nonroot_unit.sh): prove this run never
+# appended to the fleet's real audit log, which is the file this row is about.
+REALLOG=/var/log/5dive/agent-audit.log
+REALLOG_OFFSET=0
+[[ -r "$REALLOG" ]] && REALLOG_OFFSET=$(wc -c <"$REALLOG" 2>/dev/null || echo 0)
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+AUDIT_LOG="$TMP/agent-audit.log"; : > "$AUDIT_LOG"
+mkdir -p "$TMP/notify"
+
+# A reserved FAKE in the Telegram bot-token SHAPE (<digits>:<35 chars>), never a
+# real credential: 1234567890 is the reserved test id, and the secret half is
+# filler. The shape matters because case 1 also re-greps for it the way the row
+# says to verify on the live log.
+FAKE='1234567890:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+
+# args_of <n> — the args[] array of the n-th (1-based) row, one element per line.
+args_of() { sed -n "${1}p" "$AUDIT_LOG" | jq -r '.args[]' 2>/dev/null; }
+
+# --- case 1: the leak itself — positional telegram.token= ----------------------
+audit_log "agent config" ok 0 -- draft-codex set "telegram.token=$FAKE" channels=telegram
+got=$(args_of 1)
+if [[ "$got" != *"$FAKE"* ]] \
+   && grep -qx 'telegram.token=<redacted>' <<<"$got" \
+   && grep -qx 'channels=telegram' <<<"$got"; then
+  ok_t "case 1: positional telegram.token= redacted, key kept, neighbours intact"
+else
+  bad_t "case 1: positional telegram.token= redacted, key kept, neighbours intact" "$got"
+fi
+
+# The row-body verification, run against the harness log instead of the live one:
+# nothing token-SHAPED survives anywhere in the line.
+if ! grep -qE '[0-9]{8,10}:[A-Za-z0-9_-]{30,}' "$AUDIT_LOG"; then
+  ok_t "case 1b: no token-shaped value survives anywhere in the written row"
+else
+  bad_t "case 1b: no token-shaped value survives anywhere in the written row" "$(cat "$AUDIT_LOG")"
+fi
+
+# --- case 2: the pre-existing --flag= list still redacts (no regression) -------
+: > "$AUDIT_LOG"
+audit_log "agent create" ok 0 -- bot --api-key="$FAKE" --telegram-token="$FAKE" \
+  --discord-token="$FAKE" --code="$FAKE" --token="$FAKE"
+got=$(args_of 1)
+if [[ "$got" != *"$FAKE"* ]] \
+   && [[ $(grep -c '=<redacted>$' <<<"$got") -eq 5 ]]; then
+  ok_t "case 2: all five legacy --flag= forms still redacted"
+else
+  bad_t "case 2: all five legacy --flag= forms still redacted" "$got"
+fi
+
+# --- case 3: key-name rule is case-insensitive and substring-wide --------------
+: > "$AUDIT_LOG"
+audit_log "probe" ok 0 -- "TELEGRAM.TOKEN=$FAKE" "api_key=$FAKE" "--auth-secret=$FAKE" \
+  "db_password=$FAKE" "aws.credential=$FAKE" "--sort-key=name"
+got=$(args_of 1)
+missing=""
+for want in 'TELEGRAM.TOKEN=<redacted>' 'api_key=<redacted>' '--auth-secret=<redacted>' \
+            'db_password=<redacted>' 'aws.credential=<redacted>' '--sort-key=<redacted>'; do
+  grep -qx -- "$want" <<<"$got" || missing="$missing $want"
+done
+if [[ "$got" != *"$FAKE"* ]] && [[ -z "$missing" ]]; then
+  ok_t "case 3: key-name rule is case-insensitive, substring-wide, value-only"
+else
+  bad_t "case 3: key-name rule is case-insensitive, substring-wide, value-only" \
+        "missing:$missing | got: $got"
+fi
+
+# --- case 4: ordinary key=value arguments are NOT redacted --------------------
+# The failure mode that would get this fix reverted: an audit log that records
+# `<redacted>` for every argument records nothing.
+: > "$AUDIT_LOG"
+audit_log "task add" ok 0 -- --title=fix --priority=high status=todo assignee=ops DIVE-4297
+got=$(args_of 1)
+if [[ "$got" != *'<redacted>'* ]] \
+   && grep -qx -- '--priority=high' <<<"$got" \
+   && grep -qx 'assignee=ops' <<<"$got"; then
+  ok_t "case 4: ordinary key=value args are left verbatim"
+else
+  bad_t "case 4: ordinary key=value args are left verbatim" "$got"
+fi
+
+# --- case 5: a sensitive WORD with no `=` is untouched -------------------------
+: > "$AUDIT_LOG"
+audit_log "agent config" ok 0 -- draft-codex set token secret-santa --keyring
+got=$(args_of 1)
+if [[ "$got" != *'<redacted>'* ]] && grep -qx 'token' <<<"$got" \
+   && grep -qx 'secret-santa' <<<"$got" && grep -qx -- '--keyring' <<<"$got"; then
+  ok_t "case 5: bare words carrying a sensitive name but no value are untouched"
+else
+  bad_t "case 5: bare words carrying a sensitive name but no value are untouched" "$got"
+fi
+
+# --- case 6: cmd_bug.sh's mirror covers the same shape ------------------------
+# That string goes to a PUBLIC issue, so the bar is the same or higher. Sourced
+# in a subshell: cmd_bug.sh pulls in more of the tree than this harness wants.
+mirror=$(
+  # shellcheck disable=SC1090
+  source "$SRC/cmd_bug.sh" >/dev/null 2>&1
+  _bug_redact_argv "5dive agent config draft-codex set telegram.token=$FAKE channels=telegram"
+)
+if [[ -n "$mirror" && "$mirror" != *"$FAKE"* ]] \
+   && [[ "$mirror" == *'telegram.token=<redacted>'* ]] \
+   && [[ "$mirror" == *'channels=telegram'* ]]; then
+  ok_t "case 6: _bug_redact_argv mirrors the positional key=value rule"
+else
+  bad_t "case 6: _bug_redact_argv mirrors the positional key=value rule" "$mirror"
+fi
+
+# --- suite guard: the real fleet log was never written -------------------------
+now=0
+[[ -r "$REALLOG" ]] && now=$(wc -c <"$REALLOG" 2>/dev/null || echo 0)
+if [[ "$now" == "$REALLOG_OFFSET" ]]; then
+  ok_t "guard: the live /var/log/5dive/agent-audit.log was not appended to"
+else
+  bad_t "guard: the live /var/log/5dive/agent-audit.log was not appended to" \
+        "grew ${REALLOG_OFFSET} -> ${now}"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## The leak

`audit_log` (`src/lib/audit.sh`) redacted exactly five `--flag=value` forms —
`--api-key=`, `--telegram-token=`, `--discord-token=`, `--code=`, `--token=` — and wrote every
other argument verbatim. A secret passed as a **positional `key=value`** pair matched none of them:

```
5dive agent config <seat> set telegram.token=<real bot token>
```

`/var/log/5dive/agent-audit.log` is `640 root:claude`, and group `claude` contains every agent seat
on this box, so the value was readable by every seat, indefinitely.

**Blast radius (re-measured at head, 2026-09-11):** 2 bot-token-shaped values in 106,022 lines;
no rotated/older audit logs (single live file). Both are `agent config … set telegram.token=…`
lines for now-retired seats. No token value was read into this branch, a row, or this PR.
Rotation was handled human-side out-of-band (`human:y00212`, 2026-09-11 08:24) — this PR is the
write-site fix only.

## The fix

The defect is the **verbatim `args` capture**, not the one subcommand, so the new rule matches on
the **key name** of any `key=value` argument — flagged or positional, any case, substring-wide
(`*token*`, `*secret*`, `*key*`, `*password*`, `*passwd*`, `*credential*`) — rather than
enumerating verbs. Fixing only `telegram.token` would be re-earned by the next verb that takes a
secret as an argument.

- **The key is kept, only the value is replaced.** An audit row that lost the key name would trade
  one blind spot for another — the row must still say *what* was set.
- **The old `--flag=` list runs first, verbatim.** Nothing that was redacted before stops being
  redacted.
- **`cmd_bug.sh:_bug_redact_argv` gets the same rule** as a second `sed` expression. It required a
  leading `--` too, and that string is bound for a **public** GitHub issue, so the bar there is at
  least as high.

It is deliberately a wide **denylist**, and deliberately not a completeness claim: over-redacting
`--sort-key=name` costs a reader one field, under-redacting a credential costs a rotation. A secret
under a key name carrying none of those words is still recorded — the standing rule remains *do not
pass secrets as arguments*.

## Evidence

`tests/audit_key_value_secret_redaction_unit.sh` (new, 8 arms, no root / no network):

1. the leak itself — positional `telegram.token=` redacted, key kept, `channels=telegram` intact;
   1b. nothing token-**shaped** survives anywhere in the written row (the row's own verify grep);
2. all five legacy `--flag=` forms still redacted (no regression from the rewrite);
3. key rule is case-insensitive and substring-wide (`TELEGRAM.TOKEN=`, `api_key=`,
   `--auth-secret=`, `db_password=`, `aws.credential=`);
4. **over-reach guard** — `assignee=ops`, `--priority=high`, `status=todo` stay verbatim. A log that
   records `<redacted>` for everything records nothing;
5. a bare sensitive word with no `=` (`token`, `secret-santa`, `--keyring`) is untouched;
6. `_bug_redact_argv` mirrors the positional rule;
   plus a suite guard proving the run never appended to the live fleet log.

```
new test on this branch      : 8 passed, 0 failed
NEGATIVE CONTROL, origin/main @ fec70af0 (same test file, unfixed tree)
                             : 4 passed, 4 FAILED  (cases 1, 1b, 3, 6)
regression set, all green    : audit_nonroot_unit 7/0 · audit_exit_trap_row_unit 8/0
                               bug_report_pii_allowlist_unit 47/0 · agent_send_audit_unit 18/0
                               audit_task_store_classification_unit 1/0 · gate_answer_audit_unit 12/0
```

Every token value in the harness is the reserved fixture shape (`1234567890:AAAA…`), never a real
credential.

## What this PR does NOT do

- **The row's live-box verify step is still owed and is owed to the RELEASE, not to this diff.**
  `5dive-cli` is not auto-deploying, and the installed CLI on this host is `0.31.0`, so
  `5dive agent config <seat> set telegram.token=<fake>` would exercise the *unfixed* writer and
  append a fixture token to the production audit log for no information — case 1/1b reproduce that
  path in isolation instead. Re-run it on a box once this is cut and installed.
- **Log mode (DO #4) is deliberately left at `640 root:claude`.** Tightening to `600 root:root`
  blinds every agent's own `5dive trace` / audit reads — it removes the *readers*, not the
  *secret*. The secret belongs redacted at the write site, which is what this change does.
  Confirmed as ops; olivia's recommendation on the row, unchanged.
- Pre-fix history in the live log is untouched: the two rows remain, and are covered by the
  out-of-band rotation rather than by editing a tamper-evident log.

Closes DIVE-4297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
