### PR TITLE
fix(task): protect grader pending ownership (DIVE-4281)

### DIFF
--- a/changelog.d/DIVE-4281.md
+++ b/changelog.d/DIVE-4281.md
@@ -1,3 +1,3 @@
-### Fixed
+## Unreleased — fix(task): protect grader pending ownership (DIVE-4281)
 
 - Make the ephemeral grader lane classify only delivered, ungraded handoffs as pending, retire resolved requests, and refuse to reassign an active non-pool owner.

--- a/changelog.d/DIVE-4281.md
+++ b/changelog.d/DIVE-4281.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Make the ephemeral grader lane classify only delivered, ungraded handoffs as pending, retire resolved requests, and refuse to reassign an active non-pool owner.

--- a/src/task/grader_pool.sh
+++ b/src/task/grader_pool.sh
@@ -353,6 +353,59 @@ _grader_can_read() {  # <seat> <ident>
 # A customer-facing flow does not ship while its end-to-end arm is owed; this
 # one's arm is owed, so the surface ships dark rather than waiting in a branch.
 _GRADER_POOL="${_GRADER_POOL:-}"
+
+# Return the current working owner when assigning this row to a pool seat would
+# steal an active claim.  This is deliberately derived again in
+# `_grader_spawn_session`: the tick's plan and the eventual fleet mutation are
+# separated by several probes, and the owner may change between them.
+_grader_non_pool_working_owner() {  # <ident>
+  local ident="$1" row status owner seat
+  [[ -n "$ident" ]] || return 1
+  row=$(db "SELECT status||x'1f'||COALESCE(assignee,'') FROM tasks
+             WHERE ident=$(sqlq "$ident");" 2>/dev/null || printf '')
+  status="${row%%$'\x1f'*}"
+  owner="${row#*$'\x1f'}"
+  [[ "$row" == *$'\x1f'* && "$status" == "in_progress" && -n "$owner" ]] || return 1
+  for seat in $_GRADER_POOL; do
+    [[ "$owner" == "$seat" ]] && return 1
+  done
+  printf '%s' "$owner"
+}
+
+_grader_row_is_in_progress() {  # <ident>
+  [[ "$(db "SELECT status FROM tasks WHERE ident=$(sqlq "$1");" 2>/dev/null || printf '')" == "in_progress" ]]
+}
+
+# Close the durable request records whose answer is already known.  Dry-run
+# remains read-only: the pending query below independently excludes these rows,
+# while --commit appends the supersession receipt that prevents future readers
+# from repeatedly re-deriving the same stale request.
+_grader_supersede_resolved_requests() {
+  local rows req_id ident
+  rows=$(db "SELECT e.id||x'1f'||e.ident
+               FROM lifecycle_events e
+               JOIN tasks t ON t.ident=e.ident
+              WHERE e.kind='task.grade.requested'
+                AND NOT EXISTS (
+                      SELECT 1 FROM lifecycle_events n
+                       WHERE n.ident=e.ident AND n.id>e.id
+                         AND n.kind IN ('task.grade.requested','task.grade.spawned',
+                                        'task.grade.request.superseded'))
+                AND (
+                      t.status IN ('done','cancelled')
+                   OR t.handoff_delivered_at IS NULL
+                   OR t.handoff_rejected_at IS NOT NULL
+                   OR (t.graded_verdict_at IS NOT NULL AND t.graded_verdict_at>=e.ts)
+                   OR (t.graded_verdict_at IS NULL AND t.graded_at IS NOT NULL AND t.graded_at>=e.ts)
+                )
+              ORDER BY e.id;" 2>/dev/null || printf '')
+  while IFS=$'\x1f' read -r req_id ident; do
+    [[ "$req_id" =~ ^[0-9]+$ && -n "$ident" ]] || continue
+    ledger_emit task.grade.request.superseded ident="$ident" actor="$(task_actor "")" \
+      detail="grade request ${req_id} superseded by current row state" || true
+  done <<<"$rows"
+}
+
 cmd_task_grader_tick() {
   local commit=0 cap="$_GRADER_MAX_PER_ACCOUNT" json="${JSON_MODE:-0}" only=""
   while (( $# )); do
@@ -374,20 +427,30 @@ cmd_task_grader_tick() {
   done
   [[ "$cap" =~ ^[0-9]+$ ]] || fail "$E_VALIDATION" "--cap takes a whole number"
 
-  # Pending = a request with no later spawn record, whose row is still open.
+  # Pending means the LATEST request is still a delivered, ungraded handoff.
+  # A legacy grade may have no graded_verdict_at, so graded_at is its fallback.
+  # >= is intentional: both clocks have one-second precision, and a verdict in
+  # the request's second must fail closed rather than purchase a duplicate grade.
+  (( commit )) && _grader_supersede_resolved_requests
   local pending
-  pending=$(db "SELECT DISTINCT e.ident FROM lifecycle_events e
+  pending=$(db "SELECT e.ident FROM lifecycle_events e
                   JOIN tasks t ON t.ident = e.ident
                  WHERE e.kind='task.grade.requested'
-                   AND t.status NOT IN ('done','cancelled')
-                   AND NOT EXISTS (SELECT 1 FROM lifecycle_events s
-                                    WHERE s.ident=e.ident AND s.kind='task.grade.spawned'
-                                      AND s.id > e.id)
+                   AND t.handoff_delivered_at IS NOT NULL
+                   AND t.handoff_rejected_at IS NULL
+                   AND NOT (t.graded_verdict_at IS NOT NULL AND t.graded_verdict_at >= e.ts)
+                   AND NOT (t.graded_verdict_at IS NULL AND t.graded_at IS NOT NULL AND t.graded_at >= e.ts)
+                   AND ((t.status='todo' AND (t.assignee IS NULL OR t.assignee=t.verifier))
+                        OR (t.status='in_progress' AND COALESCE(t.assignee,'')<>''))
+                   AND NOT EXISTS (SELECT 1 FROM lifecycle_events n
+                                    WHERE n.ident=e.ident AND n.id > e.id
+                                      AND n.kind IN ('task.grade.requested','task.grade.spawned',
+                                                     'task.grade.request.superseded'))
                  ORDER BY e.id;" 2>/dev/null || printf '')
 
   local usage="" ; usage=$($_GRADER_USAGE_CMD 2>/dev/null || printf '')
   local n_pending=0 n_spawn=0 n_queue=0 n_refuse=0 plan=""
-  local inflight; inflight=$(db "SELECT COUNT(*) FROM lifecycle_events s
+  local inflight; inflight=$(db "SELECT COUNT(DISTINCT s.ident) FROM lifecycle_events s
                                   WHERE s.kind='task.grade.spawned'
                                     AND NOT EXISTS (SELECT 1 FROM lifecycle_events d
                                                      WHERE d.ident=s.ident
@@ -399,6 +462,26 @@ cmd_task_grader_tick() {
   while IFS= read -r ident; do
     [[ -n "$ident" ]] || continue
     [[ -z "$only" || "$ident" == "$only" ]] || continue
+    local working_owner=""
+    working_owner=$(_grader_non_pool_working_owner "$ident" 2>/dev/null || printf '')
+    if [[ -n "$working_owner" ]]; then
+      n_refuse=$((n_refuse+1))
+      plan+="skip    $ident  (owner is $working_owner, not a pool seat)"$'\n'
+      if (( commit )); then
+        local _owner_req
+        _owner_req=$(db "SELECT id FROM lifecycle_events
+                          WHERE ident=$(sqlq "$ident") AND kind='task.grade.requested'
+                          ORDER BY id DESC LIMIT 1;" 2>/dev/null || printf '')
+        [[ "$_owner_req" =~ ^[0-9]+$ ]] && \
+          ledger_emit task.grade.request.superseded ident="$ident" actor="$(task_actor "")" \
+            detail="grade request ${_owner_req} superseded: owner is ${working_owner}, not a pool seat" || true
+      fi
+      continue
+    fi
+    # A pool seat already holding the claim IS the grader in flight; asking the
+    # lane for a second session would duplicate work even though no verdict has
+    # landed yet. Non-pool claims took the explicit safety line above.
+    _grader_row_is_in_progress "$ident" && continue
     n_pending=$((n_pending+1))
     # DIVE-4251: THE POLICY IS CHECKED FIRST, before the cap, the meter and the
     # credential probe — a row the customer's box grants no grader must cost this
@@ -481,6 +564,12 @@ cmd_task_grader_tick() {
 _grader_spawn_session() {  # <seat> <ident>
   local seat="$1" ident="$2"
   [[ -n "$seat" && -n "$ident" ]] || return 1
+  local working_owner=""
+  working_owner=$(_grader_non_pool_working_owner "$ident" 2>/dev/null || printf '')
+  if [[ -n "$working_owner" ]]; then
+    warn "$ident: skip — owner is $working_owner, not a pool seat"
+    return 2
+  fi
   5dive task assign "$ident" "$seat" >/dev/null 2>&1 || return 1
   5dive agent send "$seat" "Grade delivered task ${ident}. Read the row, grade the delivery, then run 5dive task done or 5dive task reject. Checkpoint each verified arm to the row as you go." >/dev/null 2>&1
 }

--- a/tests/grader_pending_state_unit.sh
+++ b/tests/grader_pending_state_unit.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# DIVE-4281 — pending means delivered-and-ungraded, and a stale request may not
+# steal an in-progress row from its maker.
+set -uo pipefail
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+cd "$(dirname "$0")/.."
+. "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
+
+SRC=src
+TMP="$(mktemp -d /tmp/grader-pending.XXXXXX)"
+trap 'rc=$?; rm -rf "$TMP"; echo "HARNESS-RC=$rc"' EXIT
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/broker.sh lib/audit.sh \
+         lib/registry.sh lib/disk.sh lib/verify_policy.sh lib/tasks_db.sh \
+         lib/actor.sh cmd_task.sh cmd_push.sh cmd_org.sh cmd_project.sh; do
+  # shellcheck disable=SC1090
+  source "$SRC/$f"
+done
+source "$SRC/task/grader_pool.sh"
+
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+BOX_CONFIG="$TMP/box.json"; JSON_MODE=0
+mkdir -p "$TASKS_DIR"
+printf '{"verify":"always"}\n' > "$BOX_CONFIG"
+set +e
+PASS=0; FAILN=0
+ok_t()  { PASS=$((PASS+1));  printf 'ok   - %s\n' "$1"; }
+bad_t() { FAILN=$((FAILN+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+tasks_db_init >/dev/null 2>&1
+
+seed() { # <status> <assignee> -> ident
+  local status="$1" assignee="$2" title="grader pending $RANDOM"
+  db "INSERT INTO tasks
+        (title,status,assignee,verifier,maker_agent,kind,priority,created_by,
+         handoff_delivered_at,delivery_ref)
+      VALUES ($(sqlq "$title"),$(sqlq "$status"),$(sqlq_or_null "$assignee"),
+              'quinn','dev','standard','high','main','2026-01-01 00:00:00',
+              'https://github.com/o/r/pull/1');" >/dev/null
+  db "SELECT ident FROM tasks ORDER BY id DESC LIMIT 1;"
+}
+request() { # <ident> <timestamp>
+  db "INSERT INTO lifecycle_events (ts,kind,ident,actor,idem_key,detail)
+      VALUES ($(sqlq "$2"),'task.grade.requested',$(sqlq "$1"),'sys',
+              $(sqlq "request-$1-$RANDOM"),'fixture');" >/dev/null
+}
+
+UNGRADED=$(seed todo quinn); request "$UNGRADED" '2026-01-01 00:01:00'
+GRADED=$(seed todo quinn); request "$GRADED" '2026-01-01 00:01:00'
+db "UPDATE tasks SET graded_at='2026-01-01 00:02:00', graded_by='quinn',
+                     graded_verdict='pass', graded_verdict_at='2026-01-01 00:02:00'
+      WHERE ident=$(sqlq "$GRADED");" >/dev/null
+OWNER=$(seed in_progress dev); request "$OWNER" '2026-01-01 00:01:00'
+POOL_WORKING=$(seed in_progress quinn); request "$POOL_WORKING" '2026-01-01 00:01:00'
+
+# A finished grade session is not in flight, even with duplicate historical
+# spawn receipts for the same task.
+FINISHED=$(seed done quinn)
+db "INSERT INTO lifecycle_events (ts,kind,ident,actor,idem_key,detail) VALUES
+    ('2026-01-01 00:01:00','task.grade.spawned',$(sqlq "$FINISHED"),'sys','spawn-a','fixture'),
+    ('2026-01-01 00:02:00','task.grade.spawned',$(sqlq "$FINISHED"),'sys','spawn-b','fixture'),
+    ('2026-01-01 00:03:00','task.done',$(sqlq "$FINISHED"),'quinn','done-a','fixture');" >/dev/null
+
+_GRADER_POOL="quinn main2"
+_GRADER_USAGE_CMD=_gp_usage
+_gp_usage(){ printf '{"agents":[{"account":"a","name":"quinn","fiveHourPct":1,"sevenDayPct":1}]}'; }
+_grader_can_read(){ return 0; }
+
+# BODY-ONLY means body-only: no second request may appear on a graded row.
+before=$(db "SELECT COUNT(*) FROM lifecycle_events WHERE ident=$(sqlq "$GRADED") AND kind='task.grade.requested';")
+cmd_task_set_body "$GRADED" --append 'operator note only' >/dev/null 2>&1
+after=$(db "SELECT COUNT(*) FROM lifecycle_events WHERE ident=$(sqlq "$GRADED") AND kind='task.grade.requested';")
+[[ "$before" == 1 && "$after" == "$before" ]] \
+  && ok_t 'body append on a graded row emits no new grade request' \
+  || bad_t 'body append does not request a grade' "before=$before after=$after"
+
+# Dry-run is the externally consumed classification: the graded row vanishes,
+# the genuinely ungraded delivery spawns, and the active maker is an explicit
+# skip rather than an assignment target.
+out=$(cmd_task_grader_tick --cap=1 2>/dev/null)
+grep -q "spawn   $UNGRADED" <<<"$out" \
+  && ok_t 'delivered row with no later verdict is pending' \
+  || bad_t 'ungraded row is pending' "$out"
+grep -q "$GRADED" <<<"$out" \
+  && bad_t 'graded row is not pending' "$out" \
+  || ok_t 'recorded PASS after request is not pending'
+grep -q "skip    $OWNER  (owner is dev, not a pool seat)" <<<"$out" \
+  && ok_t 'in-progress non-pool owner gets the required skip line' \
+  || bad_t 'owner skip line' "$out"
+grep -q "$POOL_WORKING" <<<"$out" \
+  && bad_t 'pool seat already grading is not pending again' "$out" \
+  || ok_t 'pool seat already holding the claim is not double-spawned'
+grep -q 'cap 1 reached' <<<"$out" \
+  && bad_t 'spawned plus later done counts as zero in flight' "$out" \
+  || ok_t 'spawned plus later done counts as zero in flight'
+grep -q 'pending=1 spawn=1 queue=0 dark=1' <<<"$out" \
+  && ok_t 'summary counts only the eligible delivery as pending' \
+  || bad_t 'pending summary excludes owner and grade' "$out"
+
+# Defence in depth at the mutation boundary itself: even if a caller bypasses
+# the planner, _grader_spawn_session must refuse before either fleet verb.
+CALLS="$TMP/calls"; : > "$CALLS"
+5dive(){ printf '%s\n' "$*" >> "$CALLS"; }
+spawn_out=$(_grader_spawn_session quinn "$OWNER" 2>&1); spawn_rc=$?
+[[ $spawn_rc -ne 0 && ! -s "$CALLS" ]] \
+  && ok_t 'spawn primitive refuses before task assign or agent send' \
+  || bad_t 'spawn primitive cannot steal owner' "rc=$spawn_rc calls=$(cat "$CALLS") out=$spawn_out"
+
+# Commit turns the already-known verdict into an append-only supersession
+# receipt; the row still remains absent from the plan.
+cmd_task_grader_tick --commit --only="$GRADED" --json >/dev/null 2>&1
+sup=$(db "SELECT COUNT(*) FROM lifecycle_events WHERE ident=$(sqlq "$GRADED")
+          AND kind='task.grade.request.superseded';")
+[[ "$sup" == 1 ]] \
+  && ok_t 'commit marks the resolved request superseded' \
+  || bad_t 'resolved request has a supersession receipt' "count=$sup"
+
+printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$PASS" "$FAILN"
+[[ "$FAILN" == 0 ]]

--- a/tests/grader_tick_unit.sh
+++ b/tests/grader_tick_unit.sh
@@ -158,6 +158,24 @@ out=$(run --cap=5 --commit)
   || bad_ 'both locks off spawns 3' "got: $(spawns)"
 grep -q 'task.grade.spawned' "$EMITF" && ok_ 'records task.grade.spawned' || bad_ 'records spawn' "$(emits)"
 
+# ── an active non-pool owner is never reassigned ────────────────────────────
+# The query may encounter a stale request while its maker is already working
+# again.  This guard runs before the cap/meter/read probes and must explain the
+# refusal in the plan, not quietly turn the row into a verifier assignment.
+_grader_non_pool_working_owner(){ [[ "$1" == DIVE-2 ]] && printf 'dev'; }
+out=$(run --cap=5 --commit)
+grep -q 'skip    DIVE-2  (owner is dev, not a pool seat)' <<<"$out" \
+  && ok_ 'OWNER: plan names the non-pool working owner' \
+  || bad_ 'owner skip line' "$out"
+grep -q ':DIVE-2$' "$SPAWNF" \
+  && bad_ 'OWNER: active maker is never assigned away' "$(spawns)" \
+  || ok_ 'OWNER: active maker is never assigned away'
+[[ "$(grep -c . "$SPAWNF")" == 2 ]] \
+  && ok_ 'OWNER control: other pending rows still spawn' \
+  || bad_ 'owner control spawns the other rows' "$(spawns)"
+_grader_non_pool_working_owner(){ return 1; }
+_grader_row_is_in_progress(){ return 1; }
+
 # ── the cap ──────────────────────────────────────────────────────────────────
 out=$(run --cap=1 --commit)
 [[ $(grep -c . "$SPAWNF") == 1 ]] && ok_ 'cap=1 spawns exactly one' || bad_ 'cap=1' "got: $(spawns)"

--- a/tests/verify_policy_close_and_pool_unit.sh
+++ b/tests/verify_policy_close_and_pool_unit.sh
@@ -102,8 +102,14 @@ fi
 seed_pending() { # <override:none|skip|force> -> ident
   local ov="$1"
   local t="pool ${ov} $RANDOM"
-  db "INSERT INTO tasks (title,status,assignee,verifier,maker_agent,kind,priority,created_by,delivery_ref)
-      VALUES ($(sqlq "$t"),'todo','quinn','quinn','dev2','standard','high','main','https://github.com/o/r/pull/8');" >/dev/null
+  # This fixture says it is delivered, so stamp the canonical delivery clock
+  # that the real _task_route_to_verifier path always writes. A delivery_ref is
+  # only an artifact binding; treating it as proof of a live handoff would put
+  # already-graded merge work back into the pending pool.
+  db "INSERT INTO tasks (title,status,assignee,verifier,maker_agent,kind,priority,created_by,
+                         handoff_delivered_at,delivery_ref)
+      VALUES ($(sqlq "$t"),'todo','quinn','quinn','dev2','standard','high','main',
+              datetime('now'),'https://github.com/o/r/pull/8');" >/dev/null
   local id; id=$(db "SELECT ident FROM tasks ORDER BY id DESC LIMIT 1;")
   case "$ov" in
     skip)  db "UPDATE tasks SET verify_optout=1 WHERE ident=$(sqlq "$id");" >/dev/null ;;
@@ -227,6 +233,14 @@ fi
 # the delivery itself when it routes, which is the realistic shape.
 db "INSERT INTO lifecycle_events (kind,ident,actor,idem_key,detail)
     VALUES ('task.grade.requested',$(sqlq "$_d_skip"),'sys',$(sqlq "req-${_d_skip}-$RANDOM"),'fixture');" >/dev/null
+# Model the state after a request was queued and policy then flipped to skip:
+# the handoff remains delivered to its verifier, but the current policy must
+# decline it. cmd_task_deliver correctly leaves an opted-out row with its maker,
+# so the fixture must construct this historical transition explicitly.
+db "UPDATE tasks
+       SET status='todo', assignee='quinn', verifier='quinn',
+           handoff_delivered_at=datetime('now')
+     WHERE ident=$(sqlq "$_d_skip");" >/dev/null
 _j=$(tick_counts); _pl_now=$(planned "$_j"); _dk_now=$(jq -r '.dark' <<<"$_j")
 if [[ "$_pl_now" == "$((_pl_base+1))" && "$_dk_now" == "$((_dk_base+1))" ]]; then
   ok_t "always: the tick plans a grade for the plain delivered row and NONE for the --no-verify one (+1 planned, +1 declined)"


### PR DESCRIPTION
SHIP BLOCKER: delegated push of 0618c769 on branch dive-4281-grader-pending-owner failed with GitHub HTTP 403 for 5dive-push[bot]. Readback confirmed no remote ref and no PR. Local rail: 4/4 selected harnesses green; focused stateful harness 9/0; verdict-filter, owner-guard, and terminal-subtraction mutants all red. Branch-built CLI on the live store excluded DIVE-4196/4205/4238/4256/4246; DIVE-4263 rendered 'skip ... owner is ops, not a pool seat'. Judgment and in-flight re-derivation compiled into community/wiki/ephemeral-verifiers-spawned-per-delivery.md.
          result = 
created_by_tier = admin
previous gates = 2

human gate:
  type: decision  (tier 1)  options: Restore App permission|Admin pushes branch manually
  recommend: Restore App permission
  tier set by: axis=none
  ask:  Which recovery should unblock the GitHub 403 on the tested DIVE-4281 branch?
  answer: — pending

verify: always (box default) — a grader grades this delivery

Pushed by main from codex's tested worktree (5dive-push App returned 403 for the bot; see DIVE-4281). 🤖 Generated with [Claude Code](https://claude.com/claude-code)
