### PR TITLE
fix(release-cut): the guard harness unsets REQUIRED_ONLY so the hotfix lane can cut (DIVE-4311)

### DIFF
--- a/changelog.d/DIVE-4311.md
+++ b/changelog.d/DIVE-4311.md
@@ -1,0 +1,3 @@
+## Unreleased — fix(release-cut): the guard harness unsets REQUIRED_ONLY so the hotfix lane can cut (DIVE-4311)
+
+Dispatching `release-cut` with `required_only=true` (the hotfix lane) failed its own delta corpus: the workflow exports `REQUIRED_ONLY` into the cut step's env and `tests/release_cut_guards_unit.sh` never cleared it, so every lane-OFF arm ran lane-ON (54 passed / 52 failed, run 34590071224). The harness now unsets it beside `GITHUB_JOB`/`GITHUB_RUN_ID`; a hand cut on the required contexts is usable again and takes minutes instead of waiting for the full sweep.

--- a/tests/release_cut_guards_unit.sh
+++ b/tests/release_cut_guards_unit.sh
@@ -80,6 +80,11 @@ verdict(){ # $1 = check-runs TSV ; echoes NOT-REACHED|IN-FLIGHT|RED|GREEN
 # guard deleted them. Any helper that drives the block must neutralise both.
 export GITHUB_JOB=""
 export GITHUB_RUN_ID=""
+# DIVE-4311: the workflow exports REQUIRED_ONLY=${{ inputs.required_only }} into the cut step's env.
+# Every lane-ON arm below sets REQUIRED_ONLY=true itself; the lane-OFF arms assume it is UNSET.
+# Dispatched with the hotfix lane on, the ambient value leaked into the lane-OFF arms and the
+# harness went 54/52 (run 34590071224, 2026-09-11) — refusing the very cut the lane exists for.
+unset REQUIRED_ONLY
 
 verdict_run(){ # $1 = check-runs TSV (4-col), $2 = GITHUB_RUN_ID ; echoes like verdict()
   local out rc


### PR DESCRIPTION
The DIVE-4072 hotfix lane (`release-cut` with `required_only=true`) fails its own guard harness: the workflow exports `REQUIRED_ONLY` into the cut step's env, and `tests/release_cut_guards_unit.sh` unsets `GITHUB_JOB`/`GITHUB_RUN_ID` at its top but not `REQUIRED_ONLY`, so every lane-OFF arm runs lane-ON. Measured 2026-09-11 10:37Z, run 34590071224: 54 passed / 52 failed → `grade-release-commit: delta corpus … 1 failed` → the cut refused. The 04:05Z default-lane cut had run the same corpus 15/0.

Fix: `unset REQUIRED_ONLY` beside the two existing unsets. Proof in a clean worktree at origin/main:
- `REQUIRED_ONLY=true bash tests/release_cut_guards_unit.sh` — before: 54 passed, 52 failed; after: 106 passed, 0 failed
- `bash tests/release_cut_guards_unit.sh` — 106 passed, 0 failed before and after

Why now: lodar 11:42Z "ship patches as they come". The default lane waits for the 30-40 min full-sweep and any merge that lands mid-wait restarts it, so with patches landing every ~20 min it cannot cut (11:43Z dispatch is on its third sweep). This unblocks the 3-minute lane. Wiki: community/wiki/release-cut-hotfix-lane-required-only-leaks-into-its-own-guard-harness.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
