### PR TITLE
fix(install): a hook the fleet pin does not ship no longer fails the whole install (DIVE-4349)

### DIFF
--- a/changelog.d/DIVE-4349.md
+++ b/changelog.d/DIVE-4349.md
@@ -1,0 +1,15 @@
+## Unreleased — fix(install): a hook the fleet pin does not ship no longer fails the whole install (DIVE-4349)
+
+`install.sh` is fetched from `main` on every install and every 04:00Z self-update, but each
+`$REPO/…` download inside it resolves against the tree of the PINNED tag the fleet follows
+(`api.5dive.com/cli-version`, v0.32.3 tonight). #890 (DIVE-4306) added `hooks/stop-browser-teardown.sh`
+to the fail-closed hook loop; that file first ships in v0.34.0, so at the pin the download is a 404
+and, under `set -e`, the 404 was the entire install. Measured: the 2026-09-12 01:52Z nightly smoke
+aborted at "Installing software" with zero rows graded; no customer box was provisioned in the
+window (api log), but any fresh install and every pinned box's 04:00Z self-update would fail the
+same way until this lands.
+
+The hook now downloads through a tolerant block: present at the pin → installed as before; absent →
+skipped with a named stderr line (`not shipped at this pin`). That is the correct outcome, not a
+degradation — the bundle at a pin that predates the hook never wires it. Hooks move back into the
+fail-closed loop only once the fleet pin is at or past the tag that ships them.

--- a/install.sh
+++ b/install.sh
@@ -818,11 +818,33 @@ JOURNALD
               stop-telegram-reply-check.sh \
               posttool-telegram-relay.sh userprompt-mirror-inter-agent.sh \
               stop-mirror-inter-agent.sh push-notify.sh \
-              sessionstart-resume-context.sh stop-browser-teardown.sh; do
+              sessionstart-resume-context.sh; do
     curl -fsSL "$REPO/hooks/$hook" -o "$LIB_DIR/$hook"
     chmod 755 "$LIB_DIR/$hook"
     ok "$hook"
   done
+  # >>> DIVE-4349 hooks newer than the fleet pin are optional at that pin
+  # This script is fetched from `main` (install.5dive.com) but every $REPO/…
+  # download below resolves against the PINNED tag's tree (DIVE-4140: the
+  # fleet follows api.5dive.com/cli-version, v0.32.3 tonight). A hook that
+  # main's loop above names but the pinned tree does not carry is a 404, and
+  # under `set -e` that 404 was the whole install: the 2026-09-12 01:52Z
+  # nightly smoke aborted at "Installing software"; any fresh customer box
+  # and every pinned box's 04:00Z self-update would do the same from #890
+  # (2026-09-11 18:24Z) onward. The bundle at that
+  # pin never wires a hook it does not ship, so skipping is the correct
+  # outcome — named on stderr, never silent. Move a hook UP into the
+  # fail-closed loop only once the fleet pin is at or past the tag that ships it.
+  for hook in stop-browser-teardown.sh; do
+    if curl -fsSL "$REPO/hooks/$hook" -o "$LIB_DIR/$hook" 2>/dev/null; then
+      chmod 755 "$LIB_DIR/$hook"
+      ok "$hook"
+    else
+      rm -f "$LIB_DIR/$hook"
+      echo "  ! hooks/$hook not shipped at this pin (${GH_PINNED_TAG:-unpinned}) — skipped; the bundle at this pin does not wire it" >&2
+    fi
+  done
+  # <<< DIVE-4349
   curl -fsSL "$REPO/skills/notify-user/SKILL.md" -o "$LIB_DIR/skills/notify-user/SKILL.md"
   chmod 644 "$LIB_DIR/skills/notify-user/SKILL.md"
   ok "notify-user skill"


### PR DESCRIPTION
## What broke

`install.sh` is fetched from `main` (install.5dive.com serves it, md5-identical to `origin/main`) on every fresh install and every 04:00Z `self-update`, but every `$REPO/…` download inside it resolves against the tree of the **pinned** tag the fleet follows (`api.5dive.com/cli-version` → `v0.32.3`, DIVE-4140).

#890 (DIVE-4306, merged 2026-09-11 18:24Z) added `hooks/stop-browser-teardown.sh` to the fail-closed hook loop. That file first ships in **v0.34.0**. At the pin the download is a 404, and under `set -e` the 404 was the entire install.

Measured:
- nightly smoke 2026-09-12 01:52Z: `aborted=true, rowsGraded=0, stage=awaiting-ready`; the smoke box is the ONLY failed provision since 18:24Z (api log: no customer box was provisioned in the window), but any fresh install and every pinned box's 04:00Z self-update would fail the same way; api log: `5dive install: CLI target v0.32.3 — source: fleet stable route … curl: (22) … 404 … ERROR: 5dive CLI install via install.5dive.com failed` (verdict `/var/log/5dive/smoke/smoke-20260912T015437Z.json`, hold `hold-20260912T015437Z-v0.35.1.json`).
- Every literal `$REPO/<path>` in main's install.sh probed at `f421ba2a` (v0.32.3 peeled): all 200. Every hook in the loop: all 200 except `stop-browser-teardown.sh` → 404.

## The fix

The hook moves out of the fail-closed loop into a tolerant block: present at the pin → installed as before; absent → skipped with a named stderr line (`not shipped at this pin (v0.32.3)`). Correct, not degraded: the bundle at a pin that predates the hook never wires it. Comment in the file says when a hook may move back up (fleet pin ≥ the tag that ships it).

## Verified

- Old loop extracted verbatim and run against the v0.32.3 tree → `curl: (22) … 404` on `stop-browser-teardown.sh` (reproduces).
- New loops against the v0.32.3 tree → 11 hooks installed, teardown skipped with the named line, exit 0.
- New loops against the v0.35.1 tree → 12 hooks installed including `stop-browser-teardown.sh`.
- `bash -n install.sh` ok; pre-push rail green (title, fragment, shellcheck); `tests/install_{box_scripts_manifest,monotonicity,pin_sha,first_run_clean,update_hint}_unit.sh` pass. `tests/install_checksum_unit.sh` is red identically on pristine `origin/main` (needs `./build.sh` for `5dive.sha256`) — not this diff.
- The paid Hetzner smoke is the arm this change uniquely owes; it re-runs from the control plane once this is on `main` (install.sh is read live from main, no cut needed) — evidence lands on DIVE-4349.

## Not in this PR

A CI guard that every fail-closed download in main's install.sh exists at the fleet pin's tree — filed as DIVE-4350 (this class will recur every time a maker adds a file to install.sh while the pin lags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
