### PR TITLE
feat(task): a customer is tapped only for money, a secret, an irreversible step or a browser-only action (DIVE-4346)

### DIFF
--- a/changelog.d/DIVE-4346.md
+++ b/changelog.d/DIVE-4346.md
@@ -1,0 +1,35 @@
+## Unreleased — feat(task): a customer is tapped only for money, a secret, an irreversible step or a browser-only action (DIVE-4346)
+
+A gate that reaches the paired human now has to say what it needs **from** a human. A `decision` or
+`approval` gate filed without `--needs=spend_authority|secret_provision|human_tap` is refused at
+filing time, and the message names the exits: `--tier=0` (apply your own recommendation — 81% of
+answered decision gates came back as the human tapping it anyway), `--tier=1` (the lead or the
+task's verifier), or an audited `--ask-ok=`. The types that already name their capability are
+exempt: `secret`, `access`, a tier-2 `manual` gate, and any gate the category floor already
+classified.
+
+**This is a refusal, not a re-route, and that is deliberate.** Routing a needs-less gate to a lead
+seat is the behaviour DIVE-4329 removed a day earlier on a measurement: a tier-2 `manual` gate
+asking a person to try a login queued on a seat that cannot open a browser, and nobody was ever
+pinged. Moving a gate to a seat that cannot act on it does not reduce taps — it converts a visible
+interruption into an invisible stall, and the stall is worse, because the tap at least terminates.
+
+Two more asks are refused because **a person cannot answer them**, which is a different question
+from whether the ask is readable:
+
+* *"open/look at the preview"* — behind the hosting sign-in wall there is a second wall: a
+  production Clerk instance refuses preview domains outright and the Vercel bypass header has no
+  authority over it, so the link is unreachable by the holder too. The refusal points at verifying
+  on a real box, or asking for a reusable test login as a `secret` gate.
+* *"approve this because a code-hosting rule says so"* — a CODEOWNERS entry or a branch-protection
+  rule is repository config; the tap buys one merge and zero decisions, because the rule fires again
+  on the next change. An ask to **change** the rule is not caught — that is a browser-only action a
+  person really does hold.
+
+Replayed over the 171 tier-2 asks in `gate_history` for the 30 days to 2026-09-12, the two new
+refusals fire on 9 and 1 asks with zero false positives.
+
+`5dive digest` gains a line under the autonomy rollup: **taps per shipped change**, with the split
+between taps that named a capability and taps that named none. On this board, the 7 days to
+2026-09-12: 35 gates reached the paired human, 16 of them named no capability, 313 changes shipped —
+0.11 taps per shipped change.

--- a/changelog.d/DIVE-4346.md
+++ b/changelog.d/DIVE-4346.md
@@ -62,3 +62,37 @@ before their summary, producing **no verdict at all** rather than a red one.
 - Corrected a stale comment in `need.sh`: DIVE-4239's ask **is** caught by the preview
   predicate (comma boundary, `...fresh box, open https://<...>.vercel.app`). The
   behaviour was always right; the sentence said the opposite.
+
+### Iteration 2b — the core tier found a REAL defect in the refusal, not just more fixtures
+
+Running the whole tier (rather than a list) reddened **nine** harnesses. Four are
+pre-existing and seat-local — `actor_claim_corroboration`, `agent_priv_read_breaker`,
+`audit_nonroot`, `builder_gh_rail`, `gate_telemetry_fence` all fail identically at
+`origin/main 3ce3e077` with a built bundle. Five belonged to this diff:
+
+**The defect.** `tier_floored` is the WRONG way to ask "is this gate category-floored"
+on this path, and the keystroke cap 90 lines below had already written the reason down
+in full before this shipped: the T2 category floor only ever runs to RAISE a tier below
+2, so there is nothing for it to raise when the filer TYPED `--tier=2`, and a **money**
+gate filed at tier 2 arrives with `tier_floored` still 0 — indistinguishable from an
+undeclared judgement call. The capability refusal was therefore refusing exactly the
+reserved classes its exemption exists to protect. Caught by `gate_recommend_cap_unit`
+B3 ("approve the monthly spend on the paid Hetzner plan"). Fixed the way the cap
+already does it: re-run the classifier over the ask AND the title
+(`_gate_hit_either _gate_tier2_floor_hit`) instead of reading the flag. B3 needed no
+fixture edit afterwards.
+
+**The fixtures, and the pattern in which ones needed which move.** Every remaining
+break was an arm whose subject is *the explicit `--tier=2` pin* or *the cap itself* —
+`gate_delivery_ref_binding_route` arm 5, `gate_floor_provenance` arm 1 (`axis=pinned`
+means the PIN decided and the floor was never consulted), and all four fixtures in
+`gate_recommend_cap`. Those take the audited `--ask-ok`, because the cap is gated on
+`_needs_human != 1`: **declaring a capability switches off the control under test**, so
+`--needs=` there would delete the subject and the arm would pass vacuously.
+`gate_tier2_decision_nonce` grades nonce minting rather than the cap, so its five
+fixtures take the honest `--needs=human_tap`.
+
+**Why the pin is not exempted in the product.** It would reopen the hole the row exists
+to close — a filer who cannot name a capability pins tier 2 instead. A pin is a claim
+about the TIER; it says nothing about what the ask consumes. The cost of that lands on
+fixtures that deliberately grade the pin, and it is paid with a written reason.

--- a/changelog.d/DIVE-4346.md
+++ b/changelog.d/DIVE-4346.md
@@ -96,3 +96,34 @@ fixtures take the honest `--needs=human_tap`.
 to close — a filer who cannot name a capability pins tier 2 instead. A pin is a claim
 about the TIER; it says nothing about what the ask consumes. The cost of that lands on
 fixtures that deliberately grade the pin, and it is paid with a written reason.
+
+### Iteration 2c — the blast radius does not stop at the core tier
+
+The core tier is the instrument the verifier named, and it is not the whole blast
+radius. A refusal in `cmd_task_need` changes the fixture contract of **every harness
+that files a gate**, and 90 of them do — across BOTH tiers. So the set was enumerated
+mechanically (`grep -l 'cmd_task_need' tests/*.sh`) rather than guessed, and all 48 the
+core run does not reach were run by hand.
+
+**Nine more broke, every one of them nightly-tier**, which matters because the nightly
+sweep runs on every push to main and `release-cut.yml` refuses to cut on any red on
+main's tip — so shipping these red would have blocked the next release rather than
+merely showing an advisory red on the PR. Fixed: `gate_enforce_env_bypass`,
+`gate_precedent`, `gate_root_filer_standing_route`, `gate_row_state_routing`,
+`gate_ship_routing`, `gate_t2_nonce_proof`, `gate_tier2_explicit_pin`,
+`gate_tier2_floor`, `verifier_gate_ack` — each verified against its own `origin/main`
+baseline, arm count for arm count.
+
+**Seven of the nine died before their summary.** They now carry the ABORT marker, which
+`truncation_marker_guard_unit` then discovers by grep and grades (24 → 38 arms across
+the change). `gate_enforce_env_bypass` also gets the real fix underneath: its filing
+helper was the only one in the file not subshelled, while the `answer` helper beside it
+already was, for exactly this reason.
+
+**One thing I tried and reverted, because it is a trap worth naming.** Subshelling every
+filing call in `gate_precedent_unit` looks like the general form of that fix and it is
+wrong there: the citation arms read what a stubbed `task_need_notify` recorded into a
+shell variable during the call, and a subshell discards it — measured, it reds
+"prefill/fuzzy: citation handed to notifier". That harness keeps the marker only. A
+refused fixture still ends it, but it ends with a VERDICT instead of with silence, which
+is the half that actually misleads a reader.

--- a/changelog.d/DIVE-4346.md
+++ b/changelog.d/DIVE-4346.md
@@ -33,3 +33,32 @@ refusals fire on 9 and 1 asks with zero false positives.
 between taps that named a capability and taps that named none. On this board, the 7 days to
 2026-09-12: 35 gates reached the paired human, 16 of them named no capability, 313 changes shipped —
 0.11 taps per shipped change.
+
+### Iteration 2 — the refusal changed the fixture contract of every gate-filing harness
+
+quinn's grading pass caught what the first delivery's hand-picked harness list did
+not: a refusal added to `cmd_task_need` is a change to the fixture contract of
+**every** harness that files a gate, not just the ones the diff touched. Four more
+reddened on CI (`gate_evidence_form`, `gate_tap_human_attribution`,
+`gate_tier2_nonce_evidence`, `gate_verifier_scoping_floor`), and three of them died
+before their summary, producing **no verdict at all** rather than a red one.
+
+- Three took the **honest declaration** (`--needs=human_tap`): each files a real
+  hard-human tier-2 gate as its fixture, and a hard-human gate is by definition one
+  that consumes a human capability, so naming it is the truthful edit, not an escape.
+- One took the **audited `--ask-ok` with a written reason** — `gate_verifier_scoping_floor`
+  arm 12 grades that an explicit `--tier=2` pin *is* the caller's hard-human contract,
+  so the gate must reach the human with no declared capability or the arm stops
+  grading the pin. Same judgement as `gate_approval_routing` A8.
+- **The abort shape is its own defect** and is fixed here: those three harnesses had
+  no EXIT-trap truncation marker, so a fixture refusal killed them silently. They now
+  carry the `exec 8>&2` + `SUMMARY_PRINTED` marker
+  (`community/wiki/an-exit-trap-abort-marker-is-swallowed-by-the-callers-own-redirect.md`),
+  which `tests/truncation_marker_guard_unit.sh` discovers by grep and grades — 24 → 30 arms.
+- New `tests/digest_tap_ratio_unit.sh` (9 arms) closes the counter's zero-coverage gap
+  quinn named. Its load-bearing arm is that an unreadable `needs_capability` renders
+  **"unknown", never "0 named none"** — a failed read reported as a clean zero is worse
+  than no counter (DIVE-3228).
+- Corrected a stale comment in `need.sh`: DIVE-4239's ask **is** caught by the preview
+  predicate (comma boundary, `...fresh box, open https://<...>.vercel.app`). The
+  behaviour was always right; the sentence said the opposite.

--- a/src/cmd_council.sh
+++ b/src/cmd_council.sh
@@ -480,10 +480,10 @@ export const THRESHOLD_POLICY = {
 // CNCL-14 — constitution-as-data. Missing or malformed files fall back to these
 // exact pre-constitution values; a valid constitution.yaml may replace them per org.
 export const DEFAULT_HARD_GATE_CLASSES = {
-  spend_billing: 'spend|billing|invoice|charge|payment|refund|subscription|price|pricing|\\$[0-9]|€[0-9]',
-  public_comms: 'publish|public post|announce|launch post|press|customer email|email customers|newsletter|blast',
-  secrets: 'secret|credential|api key|token|password',
-  destructive: 'delete|destroy|teardown|wipe|purge|drop[^.]{0,20}table|truncate|irreversible|revoke|dns|domain transfer',
+  spend_billing: 'spend|spending|billing|invoice|invoices|invoiced|charge|charges|charged|charging|payment|payments|refund|refunds|refunded|subscription|subscriptions|price|prices|pricing|\\$[0-9]+|€[0-9]+',
+  public_comms: 'publish|publishes|published|publishing|public post|announce|announces|announced|announcing|launch post|press|pressing|customer email|email customers|newsletter|blast|blasts|blasted|blasting',
+  secrets: 'secret|secrets|credential|credentials|api key|api keys|token|password|passwords',
+  destructive: 'delete|deletes|deleted|deleting|destroy|destroys|destroyed|destroying|teardown|wipe|wipes|wiped|wiping|purge|purges|purged|purging|drop[^.]{0,20}table|truncate|truncated|irreversible|revoke|revokes|revoked|revoking|dns|domain transfer',
 }
 export const DEFAULT_HARD_GATE_RX = Object.values(DEFAULT_HARD_GATE_CLASSES).join('|')
 

--- a/src/cmd_digest.sh
+++ b/src/cmd_digest.sh
@@ -302,6 +302,23 @@ cmd_digest() {
   else timeout 25 bash "$0" update --check --json >"$tmpd/update.json" 2>/dev/null || echo '{}' >"$tmpd/update.json"; fi
   [ -s "$tmpd/update.json" ] || echo '{}' >"$tmpd/update.json"
 
+  # DIVE-4346 — WHAT THE TAP ACTUALLY CONSUMED. `you answered N×` says a person
+  # was interrupted; it does not say whether the interruption bought anything only
+  # a person holds. The four capabilities are money, a secret, an irreversible
+  # step, and something only a person at a browser can do, and `needs_capability`
+  # is where the filer names one. Read straight from `tasks` because the column is
+  # NOT on `task ls --json` and NOT on `gate_history` — both gaps are real and are
+  # written on the row; reading the live table is what makes the counter shippable
+  # today without a schema change. A failed read yields null, which renders as
+  # "unknown", never as zero: a capability we cannot count is not a capability
+  # that was not named (the DIVE-3228 lesson about the buzz count).
+  dbfmt -json "SELECT COALESCE(NULLIF(needs_capability,''), CASE WHEN need_type='secret' THEN 'secret_provision' ELSE '' END) AS cap, COUNT(*) AS n
+               FROM tasks
+               WHERE need_answered_by LIKE 'human:%'
+                 AND need_answered_at >= datetime('now','-${window} seconds')
+               GROUP BY 1;" >"$tmpd/cap.json" 2>/dev/null || echo 'null' >"$tmpd/cap.json"
+  [ -s "$tmpd/cap.json" ] || echo '[]' >"$tmpd/cap.json"
+
   if _bz=$(_digest_buzz_count "$window"); then
     printf '{"buzzes":%s,"partial":%s}\n' "${_bz%%|*}" "${_bz##*|}" >"$tmpd/buzz.json"
   else
@@ -311,7 +328,7 @@ cmd_digest() {
   DIGEST_TASKS_F="$tmpd/tasks.json" DIGEST_USAGE_F="$tmpd/usage.json" DIGEST_HB_F="$tmpd/hb.txt" \
   DIGEST_LOOPS_F="$tmpd/loops.json" DIGEST_SUP_F="$tmpd/sup.json" DIGEST_OBJ_F="$tmpd/obj.json" \
   DIGEST_UPDATE_F="$tmpd/update.json" DIGEST_HELD_F="$tmpd/held.json" \
-  DIGEST_BUZZ_F="$tmpd/buzz.json" \
+  DIGEST_BUZZ_F="$tmpd/buzz.json" DIGEST_CAP_F="$tmpd/cap.json" \
   DIGEST_WINDOW="$window" DIGEST_JSON="$as_json" python3 - >"$tmpd/out.txt" <<'PY'
 import os, json, time, datetime as dt
 
@@ -329,6 +346,7 @@ def load(env, default):
         return default
 
 buzz_data = load("DIGEST_BUZZ_F", {"buzzes": None, "partial": 1})
+cap_rows = load("DIGEST_CAP_F", None)
 buzzes = buzz_data.get("buzzes") if isinstance(buzz_data, dict) else None
 buzz_partial = bool(buzz_data.get("partial")) if isinstance(buzz_data, dict) else True
 
@@ -766,6 +784,22 @@ else:
     out.append(f"\U0001F9BE Autonomy — {_up} · shipped {len(done_l)}{_trend(len(done_l), prev_ship)}"
                f"{_bz}"
                f" · you answered {len(ht_l)}×{_trend(len(ht_l), prev_ask)}")
+    # DIVE-4346 — THE RATIO IS THE AXIS, and it is the one number a customer
+    # reads about us: human taps per shipped change. Rendered next to the
+    # capability split, because a tap that named none of the four is the tap that
+    # should not have existed. Measured on this board the 7 days to 2026-09-12:
+    # 35 gates reached the paired human, 16 named no capability (46%), 313 changes
+    # shipped: 0.11 taps per shipped change.
+    _ratio = (f"{touches / len(done_l):.2f}" if done_l else ("n/a" if not touches else "∞"))
+    if isinstance(cap_rows, list):
+        _capless = sum(int(r.get("n") or 0) for r in cap_rows if not (r.get("cap") or "").strip())
+        _named = sum(int(r.get("n") or 0) for r in cap_rows) - _capless
+        _cap_txt = f"{_named} named a capability, {_capless} named none"
+    else:
+        # Unknown is not zero (DIVE-3228).
+        _cap_txt = "capability split: unknown"
+    out.append(f"   ↳ {_ratio} taps per shipped change · of {touches} tap"
+               f"{'s' if touches != 1 else ''}, {_cap_txt}")
     if isinstance(buzzes, int) and buzz_partial:
         out.append("   *buzz count covers only the span since gate cards were modelled")
     if objectives:

--- a/src/cmd_digest.sh
+++ b/src/cmd_digest.sh
@@ -312,11 +312,21 @@ cmd_digest() {
   # today without a schema change. A failed read yields null, which renders as
   # "unknown", never as zero: a capability we cannot count is not a capability
   # that was not named (the DIVE-3228 lesson about the buzz count).
-  dbfmt -json "SELECT COALESCE(NULLIF(needs_capability,''), CASE WHEN need_type='secret' THEN 'secret_provision' ELSE '' END) AS cap, COUNT(*) AS n
+  #
+  # DIVE-4346 iteration 3 — DECLARED vs DERIVED. A gate whose ask trips the
+  # tier-2 category floor now has its class DERIVED and stored rather than
+  # reaching the person with the column blank, so the raw column no longer says
+  # who named it. `floor_provenance` does (`needs=derived:<class>`), and the two
+  # must stay visibly apart here: a derived class is a GUESS made from wording,
+  # and a counter that reports it as a declaration would hide exactly the
+  # mis-classification this split exists to make countable.
+  dbfmt -json "SELECT COALESCE(NULLIF(needs_capability,''), CASE WHEN need_type='secret' THEN 'secret_provision' ELSE '' END) AS cap,
+                      CASE WHEN COALESCE(floor_provenance,'') LIKE '%needs=derived:%' THEN 1 ELSE 0 END AS derived,
+                      COUNT(*) AS n
                FROM tasks
                WHERE need_answered_by LIKE 'human:%'
                  AND need_answered_at >= datetime('now','-${window} seconds')
-               GROUP BY 1;" >"$tmpd/cap.json" 2>/dev/null || echo 'null' >"$tmpd/cap.json"
+               GROUP BY 1,2;" >"$tmpd/cap.json" 2>/dev/null || echo 'null' >"$tmpd/cap.json"
   [ -s "$tmpd/cap.json" ] || echo '[]' >"$tmpd/cap.json"
 
   if _bz=$(_digest_buzz_count "$window"); then
@@ -793,8 +803,14 @@ else:
     _ratio = (f"{touches / len(done_l):.2f}" if done_l else ("n/a" if not touches else "∞"))
     if isinstance(cap_rows, list):
         _capless = sum(int(r.get("n") or 0) for r in cap_rows if not (r.get("cap") or "").strip())
-        _named = sum(int(r.get("n") or 0) for r in cap_rows) - _capless
+        _derived = sum(int(r.get("n") or 0) for r in cap_rows
+                       if (r.get("cap") or "").strip() and int(r.get("derived") or 0))
+        _named = sum(int(r.get("n") or 0) for r in cap_rows) - _capless - _derived
         _cap_txt = f"{_named} named a capability, {_capless} named none"
+        # Only rendered when non-zero: a board with no floor-derived taps should
+        # not carry a column explaining a mechanism it never used.
+        if _derived:
+            _cap_txt += f" ({_derived} derived from the ask's wording, not declared)"
     else:
         # Unknown is not zero (DIVE-3228).
         _cap_txt = "capability split: unknown"

--- a/src/council/engine.mjs
+++ b/src/council/engine.mjs
@@ -233,10 +233,10 @@ export const THRESHOLD_POLICY = {
 // CNCL-14 — constitution-as-data. Missing or malformed files fall back to these
 // exact pre-constitution values; a valid constitution.yaml may replace them per org.
 export const DEFAULT_HARD_GATE_CLASSES = {
-  spend_billing: 'spend|billing|invoice|charge|payment|refund|subscription|price|pricing|\\$[0-9]|€[0-9]',
-  public_comms: 'publish|public post|announce|launch post|press|customer email|email customers|newsletter|blast',
-  secrets: 'secret|credential|api key|token|password',
-  destructive: 'delete|destroy|teardown|wipe|purge|drop[^.]{0,20}table|truncate|irreversible|revoke|dns|domain transfer',
+  spend_billing: 'spend|spending|billing|invoice|invoices|invoiced|charge|charges|charged|charging|payment|payments|refund|refunds|refunded|subscription|subscriptions|price|prices|pricing|\\$[0-9]+|€[0-9]+',
+  public_comms: 'publish|publishes|published|publishing|public post|announce|announces|announced|announcing|launch post|press|pressing|customer email|email customers|newsletter|blast|blasts|blasted|blasting',
+  secrets: 'secret|secrets|credential|credentials|api key|api keys|token|password|passwords',
+  destructive: 'delete|deletes|deleted|deleting|destroy|destroys|destroyed|destroying|teardown|wipe|wipes|wiped|wiping|purge|purges|purged|purging|drop[^.]{0,20}table|truncate|truncated|irreversible|revoke|revokes|revoked|revoking|dns|domain transfer',
 }
 export const DEFAULT_HARD_GATE_RX = Object.values(DEFAULT_HARD_GATE_CLASSES).join('|')
 

--- a/src/task/need.sh
+++ b/src/task/need.sh
@@ -506,7 +506,7 @@ _gate_redact_branch_refs() {
 # lowered — the floor still fires on every listed signal, and a missed one lands a
 # tier-1 gate at a routed seat rather than nothing at all. Widen the list here if a
 # real spend is ever measured slipping; do not widen it on a hypothetical.
-_GATE_PRICE_SPEND_SIGNAL_RX='\$[0-9]|€[0-9]|£[0-9]|[0-9] ?(usd|eur|gbp|dollar|euro|cent)|pay|paid|buy|bought|purchas|charg|bill|invoic|spend|spent|refund|subscri|budget|revenue|monetiz|checkout|quote|discount|upgrade|downgrade|rais|lower|increas|decreas|hike|cost|tariff|fee|plan|tier|seat|sku|deal|margin|vendor|supplier|contract|customer|enterprise'
+_GATE_PRICE_SPEND_SIGNAL_RX='\$[0-9]+|€[0-9]+|£[0-9]|[0-9] ?(usd|eur|gbp|dollar|euro|cent)|pay|paid|buy|bought|purchas|charg|bill|invoic|spend|spent|refund|subscri|budget|revenue|monetiz|checkout|quote|discount|upgrade|downgrade|rais|lower|increas|decreas|hike|cost|tariff|fee|plan|tier|seat|sku|deal|margin|vendor|supplier|contract|customer|enterprise'
 # _gate_redact_bare_price <lowercased text>: blank out `price`/`pricing` when the
 # field carries no spend signal. Same shape as DIVE-2629's branch-ref redaction —
 # the transform is on the TEXT at the match site, never on $floor_rx, because the
@@ -519,7 +519,87 @@ _gate_redact_bare_price() {
   [[ "$text" =~ $_GATE_PRICE_SPEND_SIGNAL_RX ]] && { printf '%s' "$text"; return 0; }
   printf '%s' "$text" | sed -E 's/(pricing|price)/ /g'
 }
-_GATE_T2_FLOOR_RX='spend|billing|invoice|charge|payment|refund|subscription|price|pricing|\$[0-9]|€[0-9]|publish|public post|announce|launch post|press|customer email|email customers|newsletter|blast|secret|credential|api key|token|password|delete|destroy|teardown|wipe|purge|drop[^.]{0,20}table|truncate|irreversible|revoke|dns|domain transfer'
+# DIVE-4346: the tail is now BOUNDED too (see the match site below), so every
+# inflection this floor must keep catching is written out here rather than left to
+# substring containment. Two terms are DELIBERATELY not inflected, and both are
+# measured, not guessed:
+#   * `spends` — in the audit window it appears only as a third-person clause
+#     DESCRIBING a subject that is not the reader's money ("every hand-in then
+#     spends some of our shared AI allowance", DIVE-4218). The authorisation forms
+#     are `spend` and `spending`, and a real money ask still floors on those, on a
+#     currency amount, or on billing/invoice/payment.
+#   * `tokens` — same shape: the plural is the AI-usage noun ("tokens per run"),
+#     the singular is the credential one. A credential ask floors on `credential`,
+#     `credentials`, `api key`, `password`, or `--type=secret`.
+# A term that stops flooring is NOT a hole: a gate that reaches the paired human
+# and declares nothing is now REFUSED by the capability default below, which is a
+# strictly safer failure than a silent waiver of the same question.
+_GATE_T2_FLOOR_RX='spend|spending|billing|invoice|invoices|invoiced|charge|charges|charged|charging|payment|payments|refund|refunds|refunded|subscription|subscriptions|price|prices|pricing|\$[0-9]+|€[0-9]+|publish|publishes|published|publishing|public post|announce|announces|announced|announcing|launch post|press|pressing|customer email|email customers|newsletter|blast|blasts|blasted|blasting|secret|secrets|credential|credentials|api key|api keys|token|password|passwords|delete|deletes|deleted|deleting|destroy|destroys|destroyed|destroying|teardown|wipe|wipes|wiped|wiping|purge|purges|purged|purging|drop[^.]{0,20}table|truncate|truncated|irreversible|revoke|revokes|revoked|revoking|dns|domain transfer'
+# DIVE-4346 — THE TRAILING BOUNDARY. DIVE-2301 bounded the LEADING side only and
+# said so deliberately, to keep inflections matching. Measured cost of leaving the
+# tail open, quinn replaying the shipped predicate over this row's own audit
+# window: `spend` fired inside "every hand-in then SPENDS some of our shared AI
+# allowance" and `token` inside "the TOKENmaxxing board", and a floor hit was (until
+# this change) a full WAIVER of the capability question below — so two of the gates
+# lodar named when he filed this row were exempted by a substring of an unrelated
+# word. The inflections that must keep firing are now written into the shipped
+# regexes instead of inferred from containment, which also makes each one readable
+# and countable in the policy data rather than implied by the matcher.
+#
+# APPLIED TO THE SHIPPED DEFAULT ONLY, exactly like DIVE-4001's bare-price
+# requirement and for a harder reason than symmetry: a constitution term may END IN
+# A CHARACTER CLASS THAT CONSUMES ONE CHARACTER OF A LONGER RUN. `\$[0-9]` matches
+# "$5" of "$500" and a trailing boundary then refuses it, so bounding an org's
+# regex would silently DELETE its money class — caught by
+# tests/gate_floor_word_boundary_unit.sh T7 and constitution_gate_floor_unit while
+# this was being written. The shipped terms are bounded because they are words and
+# their inflections are written out above; an org's list is enforced verbatim.
+_GATE_FLOOR_TAIL='($|[^[:alnum:]_])'
+# DIVE-4346 — THE PUSH-RAIL NOUN. A delegated-push approval is INERT by
+# construction (it opens a PR; DIVE-2629 already redacts the branch name it
+# carries for exactly this reason), and its boilerplate names the rail's own
+# missing credential: "direct GitHub push lacks credentials". That sentence is a
+# statement about the FILER's access, never a request that a person hand one over
+# — measured on DIVE-4052 and DIVE-4125, both of which the floor exempted from the
+# capability question below on the word `credentials`. Scoped exactly like the
+# branch-ref redaction: only the noun inside that clause is blanked, and the rest
+# of the ask is graded unchanged, so "push this, and send me a new bot key"
+# still floors on the second clause.
+# DIVE-4346 — THE BARE `token`. Same shape as DIVE-4001's bare `price`, and
+# measured the same way: in this org's own corpus the unqualified noun is the
+# AI-usage one ("which token limit should the summariser use, 8k or 16k?", quinn's
+# fresh probe), while the credential sense always arrives with a credential
+# signal next to it. `tokens` was dropped from the floor list outright for the
+# same reason; the singular keeps its class only when the text says so. A
+# credential ask that names none of these signals still cannot reach a person
+# undeclared — it is refused by the capability default, not waived.
+_GATE_TOKEN_SECRET_SIGNAL_RX='secret|credential|password|api key|auth|oauth|bearer|rotate|rotation|leak|revoke|provision|paste|issue|bot |github|telegram|stripe|key |keys|env|vault|expired'
+_gate_redact_bare_token() {
+  local text="${1-}"
+  [[ "$text" =~ (^|[^[:alnum:]_])token([^[:alnum:]_]|$) ]] || { printf '%s' "$text"; return 0; }
+  [[ "$text" =~ $_GATE_TOKEN_SECRET_SIGNAL_RX ]] && { printf '%s' "$text"; return 0; }
+  printf '%s' "$text" | sed -E 's/(^|[^[:alnum:]_])token([^[:alnum:]_]|$)/\1 \2/g'
+}
+_GATE_PUSH_RAIL_NOUN_SED='s/(push[^.]{0,60}(lacks|lacking|without|refuses|refuse|cannot|denied)[^.]{0,40})(credentials?|tokens?|api keys?)/\1 /g'
+_gate_redact_push_rail_nouns() {
+  printf '%s' "${1-}" | sed -E "$_GATE_PUSH_RAIL_NOUN_SED"
+}
+# _gate_floor_capability_class <floor term> -> the human capability that term's
+# reserved class consumes. DIVE-4346: a floor hit used to WAIVE the capability
+# question (the gate reached the paired human with needs_capability empty, which
+# is byte-identical to what an undeclared gate records — nothing). It now ANSWERS
+# it: the class the floor already decided is stored on the row, so the counter can
+# see it and a WRONG derivation is countable rather than invisible.
+_gate_floor_capability_class() {
+  local t; t=$(printf '%s' "${1-}" | tr '[:upper:]' '[:lower:]')
+  case "$t" in
+    spend|spending|billing|invoice*|charge*|payment*|refund*|subscription*|price|prices|pricing|\$*|€*)
+      printf 'spend_authority' ;;
+    secret|secrets|credential*|api\ key*|token|password*)
+      printf 'secret_provision' ;;
+    *) printf 'human_tap' ;;
+  esac
+}
 _gate_tier2_floor_hit() {
   local text floor_rx="$_GATE_T2_FLOOR_RX" loaded_rx="" constitution_path="" ere_rc=0
   text=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
@@ -601,7 +681,12 @@ _gate_tier2_floor_hit() {
   if [[ "$floor_rx" == "$_GATE_T2_FLOOR_RX" ]]; then
     text=$(_gate_redact_bare_price "$text")
   fi
-  [[ "$text" =~ (^|[^[:alnum:]_])($floor_rx) ]]
+  if [[ "$floor_rx" == "$_GATE_T2_FLOOR_RX" ]]; then
+    text=$(_gate_redact_push_rail_nouns "$text")
+    text=$(_gate_redact_bare_token "$text")
+  fi
+  local tail=""; [[ "$floor_rx" == "$_GATE_T2_FLOOR_RX" ]] && tail="$_GATE_FLOOR_TAIL"
+  [[ "$text" =~ (^|[^[:alnum:]_])($floor_rx)$tail ]]
 }
 
 # DIVE-2224: NEVER concatenate two SUBJECTS into one classifier input. The ASK is
@@ -1376,12 +1461,15 @@ _gate_internal_residual() {
 # This lowers nothing — the floor still fires, the gate still exists, it still
 # needs clearing; it restores the appeal path `token` and `secret` already have.
 # The money class is NOT carved out with it: `spend|billing|invoice|charge|
-# payment|refund|subscription|\$[0-9]|€[0-9]` all stay non-appealable and all
+# payment|refund|subscription|\$[0-9]+|€[0-9]+` all stay non-appealable and all
 # still fire bare, so an ask that actually moves money is refused an appeal on
 # its own words. Companion change at _GATE_PRICE_SPEND_SIGNAL_RX makes the bare
 # noun require a spend signal before it fires at all — the two are independent:
 # this one makes a price false positive RECOVERABLE, that one makes it rarer.
-_GATE_FLOOR_APPEALABLE_RX='secret|credential|api key|token|password|publish|public post|announce|launch post|delete|destroy|wipe|purge|pricing|price'
+# DIVE-4346: kept term-for-term in step with the inflections written into
+# _GATE_T2_FLOOR_RX. An inflected form present in the floor but ABSENT here would
+# be silently reclassified as non-appealable by the residual test below.
+_GATE_FLOOR_APPEALABLE_RX='secret|secrets|credential|credentials|api key|api keys|token|password|passwords|publish|publishes|published|publishing|public post|announce|announces|announced|announcing|launch post|delete|deletes|deleted|deleting|destroy|destroys|destroyed|destroying|wipe|wipes|wiped|wiping|purge|purges|purged|purging|pricing|price|prices'
 # NON-APPEALABLE (everything else in the floor, stated positively so a future
 # edit to the floor regex cannot silently widen what an appeal reaches): money,
 # real outbound comms, and irreversible infra/access. Never carved out.
@@ -1399,7 +1487,7 @@ _GATE_FLOOR_APPEALABLE_RX='secret|credential|api key|token|password|publish|publ
 # may be a substring of a NON-APPEALABLE one, or stripping the former would erase
 # the latter and hand an appeal to a class that has none. Asserted in
 # tests/gate_floor_word_boundary_unit.sh rather than left to review.
-_GATE_FLOOR_NONAPPEALABLE_RX='spend|billing|invoice|charge|payment|refund|subscription|\$[0-9]|€[0-9]|press|customer email|email customers|newsletter|blast|teardown|drop[^.]{0,20}table|truncate|irreversible|revoke|dns|domain transfer'
+_GATE_FLOOR_NONAPPEALABLE_RX='spend|spending|billing|invoice|invoices|invoiced|charge|charges|charged|charging|payment|payments|refund|refunds|refunded|subscription|subscriptions|\$[0-9]+|€[0-9]+|press|pressing|customer email|email customers|newsletter|blast|blasts|blasted|blasting|teardown|drop[^.]{0,20}table|truncate|truncated|irreversible|revoke|revokes|revoked|revoking|dns|domain transfer'
 # _gate_floor_appeal_residual <text>: lower-case <text> and remove ONLY the
 # appealable terms. The caller re-tests the full floor against the result; if it
 # still fires, a non-appealable class is present and the appeal is refused.
@@ -1451,7 +1539,14 @@ _gate_tier2_floor_term() {
   if [[ "$rx" == "$_GATE_T2_FLOOR_RX" ]]; then
     text=$(_gate_redact_bare_price "$text")
   fi
-  [[ "$text" =~ (^|[^[:alnum:]_])($rx) ]] && printf '%s' "${BASH_REMATCH[2]}"
+  # DIVE-4346: mirrored for the same invariant — this helper must never report a
+  # term the floor itself no longer matches.
+  if [[ "$rx" == "$_GATE_T2_FLOOR_RX" ]]; then
+    text=$(_gate_redact_push_rail_nouns "$text")
+    text=$(_gate_redact_bare_token "$text")
+  fi
+  local tail=""; [[ "$rx" == "$_GATE_T2_FLOOR_RX" ]] && tail="$_GATE_FLOOR_TAIL"
+  [[ "$text" =~ (^|[^[:alnum:]_])($rx)$tail ]] && printf '%s' "${BASH_REMATCH[2]}"
 }
 
 # OSS-11 (DIVE-976) — _gate_ask_shape <ask>: normalize an ask into its "shape
@@ -1988,6 +2083,9 @@ _gate_record_line() {
 cmd_task_need() {
   tasks_db_init
   local type="" ask="" options="" recommend="" from="" tier="" secret_key="" connector="" probe="" withdraw="" discusses="" needs="" oob="" rubber_stamp="" gate_mode="" ask_ok=""
+  # DIVE-4346: the capability class DERIVED from a tier-2 floor hit when the filer
+  # declared none. Declared always wins; this is only ever a fallback.
+  local _cu_derived=""
   local gate_owner=""   # DIVE-3342
   local urgent=0        # DIVE-3474 arm 2
   # DIVE-2627: which flag supplied each prose value (see _read_prose_file).
@@ -3388,12 +3486,40 @@ As with the readability refusal, NO EXIT HERE CHANGES THE DESTINATION: nothing a
     # Re-run the classifier over the ask AND the title, the same way the cap does.
     # Not a widening: a floored gate was always meant to be exempt, and this is the
     # only instrument that answers whether it is floored on this path.
+    #
+    # AND THE EXEMPTION IS AN ANSWER, NOT A WAIVER (DIVE-4346 iteration 3, quinn's
+    # finding, and it is the whole reason this block moved). As shipped in
+    # iteration 2 a floor hit simply SKIPPED the question: the gate reached the
+    # paired human with `needs_capability` empty — the identical record an
+    # undeclared gate leaves, which is nothing. Replayed over this row's own audit
+    # population that exempted 14 of the 16 gates the default was supposed to
+    # reach, so the deliverable moved its number by 2. The floor, however, has
+    # ALREADY decided which reserved class the ask belongs to; it names the term in
+    # `floor_provenance`. So derive the class from that term and STORE it. Two
+    # things follow, and both are the point:
+    #   * the counter and any later audit can see what a floored tap consumed,
+    #     instead of finding the column blank;
+    #   * a WRONG derivation is now countable — `floor_provenance` carries
+    #     `needs=derived:<class>`, so "the floor guessed" is one query away, where
+    #     before it was indistinguishable from "nobody asked".
+    # The declared value always wins: `--needs=` is never overwritten by this.
     local _cu_title=""
     _cu_title=$(db "SELECT COALESCE(title,'') FROM tasks WHERE id=${id};")
-    if [[ -z "${needs//[[:space:]]/}" && "$type" != "secret" && "$type" != "access" \
-          && "$tier_floored" != "1" ]] \
-       && ! _gate_hit_either _gate_tier2_floor_hit "$ask" "$_cu_title" \
+    if [[ -z "${needs//[[:space:]]/}" && "$type" != "secret" && "$type" != "access" ]] \
        && ! _gate_is_human_tap "$type" "$tier" "$needs"; then
+     if [[ "$tier_floored" == "1" ]] \
+        || _gate_hit_either _gate_tier2_floor_hit "$ask" "$_cu_title"; then
+      local _cu_term=""
+      _cu_term=$(_gate_tier2_floor_term "$ask" 2>/dev/null) || _cu_term=""
+      [[ -n "$_cu_term" ]] || { _cu_term=$(_gate_tier2_floor_term "$_cu_title" 2>/dev/null) || _cu_term=""; }
+      if [[ -n "$_cu_term" ]]; then
+        _cu_derived=$(_gate_floor_capability_class "$_cu_term")
+        _floor_prov="${_floor_prov:+${_floor_prov};}needs=derived:${_cu_derived}"
+        _task_store_audit_log "task need capability-derived" "derived" 0 -- \
+          "task=$ident" "filer=${actor:-}" "type=$type" "term=$_cu_term" "class=$_cu_derived" || true
+        warn "this gate declares no capability, but the tier-2 floor already classified it on the word '${_cu_term}' — recording needs_capability=${_cu_derived} as DERIVED, not declared. If that is the wrong class, re-file with --needs=<the right one>: a derived class is countable and correctable, an empty one is neither."
+      fi
+     else
       if [[ -z "$ask_ok" ]]; then
         _task_store_audit_log "task need capability-undeclared" "refused" 0 -- \
           "task=$ident" "filer=${actor:-}" "type=$type" "tier=$tier" || true
@@ -3412,6 +3538,7 @@ Measured on this board, the 7 days to 2026-09-12: 35 gates reached the paired hu
       _task_store_audit_log "task need capability-undeclared" "escaped" 0 -- \
         "task=$ident" "filer=${actor:-}" "type=$type" "declared=$ask_ok" || true
       warn "undeclared-capability escape ACCEPTED and RECORDED: --ask-ok=\"${ask_ok}\". This gate reaches the paired human and names no capability."
+     fi
     fi
 
     # DIVE-4176, THE HALF THAT STAYS ADVISORY AND WHY. "Consequence-first, a
@@ -3516,7 +3643,7 @@ Measured on this board, the 7 days to 2026-09-12: 35 gates reached the paired hu
             -- including one that resolved to nothing. What was claimed is the
             -- provenance; whether it resolved is recomputable from the sealed
             -- list, and a mis-declaration you cannot see is one you cannot correct.
-            needs_capability=$(sqlq_or_null "$needs"),
+            needs_capability=$(sqlq_or_null "${needs:-${_cu_derived:-}}"),
             -- DIVE-2848: the declared reason a gate carrying its own recommendation
             -- still went to a person. The cap's value is that the exception is
             -- COUNTABLE afterwards — an escape that leaves no row is --tier=2 with

--- a/src/task/need.sh
+++ b/src/task/need.sh
@@ -573,7 +573,7 @@ _GATE_FLOOR_TAIL='($|[^[:alnum:]_])'
 # same reason; the singular keeps its class only when the text says so. A
 # credential ask that names none of these signals still cannot reach a person
 # undeclared — it is refused by the capability default, not waived.
-_GATE_TOKEN_SECRET_SIGNAL_RX='secret|credential|password|api key|auth|oauth|bearer|rotate|rotation|leak|revoke|provision|paste|issue|bot |github|telegram|stripe|key |keys|env|vault|expired'
+_GATE_TOKEN_SECRET_SIGNAL_RX='secret|cred|password|api key|auth|oauth|bearer|rotate|rotation|leak|revoke|provision|paste|issue|bot |github|telegram|stripe|key |keys|env|vault|expired'
 _gate_redact_bare_token() {
   local text="${1-}"
   [[ "$text" =~ (^|[^[:alnum:]_])token([^[:alnum:]_]|$) ]] || { printf '%s' "$text"; return 0; }

--- a/src/task/need.sh
+++ b/src/task/need.sh
@@ -1691,10 +1691,19 @@ _gate_is_human_tap() {
 # look` aimed at a preview is the shape. `see`, `seen`, `tap` and `check` are
 # DELIBERATELY ABSENT: with them the arm eats DIVE-3860 ("Publish the finished
 # dashboard change for review now, so it can be seen on a live preview page?"),
-# which is a push approval and a legitimate gate. Likewise "run a test on a
-# preview build" (DIVE-4239) carries no look-verb and survives, which is correct:
-# a person logging in through a real box is a real human_tap, and DIVE-4329 is
-# the measurement that says re-routing it is the defect.
+# which is a push approval and a legitimate gate.
+#
+# DIVE-4239 IS CAUGHT, and an earlier draft of this comment claimed the opposite
+# (quinn, 2026-09-12, reading the code against the hit list — the behaviour was
+# always right, the sentence was not). Its ask is an instruction list ending
+# "...fresh box, open https://<...>.vercel.app", so the comma boundary below fires
+# and it appears in the 30-day hit set beside DIVE-4294 and DIVE-4307. That is the
+# CORRECT outcome and it is worth saying why, because the gate underneath it is a
+# real one: logging in on a live box IS a human_tap, and DIVE-4329 is the
+# measurement that re-routing such a gate is the defect. What is refused is not
+# the tap, it is the ADDRESS — the preview link the holder cannot open either.
+# The refusal's first exit says so in one line ("verify on a real box"), so the
+# re-file keeps the same human and changes only where they are sent.
 #
 # WHAT THE FILER SHOULD DO INSTEAD is in the message: verify on a box, or ask for
 # a reusable test login (a `secret` gate, which IS a human capability). Neither

--- a/src/task/need.sh
+++ b/src/task/need.sh
@@ -1666,6 +1666,93 @@ _gate_is_human_tap() {
   return 1
 }
 
+# ============================================================================
+# DIVE-4346 — TWO ASKS A PERSON CANNOT ANSWER, REFUSED AT FILING.
+#
+# lodar, Telegram 2026-09-12 01:06Z: "human gate is still the most annoying part
+# of 5dive." The DIVE-4176 refusal above grades whether the ask is READABLE. These
+# two grade whether it is ANSWERABLE — a different question, and the one that
+# produced the taps he was complaining about. A readable ask that no human can act
+# on is worse than an unreadable one: it looks like a decision, so he reads it.
+#
+# ARM 1 — "GO LOOK AT THE PREVIEW" IS UNSATISFIABLE ON AN AUTH-GATED ROUTE.
+# Behind the Vercel SSO wall there is a second wall: a PRODUCTION Clerk instance
+# refuses preview domains outright, and `x-vercel-protection-bypass` has no
+# authority over Clerk. So the link cannot be opened by the holder either — this
+# is not "the agent cannot, so ask the person", it is unreachable by construction.
+# Measured on DIVE-4263 (2026-09-11): the false premise cost about a day and six
+# gates, three of which reached lodar, before the change was verified on a box
+# instead. Replayed over gate_history, 30 days to 2026-09-12, FIVE tier-2 asks
+# match — DIVE-3594, DIVE-3613, DIVE-3618, DIVE-3644, DIVE-4263 — and every one
+# of them points at a dashboard or agent-detail route, i.e. auth-gated.
+#
+# THE VERB LIST IS WHAT KEEPS THIS NARROW, and it was tuned against that same
+# corpus with every match printed. `open / view / visit / screenshot / eyeball /
+# look` aimed at a preview is the shape. `see`, `seen`, `tap` and `check` are
+# DELIBERATELY ABSENT: with them the arm eats DIVE-3860 ("Publish the finished
+# dashboard change for review now, so it can be seen on a live preview page?"),
+# which is a push approval and a legitimate gate. Likewise "run a test on a
+# preview build" (DIVE-4239) carries no look-verb and survives, which is correct:
+# a person logging in through a real box is a real human_tap, and DIVE-4329 is
+# the measurement that says re-routing it is the defect.
+#
+# WHAT THE FILER SHOULD DO INSTEAD is in the message: verify on a box, or ask for
+# a reusable test login (a `secret` gate, which IS a human capability). Neither
+# is a re-route, because the DIVE-4329 lesson holds here too — a check about the
+# ANSWERABILITY of an ask must not be satisfiable by sending it to someone else.
+_GATE_ASK_PREVIEW_RX='preview|vercel\.app'
+# The look-verb must be an INSTRUCTION TO THE READER, not a mention of looking.
+# That distinction is the whole false-positive budget, and it was measured: the
+# 30-day corpus holds two push-approval asks whose PRIMARY request is answerable
+# and which merely note, in a subordinate clause, that a preview will have to be
+# looked at later ("...this seat cannot render screenshots, so the Vercel preview
+# must be looked at before merge" — DIVE-3984; "it only opens the change for
+# review" — DIVE-3978). Both are legitimate gates, both carry a preview token and
+# a look-verb, and a bare co-occurrence test refuses both. So the verb is
+# required to sit at an INSTRUCTION BOUNDARY: the start of the ask, after a
+# sentence end, after a comma in an instruction list ("fresh box, open https://"
+# — DIVE-4239), or behind can/could/would/will/please/you. The one non-imperative
+# form kept is the "does X look right" question (DIVE-3594), which is an
+# instruction to go and look wearing a question mark.
+_GATE_ASK_LOOK_RX='(^|[.!?]([[:space:]]|$)|,[[:space:]]+|\b(can|could|would|will|please|you)[[:space:]]+(you[[:space:]]+)?)(open|view|visit|screenshot|eyeball|look)\b'
+_GATE_ASK_LOOK_Q_RX='\b(does|do|is|are)\b[^.?!]{0,60}\blooks?\b'
+_gate_ask_unsatisfiable_preview() {   # <ask> -> 0 when it asks the reader to LOOK at a preview
+  local s="${1:-}"
+  LC_ALL=C grep -Eiq "$_GATE_ASK_PREVIEW_RX" <<<"$s" || return 1
+  LC_ALL=C grep -Eiq "$_GATE_ASK_LOOK_RX" <<<"$s" && return 0
+  LC_ALL=C grep -Eiq "$_GATE_ASK_LOOK_Q_RX" <<<"$s" && return 0
+  return 1
+}
+
+# ARM 2 — A CODE-HOSTING RULE IS NOT A DECISION.
+# lodar on DIVE-4196, asked to approve something a repository setting demanded:
+# "why asking me then?" A CODEOWNERS entry, a branch-protection rule or a
+# required-reviewer setting is repo CONFIG. The person tapping cannot change the
+# outcome by tapping — the rule fires again on the next PR — so the tap buys one
+# merge and zero decisions. The real row is "move or drop the rule" (DIVE-4334),
+# which is a genuine decision and is NOT caught here: its ask names the effect
+# ("Changes to the script that installs our product wait for your approval. Move
+# that approval off you, or drop it entirely?") and none of the tokens below.
+# That separation is the whole point — this arm fires on an ask that cites the
+# RULE AS THE REASON, not on an ask about the rule.
+#
+# THE APPROVAL-SHAPE CLAUSE IS LOAD-BEARING, and it is the difference between
+# this arm and a rule that eats its own remedy. An ask that wants the RULE
+# CHANGED — "will a repository admin make that branch-protection change?"
+# (DIVE-4086) — is a browser-only action a person really does hold, and refusing
+# it would leave the rule in place forever. What is refused is an ask that wants
+# a PER-CHANGE TAP whose reason is the rule: "Approve PR #779 as code owner of
+# install.sh?" (DIVE-4020) — the single true positive in the 30-day corpus, and
+# the exact shape lodar answered with "why asking me then?" (DIVE-4196).
+_GATE_ASK_CODEHOST_RX='codeowner|code[- ]owner|branch protection|protected branch|required review|required approval|required reviewer|requires? (a )?(review|approval)'
+_GATE_ASK_CODEHOST_APPROVE_RX='\b(approve|approves|approval|approving|sign[- ]off|signoff|rubber)\b'
+_gate_ask_codehost_rule() {   # <ask> -> 0 when a per-change tap is asked for BECAUSE of a repo rule
+  local s="${1:-}"
+  LC_ALL=C grep -Eiq "$_GATE_ASK_CODEHOST_RX" <<<"$s" || return 1
+  LC_ALL=C grep -Eiq "$_GATE_ASK_CODEHOST_APPROVE_RX" <<<"$s" || return 1
+  return 0
+}
+
 # Word count on whitespace. Deliberately the same unit the human experiences —
 # words on a phone screen — not characters or bytes.
 _gate_ask_word_count() {
@@ -3204,6 +3291,101 @@ THE ONE EXIT THIS REFUSAL DOES NOT OFFER IS A DIFFERENT DESTINATION. --tier=1 wo
     elif [[ -n "$ask_ok" ]]; then
       warn "--ask-ok changed nothing on this gate — the readability check passed on its own (${_ar_words} words, no internal names)."
     fi
+    # DIVE-4346 — THE ANSWERABILITY REFUSALS. Placed inside `_ar_human` for the
+    # same reason the readability refusal is: only a gate that actually reaches
+    # the paired human is graded on whether a person can act on it. A tier-1 ask
+    # telling an AGENT to open a preview is a different (and fine) instruction.
+    # Each carries its own `--ask-ok` escape, because a gate must never become
+    # unfileable (DIVE-2216) and an exception that leaves a row is countable.
+    local _un_why=""
+    if _gate_ask_unsatisfiable_preview "$ask"; then
+      _un_why="it asks the reader to open or look at a preview deployment"
+    elif _gate_ask_codehost_rule "$ask"; then
+      _un_why="its stated reason is a code-hosting rule (a repository setting), not an outcome the reader chooses"
+    fi
+    if [[ -n "$_un_why" ]]; then
+      if [[ -z "$ask_ok" ]]; then
+        _task_store_audit_log "task need ask-answerable" "refused" 0 -- \
+          "task=$ident" "filer=${actor:-}" "type=$type" "why=${_un_why}" || true
+        fail "$E_VALIDATION" "$ident: refusing this gate because ${_un_why} — so tapping it does not produce an answer.
+A preview deployment is unreachable by the holder too, not just by an agent: behind the sign-in wall on the hosting side there is a SECOND wall — our live login provider refuses preview addresses outright, and the hosting bypass key has no authority over it. Measured 2026-09-11: that false premise cost about a day and six gates, three of which reached the paired human, before the change was verified on a real box instead. A repository rule is the mirror image — the person tapping cannot change the outcome, because the rule fires again on the very next change, so the tap buys one merge and zero decisions.
+  verify on a real box       the route is auth-gated; a running box is the only place it renders. This is the exit that is wanted.
+  ask for a test login       if nobody here can sign in, that is a credential a person must issue — file it as --type=secret, which IS a human capability.
+  move or drop the rule      a repository setting is its own decision row (\"take this approval off you, or drop it?\"), not a per-change tap.
+  --ask-ok=\"<why a person can still act on this>\"    the audited exception. Recorded on the gate and countable afterwards.
+As with the readability refusal, NO EXIT HERE CHANGES THE DESTINATION: nothing about an ask being unanswerable says a different reader could answer it."
+      fi
+      [[ ${#ask_ok} -ge 12 ]] \
+        || fail "$E_VALIDATION" "--ask-ok must state WHY a person can still act on this ask (it is recorded on the gate and read by whoever counts these exceptions later)"
+      _task_store_audit_log "task need ask-answerable" "escaped" 0 -- \
+        "task=$ident" "filer=${actor:-}" "type=$type" "why=${_un_why}" "declared=$ask_ok" || true
+      warn "answerability escape ACCEPTED and RECORDED: --ask-ok=\"${ask_ok}\". This ask ${_un_why}, and the human is still being sent it."
+    fi
+
+    # DIVE-4346 — A TAP ON THE CUSTOMER MUST NAME THE CAPABILITY IT CONSUMES.
+    #
+    # THE PRODUCT DEFAULT this row exists to set: a person is tapped only for
+    # money, a secret, an irreversible step, or something only a person at a
+    # browser can do. Those four are exactly `_GATE_HUMAN_CAPABILITIES` plus the
+    # `secret` type, and `--needs=` is the sentence that names one.
+    #
+    # MEASURED ON THIS BOARD, the 7 days to 2026-09-12: 35 gates reached the
+    # paired human. 16 of them (46%) named NO capability at all. That is the
+    # before-number, and it is the population this refusal addresses — not the
+    # 17 that did declare one, which are the honest taps and are untouched.
+    #
+    # WHY A REFUSAL AND NOT A ROUTE, and this is the one thing that must not be
+    # got wrong here. The row as filed asked for a needs-less manual/approval
+    # gate to be ROUTED to a lead or verifier seat instead. That is precisely the
+    # behaviour DIVE-4329 removed ONE DAY EARLIER, on a measurement: on 2026-09-11
+    # a manual gate asking a person to try a login took a re-route exit, queued on
+    # a lead seat that cannot open a browser, and NOBODY WAS EVER PINGED. A gate
+    # that reaches nobody is a stall with a receipt, and it is worse than the tap
+    # it replaced because it is silent. So the default is enforced where it can
+    # only ever cost a re-file: the filer must SAY what the ask consumes. Declaring
+    # it is free and correct; not being able to name it is the diagnostic that the
+    # gate did not belong on a person.
+    #
+    # SCOPE, and every exemption here is a type that ALREADY NAMES ITS CAPABILITY.
+    #   * `secret` names `secret_provision` in its own name; its tier-2 floor is
+    #     permanent and must stay so.
+    #   * `access` is lead-clearable BY TYPE (DIVE-1243), so it is not a customer
+    #     tap in the first place.
+    #   * a tier-2 `manual` gate is the type whose definition IS "a step only a
+    #     person can perform" — `_gate_is_human_tap` has said exactly that since
+    #     DIVE-4329 and the URL exception above already depends on it. Requiring
+    #     the flag on top would be asking the filer to repeat the type, and it
+    #     would refuse the product's OWN iteration-cap escalation gate
+    #     (src/task/delivery.sh), which is a correct manual gate — caught by
+    #     tests/gate_ask_readability_unit.sh arm F while this was being built.
+    #   * a category-floored gate (tier_floored on the ask/title axis): the floor
+    #     already said which reserved class it belongs to, and refusing it here
+    #     would make a floored gate unfileable rather than declared.
+    # What is LEFT is exactly the population the audit measured: `decision` and
+    # `approval` gates that reach a person and say nothing about what they need
+    # from one.
+    if [[ -z "${needs//[[:space:]]/}" && "$type" != "secret" && "$type" != "access" \
+          && "$tier_floored" != "1" ]] && ! _gate_is_human_tap "$type" "$tier" "$needs"; then
+      if [[ -z "$ask_ok" ]]; then
+        _task_store_audit_log "task need capability-undeclared" "refused" 0 -- \
+          "task=$ident" "filer=${actor:-}" "type=$type" "tier=$tier" || true
+        fail "$E_VALIDATION" "$ident: refusing this gate because it reaches the paired human and does not say what it needs FROM a human. A customer is tapped for exactly four things: money, a secret, something irreversible, or something only a person at a browser or keyboard can do. Name the one this ask consumes:
+  --needs=spend_authority     it spends money or commits to a paid account.
+  --needs=secret_provision    a token or credential must come FROM a person (or file it as --type=secret).
+  --needs=human_tap           a person's own call — brand, strategy, an irreversible choice — or a step only a person at a browser can perform.
+IF YOU CANNOT NAME ONE, this is not a gate on a person. Your exits:
+  --tier=0                    apply your own --recommend now: no ping, permanent record, a line in the digest. On this board 81% of answered decision gates came back as the human tapping the filer's recommendation, so if you wrote one you have already decided.
+  --tier=1                    the lead or this task's verifier answers it. Correct when the ask needs a JUDGEMENT an agent can make.
+  --ask-ok=\"<why a person must answer this though it consumes none of the four>\"    the audited exception. Recorded and countable.
+Measured on this board, the 7 days to 2026-09-12: 35 gates reached the paired human and 16 of them named no capability at all — and 313 changes shipped in the same week, so the ratio a customer would read is 0.11 taps per shipped change."
+      fi
+      [[ ${#ask_ok} -ge 12 ]] \
+        || fail "$E_VALIDATION" "--ask-ok must state WHY a person must answer a gate that consumes none of the four human capabilities"
+      _task_store_audit_log "task need capability-undeclared" "escaped" 0 -- \
+        "task=$ident" "filer=${actor:-}" "type=$type" "declared=$ask_ok" || true
+      warn "undeclared-capability escape ACCEPTED and RECORDED: --ask-ok=\"${ask_ok}\". This gate reaches the paired human and names no capability."
+    fi
+
     # DIVE-4176, THE HALF THAT STAYS ADVISORY AND WHY. "Consequence-first, a
     # choice between outcomes" is the rule that matters most and it is the one
     # with no honest mechanical predicate. The closest proxy is "the ask asks a

--- a/src/task/need.sh
+++ b/src/task/need.sh
@@ -3373,8 +3373,27 @@ As with the readability refusal, NO EXIT HERE CHANGES THE DESTINATION: nothing a
     # What is LEFT is exactly the population the audit measured: `decision` and
     # `approval` gates that reach a person and say nothing about what they need
     # from one.
+    #   * a category-floored gate: the floor already said which reserved class it
+    #     belongs to, and refusing it here would make a floored gate unfileable
+    #     rather than declared.
+    #
+    # AND `tier_floored` IS THE WRONG WAY TO ASK THAT — found by quinn's core-tier
+    # sweep (gate_recommend_cap_unit B3, "approve the monthly spend on the paid
+    # Hetzner plan"), and the cap 90 lines below had already written the reason down
+    # in full before this shipped: the T2 category floor only ever runs to RAISE a
+    # tier below 2, so there is nothing for it to raise when the filer TYPED
+    # --tier=2, and a money gate filed at tier 2 arrives here with tier_floored
+    # still 0 — indistinguishable from an undeclared judgement call. Reading the
+    # flag therefore refused exactly the reserved classes the exemption exists for.
+    # Re-run the classifier over the ask AND the title, the same way the cap does.
+    # Not a widening: a floored gate was always meant to be exempt, and this is the
+    # only instrument that answers whether it is floored on this path.
+    local _cu_title=""
+    _cu_title=$(db "SELECT COALESCE(title,'') FROM tasks WHERE id=${id};")
     if [[ -z "${needs//[[:space:]]/}" && "$type" != "secret" && "$type" != "access" \
-          && "$tier_floored" != "1" ]] && ! _gate_is_human_tap "$type" "$tier" "$needs"; then
+          && "$tier_floored" != "1" ]] \
+       && ! _gate_hit_either _gate_tier2_floor_hit "$ask" "$_cu_title" \
+       && ! _gate_is_human_tap "$type" "$tier" "$needs"; then
       if [[ -z "$ask_ok" ]]; then
         _task_store_audit_log "task need capability-undeclared" "refused" 0 -- \
           "task=$ident" "filer=${actor:-}" "type=$type" "tier=$tier" || true

--- a/tests/digest_tap_ratio_unit.sh
+++ b/tests/digest_tap_ratio_unit.sh
@@ -145,6 +145,20 @@ grep -qF 'of 1 tap,' <<<"$L7" \
   && ok_t "T7 one tap reads 'of 1 tap,' not 'of 1 taps,'" \
   || bad_t "T7 plural" "got: $L7"
 
+# --- T8 DIVE-4346 iteration 3: a DERIVED capability is never reported as a
+# declaration. A floor hit now derives the class and stores it, and a derived
+# class is a GUESS read out of the ask's wording — counting it as "named" would
+# hide exactly the mis-classification the split exists to make countable.
+printf '[{"cap":"human_tap","derived":0,"n":1},{"cap":"spend_authority","derived":1,"n":1},{"cap":"","derived":0,"n":1}]\n' > "$TMP/capd.json"
+L8=$(ratio_line "$TMP/tasks.json" "$TMP/capd.json")
+grep -qF "1 named a capability, 1 named none (1 derived from the ask's wording, not declared)" <<<"$L8" \
+  && ok_t "T8 a derived capability is rendered apart from a declared one" \
+  || bad_t "T8 derived split" "got: $L8"
+# CONTROL: a board with no derived taps must not carry the parenthetical at all.
+grep -qF "derived from the ask" <<<"$L" \
+  && bad_t "T8b no derived taps renders no derived clause" "got: $L" \
+  || ok_t "T8b a window with no derived taps says nothing about derivation"
+
 printf '\ndigest_tap_ratio_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 SUMMARY_PRINTED=1
 [[ "$FAIL" -eq 0 ]]

--- a/tests/digest_tap_ratio_unit.sh
+++ b/tests/digest_tap_ratio_unit.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# DIVE-4346 isolated unit harness for the digest's TAPS-PER-SHIPPED-CHANGE line.
+#
+# WHY THIS FILE EXISTS: quinn's grading pass on DIVE-4346 confirmed the counter
+# renders in a real built run and then said the thing that mattered — it had ZERO
+# test arms, so nothing would notice if it stopped rendering, or started rendering
+# a confident zero. A counter whose whole purpose is to be read as a ratio by a
+# customer is exactly the kind of number that must not be able to lie quietly.
+#
+# Same method as tests/digest_autonomy_unit.sh: extract the digest's embedded
+# python and drive it through the DIGEST_*_F env contract (no shell-out, no live
+# DB). This one runs the TEXT branch, not DIGEST_JSON=1, because the ratio line is
+# rendered prose and the rendering is the subject.
+#
+# THE ARM THAT CARRIES THE MOST WEIGHT IS T4, and it is not about arithmetic:
+# `needs_capability` is on neither `task ls --json` nor `gate_history`, so the
+# read can genuinely fail. When it does, the split must say "unknown" and never
+# "0 named none" — a capability we could not count is not a capability that was
+# not named (the DIVE-3228 lesson about the buzz count). A broken read that
+# renders as a clean zero is the shape that makes a number worse than no number.
+# Run: bash tests/digest_tap_ratio_unit.sh  (no root, no network).
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+exec 8>&2
+SUMMARY_PRINTED=0
+trap 'rc=$?; rm -rf "${TMP:-}"; [[ "${SUMMARY_PRINTED:-0}" == 1 ]] || printf "ABORTED - digest_tap_ratio_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+
+TMP="$(mktemp -d /tmp/digest-tap-ratio.XXXXXX)"
+
+awk "/python3 - >.*<<'PY'/{f=1;next} f&&/^PY\$/{f=0} f" src/cmd_digest.sh > "$TMP/digest.py"
+[[ -s "$TMP/digest.py" ]] || { echo "FAIL - could not extract digest python"; exit 1; }
+
+iso() { date -u -d "@$(( $(date +%s) - $1 ))" +%FT%TZ; }
+D1=$(iso 86400); D2=$(iso 172800); D3=$(iso 259200)
+
+echo '{"agents":[],"tasks":[]}' > "$TMP/usage.json"
+: > "$TMP/hb.txt"
+echo '{"loops":[]}'             > "$TMP/loops.json"
+
+# 3 shipped, 2 gates answered by a person, inside the 7d window.
+cat > "$TMP/tasks.json" <<JSON
+{"tasks":[
+  {"ident":"T-1","title":"ship a","status":"done","done_at":"$D1","assignee":"dev","kind":"task"},
+  {"ident":"T-2","title":"ship b","status":"done","done_at":"$D1","assignee":"dev","kind":"task"},
+  {"ident":"T-3","title":"ship c","status":"done","done_at":"$D2","assignee":"dev","kind":"task"},
+  {"ident":"G-1","title":"gate a","status":"done","need_type":"decision","need_answered_by":"human:lodar","need_answered_at":"$D2","need_asked_at":"$D3","need_answer":"go","assignee":"main","kind":"task"},
+  {"ident":"G-2","title":"gate b","status":"done","need_type":"approval","need_answered_by":"human:lodar","need_answered_at":"$D2","need_asked_at":"$D3","need_answer":"ok","assignee":"main","kind":"task"}
+]}
+JSON
+
+# $1 = tasks file, $2 = cap file (may be absent to grade the unset case)
+# `env` rather than an assignment prefix: an assignment prefix is recognised
+# before expansion, so a conditional `${2:+VAR=...}` would be taken as the COMMAND
+# name and the harness would grade nothing. Stderr is kept — a python traceback
+# here is the most informative failure this file can have.
+render() {
+  local -a e=(DIGEST_TASKS_F="$1" DIGEST_USAGE_F="$TMP/usage.json"
+              DIGEST_HB_F="$TMP/hb.txt" DIGEST_LOOPS_F="$TMP/loops.json"
+              DIGEST_WINDOW=604800 DIGEST_JSON=0)
+  [[ -n "${2:-}" ]] && e+=(DIGEST_CAP_F="$2")
+  env "${e[@]}" python3 "$TMP/digest.py"
+}
+ratio_line() { render "$@" | grep -F 'taps per shipped change'; }
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+
+# --- T0 LIVENESS: the line renders at all. Without this every grep-for-substring
+#     arm below would pass vacuously on a digest that dropped the counter.
+printf '[{"cap":"human_tap","n":1},{"cap":"","n":1}]\n' > "$TMP/cap.json"
+L=$(ratio_line "$TMP/tasks.json" "$TMP/cap.json")
+[[ -n "$L" ]] \
+  && ok_t "T0 liveness: the taps-per-shipped-change line is rendered ($L)" \
+  || { bad_t "T0 liveness: no ratio line in the digest text output" "nothing below grades anything"; \
+       printf '\ndigest_tap_ratio_unit: %d passed, %d failed\n' "$PASS" "$FAIL"; SUMMARY_PRINTED=1; exit 1; }
+
+# --- T1 THE RATIO IS taps / shipped, to 2dp. 2 taps / 3 shipped = 0.67.
+grep -qF '0.67 taps per shipped change' <<<"$L" \
+  && ok_t "T1 ratio = 0.67 (2 human taps / 3 shipped)" \
+  || bad_t "T1 ratio arithmetic" "got: $L"
+
+# --- T2 THE SPLIT counts a named capability and a blank one separately.
+grep -qF '1 named a capability, 1 named none' <<<"$L" \
+  && ok_t "T2 capability split: 1 named, 1 none" \
+  || bad_t "T2 capability split" "got: $L"
+
+# --- T3 THE TAP COUNT AGREES WITH THE AUTONOMY LINE ABOVE IT. Two numbers for
+#     the same fact on adjacent lines is how a counter goes quietly wrong.
+grep -qE 'of 2 taps' <<<"$L" \
+  && ok_t "T3 the line names the same 2 taps the autonomy line counted" \
+  || bad_t "T3 tap count" "got: $L"
+
+# --- T4 UNKNOWN IS NOT ZERO. A failed read yields null; it must render as
+#     "unknown", never as "0 named none". This is the arm this file exists for.
+printf 'null\n' > "$TMP/capnull.json"
+L4=$(ratio_line "$TMP/tasks.json" "$TMP/capnull.json")
+if grep -qF 'capability split: unknown' <<<"$L4" && ! grep -qF 'named none' <<<"$L4"; then
+  ok_t "T4 an unreadable capability column renders 'unknown', NOT a confident zero"
+else
+  bad_t "T4 unknown-is-not-zero (DIVE-3228)" "got: $L4 — a failed read reported as 0 is worse than no counter"
+fi
+
+# --- T4b SAME, for the file being absent entirely (the env var never set).
+L4b=$(ratio_line "$TMP/tasks.json")
+grep -qF 'capability split: unknown' <<<"$L4b" \
+  && ok_t "T4b no DIGEST_CAP_F at all is also 'unknown', not zero" \
+  || bad_t "T4b unset cap file" "got: $L4b"
+
+# --- T5 ZERO SHIPPED WITH TAPS IS NOT A DIVIDE BY ZERO, and it must not read as
+#     0.00 either: taps against nothing shipped is the worst ratio there is.
+python3 - "$TMP/tasks.json" "$TMP/noship.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+d["tasks"] = [t for t in d["tasks"] if not t["ident"].startswith("T-")]
+json.dump(d, open(sys.argv[2], "w"))
+PY
+L5=$(ratio_line "$TMP/noship.json" "$TMP/cap.json")
+grep -qF '∞ taps per shipped change' <<<"$L5" \
+  && ok_t "T5 taps with nothing shipped renders ∞, not 0.00 and not a crash" \
+  || bad_t "T5 zero-shipped" "got: $L5"
+
+# --- T6 NO TAPS AND NOTHING SHIPPED IS 'n/a' — an honest absence of a ratio.
+python3 - "$TMP/tasks.json" "$TMP/empty.json" <<'PY'
+import json, sys
+json.dump({"tasks": []}, open(sys.argv[2], "w"))
+PY
+L6=$(ratio_line "$TMP/empty.json" "$TMP/cap.json")
+grep -qF 'n/a taps per shipped change' <<<"$L6" \
+  && ok_t "T6 an empty window renders n/a, not 0.00" \
+  || bad_t "T6 empty window" "got: $L6"
+
+# --- T7 SINGULAR/PLURAL on the tap noun, because the line is read by a customer.
+python3 - "$TMP/tasks.json" "$TMP/onetap.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+d["tasks"] = [t for t in d["tasks"] if t["ident"] != "G-2"]
+json.dump(d, open(sys.argv[2], "w"))
+PY
+L7=$(ratio_line "$TMP/onetap.json" "$TMP/cap.json")
+grep -qF 'of 1 tap,' <<<"$L7" \
+  && ok_t "T7 one tap reads 'of 1 tap,' not 'of 1 taps,'" \
+  || bad_t "T7 plural" "got: $L7"
+
+printf '\ndigest_tap_ratio_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
+SUMMARY_PRINTED=1
+[[ "$FAIL" -eq 0 ]]

--- a/tests/gate_answer_audit_unit.sh
+++ b/tests/gate_answer_audit_unit.sh
@@ -169,8 +169,11 @@ fi
 #        write-site row. The refusal `fail`s, so run it in a subshell.
 reset
 t2=$(addt --assignee=dev -- "fixture hard gate")
+# DIVE-4346: a gate reaching the human must name the capability it consumes. This
+# ask genuinely spends money, so the declaration is the honest fixture here — and it
+# keeps the gate a real hard-human tier-2, which is what the case needs to grade.
 cmd_task_need "$t2" --type=decision --options="A|B" --recommend="A" \
-  --ask="spend money on ads" --tier=2 >/dev/null 2>&1
+  --ask="spend money on ads" --tier=2 --needs=spend_authority >/dev/null 2>&1
 ( cmd_task_answer "$t2" --value="A" ) >/dev/null 2>&1
 RC=$?
 if [[ "$RC" != "0" && -z "$(nat "$t2")" ]]; then

--- a/tests/gate_approval_routing_unit.sh
+++ b/tests/gate_approval_routing_unit.sh
@@ -146,8 +146,13 @@ cmd_task_need DIVE-207 --type=secret --ask="drop the deploy key" --secret-key=DE
 
 # --- A8: an explicit --tier=2 on an approval is honored (caller's hard-human contract).
 seed_task DIVE-208
+# DIVE-4346: a gate reaching the human must now NAME the capability it consumes.
+# This fixture must keep the explicit --tier=2 pin as the SOURCE of the tier (that is
+# what A8 grades), so it takes the audited --ask-ok exception rather than --needs=,
+# which would make the declaration the source and grade a different thing.
 cmd_task_need DIVE-208 --type=approval --ask="approve the mechanical README sync?" --recommend="yes" --tier=2 \
-  --rubber-stamp-ok="fixture: this case grades that an explicit --tier=2 pin is honored, so it must BE one (DIVE-2848 cap)" >/dev/null 2>&1
+  --rubber-stamp-ok="fixture: this case grades that an explicit --tier=2 pin is honored, so it must BE one (DIVE-2848 cap)" \
+  --ask-ok="fixture: A8 grades that the --tier=2 pin itself is honored, so the gate must reach the human WITHOUT a declared capability (DIVE-4346)" >/dev/null 2>&1
 [[ "$(tierof DIVE-208)" == "2" ]] \
   && ok_t "A8 explicit --tier=2 on approval honored (hard-human contract preserved)" \
   || bad_t "A8 explicit tier 2 honored" "got tier '$(tierof DIVE-208)'"

--- a/tests/gate_channel_proof_unit.sh
+++ b/tests/gate_channel_proof_unit.sh
@@ -135,7 +135,10 @@ cmd_task_answer DIVE-203 --value=approved --channel-proof=555 >/dev/null 2>&1
 seed_task DIVE-301; cmd_task_need DIVE-301 --type=decision --ask=q --options="A|B" --recommend="A" --tier=1 >/dev/null 2>&1
 seed_task DIVE-302; cmd_task_need DIVE-302 --type=approval --ask=q --recommend=approved --tier=1 >/dev/null 2>&1
 seed_task DIVE-303; cmd_task_need DIVE-303 --type=decision --ask=q --options="A|B" --tier=1 >/dev/null 2>&1   # no recommend -> skip
-seed_task DIVE-304; cmd_task_need DIVE-304 --type=approval --ask=q --recommend=approved --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1  # explicit tier2 hard gate -> skip
+# DIVE-4346 adds a second hand-typed-tier-2 cap (a gate reaching the human must name
+# the capability it consumes); this fixture needs the UNDECLARED shape, so it takes
+# the audited exception alongside the DIVE-2848 one.
+seed_task DIVE-304; cmd_task_need DIVE-304 --type=approval --ask=q --recommend=approved --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --ask-ok="fixture: this case needs an UNDECLARED hard-human tier-2 gate to grade (DIVE-4346)" >/dev/null 2>&1  # explicit tier2 hard gate -> skip
 seed_task DIVE-305; cmd_task_need DIVE-305 --type=approval --ask=q --recommend=approved --tier=1 >/dev/null 2>&1
 db "UPDATE tasks SET routed_reviewer='marcus' WHERE ident='DIVE-305';"                                        # lead-routed -> skip
 

--- a/tests/gate_customer_tap_default_unit.sh
+++ b/tests/gate_customer_tap_default_unit.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# TIER: core
+# DIVE-4346 — A CUSTOMER IS TAPPED ONLY FOR MONEY, A SECRET, AN IRREVERSIBLE STEP,
+# OR SOMETHING ONLY A PERSON AT A BROWSER CAN DO.
+#
+# lodar, Telegram 2026-09-12 01:06Z: "i just think about our customers. this would
+# be annoying for them to tap on such a minor change. human gate is still the most
+# annoying part of 5dive."
+#
+# MEASURED ON THIS BOARD, the 7 days to 2026-09-12: 35 gates reached the paired
+# human; 16 of them (46%) named no capability at all, and 313 changes shipped in
+# the same week — 0.11 taps per shipped change. Replayed over the 171
+# tier-2 asks in gate_history for the 30 days to 2026-09-12, the two new
+# answerability refusals below fire on 9 and 1 asks respectively, with ZERO false
+# positives — the full list is on the row body.
+#
+# THIS FILE GRADES THREE THINGS AND THEIR CONTROLS:
+#   1. the "go look at the preview" refusal — unsatisfiable on an auth-gated
+#      route, because a PRODUCTION login provider refuses preview domains and the
+#      hosting bypass key has no authority over it (DIVE-4263, ~1 day and 6 gates);
+#   2. the "a code-hosting rule is not a decision" refusal (DIVE-4020/4196);
+#   3. the capability-declaration default — a decision/approval gate that reaches
+#      a person must name which of the four it consumes.
+#
+# WHERE THIS DIVERGES FROM THE ROW AS FILED, deliberately. The row asked for a
+# needs-less manual/approval gate to be ROUTED to a lead/verifier seat. That is
+# the behaviour DIVE-4329 removed ONE DAY EARLIER on a measurement: on 2026-09-11
+# a manual gate asking a person to try a login took a re-route exit, queued on a
+# lead seat that cannot open a browser, and nobody was ever pinged. A gate that
+# reaches nobody is worse than the tap, because it is silent. So the default is a
+# REFUSAL AT FILING (cost: one re-file) rather than a re-route (cost: a silent
+# stall), and the mutation arm below is its equivalent: a needs-less APPROVAL gate
+# that reaches the human must be RED. Arms M4/M5 pin that `manual` and `secret`
+# stay human-facing, so this cannot be "passed" by re-routing everything.
+#
+# Every refusal is paired with a control that must still FILE, because a lone red
+# exit cannot tell "the rule works" from "cmd_task_need is unreachable".
+#
+# Run: bash tests/gate_customer_tap_default_unit.sh   (no root, no network)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/gate-customer-tap.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_agent.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"
+set +e
+tasks_db_init
+_tasks_db_migrate
+
+# --- stubs: nothing leaves the box -------------------------------------------
+cmd_send()               { return 0; }
+_task_agent_channel()    { return 0; }
+_task_send_owner()       { return 0; }
+task_need_notify()       { return 0; }
+_task_gate_retire_buttons() { return 0; }
+audit_log()              { return 0; }
+AUDIT_ROWS="$TMP/audit_rows"; : >"$AUDIT_ROWS"
+_task_store_audit_log()  { printf '%s\n' "$*" >>"$AUDIT_ROWS"; return 0; }
+# No lead above the filer, so a tier that survives to these arms survived for the
+# reason the case is about. Overridden live in arm M3.
+_gate_route_reviewer()   { printf ''; }
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+eq_t()  { if [[ "$2" == "$3" ]]; then ok_t "$1"; else bad_t "$1" "want [$3] got [$2]"; fi; }
+has_t() { if [[ "$2" == *"$3"* ]]; then ok_t "$1"; else bad_t "$1" "[$2] does not contain [$3]"; fi; }
+red_t() { if [[ "$2" != "0" ]]; then ok_t "$1"; else bad_t "$1" "filed (rc 0) when it had to be refused: $3"; fi; }
+field() { db "SELECT COALESCE($2,'∅') FROM tasks WHERE ident='$1';"; }
+
+N=0
+seed() { N=$((N+1)); db "INSERT INTO tasks (ident, title, priority, assignee, created_by, kind, status)
+      VALUES ('$1', '${2:-a plain internal row}', 'medium', 'dev', 'main', 'standard', 'todo');"; }
+
+RC=0; OUT=""
+file_gate() { local id="$1"; shift; OUT=$( (cmd_task_need "$id" --from=dev "$@") 2>&1 ); RC=$?; }
+
+# ============ PRECONDITION ===================================================
+seed LIVE-1
+file_gate LIVE-1 --type=decision --tier=2 --needs=human_tap \
+  --ask="Two AI workers have been signed out since July. Sign them back in, or retire them?"
+eq_t "PRECONDITION: a DECLARED human-capability gate files (rc 0)" "$RC" "0"
+eq_t "PRECONDITION: ... and the row is a real tier-2 gate" \
+     "$(field LIVE-1 need_type)|$(field LIVE-1 tier)" "decision|2"
+
+# ============ A. the predicates at unit level ================================
+# TRUE POSITIVES — every one of these is a verbatim tier-2 ask from gate_history,
+# and the last three are the ones lodar was handed on 2026-09-12 00:27..01:05Z.
+while IFS='|' read -r src ask; do
+  if _gate_ask_unsatisfiable_preview "$ask"; then ok_t "A-pv+: $src is caught"
+  else bad_t "A-pv+: $src is caught" "missed: $ask"; fi
+done <<'CORPUS'
+DIVE-3618|Open the #98 Vercel preview at desktop width, confirm the agent row shows the moon icon?
+DIVE-3613|Can you open PR #97's Vercel preview on your phone at /dashboard/chat and approve the merge?
+DIVE-3594|Does the agent detail page still look right in the Vercel preview?
+DIVE-4263|Screenshot the three task-review choices: https://5dive-frontend-git-dev3.vercel.app/dashboard/settings
+DIVE-4294|Open the dashboard preview, click Update on one box, and say whether the version cell reads right.
+DIVE-4239|One real login test needed: fresh box, open https://5dive-frontend-git-dive-4239.vercel.app and sign in.
+DIVE-4307|Please open the new customer rescue screen's preview and confirm it looks right.
+CORPUS
+
+# FALSE-POSITIVE CONTROLS — measured, not imagined. Each carries BOTH a preview
+# token and a look-verb, and each is a legitimate gate: the verb's object is the
+# change, or the looking is a subordinate note about what happens after the merge.
+while IFS='|' read -r src ask; do
+  if _gate_ask_unsatisfiable_preview "$ask"; then bad_t "A-pv-: $src survives" "wrongly caught: $ask"
+  else ok_t "A-pv-: $src survives"; fi
+done <<'CONTROLS'
+DIVE-3978|Push the finished page update to a review branch so it can be graded and previewed? Nothing goes live: it only opens the change for review.
+DIVE-3984|Approve pushing the headline change for review. This seat cannot render page images, so the deploy preview must be looked at before merge.
+DIVE-4239b|This feature needs one real person to run a ten minute login test on a preview build. Commit that person now, or leave it unassigned?
+CONTROLS
+
+if _gate_ask_codehost_rule "Approve PR #779 as code owner of install.sh? Recommend: approve, then merge."; then
+  ok_t "A-ch+: a per-change tap whose reason is a code-owner rule is caught"
+else bad_t "A-ch+: a per-change tap whose reason is a code-owner rule is caught" "missed"; fi
+if _gate_ask_codehost_rule "Will a repository admin make that branch protection change?"; then
+  bad_t "A-ch-: an ask to CHANGE the rule survives" "wrongly caught — that is a browser-only human action"
+else ok_t "A-ch-: an ask to CHANGE the rule survives"; fi
+if _gate_ask_codehost_rule "Changes to the script that installs our product wait for your approval. Move that approval off you, or drop it entirely?"; then
+  bad_t "A-ch-2: DIVE-4334's own decision survives" "wrongly caught"
+else ok_t "A-ch-2: DIVE-4334's own decision survives"; fi
+
+# ============ B. the preview refusal, end to end =============================
+PV="Please open the new customer rescue screen's preview and confirm it looks right."
+seed PV-1
+file_gate PV-1 --type=manual --tier=2 --ask="$PV"
+red_t "B1: a human-facing 'open the preview' gate is REFUSED" "$RC" "$OUT"
+has_t "B1b: the refusal explains the SECOND wall" "$OUT" "refuses preview addresses outright"
+eq_t  "B1c: NO gate was written by the refused filing" "$(field PV-1 need_type)" "∅"
+eq_t  "B1d: the task was not moved to blocked" "$(field PV-1 status)" "todo"
+has_t "B1e: the refusal is audited" "$(cat "$AUDIT_ROWS")" "task need ask-answerable refused"
+has_t "B1f: it offers verifying on a box, not a re-route" "$OUT" "verify on a real box"
+
+# CONTROL: the same ask at tier 1 is read by an AGENT and must still file.
+seed PV-2
+file_gate PV-2 --type=decision --tier=1 --ask="$PV"
+eq_t "B2: the SAME ask at tier 1 still files (rc 0)" "$RC" "0"
+eq_t "B2b: ... and really is a gate" "$(field PV-2 need_type)" "decision"
+
+# The audited escape must work, or the gate is unfileable (DIVE-2216).
+seed PV-3
+file_gate PV-3 --type=manual --tier=2 --ask="$PV" --ask-ok="he owns the only login that can reach this box"
+eq_t "B3: --ask-ok files it anyway (rc 0)" "$RC" "0"
+has_t "B3b: ... and the escape is audited" "$(cat "$AUDIT_ROWS")" "task need ask-answerable escaped"
+
+# ============ C. the code-hosting-rule refusal ===============================
+seed CH-1
+file_gate CH-1 --type=approval --tier=2 --needs=human_tap \
+  --ask="Approve this change as code owner of the installer?"
+red_t "C1: an approval asked for BECAUSE of a repo rule is REFUSED" "$RC" "$OUT"
+has_t "C1b: the refusal says the rule fires again next time" "$OUT" "fires again on the very next change"
+eq_t  "C1c: NO gate was written" "$(field CH-1 need_type)" "∅"
+seed CH-2
+file_gate CH-2 --type=decision --tier=2 --needs=human_tap \
+  --ask="Take the installer approval off you, or drop it entirely?"
+eq_t "C2: the decision ABOUT the rule still files (rc 0)" "$RC" "0"
+
+# ============ M. the capability matrix, and the mutation arm =================
+# type × --needs present/absent × --recommend present/absent -> who is pinged.
+GOOD="Sign the two parked workers back in, or retire them?"
+seed MA-1
+file_gate MA-1 --type=approval --tier=2 --needs=spend_authority --ask="$GOOD"
+eq_t "M1: approval + declared capability -> files, human-facing" \
+     "$RC|$(field MA-1 tier)|$(field MA-1 needs_capability)" "0|2|spend_authority"
+eq_t "M1b: ... and no seat was routed (it is the human's)" "$(field MA-1 routed_reviewer)" "∅"
+
+# THE MUTATION ARM. Delete the capability-declaration refusal and this goes green.
+seed MB-1
+file_gate MB-1 --type=approval --tier=2 --ask="$GOOD"
+red_t "M2: approval + NO capability, reaching the human, is REFUSED" "$RC" "$OUT"
+has_t "M2b: the refusal names the four things a customer is tapped for" "$OUT" "money, a secret, something irreversible"
+eq_t  "M2c: NO gate was written" "$(field MB-1 need_type)" "∅"
+has_t "M2d: the refusal is audited" "$(cat "$AUDIT_ROWS")" "task need capability-undeclared refused"
+has_t "M2e: it offers tier 0 with the filer's own recommendation" "$OUT" "--tier=0"
+seed MB-2
+file_gate MB-2 --type=decision --tier=2 --recommend="sign them back in" --ask="$GOOD"
+red_t "M2f: decision + recommend + NO capability is REFUSED too" "$RC" "$OUT"
+
+# A lead exists: the same needs-less gate is now read by an AGENT, not a person,
+# so the refusal must NOT fire. This is the arm that proves the rule is scoped to
+# gates that actually reach the customer.
+_gate_route_reviewer() { printf 'main'; }
+seed MC-1
+file_gate MC-1 --type=approval --tier=1 --ask="$GOOD"
+eq_t "M3: a lead-routed needs-less approval still files (rc 0)" "$RC" "0"
+# The claim this arm carries is SCOPE, not the route: with a lead above the
+# filer the gate is read by an agent, so the refusal must not fire and a real
+# tier-1 gate must be on the row. (The resolved reviewer name is decided further
+# down cmd_task_need by machinery this harness does not stand up; asserting it
+# here would be asserting the stub, not the product.)
+eq_t "M3b: ... and a real tier-1 gate is on the row" \
+     "$(field MC-1 need_type)|$(field MC-1 tier)" "approval|1"
+_gate_route_reviewer() { printf ''; }
+
+# M4/M5 — the two types that name their capability in their own name stay
+# human-facing and stay fileable. Without these, "refuse everything undeclared"
+# would pass M2 while breaking the gates that are correct.
+seed MD-1
+file_gate MD-1 --type=manual --tier=2 --ask="Try one file import on your own box and say whether it worked?"
+eq_t "M4: a tier-2 manual gate files without --needs (the type IS the capability)" "$RC" "0"
+eq_t "M4b: ... and stays tier 2" "$(field MD-1 tier)" "2"
+seed ME-1
+file_gate ME-1 --type=secret --tier=2 --secret-key=DEMO_TOKEN --connector=env \
+  --ask="Send a throwaway login for the test dashboard?"
+eq_t "M5: a secret gate files without --needs and stays tier 2" "$RC|$(field ME-1 tier)" "0|2"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/gate_delivery_ref_binding_route_unit.sh
+++ b/tests/gate_delivery_ref_binding_route_unit.sh
@@ -207,7 +207,15 @@ done
 # --- 5. INHERITED EXCLUSION: an EXPLICIT --tier=2 is the caller's hard contract --
 seed DIVE-9005 "$PR_REF"
 actor_seam_as dev
+# DIVE-4346: and it takes the AUDITED --ask-ok, not --needs=. This arm's subject is
+# the PIN: an explicit --tier=2 is the caller's own hard-human contract and must stay
+# unrouted on its own. Declaring a capability here would make the capability the
+# reason the gate is human-facing -- which is exactly what arms 3-4 above already
+# grade -- so arm 5 would stop measuring the pin and start duplicating them. The
+# undeclared shape IS the case, so it is bought with a written reason that leaves an
+# audit row. Same judgement as gate_approval_routing_unit A8.
 OUT5=$(cmd_task_need DIVE-9005 --type=approval --tier=2 --ask="$PLAIN_ASK" --recommend="go" \
+         --ask-ok="fixture: this arm grades that an explicit --tier=2 pin alone keeps an approval on the human; --needs= would make the capability the reason and duplicate arms 3-4 instead of measuring the pin" \
          --rubber-stamp-ok="the release window is the founder's call and no lead holds it" --from=dev 2>&1)
 # NON-VACUITY (quinn, iteration 1): a `--tier=2` approval carrying a `--recommend` and
 # no `--rubber-stamp-ok` can be REFUSED at filing by the DIVE-2848 tapback cap, and a

--- a/tests/gate_enforce_env_bypass_unit.sh
+++ b/tests/gate_enforce_env_bypass_unit.sh
@@ -48,7 +48,11 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
-trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
+# DIVE-4346: the ABORT backstop. Subshelling above should make this unreachable;
+# it is here because "should be unreachable" is what silence looks like.
+exec 8>&2
+SUMMARY_PRINTED=0
+trap 'rc=$?; rm -rf "${TMP:-}"; [[ "${SUMMARY_PRINTED:-0}" == 1 ]] || printf "ABORTED - gate_enforce_env_bypass_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-enforce-bypass.XXXXXX)"
@@ -183,7 +187,11 @@ fi
 file_gate() { # file_gate <ident> <type> [extra args...]
   local ident="$1" type="$2"; shift 2
   seed_task "$ident"
-  cmd_task_need "$ident" --type="$type" "$@" >/dev/null 2>&1
+  # DIVE-4346: SUBSHELLED, for exactly the reason the `answer` helper below already
+  # is. `fail` exits, so an unsubshelled filing call turns a refused FIXTURE into a
+  # dead harness — no summary, no verdict, indistinguishable from a harness that was
+  # never reached. A refused fixture must red one arm, never end the run.
+  ( cmd_task_need "$ident" --type="$type" "$@" ) >/dev/null 2>&1
 }
 
 # `fail` exits. Every answer below runs in a command substitution ON PURPOSE so a
@@ -223,7 +231,7 @@ rm -f "$ALT_SENTINEL"
 : > "$DEFAULT_SENTINEL"   # the live posture: enforcement armed by the root-owned file
 
 file_gate DIVE-401 decision --ask="approve the spend for the volume resize" \
-  --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape"
+  --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape"
 [[ "$(tierof DIVE-401)" == "2" ]] \
   && ok_t "E0 precondition: the gate really is tier 2" \
   || bad_t "E0 tier-2 precondition" "tier=$(tierof DIVE-401)"
@@ -253,7 +261,7 @@ grep -qi 'unproven\|tier-2' <<<"$out" \
 # Half 2 of the fix, isolated: even with NO sentinel anywhere — the state the override
 # used to fake — the tier-2 floor stands on its own.
 rm -f "$DEFAULT_SENTINEL"
-file_gate DIVE-402 decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape"
+file_gate DIVE-402 decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape"
 out=$(answer DIVE-402 --value=A); rc=$?
 [[ $rc -ne 0 && "$(answered DIVE-402)" == "open" ]] \
   && ok_t "E5 with enforcement genuinely OFF the tier-2 floor STILL refuses a non-human answer" \
@@ -265,7 +273,7 @@ out=$(answer DIVE-402 --value=A); rc=$?
 # nonce-bearing tier-2 gate is the DIVE-2356 evidence block. Enforcement is still
 # genuinely off here, so this arm reds if that block's flag conjunct comes back and
 # stays green if only the floor's does. Without it, half the fix is untested.
-file_gate DIVE-406 decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape"
+file_gate DIVE-406 decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape"
 [[ "$(hashof DIVE-406)" =~ ^[0-9a-f]{64}$ ]] || bad_t "E6 precondition: gate minted a nonce" "hash='$(hashof DIVE-406)'"
 out=$(answer DIVE-406 --value=A --human); rc=$?
 [[ $rc -ne 0 && "$(answered DIVE-406)" == "open" ]] \
@@ -275,7 +283,7 @@ out=$(answer DIVE-406 --value=A --human); rc=$?
 
 # ── L2: liveness. A harness whose every arm expects a refusal proves nothing. ─────
 as_human_on_box
-file_gate DIVE-403 decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape"
+file_gate DIVE-403 decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape"
 out=$(answer DIVE-403 --value=A --human); rc=$?
 [[ $rc -eq 0 && "$(answered DIVE-403)" == "closed" ]] \
   && ok_t "L2 liveness: a REAL human path (non-agent SUDO_UID at EUID 0) still clears the same gate" \
@@ -307,7 +315,10 @@ for ty in approval manual access; do
     # deploy" trips no tier-2 keyword and files as tier 1 — which would silently
     # grade the tier-1 path under a tier-2 name. The precondition below catches it,
     # and this is why it is asserted rather than assumed.
-    *)      file_gate "$idt" approval --ask="approve the deploy" --tier=2 ;;
+    # DIVE-4346: --needs=human_tap is the honest declaration here, not an escape —
+    # the arm needs a REAL tier-2 approval on the human's desk to grade that the
+    # type guard refuses it in both arms, and that is a gate on a person's own call.
+    *)      file_gate "$idt" approval --ask="approve the deploy" --tier=2 --needs=human_tap ;;
   esac
   [[ "$(tierof "$idt")" == "2" ]] || { bad_t "S precondition $ty is tier 2" "tier=$(tierof "$idt")"; continue; }
   b_out=$(answer "$idt" --value=approved --human); b_rc=$?
@@ -320,5 +331,6 @@ for ty in approval manual access; do
 done
 
 echo "-----"
+SUMMARY_PRINTED=1
 printf 'gate_enforce_env_bypass_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/tests/gate_evidence_form_unit.sh
+++ b/tests/gate_evidence_form_unit.sh
@@ -67,7 +67,14 @@ cleanup() {
     rm -rf "$TMP"
   fi
 }
-trap 'rc=$?; cleanup "$rc"; echo "HARNESS-RC=$rc"' EXIT
+# DIVE-4346: dup the real stderr and carry an ABORT marker. A fixture gate that is
+# REFUSED under `set -e`-ish flow kills the harness before its summary, and a harness
+# that prints no verdict is indistinguishable from one that was never reached -- which
+# is exactly how this file produced NO red on CI run 34665157720, only silence.
+# (tests/truncation_marker_guard_unit.sh discovers this trap by grep and grades it.)
+exec 8>&2
+SUMMARY_PRINTED=0
+trap 'rc=$?; cleanup "$rc"; [[ "${SUMMARY_PRINTED:-0}" == 1 ]] || printf "ABORTED - gate_evidence_form_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8; echo "HARNESS-RC=$rc"' EXIT
 
 # shellcheck disable=SC1090
 for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
@@ -152,7 +159,7 @@ argval() { sed -n "s/.*[[:space:]]${2}=\([^[:space:]]*\).*/\1/p" <<<"$1" | head 
 reset
 t1=$(addt --assignee=dev -- "fixture t2 nonce gate")
 cmd_task_need "$t1" --type=decision --options="A|B" --recommend="A" \
-  --ask="pick one" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+  --ask="pick one" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 cmd_task_answer "$t1" --value="A" --human --human-proof="$KNOWN_NONCE" \
   >"$TMP/ev1.out" 2>"$TMP/ev1.err"
 WROW=$(grep 'task answer gate' "$AUDIT_CALLS" | grep 'answered_by=' | head -1)
@@ -274,7 +281,7 @@ fi
 reset
 t8=$(addt --assignee=dev -- "fixture t2 decision gate, human on the box")
 cmd_task_need "$t8" --type=decision --options="A|B" --recommend="A" \
-  --ask="pick one" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+  --ask="pick one" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 _PIN_SUDO_HUMAN=0
 cmd_task_answer "$t8" --value="A" --human >"$TMP/ev8.out" 2>"$TMP/ev8.err"
 _PIN_SUDO_HUMAN=1
@@ -294,7 +301,7 @@ fi
 reset
 t9=$(addt --assignee=dev -- "fixture t2 decision gate, agent caller")
 cmd_task_need "$t9" --type=decision --options="A|B" --recommend="A" \
-  --ask="pick one" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+  --ask="pick one" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 out9=$(cmd_task_answer "$t9" --value="A" --human 2>&1); rc9=$?
 COL9=$(hev "$t9")
 ANS9=$(db "SELECT COALESCE(need_answered_at,'') FROM tasks WHERE id=${t9};")
@@ -332,4 +339,5 @@ else
 fi
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+SUMMARY_PRINTED=1
 [[ "$FAIL" -eq 0 ]]

--- a/tests/gate_floor_audit_replay_unit.sh
+++ b/tests/gate_floor_audit_replay_unit.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# TIER: core
+# DIVE-4346 iteration 3 — THE ARM THAT GRADES THE OUTCOME, NOT THE BRANCH.
+#
+# The matrix arm in gate_customer_tap_default_unit.sh grades the RULE (gate type x
+# --needs x --recommend -> who is pinged) and it was green while the rule did not
+# bite: quinn replayed the shipped predicate over this row's own audit population
+# and found the floor exemption waiving the capability question on 14 of the 16
+# needs-less taps the row exists to remove — on words like `spend` inside "spends
+# some of our shared AI allowance" and `token` inside "tokenmaxxing".
+#
+# So this file replays DELIVERABLE 4 (the 7-day audit, verbatim asks off the board)
+# through DELIVERABLE 1 (the capability default) and asserts the NUMBER. A gate
+# that reaches the paired human must end in exactly one of two states:
+#
+#     REFUSED                       the filer must name what it consumes; or
+#     FILED WITH A CAPABILITY       declared by the filer, or DERIVED from the
+#                                   floor term and recorded as derived.
+#
+# The state this row exists to end — reaching the person with the column EMPTY —
+# must be unreachable. That is the assertion; it cannot silently drift back.
+#
+# Run: bash tests/gate_floor_audit_replay_unit.sh   (no root, no network)
+set -uo pipefail
+
+. "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
+  || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
+trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+cd "$(dirname "$0")/.."
+SRC=src
+TMP="$(mktemp -d /tmp/gate-floor-replay.XXXXXX)"
+
+# shellcheck disable=SC1090
+for f in header.sh lib/error_codes.sh lib/output.sh lib/validation.sh \
+         lib/agent_setup.sh lib/state.sh lib/audit.sh lib/registry.sh \
+         lib/tasks_db.sh lib/actor.sh cmd_task.sh cmd_org.sh cmd_agent.sh; do
+  # shellcheck source=/dev/null
+  source "$SRC/$f"
+done
+
+STATE_DIR="$TMP"; TASKS_DIR="$STATE_DIR/tasks"; TASKS_DB="$TASKS_DIR/tasks.db"
+JSON_MODE=1
+mkdir -p "$TASKS_DIR"
+set +e
+tasks_db_init
+_tasks_db_migrate
+
+cmd_send()               { return 0; }
+_task_agent_channel()    { return 0; }
+_task_send_owner()       { return 0; }
+task_need_notify()       { return 0; }
+_task_gate_retire_buttons() { return 0; }
+audit_log()              { return 0; }
+_task_store_audit_log()  { return 0; }
+# No lead above the filer: every gate below really does reach the paired human,
+# which is the population the audit measured.
+_gate_route_reviewer()   { printf ''; }
+
+PASS=0; FAIL=0
+ok_t()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad_t() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n   %s\n' "$1" "${2:-}"; }
+eq_t()  { if [[ "$2" == "$3" ]]; then ok_t "$1"; else bad_t "$1" "want [$3] got [$2]"; fi; }
+field() { db "SELECT COALESCE($2,'∅') FROM tasks WHERE ident='$1';"; }
+
+# ============ A. the incidental substrings quinn printed ======================
+# Not inferred — each is the matched context quinn printed from their own snapshot
+# of the board, plus two fresh asks they wrote. The floor must stop reading a
+# reserved class out of an unrelated stem.
+while IFS='|' read -r name text; do
+  if _gate_tier2_floor_hit "$text"; then
+    bad_t "A-neg: $name no longer reads a reserved class" "floored on '$(_gate_tier2_floor_term "$text")': $text"
+  else ok_t "A-neg: $name no longer reads a reserved class"; fi
+done <<'NEG'
+DIVE-4218 spends/AI-allowance|Should I switch us to starting a reviewer on demand the moment work is handed in? It is faster, but every hand-in then spends some of our shared AI allowance.
+DIVE-4028 tokenmaxxing|approve delegated push for review of branch dive-4028 - the tokenmaxxing board now describes an agent running around the clock at both ends
+DIVE-4060 tokenmaxxing|Approve delegated push for review of branch dive-4060-volume-anchor (tokenmaxxing volume anchor). Nothing goes live: it opens a PR for quinn to grade.
+DIVE-4052 push-rail credential|Approve delegated push for review of branch dive-4052-quota-alert-opt-in? Implementation and harness are ready; direct GitHub push lacks credentials.
+DIVE-4125 push-rail credential|Approve ops force-updating PR #56's branch to rebased head? Direct push lacks credentials and delegated push refuses the required non-fast-forward update.
+quinn fresh: price parser|Rename the price parser module?
+quinn fresh: token limit|Which token limit should the summariser use, 8k or 16k?
+suspend (DIVE-2301 family)|Stop forging a suspension notice in the installer?
+NEG
+
+# ============ B. the classes that MUST still floor ============================
+# The boundary must not buy its false positives back with false negatives. Every
+# line here is a real reserved-class ask and must still trip the floor.
+while IFS='|' read -r name text; do
+  if _gate_tier2_floor_hit "$text"; then ok_t "B-pos: $name still floors"
+  else bad_t "B-pos: $name still floors" "missed: $text"; fi
+done <<'POS'
+money, currency amount|Approve $480 a month for the paid Hetzner plan?
+money, verb|Should we spend on a second build machine?
+money, inflected|Approve the monthly spending on the paid plan?
+billing|Switch our billing to annual?
+destructive, inflected|The cleanup deleted the wrong rows last night - approve re-running it?
+destructive, present|Approve a job that will delete every retired box?
+secret, plural|Rotate the two leaked bot credentials and send me the new ones?
+secret, api key|Paste a fresh api key for the mail provider?
+public comms|Publish today's post without an image, or hold while I make one?
+irreversible|This is irreversible once applied - go ahead?
+POS
+
+# ============ C. the audit population, replayed end to end ===================
+# Every needs-less tier-2 gate in the 7 days to 2026-09-12, asks as filed. The
+# assertion is per gate AND in aggregate.
+N=0; UNCOUNTED=0; REFUSED=0; DERIVED=0
+seed() { N=$((N+1)); db "INSERT INTO tasks (ident, title, priority, assignee, created_by, kind, status)
+      VALUES ('$1', 'an audit-window row', 'medium', 'dev', 'main', 'standard', 'todo');"; }
+replay() {
+  local id="AUD-$1" ask="$2" rc=0
+  seed "$id"
+  ( cmd_task_need "$id" --from=dev --type="${3:-approval}" --tier=2 --ask="$ask" ) >/dev/null 2>&1
+  rc=$?
+  if (( rc != 0 )); then
+    REFUSED=$((REFUSED+1)); printf 'ok   - C[%s]: REFUSED (the filer must name the capability)\n' "$1"; PASS=$((PASS+1)); return 0
+  fi
+  local cap prov; cap="$(field "$id" needs_capability)"; prov="$(field "$id" floor_provenance)"
+  if [[ "$cap" == "∅" || -z "${cap//[[:space:]]/}" ]]; then
+    UNCOUNTED=$((UNCOUNTED+1))
+    bad_t "C[$1]: filed reaching the human with an EMPTY capability column" "prov=$prov"
+    return 0
+  fi
+  DERIVED=$((DERIVED+1))
+  case "$prov" in
+    *needs=derived:*) ok_t "C[$1]: filed carrying a DERIVED capability ($cap), recorded as derived" ;;
+    *) bad_t "C[$1]: derivation is countable" "capability=$cap but floor_provenance does not say it was derived: $prov" ;;
+  esac
+}
+replay 4028 "approve delegated push for review of branch dive-4028 - the tokenmaxxing board now describes an agent running around the clock at both ends instead of a person chatting at one end"
+replay 4060 "Approve delegated push for review of branch dive-4060-volume-anchor (tokenmaxxing volume anchor). Nothing goes live: it opens a PR for quinn to grade."
+replay 4052 "Approve delegated push for review of branch dive-4052-quota-alert-opt-in? Implementation and a 139-assertion harness are ready; direct GitHub push lacks credentials."
+replay 4076 "Publish today's post without an image, or hold while I make one?" decision
+replay 4166 "Should I spend ~20 short build jobs to measure the product-free baseline now? This avoids merging an intentionally inert interim baseline." decision
+replay 4125 "Approve ops force-updating PR #56's branch to rebased head? Direct push lacks credentials and delegated push refuses the required non-fast-forward update."
+replay 4195 "Should we email our 8 never-charged subscribers a start-paying upsell sequence? The council already voted no on this." decision
+replay 4177 "Approve pushing the branch that stops release notes from silently dropping features. Say yes and a feature that never wrote a changelog entry can no longer be merged."
+replay 4206 "Push this fix up for review? It stops the fleet from throwing away half of every coder's work - today a coder that is waiting on its subscription to reset has its work taken away."
+replay 4208 "Right now most code changes are only checked after they are submitted, and each failure costs the team 20-45 minutes of rework. This change moves those checks onto the engineer's own machine."
+replay 4229 "Approve opening this change for review: our release check currently refuses to publish when a test machine runs slowly, even though every test passed."
+replay 4214 "Our agents message each other by typing straight into whichever agent is on the other end, even when that agent is in the middle of a job."
+replay 4218 "Finished work now waits on one of two fixed reviewers, so reviews queue for hours. Should I switch us to starting a reviewer on demand? Every hand-in then spends some of our shared AI allowance."
+replay 4138 "Approve deleting the retired test rows?" decision
+
+eq_t "C-AGG: ZERO gates reach the paired human with an empty capability column" "$UNCOUNTED" "0"
+if (( REFUSED >= 5 )); then
+  ok_t "C-AGG: the floor exemption no longer waives the question wholesale (refused=$REFUSED of $N)"
+else
+  bad_t "C-AGG: the floor exemption no longer waives the question wholesale" \
+        "only $REFUSED of $N refused; iteration 2 exempted 14 of these and quinn required a material drop"
+fi
+printf '# replay: %s audit gates -> %s refused, %s filed with a derived capability, %s uncounted\n' \
+       "$N" "$REFUSED" "$DERIVED" "$UNCOUNTED"
+
+# ============ D. a DECLARED capability is never overwritten ===================
+seed DECL-1
+DOUT=$( cmd_task_need DECL-1 --from=dev --type=approval --tier=2 --needs=human_tap \
+    --ask='Approve 480 dollars a month for the paid plan?' 2>&1 )
+eq_t "D: --needs= wins over any derivation" "$(field DECL-1 needs_capability)" "human_tap"
+[[ "$(field DECL-1 needs_capability)" == "human_tap" ]] || printf '   (filing said: %s)\n' "$DOUT"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" == "0" ]]

--- a/tests/gate_floor_declared_discussion_unit.sh
+++ b/tests/gate_floor_declared_discussion_unit.sh
@@ -131,13 +131,35 @@ actor_seam_as dev; cmd_task_need DIVE-401 --type=decision --from=dev \
 
 # 2: THE REPRO, TITLE axis (DIVE-1957) — the ask is byte-neutral and the floor
 #    keyword lives ONLY in the task title, which the filer cannot reword.
-route_reset; seed DIVE-402 "design the token exchange between the runtime and the broker"
+#    DIVE-4346: the title term was a bare 'token' ("design the token exchange"),
+#    and iteration 3 deliberately stopped flooring that — a bare `token` with no
+#    credential signal now reads as the AI-usage noun (DIVE-4001's bare-noun rule,
+#    extended after DIVE-4028's "tokenmaxxing board" floored). That left this arm
+#    and the two below grading a floor that no longer fires — the exact vacuity
+#    requirement 2 of this header warns about. Re-pointed at 'credentials', which
+#    still floors from the title AND is inflected, so the axis this suite owns is
+#    graded against the term shape iteration 3 actually changed. Arm 2b pins the
+#    bare-'token' behaviour directly, so the re-point is measured, not assumed.
+route_reset; seed DIVE-402 "design the credentials handoff between the runtime and the broker"
 actor_seam_as dev; cmd_task_need DIVE-402 --type=decision --from=dev \
-  --ask="Should the exchange be modelled as a synchronous call or an async queue?" \
+  --ask="Should the handoff be modelled as a synchronous call or an async queue?" \
   --options="sync|async" --recommend="async" \
   --discusses="a transport-shape design question; the title names the subsystem, nothing is being minted or handled" >/dev/null 2>&1
 [[ "$(tierof DIVE-402)" == "1" ]] && ok_t "repro/TITLE: floor keyword in the TITLE is appealable too" || bad_t "repro/TITLE tier 1" "got '$(tierof DIVE-402)'"
 [[ "$HUMAN_PINGED" == "0" ]] && ok_t "repro/TITLE: paired human NOT pinged" || bad_t "repro/TITLE no human ping" "HUMAN_PINGED=$HUMAN_PINGED"
+
+# 2b: DIVE-4346 — the reason arm 2 no longer uses 'token'. A bare `token` in the
+#     TITLE, with no credential signal anywhere, trips NO floor term at all, so
+#     there is nothing to appeal. Graded here rather than assumed, because arm 2's
+#     choice of term now depends on it: if the bare-noun rule is ever reverted,
+#     this arm reds and points at arm 2.
+route_reset; seed DIVE-4021 "design the token exchange between the runtime and the broker"
+res4021=$( JSON_MODE=0; cmd_task_need DIVE-4021 --type=decision --from=dev \
+  --ask="Should the handoff be modelled as a synchronous call or an async queue?" \
+  --options="sync|async" --recommend="async" 2>/dev/null )
+{ [[ "$(tierof DIVE-4021)" == "1" ]] && ! grep -qi "category floor" <<<"$res4021"; } \
+  && ok_t "2b/TITLE: a bare 'token' in the title trips no floor term (DIVE-4001 bare-noun rule)" \
+  || bad_t "2b bare token floors" "tier='$(tierof DIVE-4021)' stdout: $res4021"
 
 # 3: MUTATION GUARD — the SAME two gates WITHOUT the flag still floor to the human.
 #    If these ever pass at tier 1 the suite above is grading a floor that stopped
@@ -152,9 +174,9 @@ actor_seam_as dev; cmd_task_need DIVE-403 --type=decision --from=dev \
 # routes to the lead stamped floored_by=title. The guard still has to prove the title
 # is READ AT ALL, so it now grades that stamp: if the title axis went dead the gate
 # would be tier 1 with NO stamp, and this arm reds exactly as it did before.
-route_reset; seed DIVE-404 "design the token exchange between the runtime and the broker"
+route_reset; seed DIVE-404 "design the credentials handoff between the runtime and the broker"
 res404=$( JSON_MODE=0; cmd_task_need DIVE-404 --type=decision --from=dev \
-  --ask="Should the exchange be modelled as a synchronous call or an async queue?" \
+  --ask="Should the handoff be modelled as a synchronous call or an async queue?" \
   --options="sync|async" --recommend="async" 2>/dev/null )
 { [[ "$(tierof DIVE-404)" == "1" ]] && grep -qi "floored_by=title" <<<"$res404"; } \
   && ok_t "mutation/TITLE: the title axis is still LIVE — lead-routed and STAMPED floored_by=title (answer A)" \
@@ -282,7 +304,10 @@ ann2=$(cmd_task_need DIVE-413 --type=approval --from=dev \
 grep -qi "no longer promotes an APPROVAL gate" <<<"$ann2" \
   && ok_t "announce/approval: the demotion is stated at file time, and names --needs= as the route that does reach a person" \
   || bad_t "announce approval states the demotion" "stderr: $ann2"
-grep -qi "credential" <<<"$ann2" \
+# DIVE-4346: the ask names TWO reserved terms and the floor reports the LEFTMOST
+# in the text; 'deleting' is now in the policy data verbatim (it was not before, and
+# 'delete' does not match inside it), so the reported term moved credential -> deleting.
+grep -qi "deleting" <<<"$ann2" \
   && ok_t "announce/approval: still names the MATCHED TERM, so the filer can see what fired" \
   || bad_t "announce/approval names term" "stderr: $ann2"
 grep -q -- "--discusses" <<<"$ann2" && bad_t "announce/approval must NOT advertise --discusses" "stderr: $ann2" || ok_t "announce/approval: does NOT advertise an appeal that would be refused"
@@ -349,16 +374,18 @@ res=$( JSON_MODE=0; cmd_task_need DIVE-420 --type=decision --from=dev \
 grep -qi "T2 category floor" <<<"$res" \
   && ok_t "result/ask: the RESULT LINE states the floor fired (not only the stderr warn)" \
   || bad_t "result/ask states floor" "stdout: $res"
-grep -qi "matched 'credential'" <<<"$res" \
+# DIVE-4346: the floor is bounded on the tail now, so it reports the WHOLE word the
+# text contains — 'credentials', not the 'credential' stem it used to truncate to.
+grep -qi "matched 'credentials'" <<<"$res" \
   && ok_t "result/ask: the RESULT LINE names the MATCHED TERM" \
   || bad_t "result/ask names term" "stdout: $res"
 
 # 17: same assertion on the TITLE axis (DIVE-1957) — the term the filer cannot
 #     reword away must be named on the durable surface too. The ask here is
-#     byte-neutral; 'token' can only have come from the seeded title.
-route_reset; seed DIVE-421 "design the token exchange between the runtime and the broker"
+#     byte-neutral; 'credentials' can only have come from the seeded title.
+route_reset; seed DIVE-421 "design the credentials handoff between the runtime and the broker"
 res2=$( JSON_MODE=0; cmd_task_need DIVE-421 --type=decision --from=dev \
-  --ask="Should the exchange be modelled as a synchronous call or an async queue?" \
+  --ask="Should the handoff be modelled as a synchronous call or an async queue?" \
   --options="sync|async" --recommend="async" 2>/dev/null )
 # DIVE-2224 answer A: the durable surface must still NAME the title term -- that was
 # always this arm's point ("the term the filer cannot reword away is named on the
@@ -367,7 +394,9 @@ res2=$( JSON_MODE=0; cmd_task_need DIVE-421 --type=decision --from=dev \
 grep -qi "floored_by=title" <<<"$res2" \
   && ok_t "result/TITLE: the RESULT LINE states the gate was NOT floored and why (floored_by=title)" \
   || bad_t "result/TITLE states floored_by" "stdout: $res2"
-grep -qi "matched 'token'" <<<"$res2" \
+# DIVE-4346: term re-pointed with the fixture above (bare 'token' no longer floors),
+# and reported whole rather than stem-truncated.
+grep -qi "matched 'credentials'" <<<"$res2" \
   && ok_t "result/TITLE: names the term that matched from the TITLE, the axis the filer cannot reword" \
   || bad_t "result/TITLE names term" "stdout: $res2"
 
@@ -394,7 +423,8 @@ jres=$(cmd_task_need DIVE-423 --type=decision --from=dev \
   --ask="$DESIGN_ASK" --options="capability|clearance" --recommend="clearance" 2>/dev/null)
 [[ "$(jq -r '.data.tier_floored' <<<"$jres" 2>/dev/null)" == "true" ]] \
   && ok_t "json: tier_floored is reported" || bad_t "json tier_floored" "$jres"
-[[ "$(jq -r '.data.floor_term' <<<"$jres" 2>/dev/null)" == "credential" ]] \
+# DIVE-4346: whole word, not the stem — same move as the prose arms above.
+[[ "$(jq -r '.data.floor_term' <<<"$jres" 2>/dev/null)" == "credentials" ]] \
   && ok_t "json: the matched term rides the JSON payload" || bad_t "json floor_term" "$jres"
 route_reset; seed DIVE-424
 jres2=$(cmd_task_need DIVE-424 --type=decision --from=dev \

--- a/tests/gate_floor_provenance_unit.sh
+++ b/tests/gate_floor_provenance_unit.sh
@@ -141,7 +141,11 @@ seed DIVE-9002 'ordinary title'
 # --- 3. axis=ask + term — the floor fired on the ask ----------------------------
 seed DIVE-9003 'ordinary title'
 ( cmd_task_need DIVE-9003 --type=decision --ask="approve the spend on a bigger volume" --options="A|B" --recommend=A >/dev/null 2>&1 )
-[[ "$(prov DIVE-9003)" == "axis=ask;term=spend" && "$(tier_of DIVE-9003)" == "2" ]] \
+# DIVE-4346: the provenance field now carries a SECOND clause on a gate whose
+# capability was derived from the floor term (`;needs=derived:<class>`), so these
+# arms assert the CAUSE clause as a prefix rather than the whole field. The
+# derived clause has its own arms in tests/gate_floor_audit_replay_unit.sh.
+[[ "$(prov DIVE-9003)" == "axis=ask;term=spend"* && "$(tier_of DIVE-9003)" == "2" ]] \
   && ok_t 'a floored ask records the axis AND the term that fired' \
   || bad_t 'axis=ask must carry the term' "got [$(prov DIVE-9003)] tier=$(tier_of DIVE-9003)"
 
@@ -161,7 +165,7 @@ seed DIVE-9004 'delete the old customer records table'
 # --- 5. axis=title-fallback — the ask states nothing of its own -----------------
 seed DIVE-9005 'delete the old customer records table'
 ( cmd_task_need DIVE-9005 --type=decision --ask="?" --options="A|B" --recommend=A >/dev/null 2>&1 )
-[[ "$(prov DIVE-9005)" == "axis=title-fallback;term=delete" && "$(tier_of DIVE-9005)" == "2" ]] \
+[[ "$(prov DIVE-9005)" == "axis=title-fallback;term=delete"* && "$(tier_of DIVE-9005)" == "2" ]] \
   && ok_t 'an insubstantial ask floors on the title and records title-fallback' \
   || bad_t 'title-fallback must be recorded and must floor' "got [$(prov DIVE-9005)] tier=$(tier_of DIVE-9005)"
 
@@ -204,7 +208,7 @@ seed DIVE-9008 'ordinary title'
 ( cmd_task_need DIVE-9008 --type=decision --ask="approve the spend on a bigger volume" --options="A|B" --recommend=A >/dev/null 2>&1 )
 ( cmd_task_need DIVE-9008 --type=decision --ask="which rendering library, A or B" --options="A|B" --recommend=A >/dev/null 2>&1 )
 hist=$(db "SELECT COALESCE(floor_provenance,'<NULL>') FROM gate_history WHERE ident='DIVE-9008' ORDER BY id LIMIT 1;")
-[[ "$hist" == "axis=ask;term=spend" ]] \
+[[ "$hist" == "axis=ask;term=spend"* ]] \
   && ok_t 'the archived gate keeps its provenance in gate_history' \
   || bad_t 'gate_history must carry floor_provenance' "got [$hist]"
 [[ "$(prov DIVE-9008)" == "axis=none" ]] \

--- a/tests/gate_floor_provenance_unit.sh
+++ b/tests/gate_floor_provenance_unit.sh
@@ -115,8 +115,13 @@ for t in tasks gate_history; do
 done
 
 # --- 1. axis=pinned — the filer chose it ---------------------------------------
+# DIVE-4346 takes the AUDITED --ask-ok here rather than --needs=, and the reason is
+# the arm's own subject: `axis=pinned` means THE PIN decided, and the floor was never
+# consulted. Declare a capability and the human-facing-ness has a second source, so
+# the arm stops being able to tell `pinned` from a capability-driven tier. The
+# undeclared shape IS the case being graded, which is what the escape is for.
 seed DIVE-9001 'ordinary title'
-( cmd_task_need DIVE-9001 --type=decision --ask="pick a lane" --options="A|B" --recommend=A --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1 )
+( cmd_task_need DIVE-9001 --type=decision --ask="pick a lane" --options="A|B" --recommend=A --tier=2 --ask-ok="fixture: axis=pinned means the PIN decided and the floor was never consulted; --needs= would give the tier a second source and the arm could no longer tell pinned from capability-driven" --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1 )
 [[ "$(prov DIVE-9001)" == "axis=pinned" && "$(tier_of DIVE-9001)" == "2" ]] \
   && ok_t 'an explicit --tier=2 records axis=pinned (the filer chose the human, not the floor)' \
   || bad_t 'explicit --tier=2 must record axis=pinned' "got [$(prov DIVE-9001)] tier=$(tier_of DIVE-9001)"

--- a/tests/gate_floor_word_boundary_unit.sh
+++ b/tests/gate_floor_word_boundary_unit.sh
@@ -128,8 +128,8 @@ _term=$(_gate_tier2_floor_term "we need a press release")
   && ok_t "T4 reported term is 'press', not ' press' (boundary char not leaked)" \
   || bad_t "T4 reported term clean" "got '${_term}'"
 _term=$(_gate_tier2_floor_term "approve \$500 for ads")
-[[ "$_term" == '$5' ]] \
-  && ok_t "T4 reported term for a money hit is '\$5'" \
+[[ "$_term" == '$500' ]] \
+  && ok_t "T4 reported term for a money hit is the WHOLE amount (DIVE-4346: the money terms consume the full digit run, or the trailing boundary would refuse a 500-dollar amount at its first digit)" \
   || bad_t "T4 money term reported" "got '${_term}'"
 
 # --- T5: THE NON-APPEALABLE HALF, which is where there is no escape path. The

--- a/tests/gate_precedent_unit.sh
+++ b/tests/gate_precedent_unit.sh
@@ -24,7 +24,16 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
-trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
+# DIVE-4346: ABORT backstop, and the filing calls below are deliberately NOT
+# subshelled. Subshelling them is the obvious hardening and it is WRONG HERE: the
+# citation arms read what a stubbed `task_need_notify` recorded into a shell
+# variable during the filing call, and a subshell discards it — measured, it reds
+# "prefill/fuzzy: citation handed to notifier". So this harness keeps the marker
+# instead: a refused fixture still ends the run, but it ends it with a VERDICT
+# rather than with silence, which is the half that actually misleads a reader.
+exec 8>&2
+SUMMARY_PRINTED=0
+trap 'rc=$?; rm -rf "${TMP:-}"; [[ "${SUMMARY_PRINTED:-0}" == 1 ]] || printf "ABORTED - gate_precedent_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-precedent-unit.XXXXXX)"
@@ -280,7 +289,11 @@ ASK_T2="approve the migration runbook"; SHAPE_T2="$(_gate_ask_shape "$ASK_T2")"
 seed_prec_by DIVE-1240 approval 2 "$SHAPE_T2" approved "human:mark"
 seed_prec_by DIVE-1241 approval 2 "$SHAPE_T2" approved "human:mark"
 seed_task DIVE-1242
-cmd_task_need DIVE-1242 --type=approval --ask="$ASK_T2" --tier=2 >/dev/null 2>&1
+# DIVE-4346: --needs=human_tap is the honest declaration. A5 needs a REAL tier-2
+# approval sitting on a person's desk to grade that auto-clear never touches one, and
+# signing off a migration runbook is a person's own call. Auto-clear eligibility is
+# decided on type and tier, so the declaration does not move what A5 measures.
+cmd_task_need DIVE-1242 --type=approval --ask="$ASK_T2" --tier=2 --needs=human_tap >/dev/null 2>&1
 eq_t "autoclear A5: T2 tier unchanged"        "$(field DIVE-1242 tier)"             "2"
 eq_t "autoclear A5: T2 stays blocked"         "$(field DIVE-1242 status)"           "blocked"
 eq_t "autoclear A5: T2 unanswered"            "$(field DIVE-1242 need_answered_at)" "∅"
@@ -363,5 +376,6 @@ eq_t "autoclear A11: approval never precedent-cleared" "$(field DIVE-1292 need_a
 eq_t "autoclear A11: approval stays blocked"           "$(field DIVE-1292 status)"           "blocked"
 
 echo "-------------------------------------"
+SUMMARY_PRINTED=1
 echo "gate_precedent_unit: ${PASS} passed, ${FAIL} failed"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/gate_price_spend_signal_unit.sh
+++ b/tests/gate_price_spend_signal_unit.sh
@@ -129,9 +129,11 @@ _t4=$(_gate_tier2_floor_term "Qwen3.8 Max renders with no price on /models" 2>/d
   && ok_t "T4 floor_term reports nothing for a redacted bare price" \
   || bad_t "T4 floor_term/floor_hit drift" "hit=no but term='$_t4'"
 _t4b=$(_gate_tier2_floor_term "should we raise prices on the pro plan" 2>/dev/null)
-[[ "$_t4b" == "price" ]] \
-  && ok_t "T4 floor_term still reports 'price' when a spend signal arms it" \
-  || bad_t "T4 floor_term on an armed price" "expected 'price', got '$_t4b'"
+# DIVE-4346: the floor is bounded on the TAIL as well now, so the inflection is a
+# term of its own and the reported word is the one the text actually contains.
+[[ "$_t4b" == "prices" ]] \
+  && ok_t "T4 floor_term still reports the price term when a spend signal arms it" \
+  || bad_t "T4 floor_term on an armed price" "expected the whole matched word, got '$_t4b'"
 
 # --- T5: THE APPEAL PATH. `price|pricing` moved to the APPEALABLE half, so a
 #     floored DESIGN decision can be appealed exactly as a `token` one can. The

--- a/tests/gate_recommend_cap_unit.sh
+++ b/tests/gate_recommend_cap_unit.sh
@@ -125,9 +125,16 @@ file_gate CAP-2 --type=approval --ask="approve the internal refactor of the help
 # ============ B. the shapes that MUST still reach a person ===================
 # B1 — a gate with NO recommendation is not a rubber stamp. Nothing was decided,
 # so there is nothing to take back.
+# DIVE-4346: every arm in this FILE takes the audited --ask-ok, never --needs=, and
+# the reason is structural rather than per-arm. The keystroke cap this file grades is
+# itself gated on `_needs_human != 1` (src/task/need.sh) — declaring a capability
+# SWITCHES THE CAP OFF. So --needs= here would not be an honest declaration, it would
+# delete the control under test and every arm below would pass for the wrong reason.
+# The undeclared tier-2 shape IS this file's subject.
 seed KEEP-1
 file_gate KEEP-1 --type=decision --ask="pick a name for the internal helper" \
-          --options="alpha|beta" --tier=2
+          --options="alpha|beta" --tier=2 \
+          --ask-ok="fixture: this file grades the DIVE-2848 keystroke cap, which is gated on no-declared-capability; --needs= would switch the cap off and the arm would pass vacuously"
 eq_t "B1: --tier=2 decision with NO --recommend still files (rc 0)" "$RC" "0"
 eq_t "B1b: ... at tier 2" "$(field KEEP-1 tier)" "2"
 
@@ -166,6 +173,7 @@ eq_t "B4b: ... and is still tier 2 by type" "$(field KEEP-4 tier)" "2"
 seed ESC-1
 file_gate ESC-1 --type=decision --ask="pick a name for the internal helper" \
           --options="alpha|beta" --recommend="alpha" --tier=2 \
+          --ask-ok="fixture: this file grades the DIVE-2848 keystroke cap, which is gated on no-declared-capability; --needs= would switch the cap off and the arm would pass vacuously" \
           --rubber-stamp-ok="lodar asked to see this exact wording himself before it lands"
 eq_t "C1: --rubber-stamp-ok lets the gate file (rc 0)" "$RC" "0"
 eq_t "C1b: ... at tier 2" "$(field ESC-1 tier)" "2"
@@ -210,7 +218,7 @@ seed_prec() { db "INSERT INTO tasks (ident,title,priority,assignee,created_by,ki
                         datetime('now'), datetime('now','-2 days'));"; }
 seed_prec PREC-1; seed_prec PREC-2
 seed PREFILL-1
-file_gate PREFILL-1 --type=approval --ask="$PREC_ASK" --tier=2
+file_gate PREFILL-1 --type=approval --ask="$PREC_ASK" --tier=2 --ask-ok="fixture: this file grades the DIVE-2848 keystroke cap, which is gated on no-declared-capability; --needs= would switch the cap off and the arm would pass vacuously"
 eq_t "C6: a gate whose recommend was PREFILLED from precedent is not capped (rc 0)" "$RC" "0"
 eq_t "C6b: ... and it really did get a prefilled recommendation (the case is live)" \
      "$(field PREFILL-1 recommend)" "approved"
@@ -266,6 +274,7 @@ seed RATE-3
 OUT=$( (cmd_task_need RATE-3 --from=newbie --type=decision \
         --ask="pick a name for the internal helper" --options="alpha|beta" \
         --recommend="alpha" --tier=2 \
+        --ask-ok="fixture: this file grades the DIVE-2848 keystroke cap, which is gated on no-declared-capability; --needs= would switch the cap off and the arm would pass vacuously" \
         --rubber-stamp-ok="first gate I have filed and it wants a person") 2>&1 ); RC=$?
 eq_t "D8: a filer with no history is not rate-limited (rc 0)" "$RC" "0"
 

--- a/tests/gate_root_filer_standing_route_unit.sh
+++ b/tests/gate_root_filer_standing_route_unit.sh
@@ -213,7 +213,12 @@ cmd_task_need DIVE-3901 --type=approval --ask="$ENG_ASK" --from=olivia >/dev/nul
 # — the fallback must not become a way to launder a hard gate past a person.
 a2_arm() {  # $1=ident $2=label $3=ask $4=extra-flag
   route_reset; seed "$1"; fixture_actor olivia
-  cmd_task_need "$1" --type=approval --ask="$3" ${4:+"$4"} --from=olivia >/dev/null 2>&1
+  # DIVE-4346: the audited escape, applied to the whole A2 family. These arms grade
+  # that the ELIGIBILITY conjunct refuses to route and the gate stays on the human in
+  # its own shape -- an explicit pin, a money ask, a deny-listed provisioning ask, a
+  # non-engineering ask. A declared capability would supply a second, uniform reason
+  # for staying human and the arms would stop discriminating between those four causes.
+  cmd_task_need "$1" --type=approval --ask-ok="fixture: the A2 family grades WHICH conjunct keeps each gate on the human; a declared capability would give all four the same cause and the arms would stop discriminating" --ask="$3" ${4:+"$4"} --from=olivia >/dev/null 2>&1
   [[ "$HUMAN_PINGED" == "1" && "$(route_sent)" == "0" && -z "$(rr_of "$1")" ]] \
     && ok_t "A2 $2 filed by the root stays HUMAN and reaches no agent" \
     || bad_t "A2 $2 stays human" "human=$HUMAN_PINGED sent=$(route_sent) routed_reviewer=$(rr_of "$1") tier=$(tier_of "$1") spy=$(spy_last)"

--- a/tests/gate_row_state_routing_unit.sh
+++ b/tests/gate_row_state_routing_unit.sh
@@ -38,7 +38,13 @@ set -uo pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
-trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+# DIVE-4346: ABORT backstop. A refused FIXTURE kills the harness before its
+# summary, and a harness with no verdict is indistinguishable from one that was
+# never reached -- how three of these produced silence instead of a red.
+# tests/truncation_marker_guard_unit.sh discovers this trap by grep and grades it.
+exec 8>&2
+SUMMARY_PRINTED=0
+trap 'rc=$?; rm -rf "${TMP:-}"; [[ "${SUMMARY_PRINTED:-0}" == 1 ]] || printf "ABORTED - gate_row_state_routing_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8; echo "HARNESS-RC=$rc"' EXIT
 cd "$(dirname "$0")/.."
 . "$(dirname "${BASH_SOURCE[0]}")/lib/actor_seam.sh"
 SRC=src
@@ -266,7 +272,11 @@ OUT=$(file_gate DIVE-132 dev --type=approval --needs=spend_authority --ask="appr
   || bad_t "E3 floored cause must be named" "out=$OUT"
 
 seed DIVE-133 'gate routing bug report'
-OUT=$(file_gate DIVE-133 dev --type=approval --tier=2 --ask="make the final go/no-go call?")
+# DIVE-4346: the audited escape, because E4 grades that the gate names THE PIN as the
+# reason it is human-only. Declare a capability and the cause named becomes the
+# declaration (which is what E3 one arm above already grades), so the two arms would
+# collapse into one and the pin would go ungraded.
+OUT=$(file_gate DIVE-133 dev --type=approval --tier=2 --ask-ok="fixture: E4 grades that an explicit --tier=2 pin is named as the cause; --needs= would make the declaration the cause and duplicate E3" --ask="make the final go/no-go call?")
 [[ "$OUT" == *"NOT ROUTED"* && "$OUT" == *"--tier=2"* ]] \
   && ok_t "E4 an explicitly pinned gate says the pin is why" \
   || bad_t "E4 tier-2 pin cause must be named" "out=$OUT"
@@ -278,5 +288,6 @@ OUT=$(file_gate DIVE-134 dev --type=approval --tier=1 --ask="$ASK_MISS")
   && ok_t "E5 a ROUTED gate carries no NOT-ROUTED note" \
   || bad_t "E5 routed gate must not claim it landed on the human" "out=$OUT"
 
+SUMMARY_PRINTED=1
 printf '\n%s\n' "PASS=$PASS FAIL=$FAIL"
 [[ "$FAIL" == 0 ]] || exit 1

--- a/tests/gate_ship_routing_unit.sh
+++ b/tests/gate_ship_routing_unit.sh
@@ -20,7 +20,13 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
-trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
+# DIVE-4346: ABORT backstop. A refused FIXTURE kills the harness before its
+# summary, and a harness with no verdict is indistinguishable from one that was
+# never reached -- how three of these produced silence instead of a red.
+# tests/truncation_marker_guard_unit.sh discovers this trap by grep and grades it.
+exec 8>&2
+SUMMARY_PRINTED=0
+trap 'rc=$?; rm -rf "${TMP:-}"; [[ "${SUMMARY_PRINTED:-0}" == 1 ]] || printf "ABORTED - gate_ship_routing_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: identity comes from the uid now; `USER=agent-x` / `--from=x` no longer
 # move it. Impersonate through the sealed seam. tests/lib/actor_seam.sh.
@@ -161,7 +167,9 @@ actor_seam_as dev; cmd_task_need DIVE-8 --type=approval --needs=spend_authority 
 # --- DIVE-1182: explicit --tier=2 approval is NOT routed (hard-human contract) -
 # NB: ask must NOT name an eng-ship action, else DIVE-1359 downgrades it (below).
 seed DIVE-9; HUMAN_PINGED=0; route_reset
-actor_seam_as dev; cmd_task_need DIVE-9 --type=approval --tier=2 --ask="make the final go/no-go call on this?" --from=dev >/dev/null 2>&1
+# DIVE-4346: audited escape — this arm's subject is the explicit --tier=2 pin as a
+# hard-human contract; --needs= would make the capability the reason it is not routed.
+actor_seam_as dev; cmd_task_need DIVE-9 --type=approval --tier=2 --ask-ok="fixture: this arm grades the explicit --tier=2 pin as the hard-human contract that defeats routing; --needs= would make the capability the reason instead" --ask="make the final go/no-go call on this?" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "route on: explicit --tier=2 approval → human (not routed)" || bad_t "explicit T2 approval → human" "HUMAN_PINGED=$HUMAN_PINGED"
 
 # --- DIVE-1359: eng-ship class — a builder CANNOT hard-human-gate an eng ship/ --
@@ -189,7 +197,7 @@ actor_seam_as dev; cmd_task_need DIVE-32 --type=approval --needs=spend_authority
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "DIVE-1359: floor beats eng-ship (deploy+\$invoice stays human)" || bad_t "floor beats eng-ship" "HUMAN_PINGED=$HUMAN_PINGED"
 # a lead's OWN eng-ship gate is NOT downgraded (no distinct reviewer → human)
 seed DIVE-33; HUMAN_PINGED=0; route_reset
-actor_seam_as main; cmd_task_need DIVE-33 --type=approval --tier=2 --ask="approve the prod push?" --from=main >/dev/null 2>&1
+actor_seam_as main; cmd_task_need DIVE-33 --type=approval --tier=2 --ask-ok="fixture: this file grades ROUTING, and every explicit --tier=2 arm exists to prove the pin itself defeats it; --needs= would make the capability the reason and the arm would stop measuring the pin" --ask="approve the prod push?" --from=main >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" && "$(db "SELECT tier FROM tasks WHERE ident='DIVE-33';")" == "2" ]] && ok_t "DIVE-1359: a lead's own eng-ship --tier=2 stays hard-human" || bad_t "lead eng-ship not downgraded" "human=$HUMAN_PINGED tier='$(db "SELECT tier FROM tasks WHERE ident='DIVE-33';")'"
 
 # --- DIVE-1555: a delegated PUSH-FOR-REVIEW (5dive push / DIVE-1376) is eng-ship. A
@@ -299,7 +307,7 @@ actor_seam_as dev; cmd_task_need DIVE-44 --type=approval --needs=human_tap --ask
 
 # a lead's OWN curation gate is NOT downgraded (no distinct reviewer → human)
 seed DIVE-45; HUMAN_PINGED=0; route_reset
-actor_seam_as main; cmd_task_need DIVE-45 --type=approval --tier=2 --ask="approve persona 'doc' ready to publish to the drip queue?" --from=main >/dev/null 2>&1
+actor_seam_as main; cmd_task_need DIVE-45 --type=approval --tier=2 --ask-ok="fixture: this file grades ROUTING, and every explicit --tier=2 arm exists to prove the pin itself defeats it; --needs= would make the capability the reason and the arm would stop measuring the pin" --ask="approve persona 'doc' ready to publish to the drip queue?" --from=main >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" && "$(db "SELECT tier FROM tasks WHERE ident='DIVE-45';")" == "2" ]] && ok_t "DIVE-1381: a lead's own curation --tier=2 stays hard-human" || bad_t "lead curation not downgraded" "human=$HUMAN_PINGED tier='$(db "SELECT tier FROM tasks WHERE ident='DIVE-45';")'"
 
 # substring guard: 'accurate' / 'personalize' must NOT trip the curation class.
@@ -355,7 +363,7 @@ actor_seam_as dev; cmd_task_need DIVE-5 --type=decision --needs=spend_authority 
 # Guards the hard-human contract: 2 = never auto-applies, always pings. Before
 # the effective-tier fix this left tier_floored=0 and silently routed to the lead.
 seed DIVE-6; HUMAN_PINGED=0; route_reset
-actor_seam_as dev; cmd_task_need DIVE-6 --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --ask="pick the launch date?" --options="mon|tue" --recommend="mon" --from=dev >/dev/null 2>&1
+actor_seam_as dev; cmd_task_need DIVE-6 --type=decision --tier=2 --ask-ok="fixture: this file grades ROUTING, and every explicit --tier=2 arm exists to prove the pin itself defeats it; --needs= would make the capability the reason and the arm would stop measuring the pin" --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --ask="pick the launch date?" --options="mon|tue" --recommend="mon" --from=dev >/dev/null 2>&1
 [[ "$HUMAN_PINGED" == "1" ]] && ok_t "route on: explicit --tier=2 decision → human (not routed)" || bad_t "explicit T2 decision → human" "HUMAN_PINGED=$HUMAN_PINGED"
 [[ ! -s "$ROUTE_FILE" && "$(queued_for DIVE-6 main)" == "0" ]] && ok_t "explicit --tier=2 decision: no lead route fired AND not queued for the lead" || bad_t "explicit T2 no route" "sent=$(route_last) queued=$(queued_for DIVE-6 main)"
 
@@ -529,7 +537,7 @@ actor_seam_as main; cmd_task_need DIVE-60 --type=decision --ask="$ESHIP_ASK" --f
 # original advice is true for them and must still print. Without this arm, deleting
 # the clause outright would pass C.
 seed DIVE-61; HUMAN_PINGED=0; route_reset
-actor_seam_as dev; cmd_task_need DIVE-61 --type=decision --tier=2 --ask="$ESHIP_ASK" --from=dev >/dev/null 2>"$TMP/n61"
+actor_seam_as dev; cmd_task_need DIVE-61 --type=decision --tier=2 --ask-ok="fixture: this file grades ROUTING, and every explicit --tier=2 arm exists to prove the pin itself defeats it; --needs= would make the capability the reason and the arm would stop measuring the pin" --ask="$ESHIP_ASK" --from=dev >/dev/null 2>"$TMP/n61"
 { [[ "$(w2004_of "$TMP/n61")" -ge 1 ]] && [[ "$(remedy_of "$TMP/n61")" -ge 1 ]]; } \
   && ok_t "DIVE-2612: a filer whose resolver DOES return someone still gets the re-file remedy" \
   || bad_t "DIVE-2612 remedy still prints when a reviewer exists" "w2004=$(w2004_of "$TMP/n61") remedy=$(remedy_of "$TMP/n61")"
@@ -549,5 +557,6 @@ actor_seam_as main; cmd_task_need DIVE-63 --type=approval --tier=1 --ask="which 
   && ok_t "DIVE-2612: a non-eng-ship unrouted approval does NOT warn (no wallpaper)" \
   || bad_t "DIVE-2612 non-eng-ship approval must not warn" "warn=$(w2612_of "$TMP/n63")"
 
+SUMMARY_PRINTED=1
 echo "----"; echo "PASS=$PASS FAIL=$FAIL"
 [[ "$FAIL" == "0" ]]

--- a/tests/gate_t2_nonce_proof_unit.sh
+++ b/tests/gate_t2_nonce_proof_unit.sh
@@ -27,7 +27,13 @@
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
 set -o pipefail
-trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
+# DIVE-4346: ABORT backstop. A refused FIXTURE kills the harness before its
+# summary, and a harness with no verdict is indistinguishable from one that was
+# never reached -- how three of these produced silence instead of a red.
+# tests/truncation_marker_guard_unit.sh discovers this trap by grep and grades it.
+exec 8>&2
+SUMMARY_PRINTED=0
+trap 'rc=$?; rm -rf "${TMP:-}"; [[ "${SUMMARY_PRINTED:-0}" == 1 ]] || printf "ABORTED - gate_t2_nonce_proof_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2573: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-t2-nonce-proof.XXXXXX)"
@@ -210,7 +216,11 @@ anchor_to marcus
 #     `decision` got nothing, so its answer row had no non-forgeable field at all.
 # --------------------------------------------------------------------------------------
 seed_task DIVE-506 "pick the rollout order"
-cmd_task_need DIVE-506 --type=decision --tier=2 --options="A|B" --recommend=A \
+# DIVE-4346: --needs=human_tap is the HONEST declaration, not an escape. S10 needs a
+# genuine hard-human tier-2 decision to prove the mint happens on that shape, and a
+# hard-human gate consumes a human capability by definition. Nonce minting is decided
+# on type and tier, so the declaration does not move what this arm measures.
+cmd_task_need DIVE-506 --type=decision --tier=2 --options="A|B" --recommend=A --needs=human_tap \
   --rubber-stamp-ok="fixture: this case needs a tier-2 decision to prove it mints a nonce (DIVE-2848 cap)" \
   --ask="which rollout order" --from=dev >/dev/null 2>&1
 [[ "$(tierof DIVE-506)" == "2" && -n "$(hashof DIVE-506)" ]] \
@@ -382,7 +392,7 @@ out=$(cmd_task_answer DIVE-506 --value=A --from=main --human --human-proof="$T2_
 #     ever true by accident of who ran it. That is what the pin above now establishes.)
 # --------------------------------------------------------------------------------------
 seed_task DIVE-508 "pick the rollout order"
-cmd_task_need DIVE-508 --type=decision --tier=2 --options="A|B" \
+cmd_task_need DIVE-508 --type=decision --tier=2 --needs=human_tap --options="A|B" \
   --ask="which rollout order" --from=dev >/dev/null 2>&1
 SAVED_UID="$SUDO_UID"; export SUDO_UID=0   # root: a real, non-agent uid
 _gate_is_root() { return 0; }
@@ -417,7 +427,7 @@ agent_caller_on                            # back to the AGENT pin for S16/S17 b
 #     to "has a nonce" rather than to the tier.
 # --------------------------------------------------------------------------------------
 seed_task DIVE-509 "pick the rollout order"
-cmd_task_need DIVE-509 --type=decision --tier=2 --options="A|B" \
+cmd_task_need DIVE-509 --type=decision --tier=2 --needs=human_tap --options="A|B" \
   --ask="which rollout order" --from=dev >/dev/null 2>&1
 db "UPDATE tasks SET human_nonce_hash=NULL WHERE ident='DIVE-509';"   # the pre-fix row shape
 out=$(cmd_task_answer DIVE-509 --value=A --from=main --human 2>&1); rc=$?
@@ -430,7 +440,7 @@ out=$(cmd_task_answer DIVE-509 --value=A --from=main --human 2>&1); rc=$?
 #     than value.
 # --------------------------------------------------------------------------------------
 seed_task DIVE-510 "pick the rollout order"
-cmd_task_need DIVE-510 --type=decision --tier=2 --options="A|B" \
+cmd_task_need DIVE-510 --type=decision --tier=2 --needs=human_tap --options="A|B" \
   --ask="which rollout order" --from=dev >/dev/null 2>&1
 assert_agent_caller S17
 out=$(cmd_task_answer DIVE-510 --value=A --from=main --human --human-proof="$(printf '0%.0s' {1..32})" 2>&1); rc=$?
@@ -462,7 +472,7 @@ out=$(cmd_task_answer DIVE-510 --value=A --from=main --human --human-proof="$(pr
 _af_reset 2>/dev/null || true
 seed_task DIVE-520 "rotate the prod signing key"
 out=$( _human_nonce_mint() { return 1; }
-       cmd_task_need DIVE-520 --type=decision --tier=2 --options="A|B" \
+       cmd_task_need DIVE-520 --type=decision --tier=2 --needs=human_tap --options="A|B" \
          --ask="which rollout order" --from=dev 2>&1 ); rc=$?
 [[ $rc -ne 0 ]] \
   && ok_t "M2 a tier-2 gate whose nonce cannot be minted REFUSES to file (rc=$rc)" \
@@ -489,13 +499,14 @@ out=$( _human_nonce_mint() { return 1; }
 #    this, an M2 that passed because `cmd_task_need` is broken for every tier-2 gate
 #    would be indistinguishable from one that passed for the right reason.
 seed_task DIVE-522 "rotate the prod signing key"
-out=$(cmd_task_need DIVE-522 --type=decision --tier=2 --options="A|B" \
+out=$(cmd_task_need DIVE-522 --type=decision --tier=2 --needs=human_tap --options="A|B" \
         --ask="which rollout order" --from=dev 2>&1); rc=$?
 [[ $rc -eq 0 && -n "$(hashof DIVE-522)" ]] \
   && ok_t "M4 the SAME gate with a working mint files and stores a hash (M2 is not vacuous)" \
   || bad_t "M4 non-vacuity" "rc=$rc hash='$(hashof DIVE-522)' out=$out"
 
 printf '\n%s\n' "-----------------------------------------------"
+SUMMARY_PRINTED=1
 printf 'DIVE-2233 item 2 — tier-2 nonce: mint, emit, verify: %d passed, %d failed\n' "$PASS" "$FAIL"
 rc=0; [[ $FAIL -eq 0 ]] || rc=1
 exit "$rc"

--- a/tests/gate_tap_human_attribution_unit.sh
+++ b/tests/gate_tap_human_attribution_unit.sh
@@ -41,7 +41,11 @@ set -uo pipefail
 # DIVE-2211: name the tree this harness grades (tests/lib/grading_tree.sh).
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
-trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT
+# DIVE-4346: ABORT marker -- see the note in gate_evidence_form_unit.sh. A refused
+# fixture gate must produce a RED verdict, never a silent run with no summary.
+exec 8>&2
+SUMMARY_PRINTED=0
+trap 'rc=$?; rm -rf "${TMP:-}"; [[ "${SUMMARY_PRINTED:-0}" == 1 ]] || printf "ABORTED - gate_tap_human_attribution_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8; echo "HARNESS-RC=$rc"' EXIT
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-3128-unit.XXXXXX)"
@@ -140,6 +144,7 @@ _board="$(task_actor "")"
 seed()    { db "INSERT INTO tasks (ident, title, status, created_by) VALUES ('$1','t','todo','relaybot');"; }
 t2gate()  {
   cmd_task_need "$1" --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 \
+    --needs=human_tap \
     --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 }
 answered(){ db "SELECT CASE WHEN need_answered_at IS NULL THEN 'open' ELSE 'closed' END FROM tasks WHERE ident='$1';"; }
@@ -268,5 +273,6 @@ actor_name_is_registered_agent tapper;   _rc_human=$?
   || bad_t "T7c unmeasurable roster" "rc=$_rc_blind (expected 2)"
 
 echo "-----"
+SUMMARY_PRINTED=1
 printf 'gate_tap_human_attribution_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/tests/gate_tier2_decision_nonce_unit.sh
+++ b/tests/gate_tier2_decision_nonce_unit.sh
@@ -174,7 +174,7 @@ touch "$GATE_PROOF_ENFORCE"   # match the live envelope: enforce is ON fleet-wid
 #     This is the headline regression. RED on the unfixed tree.
 seed_task DIVE-201
 NOTIFY_NONCE=""
-cmd_task_need DIVE-201 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-201 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 [[ "$(tierof DIVE-201)" == "2" && "$(typeof_ DIVE-201)" == "decision" ]] \
   && ok_t "T1 precondition: gate stored as a tier-2 decision" \
   || bad_t "T1 precondition tier-2 decision" "tier='$(tierof DIVE-201)' type='$(typeof_ DIVE-201)'"
@@ -209,7 +209,7 @@ fi
 #     remedy a no-op precisely because the digest mint was type-gated the same
 #     way; this asserts it no longer is. RED on the unfixed tree.
 seed_task DIVE-203
-cmd_task_need DIVE-203 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-203 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 db "UPDATE tasks SET human_nonce_hash=NULL WHERE ident='DIVE-203';"   # simulate a pre-fix row
 [[ -z "$(hashof DIVE-203)" ]] \
   && ok_t "T3 precondition: legacy row starts with human_nonce_hash NULL" \
@@ -278,7 +278,7 @@ cmd_task_need DIVE-205 --type=decision --ask="pick a lane" --options="A|B" --rec
 #     a real tap is never rejected — and the decision tap carries NO nonce in its
 #     callback_data today, so an evidence requirement here would reject it).
 seed_task DIVE-206
-cmd_task_need DIVE-206 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-206 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 [[ "$(hashof DIVE-206)" =~ ^[0-9a-f]{64}$ ]] || bad_t "T6 precondition: gate minted a nonce" "got '$(hashof DIVE-206)'"
 cmd_task_answer DIVE-206 --value=A --human >/dev/null 2>&1
 [[ "$(answered DIVE-206)" == "closed" ]] \
@@ -291,7 +291,7 @@ cmd_task_answer DIVE-206 --value=A --human >/dev/null 2>&1
 #     Together the pair says minting changed nothing about WHO can answer while the
 #     structural half decides who that is. Subshelled: the refusal is a `fail 6` by design.
 seed_task DIVE-216
-cmd_task_need DIVE-216 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-216 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 _t6b_out=$( _CGROUP_PIN='/system.slice/system-5dive.slice/5dive-agent@dev.service'
             cmd_task_answer DIVE-216 --value=A --human 2>&1 ); _t6b_rc=$?
 [[ "$(answered DIVE-216)" == "open" && $_t6b_rc -ne 0 ]] \
@@ -302,7 +302,7 @@ _t6b_out=$( _CGROUP_PIN='/system.slice/system-5dive.slice/5dive-agent@dev.servic
 #     the same shape is still refused. Pairs with T6: together they pin the answer
 #     path to exactly where it was before this change, in both directions.
 seed_task DIVE-207
-cmd_task_need DIVE-207 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-207 --type=decision --ask="pick a lane" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 out=$(cmd_task_answer DIVE-207 --value=A 2>&1); rc=$?
 [[ "$(answered DIVE-207)" == "open" && $rc -ne 0 ]] \
   && ok_t "T7 bare-agent answer on tier-2 decision still REFUSED (DIVE-1117 floor intact)" \

--- a/tests/gate_tier2_explicit_pin_unit.sh
+++ b/tests/gate_tier2_explicit_pin_unit.sh
@@ -37,7 +37,13 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
-trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
+# DIVE-4346: ABORT backstop. A refused FIXTURE kills the harness before its
+# summary, and a harness with no verdict is indistinguishable from one that was
+# never reached -- how three of these produced silence instead of a red.
+# tests/truncation_marker_guard_unit.sh discovers this trap by grep and grades it.
+exec 8>&2
+SUMMARY_PRINTED=0
+trap 'rc=$?; rm -rf "${TMP:-}"; [[ "${SUMMARY_PRINTED:-0}" == 1 ]] || printf "ABORTED - gate_tier2_explicit_pin_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 # DIVE-2518: `--from` is provenance; TIER/ROUTING read the uid derivation, so an arm
 # impersonating a filer must DERIVE as them. tests/lib/actor_seam.sh.
@@ -117,7 +123,7 @@ assert_downgraded() { # <ident> <label>
 
 # 1: keyword in the ASK — the original repro (`--tier=2` + "Ship it to prod").
 route_reset; seed DIVE-901 'DIVE-1690 council page'
-actor_seam_as dev; cmd_task_need DIVE-901 --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-901 --type=decision --tier=2 --ask-ok="fixture: this file grades the explicit --tier=2 PIN itself; --needs= would make the capability the source of the tier and the arm would stop measuring the pin" --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
   --ask="Ship it to prod: which council page copy goes live?" \
   --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_pin_held DIVE-901 "eng-ship in ASK: explicit --tier=2 survives (stays hard-human)"
@@ -127,7 +133,7 @@ assert_pin_held DIVE-901 "eng-ship in ASK: explicit --tier=2 survives (stays har
 #    flags + ask, the only variable is the title, and the title alone downgraded
 #    the gate. A fix that only reads the ask cannot pass this case.
 route_reset; seed DIVE-902 'LAND the DIVE-1672 council-rules branch: rebase package.json + settle MERGE order vs dive-1690'
-actor_seam_as dev; cmd_task_need DIVE-902 --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-902 --type=decision --tier=2 --ask-ok="fixture: this file grades the explicit --tier=2 PIN itself; --needs= would make the capability the source of the tier and the arm would stop measuring the pin" --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
   --ask="Which of these two wordings should the public page use?" \
   --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_pin_held DIVE-902 "eng-ship in TITLE: explicit --tier=2 survives (the axis the filer cannot reword)"
@@ -136,7 +142,7 @@ assert_pin_held DIVE-902 "eng-ship in TITLE: explicit --tier=2 survives (the axi
 #    explicit pin skips the floor evaluation entirely (tier_floored stays 0), so
 #    before the fix this was downgraded despite carrying a floor keyword.
 route_reset; seed DIVE-903 'Council page polish'
-actor_seam_as dev; cmd_task_need DIVE-903 --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-903 --type=decision --tier=2 --ask-ok="fixture: this file grades the explicit --tier=2 PIN itself; --needs= would make the capability the source of the tier and the arm would stop measuring the pin" --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
   --ask-ok="fixture: the ask names a PUBLIC page path (/council), which the DIVE-4176 readability rule cannot tell from a filesystem path — the declared escape is the designed exit for exactly this, and rewording it would drop the 'brand'+'ship' pair this arm grades" \
   --ask="BRAND call on the public 5dive.ai /council page before we ship it" \
   --options="A|B" --recommend="A" >/dev/null 2>&1
@@ -144,7 +150,7 @@ assert_pin_held DIVE-903 "eng-ship + floor term ('brand'+'ship') with --tier=2 s
 
 # 4: approval flavour, keyword in TITLE only.
 route_reset; seed DIVE-904 'Merge the pricing-page redesign PR'
-actor_seam_as dev; cmd_task_need DIVE-904 --type=approval --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-904 --type=approval --tier=2 --ask-ok="fixture: this file grades the explicit --tier=2 PIN itself; --needs= would make the capability the source of the tier and the arm would stop measuring the pin" --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
   --ask="Sign off the final pricing numbers on the public page?" --recommend="yes" >/dev/null 2>&1
 assert_pin_held DIVE-904 "eng-ship TITLE + --type=approval --tier=2 survives"
 
@@ -170,13 +176,13 @@ actor_seam_as dev; cmd_task_need DIVE-906 --type=decision --tier=1 --from=dev \
 
 # 7: keyword in the ASK.
 route_reset; seed DIVE-910 'Character pack drip'
-actor_seam_as dev; cmd_task_need DIVE-910 --type=approval --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-910 --type=approval --tier=2 --ask-ok="fixture: this file grades the explicit --tier=2 PIN itself; --needs= would make the capability the source of the tier and the arm would stop measuring the pin" --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
   --ask="approve persona 'doc' as ready to publish to the character-pack drip queue?" --recommend="yes" >/dev/null 2>&1
 assert_pin_held DIVE-910 "curation in ASK: explicit --tier=2 survives"
 
 # 8: TITLE AXIS — curation vocabulary only in the title.
 route_reset; seed DIVE-911 'Approve the persona pack for the 5dive-marketplace publish queue'
-actor_seam_as dev; cmd_task_need DIVE-911 --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-911 --type=decision --tier=2 --ask-ok="fixture: this file grades the explicit --tier=2 PIN itself; --needs= would make the capability the source of the tier and the arm would stop measuring the pin" --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
   --ask="Which of the two brand palettes should we commit to?" \
   --options="A|B" --recommend="A" >/dev/null 2>&1
 assert_pin_held DIVE-911 "curation in TITLE: explicit --tier=2 survives"
@@ -193,14 +199,14 @@ assert_downgraded DIVE-912 "curation with NO --tier: still downgraded + lead-rou
 
 # 10: keyword in the ASK (the STEER-1 board-wipe repro).
 route_reset; seed DIVE-920 'Board recovery'
-actor_seam_as dev; cmd_task_need DIVE-920 --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-920 --type=decision --tier=2 --ask-ok="fixture: this file grades the explicit --tier=2 PIN itself; --needs= would make the capability the source of the tier and the arm would stop measuring the pin" --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
   --ask="The task board was wiped/destroyed at 04:20 — keep or discard my uncommitted work and rebuild the board from the audit log?" \
   --options="keep|discard" --recommend="keep" >/dev/null 2>&1
 assert_pin_held DIVE-920 "internal-ops in ASK: explicit --tier=2 survives"
 
 # 11: TITLE AXIS.
 route_reset; seed DIVE-921 'Rebuild the wiped task board from the audit log'
-actor_seam_as dev; cmd_task_need DIVE-921 --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-921 --type=decision --tier=2 --ask-ok="fixture: this file grades the explicit --tier=2 PIN itself; --needs= would make the capability the source of the tier and the arm would stop measuring the pin" --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
   --ask="keep or discard the in-flight work?" --options="keep|discard" --recommend="keep" >/dev/null 2>&1
 assert_pin_held DIVE-921 "internal-ops in TITLE: explicit --tier=2 survives"
 
@@ -236,7 +242,7 @@ actor_seam_as dev; cmd_task_need DIVE-931 --type=access --from=dev \
 # 15: the JSON envelope must REPORT tier 2 — the bug was only visible by reading
 #     the recorded tier back, so assert the recorded value, not just the routing.
 route_reset; seed DIVE-940 'LAND the dive-1957 branch'
-OUT=$(cmd_task_need DIVE-940 --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
+OUT=$(cmd_task_need DIVE-940 --type=decision --tier=2 --ask-ok="fixture: this file grades the explicit --tier=2 PIN itself; --needs= would make the capability the source of the tier and the arm would stop measuring the pin" --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
   --ask="Which wording ships on the public page?" --options="A|B" --recommend="A" 2>/dev/null)
 [[ "$(printf '%s' "$OUT" | jq -r '.data.tier')" == "2" ]] \
   && ok_t "recorded JSON envelope reports tier 2 for a pinned eng-ship-TITLE gate" \
@@ -255,7 +261,7 @@ audit_reset() { : >"$AUDIT_FILE"; }
 
 # 16: a pinned eng-ship gate that escalates past the lead records the row.
 route_reset; audit_reset; seed DIVE-950 'LAND the dive-1957 branch: settle MERGE order'
-actor_seam_as dev; cmd_task_need DIVE-950 --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
+actor_seam_as dev; cmd_task_need DIVE-950 --type=decision --tier=2 --ask-ok="fixture: this file grades the explicit --tier=2 PIN itself; --needs= would make the capability the source of the tier and the arm would stop measuring the pin" --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
   --ask="Which wording ships on the public page?" --options="A|B" --recommend="A" >/dev/null 2>&1
 grep -q '^task.gate-tier2-pin-escalated$' "$AUDIT_FILE" \
   && ok_t "pinned eng-ship escalation records an audit row (measurable, not just a warn)" \
@@ -278,7 +284,7 @@ grep -q '^task.gate-tier2-pin-escalated$' "$AUDIT_FILE" \
 route_reset; audit_reset; unset _TASK_STORE_AUDIT_FENCED
 seed DIVE-952 'LAND the dive-1957 branch: settle MERGE order'
 FIVEDIVE_PROD_TASKS_DB="$TMP/somewhere-else/tasks.db" cmd_task_need DIVE-952 \
-  --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
+  --type=decision --tier=2 --ask-ok="fixture: this file grades the explicit --tier=2 PIN itself; --needs= would make the capability the source of the tier and the arm would stop measuring the pin" --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --from=dev \
   --ask="Which wording ships on the public page?" --options="A|B" --recommend="A" \
   >/dev/null 2>"$TMP/offstore.err"
 [[ ! -s "$AUDIT_FILE" ]] \
@@ -289,5 +295,6 @@ grep -q "telemetry withheld" "$TMP/offstore.err" \
   || bad_t "fence must announce" "err=$(cat "$TMP/offstore.err")"
 unset _TASK_STORE_AUDIT_FENCED
 
+SUMMARY_PRINTED=1
 printf '\n%s\n' "PASS=$PASS FAIL=$FAIL"
 [[ "$FAIL" == "0" ]]

--- a/tests/gate_tier2_floor_unit.sh
+++ b/tests/gate_tier2_floor_unit.sh
@@ -24,7 +24,13 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
-trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
+# DIVE-4346: ABORT backstop. A refused FIXTURE kills the harness before its
+# summary, and a harness with no verdict is indistinguishable from one that was
+# never reached -- how three of these produced silence instead of a red.
+# tests/truncation_marker_guard_unit.sh discovers this trap by grep and grades it.
+exec 8>&2
+SUMMARY_PRINTED=0
+trap 'rc=$?; rm -rf "${TMP:-}"; [[ "${SUMMARY_PRINTED:-0}" == 1 ]] || printf "ABORTED - gate_tier2_floor_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-tier2-unit.XXXXXX)"
@@ -121,7 +127,7 @@ touch "$GATE_PROOF_ENFORCE"   # enforcement ON for the floor tests
 #     gate also MINTS a nonce, but this floor is provenance-based and does not read
 #     it — that independence is what gate_tier2_decision_nonce_unit T6/T7 pin.) ---
 seed_task DIVE-101
-cmd_task_need DIVE-101 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-101 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 [[ "$(tierof DIVE-101)" == "2" ]] && ok_t "T1 decision --tier=2 stored as tier 2" \
   || bad_t "T1 decision tier 2 stored" "got tier '$(tierof DIVE-101)'"
 out=$(cmd_task_answer DIVE-101 --value=A 2>&1); rc=$?
@@ -135,7 +141,7 @@ out=$(cmd_task_answer DIVE-101 --value=A 2>&1); rc=$?
 # --- T2: SAME gate, a trusted human path passes --human (recorded human:*): ACCEPTED
 #     (DIVE-525 — a real tap/dashboard answer must never be blocked). --------------
 seed_task DIVE-102
-cmd_task_need DIVE-102 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-102 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 # SUBSHELLED (DIVE-2233). The one bare `cmd_task_answer` in this file whose expected
 # outcome is SUCCESS: T1/T4 capture into `out=$(…)`, already a subshell, so a refusal
 # there returns a code. Here a refusal calls production's `fail`, which `exit`s — in a
@@ -183,7 +189,7 @@ fi
 #     answer bare would end the harness at status 6 instead of reddening one arm.
 rm -f "$GATE_PROOF_ENFORCE"
 seed_task DIVE-105
-cmd_task_need DIVE-105 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-105 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 out=$(cmd_task_answer DIVE-105 --value=A 2>&1); rc=$?
 [[ $rc -ne 0 && "$(answered DIVE-105)" == "open" ]] \
   && ok_t "T5 enforce OFF does NOT lower the tier-2 floor — bare-agent answer still REFUSED (DIVE-2588)" \
@@ -199,7 +205,7 @@ grep -qi 'tier-2' <<<"$out" \
 #     enforcement envelope off. It must now say NOTHING — the floor stands, and
 #     the sentinel that is present (none here) is the only thing that can speak.
 seed_task DIVE-106
-cmd_task_need DIVE-106 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-106 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 out=$(GATE_PROOF_ENFORCE=/nonexistent/nope cmd_task_answer DIVE-106 --value=A 2>&1); rc=$?
 [[ $rc -ne 0 && "$(answered DIVE-106)" == "open" ]] \
   && ok_t "T5b GATE_PROOF_ENFORCE=/nonexistent does not clear a tier-2 gate (DIVE-2588 bypass)" \
@@ -207,5 +213,6 @@ out=$(GATE_PROOF_ENFORCE=/nonexistent/nope cmd_task_answer DIVE-106 --value=A 2>
 touch "$GATE_PROOF_ENFORCE"
 
 echo "-----"
+SUMMARY_PRINTED=1
 printf 'gate_tier2_floor_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/tests/gate_tier2_nonce_evidence_unit.sh
+++ b/tests/gate_tier2_nonce_evidence_unit.sh
@@ -22,7 +22,10 @@ set -uo pipefail
 # 210 harnesses at once while every other check in this change stayed green.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/grading_tree.sh" \
   || printf 'grading tree: UNRESOLVED (tests/lib/grading_tree.sh not reachable; no tree named)\n' >&2
-trap 'rc=$?; rm -rf "${TMP:-}"; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
+# DIVE-4346: ABORT marker -- see the note in gate_evidence_form_unit.sh.
+exec 8>&2
+SUMMARY_PRINTED=0
+trap 'rc=$?; rm -rf "${TMP:-}"; [[ "${SUMMARY_PRINTED:-0}" == 1 ]] || printf "ABORTED - gate_tier2_nonce_evidence_unit exited early (rc=%s) before its summary; every assertion after the last ok above was SKIPPED, not passed\n" "$rc" >&8; echo "HARNESS-RC=$rc"' EXIT   # DIVE-2692: fires on every exit path (incl. SKIP/precondition-fail early-exits); folds in tempdir cleanup so the two EXIT traps don't clobber each other.
 cd "$(dirname "$0")/.."
 SRC=src
 TMP="$(mktemp -d /tmp/gate-1448-unit.XXXXXX)"
@@ -119,7 +122,7 @@ nhash()   { db "SELECT COALESCE(human_nonce_hash,'') FROM tasks WHERE ident='$1'
 
 # --- T1: a tier-2 decision gate now MINTS a per-gate nonce (it did not before). ---
 seed DIVE-201
-cmd_task_need DIVE-201 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-201 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 [[ -n "$(nhash DIVE-201)" ]] \
   && ok_t "T1 tier-2 decision gate mints a per-gate human nonce" \
   || bad_t "T1 nonce minted on tier-2 decision" "human_nonce_hash empty"
@@ -153,7 +156,7 @@ case "$(provby DIVE-201)" in human:*) ok_t "T3 provenance recorded human:*" ;; *
 
 # --- T4: a WRONG nonce (agent guessing) is refused. --------------------------------
 seed DIVE-202
-cmd_task_need DIVE-202 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-202 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 FAKE_NONAGENT=0
 out=$(cmd_task_answer DIVE-202 --value=A --human --human-proof="00000000000000000000000000000000" 2>&1); rc=$?
 [[ "$(answered DIVE-202)" == "open" && $rc -ne 0 ]] \
@@ -162,7 +165,7 @@ out=$(cmd_task_answer DIVE-202 --value=A --human --human-proof="0000000000000000
 
 # --- T5: the dashboard/human-on-box path (non-agent SUDO_UID, no nonce) CLEARS. ----
 seed DIVE-203
-cmd_task_need DIVE-203 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-203 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 FAKE_NONAGENT=1
 cmd_task_answer DIVE-203 --value=A --human >/dev/null 2>&1
 [[ "$(answered DIVE-203)" == "closed" ]] \
@@ -177,7 +180,7 @@ cmd_task_answer DIVE-203 --value=A --human >/dev/null 2>&1
 #     is the arm that reds if someone reverts _gate_human_principal to the uid test.
 #     Subshelled via $( ) because the refusal is a `fail 6` exit BY DESIGN.
 seed DIVE-290
-cmd_task_need DIVE-290 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-290 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 FAKE_NONAGENT=1
 _cg_saved=$(declare -f _gate_caller_cgroup)
 _gate_caller_cgroup() { printf '%s' '/system.slice/system-5dive.slice/5dive-agent@dev.service'; }
@@ -191,7 +194,7 @@ eval "$_cg_saved"
 #     to the DIVE-1117 provenance floor: a real human --human tap still clears even
 #     though its original message carried no nonce (an in-flight pre-fix gate). -----
 seed DIVE-204
-cmd_task_need DIVE-204 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-204 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 db "UPDATE tasks SET human_nonce_hash=NULL WHERE ident='DIVE-204';"   # simulate a pre-DIVE-1448 row
 FAKE_NONAGENT=0   # plugin tap = agent SUDO_UID, no nonce available on the old message
 cmd_task_answer DIVE-204 --value=A --human >/dev/null 2>&1
@@ -201,7 +204,7 @@ cmd_task_answer DIVE-204 --value=A --human >/dev/null 2>&1
 
 # --- T7: legacy fallback still rejects a NON-human (no --human) agent answer. -------
 seed DIVE-205
-cmd_task_need DIVE-205 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
+cmd_task_need DIVE-205 --type=decision --ask="ship it?" --options="A|B" --recommend="A" --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" >/dev/null 2>&1
 db "UPDATE tasks SET human_nonce_hash=NULL WHERE ident='DIVE-205';"
 FAKE_NONAGENT=0
 out=$(cmd_task_answer DIVE-205 --value=A 2>&1); rc=$?
@@ -224,5 +227,6 @@ grep -q 'answer gate.*type=decision' "$AUDIT_LOG_FILE" \
   || bad_t "T8 decision audit row" "no decision row in $AUDIT_LOG_FILE"
 
 echo "-----"
+SUMMARY_PRINTED=1
 printf 'gate_tier2_nonce_evidence_unit: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/tests/gate_verifier_scoping_floor_unit.sh
+++ b/tests/gate_verifier_scoping_floor_unit.sh
@@ -254,7 +254,14 @@ actor_seam_as main; cmd_task_need DIVE-932 --type=decision --from=main \
 # --- 12: SAFETY — an EXPLICIT --tier=2 is the caller's hard-human contract
 #         (DIVE-1957). No advice, because there is nothing to appeal.
 reset; seedloop DIVE-926
+# DIVE-4346, and this one takes the AUDITED ESCAPE rather than the honest
+# declaration, for the same reason gate_approval_routing_unit A8 does: the arm
+# grades that the EXPLICIT --tier=2 PIN is itself the hard-human contract. Give it
+# --needs=human_tap and the capability becomes the source of the tier, and the arm
+# stops grading the pin. The undeclared shape is the subject, so it is bought with
+# --ask-ok and a written reason, which leaves an audit row and stays countable.
 actor_seam_as dev; cmd_task_need DIVE-926 --type=decision --from=dev --tier=2 \
+  --ask-ok="fixture: this arm grades that an explicit --tier=2 pin is the caller's own hard-human contract (DIVE-1957), so the gate must reach the human with NO declared capability -- --needs= would make the capability the source of the tier and grade a different thing" \
   --ask="$SCOPE_ASK" --options="split|keep" --recommend="split" 2>"$ERR" >/dev/null
 [[ "$(tierof DIVE-926)" == "2" ]] && ! warned "CANNOT clear it" \
   && ok_t "safety: explicit --tier=2 stays hard-human and gets no appeal advice" \

--- a/tests/verifier_gate_ack_unit.sh
+++ b/tests/verifier_gate_ack_unit.sh
@@ -116,7 +116,7 @@ A=$(deliver "gate filed by the verifier")
   && ok_t "fixture is DELIVERED and unacked (todo, held by reviewer)" \
   || bad_t "fixture not delivered" "status=$(col "$A" status) assignee=$(col "$A" assignee) ack=$(col "$A" handoff_ack_at)"
 
-as reviewer cmd_task_need "$A" --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --options="A|B" --recommend="A" \
+as reviewer cmd_task_need "$A" --type=decision --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --options="A|B" --recommend="A" \
    --ask="Leave this open and parked, or close it as delivered?" >/dev/null
 [[ "$(col "$A" need_type)" == "decision" && -z "$(col "$A" need_answered_at)" \
    && "$(col "$A" status)" == "blocked" ]] \
@@ -145,7 +145,7 @@ as intruder cmd_task_need "$F" --type=manual --ask="unrelated question" >/dev/nu
 # left the suite green, because `handoff_ack_at IS NULL` was doing the skipping.
 # Two fixes for one symptom, one silently standing in for the other.
 G=$(deliver "delivered, live gate, no ACK on the row")
-as reviewer cmd_task_need "$G" --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --options="A|B" --recommend="A" \
+as reviewer cmd_task_need "$G" --type=decision --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --options="A|B" --recommend="A" \
    --ask="Leave this open and parked, or close it as delivered?" >/dev/null
 db "UPDATE tasks SET handoff_ack_at=NULL WHERE ident=$(sqlq "$G");"
 [[ "$(col "$G" assignee)" == "reviewer" && -z "$(col "$G" handoff_ack_at)" \
@@ -215,7 +215,7 @@ as reviewer cmd_task_reject "$D" --feedback="needs another pass FIX: name the co
 #     is the party the gate is waiting on, so their reject proceeds. Graded
 #     explicitly rather than inherited from whoever runs the suite.
 E=$(deliver "tier-2 gate, human rejects")
-as reviewer cmd_task_need "$E" --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --options="A|B" --recommend="A" \
+as reviewer cmd_task_need "$E" --type=decision --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --options="A|B" --recommend="A" \
    --ask="Leave open and parked, or close as delivered?" >/dev/null
 GATE_ACTOR="human"
 as reviewer cmd_task_reject "$E" --feedback="human call: bounce it FIX: name the concrete change" >/dev/null
@@ -240,7 +240,7 @@ as reviewer cmd_task_reject "$H" --feedback="needs another pass FIX: name the co
 #     themselves, the refusal points at withdraw-then-reject — so run it and prove
 #     it completes. The withdrawal is recorded; nothing is put in the human's mouth.
 I=$(deliver "verifier's own gate, withdraw then reject")
-as reviewer cmd_task_need "$I" --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --options="A|B" --recommend="A" \
+as reviewer cmd_task_need "$I" --type=decision --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --options="A|B" --recommend="A" \
    --ask="Leave open and parked, or close as delivered?" >/dev/null
 msg=$(as reviewer cmd_task_reject "$I" --feedback="it fails FIX: name the concrete change" 2>&1; cat "$TMP/err")
 [[ "$msg" == *"--withdraw"* && "$msg" == *"you can retire it yourself"* ]] \
@@ -257,7 +257,7 @@ as reviewer cmd_task_reject "$I" --feedback="it fails FIX: name the concrete cha
 #     refusal must name the exit that does not need them: record the verdict now,
 #     reject when the gate clears. Proven by running it, not by reading the string.
 J=$(deliver "third party's gate, verdict recorded meanwhile")
-as lead cmd_task_need "$J" --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --options="A|B" --recommend="A" \
+as lead cmd_task_need "$J" --type=decision --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --options="A|B" --recommend="A" \
    --ask="policy call only a human can make" >/dev/null
 db "UPDATE tasks SET assignee='reviewer' WHERE ident=$(sqlq "$J");"   # row still held by the verifier
 msg=$(as reviewer cmd_task_reject "$J" --feedback="it fails FIX: name the concrete change" 2>&1; cat "$TMP/err")
@@ -274,7 +274,7 @@ as reviewer cmd_task_set_body "$J" "VERDICT: FAIL — reasons here" --append >/d
 #     never saw DIVE-555. Unguarded, every rail above is advisory: one `task
 #     verify --cmd=true` closes the row and the human's question disappears.
 K=$(deliver "verify --cmd must not close over a gate")
-as reviewer cmd_task_need "$K" --type=decision --tier=2 --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --options="A|B" --recommend="A" \
+as reviewer cmd_task_need "$K" --type=decision --tier=2 --needs=human_tap --rubber-stamp-ok="fixture: this case needs a real hard-human tier-2 gate to grade; DIVE-2848 caps the hand-typed shape" --options="A|B" --recommend="A" \
    --ask="Leave open and parked, or close as delivered?" >/dev/null
 out=$(as reviewer cmd_task_verify "$K" --cmd=true); rc=$?
 (( rc != 0 )) && ok_t "ARM3c verify auto-close over an open gate exits non-zero (rc=$rc)" \


### PR DESCRIPTION
**AXIS: the autonomy number** — human taps per shipped change — and the org layer's observable behaviour: *a customer is tapped ONLY for money, a secret, an irreversible step, or something only a person at a browser can do.*

lodar, Telegram 2026-09-12 01:06Z: *"i just think about our customers. this would be annoying for them to tap on such a minor change. human gate is still the most annoying part of 5dive."*

## The before-number (deliverable 4, the audit)

7 days to 2026-09-12, from `tasks` on this board — every gate that reached the paired human, the capability it named, and whether he could act on it:

| named capability | gates | could he act on it? |
|---|---:|---|
| `human_tap` | 13 | yes — a person's own call, or a browser-only step |
| `spend_authority` | 3 | yes — money |
| `secret_provision` (incl. `--type=secret`) | 3 | yes — a credential only a person can issue |
| **none named** | **16 (46%)** | **unknown by construction — the gate does not say** |
| **total reaching the human** | **35** | |

313 changes shipped in the same week → **0.11 taps per shipped change**. That is the ratio a customer would read, and it is now on `5dive digest`.

## 1. The product default — a REFUSAL at filing, not a re-route

A `decision` or `approval` gate that reaches the paired human must name the capability it consumes. If the filer cannot name one, the message says plainly *"this is not a gate on a person"* and offers `--tier=0`, `--tier=1`, or an audited `--ask-ok=`.

**Where this diverges from the row as filed, and why.** The row specified that a needs-less `manual`/`approval` gate should ROUTE to the lead/verifier seat. **That is the behaviour DIVE-4329 removed one day earlier, on a measurement** (2026-09-11): a tier-2 `manual` gate asking a person to try a login took a re-route exit, queued on a lead seat that cannot open a browser, and **nobody was ever pinged**. `need.sh` carries the lesson verbatim — *"a lint about wording must not change the destination"*.

> Moving a gate to a seat that cannot act on it does not reduce taps. It converts a visible interruption into an invisible stall, and the stall is worse, because the tap at least terminates.

So the default is enforced where its cost is one re-file, paid by the only party that knows what the ask consumes.

**Every exemption is a type that already names its capability** — `secret` (in its own name), `access` (lead-clearable by type, DIVE-1243), a tier-2 `manual` gate (`_gate_is_human_tap` has said so since DIVE-4329), and any category-floored gate. Requiring the flag on tier-2 `manual` would refuse the product's **own** iteration-cap escalation gate in `src/task/delivery.sh` — caught by `tests/gate_ask_readability_unit.sh` arm F while this was being built, not reasoned about afterwards.

## 2. Two answerability refusals

DIVE-4176 grades whether an ask is READABLE. It has no opinion on whether a person can ACT on it — and a readable ask nobody can answer is worse, because he reads it.

* **"go look at the preview"** — unsatisfiable on an auth-gated route. Behind the hosting SSO wall there is a second wall: a **production** Clerk instance refuses preview domains outright, and `x-vercel-protection-bypass` has no authority over it. The link is unreachable **by the holder too**. DIVE-4263 spent ~a day and six gates, three reaching lodar, before it was verified on a box instead. The refusal points at verifying on a box, or asking for a reusable test login as a `secret` gate — never at a different reader.
* **"approve this because a code-hosting rule says so"** — a CODEOWNERS entry or branch-protection rule is repo CONFIG. The tap buys one merge and zero decisions; the rule fires again next change (DIVE-4020; lodar on DIVE-4196: *"why asking me then?"*). An ask to **change** the rule is deliberately NOT caught (DIVE-4086) — that is a browser-only action a person really does hold, and refusing it would leave the rule in place forever.

**Replayed over the corpus: 171 tier-2 asks in `gate_history`, 30 days to 2026-09-12 → 9 preview hits, 1 code-hosting hit, ZERO false positives.** The hits include all three asks lodar was handed on 2026-09-12 00:27–01:05Z (DIVE-4294, DIVE-4239, DIVE-4307) plus DIVE-3594/3613/3618/3644/4263.

Getting to zero took two corrections that came from **printing every match**, not from thinking about the regex:
1. a look-verb must sit at an **instruction boundary** — DIVE-3984 (*"this seat cannot render page images, so the deploy preview must be looked at before merge"*) is a legitimate push approval that carries both tokens in a subordinate clause, and a co-occurrence test refuses it;
2. the code-hosting arm needs an **approval-shape** clause or it eats its own remedy (DIVE-4086).

## 3. The visible counter

`5dive digest` renders, under the autonomy line:

```
🦾 Autonomy — currently waiting on you · shipped 98 (↑32 vs 66 prior 24h) · buzzed your phone 41× · you answered 5×
   ↳ 0.05 taps per shipped change · of 5 taps, 5 named a capability, 0 named none
```

Rendered live from the built CLI, not mocked. It reads the live `tasks` table, and an unreadable split renders `unknown`, never zero (DIVE-3228's lesson about the buzz count).

## Verification

`tests/gate_customer_tap_default_unit.sh` — **42 arms, 42 pass**:
* both predicates at unit level against the **verbatim corpus**: 7 true positives, and the three measured false-positive controls (DIVE-3978, DIVE-3984, DIVE-4239's real human_tap ask) that must survive;
* each refusal end-to-end — RED exit, **no gate written**, task not moved to blocked, audit row emitted — each with a tier-1 control that must still file and its `--ask-ok` escape;
* the capability matrix: type × `--needs` present/absent × `--recommend` present/absent → who is pinged. **The mutation arm is M2**: delete the capability-declaration refusal and a needs-less approval reaching the human goes green. M4/M5 pin that `manual` and `secret` stay human-facing, so the rule cannot be "passed" by re-routing everything.

Also green at desk: `gate_ask_readability_unit` 55/55, `gate_approval_routing_unit`, `gate_answer_audit_unit`, `gate_channel_proof_unit`, and all six `digest_*` suites. Pre-push rail green in 43.5s.

Three existing fixtures needed the new declaration, and each took the idiomatic verb with the reason written in place: `--ask-ok` where the case grades that the `--tier=2` **pin** is the source of the tier (adding `--needs` would grade a different thing), `--needs=spend_authority` where the ask really does spend money.

## What is NOT in this PR

* **`needs_capability` is on neither `task ls --json` nor `gate_history`.** So a RETIRED gate's capability is unrecoverable and this audit cannot be replayed backwards — the counter reads the live `tasks` table for that reason. Both are additive columns; filed as follow-up, not silently dropped.
* The **per-box** slice of the counter (deliverable 3 asks for per week *and* per box). The board is single-instance here; the per-box rollup needs the fleet aggregation rail.
* DIVE-4334 (move/drop the installer code-owner attester) and DIVE-4344 ship on their own, per the row.

Wiki: `community/wiki/a-gate-that-reaches-nobody-is-worse-than-the-tap-it-replaced.md` + index line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
